### PR TITLE
feat: Network inspector tool

### DIFF
--- a/packages/tool-server/src/blueprints/network-inspector.ts
+++ b/packages/tool-server/src/blueprints/network-inspector.ts
@@ -1,0 +1,56 @@
+import {
+  TypedEventEmitter,
+  type ServiceBlueprint,
+  type ServiceEvents,
+} from "@argent/registry";
+import type { CDPClient } from "../utils/debugger/cdp-client";
+import type { JsRuntimeDebuggerApi } from "./js-runtime-debugger";
+import { NETWORK_INTERCEPTOR_SCRIPT } from "../utils/debugger/scripts/network-interceptor";
+
+export const NETWORK_INSPECTOR_NAMESPACE = "NetworkInspector";
+
+export interface NetworkInspectorApi {
+  port: number;
+  cdp: CDPClient;
+}
+
+export const networkInspectorBlueprint: ServiceBlueprint<
+  NetworkInspectorApi,
+  string
+> = {
+  namespace: NETWORK_INSPECTOR_NAMESPACE,
+
+  getURN(port: string) {
+    return `${NETWORK_INSPECTOR_NAMESPACE}:${port}`;
+  },
+
+  getDependencies(port: string) {
+    return { debugger: `JsRuntimeDebugger:${port}` };
+  },
+
+  async factory(deps, _payload) {
+    const debuggerApi = deps.debugger as JsRuntimeDebuggerApi;
+    const cdp = debuggerApi.cdp;
+    const ignore = () => {};
+
+    // Inject the fetch-level network interceptor. Idempotent — the script
+    // guards itself with __radon_network_installed.
+    await cdp.evaluate(NETWORK_INTERCEPTOR_SCRIPT).catch(ignore);
+
+    const api: NetworkInspectorApi = { port: debuggerApi.port, cdp };
+
+    const events = new TypedEventEmitter<ServiceEvents>();
+
+    cdp.events.on("disconnected", (error) => {
+      events.emit("terminated", error ?? new Error("CDP disconnected"));
+    });
+
+    return {
+      api,
+      dispose: async () => {
+        // Nothing to dispose — the CDP connection is owned by JsRuntimeDebugger.
+      },
+      events,
+    };
+  },
+};

--- a/packages/tool-server/src/tools/network/network-logs.ts
+++ b/packages/tool-server/src/tools/network/network-logs.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import type { ToolDefinition } from "@argent/registry";
+import type { NetworkInspectorApi } from "../../blueprints/network-inspector";
+import {
+  NETWORK_INTERCEPTOR_SCRIPT,
+  makeNetworkLogReadScript,
+} from "../../utils/debugger/scripts/network-interceptor";
+
+const ITEMS_PER_PAGE = 50;
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface LogEntry {
+  id: number;
+  requestId: string;
+  state: string;
+  request?: { url: string; method: string };
+  response?: { status: number; statusText: string; mimeType: string };
+  resourceType?: string;
+  encodedDataLength?: number;
+  timestamp?: number;
+  durationMs?: number;
+  errorText?: string;
+}
+
+function formatEntry(entry: LogEntry): string {
+  const method = entry.request?.method ?? "???";
+  const url = entry.request?.url ?? "unknown";
+
+  let name: string;
+  try {
+    const parsed = new URL(url);
+    name = parsed.pathname === "/" ? parsed.hostname : parsed.pathname;
+  } catch {
+    name = url;
+  }
+
+  let status: string;
+  if (entry.state === "failed") {
+    status = entry.errorText ?? "failed";
+  } else if (entry.response) {
+    status = `${entry.response.status} ${entry.response.statusText}`;
+  } else {
+    status = "pending";
+  }
+
+  const type = entry.resourceType ?? "";
+  const size =
+    entry.encodedDataLength != null ? formatBytes(entry.encodedDataLength) : "";
+  const duration = entry.durationMs != null ? `${entry.durationMs} ms` : "";
+
+  return `{id: ${entry.requestId}} "${method} ${name}" ${status} ${type} ${size} ${duration}`.trim();
+}
+
+const zodSchema = z.object({
+  port: z.coerce.number().default(8081).describe("Metro server port"),
+  pageIndex: z
+    .union([z.coerce.number().int().nonnegative(), z.literal("latest")])
+    .default("latest")
+    .describe(
+      'Page index (0-based) or "latest" for the most recent page. Each page contains up to 50 entries.'
+    ),
+});
+
+export const networkLogsTool: ToolDefinition<
+  z.infer<typeof zodSchema>,
+  string
+> = {
+  id: "view-network-logs",
+  description: `View captured network (HTTP) requests from the running React Native app.
+Returns a paginated list of requests with method, URL, status, resource type, size, and duration.
+Each entry includes a requestId that can be passed to view-network-request-details for full details.
+Network interception is injected into the JS runtime — it captures fetch() calls.`,
+  zodSchema,
+  services: (params) => ({
+    inspector: `NetworkInspector:${params.port}`,
+  }),
+  async execute(services, params) {
+    const api = services.inspector as NetworkInspectorApi;
+
+    // Ensure the interceptor is installed (idempotent).
+    await api.cdp.evaluate(NETWORK_INTERCEPTOR_SCRIPT).catch(() => {});
+
+    // First get the total count for pagination by running the read script with a
+    // zero-length slice — same filtering logic, no duplication.
+    const countRaw = await api.cdp.evaluate(
+      makeNetworkLogReadScript(0, 0, api.port),
+    );
+    const { total } = JSON.parse(countRaw as string) as { total: number };
+
+    if (total === 0) {
+      return "No network traffic captured. Make sure the app is running and making HTTP requests. Network interception is active — it captures fetch() calls.";
+    }
+
+    const pageCount = Math.ceil(total / ITEMS_PER_PAGE);
+    const pageIndex =
+      params.pageIndex === "latest"
+        ? pageCount - 1
+        : (params.pageIndex as number);
+
+    if (pageIndex < 0 || pageIndex >= pageCount) {
+      return `Page index out of range. Valid range: 0-${pageCount - 1} (${pageCount} pages, ${total} total requests).`;
+    }
+
+    const start = pageIndex * ITEMS_PER_PAGE;
+    const readScript = makeNetworkLogReadScript(start, ITEMS_PER_PAGE, api.port);
+    const raw = await api.cdp.evaluate(readScript);
+    const data = JSON.parse(raw as string) as {
+      entries: LogEntry[];
+      total: number;
+      interceptorInstalled: boolean;
+    };
+
+    if (!data.interceptorInstalled) {
+      return "Network interceptor not installed. Try reconnecting with network-inspector-connect.";
+    }
+
+    const lines = data.entries.map(formatEntry);
+
+    return `=== NETWORK LOGS (page ${pageIndex + 1}/${pageCount}, ${data.total} total) ===\n\n${lines.join("\n")}`;
+  },
+};

--- a/packages/tool-server/src/tools/network/network-request.ts
+++ b/packages/tool-server/src/tools/network/network-request.ts
@@ -1,0 +1,179 @@
+import { z } from "zod";
+import type { ToolDefinition } from "@argent/registry";
+import type { NetworkInspectorApi } from "../../blueprints/network-inspector";
+import {
+  NETWORK_INTERCEPTOR_SCRIPT,
+  makeNetworkDetailReadScript,
+} from "../../utils/debugger/scripts/network-interceptor";
+
+/**
+ * Header names (lowercase) that should be redacted to avoid leaking secrets.
+ */
+const SENSITIVE_HEADER_PATTERNS = [
+  "auth",
+  "cookie",
+  "token",
+  "secret",
+  "key",
+  "session",
+  "credential",
+  "password",
+  "api-key",
+  "apikey",
+  "x-api-key",
+];
+
+function isSensitiveHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return SENSITIVE_HEADER_PATTERNS.some((p) => lower.includes(p));
+}
+
+function redactHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> {
+  if (!headers) return {};
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    result[key] = isSensitiveHeader(key) ? "[REDACTED]" : value;
+  }
+  return result;
+}
+
+/** Max response body content size shown to AI to avoid context bloat. */
+const MAX_BODY_SIZE = 1000;
+
+const zodSchema = z.object({
+  port: z.coerce.number().default(8081).describe("Metro server port"),
+  requestId: z
+    .string()
+    .describe(
+      "The requestId from view-network-logs to get full details for",
+    ),
+  includeBody: z
+    .coerce.boolean()
+    .default(true)
+    .describe(
+      "Whether to include the response body (if captured). Defaults to true.",
+    ),
+});
+
+interface RawEntry {
+  id: number;
+  requestId: string;
+  state: string;
+  request?: {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    postData?: string;
+  };
+  response?: {
+    url: string;
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    mimeType: string;
+  };
+  resourceType?: string;
+  encodedDataLength?: number;
+  timestamp?: number;
+  wallTime?: number;
+  durationMs?: number;
+  errorText?: string;
+  initiator?: { type: string; url?: string; lineNumber?: number };
+  responseBody?: string;
+}
+
+interface NetworkRequestDetails {
+  requestId: string;
+  state: string;
+  resourceType?: string;
+  durationMs?: number;
+  encodedDataLength?: number;
+  request?: {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    postData?: string;
+  };
+  response?: {
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    mimeType: string;
+    body?: string;
+  };
+  errorText?: string;
+  initiator?: { type: string; url?: string; lineNumber?: number };
+}
+
+export const networkRequestTool: ToolDefinition<
+  z.infer<typeof zodSchema>,
+  NetworkRequestDetails | string
+> = {
+  id: "view-network-request-details",
+  description: `Get full details of a specific network request by its requestId (from view-network-logs).
+Returns request/response headers (sensitive headers redacted), status, timing, and optionally the response body.
+Large response bodies are truncated. Use this after view-network-logs to inspect individual requests.`,
+  zodSchema,
+  services: (params) => ({
+    inspector: `NetworkInspector:${params.port}`,
+  }),
+  async execute(services, params) {
+    const api = services.inspector as NetworkInspectorApi;
+
+    // Ensure the interceptor is installed (idempotent).
+    await api.cdp.evaluate(NETWORK_INTERCEPTOR_SCRIPT).catch(() => {});
+
+    const script = makeNetworkDetailReadScript(params.requestId);
+    const raw = await api.cdp.evaluate(script);
+    const data = JSON.parse(raw as string) as RawEntry | { error: string };
+
+    if ("error" in data) {
+      return `${data.error}. Use view-network-logs to list available requests.`;
+    }
+
+    const entry = data as RawEntry;
+
+    const details: NetworkRequestDetails = {
+      requestId: entry.requestId,
+      state: entry.state,
+      resourceType: entry.resourceType,
+      durationMs: entry.durationMs,
+      encodedDataLength: entry.encodedDataLength,
+      errorText: entry.errorText,
+      initiator: entry.initiator,
+    };
+
+    if (entry.request) {
+      details.request = {
+        url: entry.request.url,
+        method: entry.request.method,
+        headers: redactHeaders(entry.request.headers),
+        postData: entry.request.postData,
+      };
+    }
+
+    if (entry.response) {
+      const resp: NetworkRequestDetails["response"] = {
+        status: entry.response.status,
+        statusText: entry.response.statusText,
+        headers: redactHeaders(entry.response.headers),
+        mimeType: entry.response.mimeType,
+      };
+
+      if (params.includeBody && entry.responseBody != null) {
+        const body = entry.responseBody;
+        if (body.length > MAX_BODY_SIZE) {
+          resp.body = `[TRUNCATED — original size: ${body.length} chars, MIME: ${entry.response.mimeType}]\n${body.slice(0, MAX_BODY_SIZE)}...`;
+        } else {
+          resp.body = body;
+        }
+      }
+
+      details.response = resp;
+    }
+
+    return details;
+  },
+};

--- a/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
@@ -1,0 +1,193 @@
+/**
+ * JS script injected via Runtime.evaluate to intercept network requests.
+ * Monkey-patches globalThis.fetch and XMLHttpRequest to capture request/response
+ * metadata and store them in globalThis.__radon_network_log.
+ *
+ * The network tools read this array via Runtime.evaluate to fetch captured logs.
+ * Each entry follows the NetworkLogEntry shape used by the tools.
+ *
+ * Designed to be idempotent — calling it twice won't double-patch.
+ */
+export const NETWORK_INTERCEPTOR_SCRIPT = `(function() {
+  if (globalThis.__radon_network_installed) return JSON.stringify({ installed: false, reason: 'already installed' });
+  globalThis.__radon_network_installed = true;
+
+  var log = [];
+  globalThis.__radon_network_log = log;
+  var byId = {};
+  globalThis.__radon_network_by_id = byId;
+  var nextReqId = 1;
+  var MAX_ENTRIES = 2000;
+  function genId() { return 'rn-net-' + (nextReqId++); }
+  function ts() { return Date.now() / 1000; }
+
+  function getOrCreate(reqId) {
+    if (byId[reqId]) return byId[reqId];
+    var entry = {
+      id: log.length,
+      requestId: reqId,
+      state: 'pending'
+    };
+    log.push(entry);
+    byId[reqId] = entry;
+    if (log.length > MAX_ENTRIES) {
+      var removed = log.splice(0, log.length - MAX_ENTRIES);
+      for (var i = 0; i < removed.length; i++) {
+        delete byId[removed[i].requestId];
+      }
+    }
+    return entry;
+  }
+
+  // ── Patch fetch ──
+  var origFetch = globalThis.fetch;
+  if (origFetch) {
+    globalThis.fetch = function(input, init) {
+      var reqId = genId();
+      var method = (init && init.method) ? init.method.toUpperCase() : 'GET';
+      var url = typeof input === 'string' ? input : (input && input.url ? input.url : String(input));
+      var headers = {};
+      if (init && init.headers) {
+        if (typeof init.headers.forEach === 'function') {
+          init.headers.forEach(function(v, k) { headers[k] = v; });
+        } else if (typeof init.headers === 'object') {
+          var ks = Object.keys(init.headers);
+          for (var i = 0; i < ks.length; i++) { headers[ks[i]] = String(init.headers[ks[i]]); }
+        }
+      }
+      var postData = (init && init.body && typeof init.body === 'string') ? init.body : undefined;
+      var t = ts();
+
+      var entry = getOrCreate(reqId);
+      entry.request = { url: url, method: method, headers: headers, postData: postData };
+      entry.timestamp = t;
+      entry.wallTime = t;
+      entry.resourceType = 'Fetch';
+
+      return origFetch.apply(globalThis, arguments).then(function(response) {
+        var respHeaders = {};
+        if (response.headers && typeof response.headers.forEach === 'function') {
+          response.headers.forEach(function(v, k) { respHeaders[k] = v; });
+        }
+        var contentType = respHeaders['content-type'] || '';
+        var mimeType = contentType.split(';')[0].trim();
+
+        entry.response = {
+          url: response.url || url,
+          status: response.status,
+          statusText: response.statusText || '',
+          headers: respHeaders,
+          mimeType: mimeType
+        };
+
+        var cloned = response.clone();
+        cloned.text().then(function(body) {
+          entry.state = 'finished';
+          entry.encodedDataLength = body.length;
+          entry.durationMs = Math.round((ts() - t) * 1000);
+          entry.responseBody = body;
+        }).catch(function() {
+          entry.state = 'finished';
+          entry.encodedDataLength = 0;
+          entry.durationMs = Math.round((ts() - t) * 1000);
+        });
+
+        return response;
+      }).catch(function(err) {
+        entry.state = 'failed';
+        entry.errorText = err ? (err.message || String(err)) : 'Network error';
+        entry.durationMs = Math.round((ts() - t) * 1000);
+        throw err;
+      });
+    };
+  }
+
+  // Note: XHR is intentionally NOT patched. In React Native, fetch() is built
+  // on top of XMLHttpRequest internally, so patching both would double-count
+  // every request. Since virtually all RN code uses fetch(), patching only
+  // fetch captures all meaningful traffic without duplicates.
+
+  return JSON.stringify({ installed: true });
+})()`;
+
+/**
+ * Script to read captured network logs from the JS runtime.
+ * Returns JSON with the entries array and total count.
+ * Accepts optional start index and limit for pagination.
+ */
+export function makeNetworkLogReadScript(
+  start: number,
+  limit: number,
+  metroPort: number,
+): string {
+  return `(function() {
+  var log = globalThis.__radon_network_log;
+  if (!log) return JSON.stringify({ entries: [], total: 0, interceptorInstalled: false });
+
+  // Filter out requests to the Metro server
+  var filtered = [];
+  for (var i = 0; i < log.length; i++) {
+    var e = log[i];
+    if (e.request && e.request.url) {
+      try {
+        var u = e.request.url;
+        if ((u.indexOf('://localhost:${metroPort}') !== -1 || u.indexOf('://127.0.0.1:${metroPort}') !== -1)) continue;
+      } catch(ex) {}
+    }
+    filtered.push(e);
+  }
+
+  var total = filtered.length;
+  var start = ${start};
+  var limit = ${limit};
+  var slice = filtered.slice(start, start + limit);
+
+  // Strip responseBody from list view (too large)
+  var entries = [];
+  for (var j = 0; j < slice.length; j++) {
+    var s = slice[j];
+    entries.push({
+      id: s.id,
+      requestId: s.requestId,
+      state: s.state,
+      request: s.request ? { url: s.request.url, method: s.request.method } : undefined,
+      response: s.response ? { status: s.response.status, statusText: s.response.statusText, mimeType: s.response.mimeType } : undefined,
+      resourceType: s.resourceType,
+      encodedDataLength: s.encodedDataLength,
+      timestamp: s.timestamp,
+      durationMs: s.durationMs,
+      errorText: s.errorText
+    });
+  }
+
+  return JSON.stringify({ entries: entries, total: total, interceptorInstalled: true });
+})()`;
+}
+
+/**
+ * Script to read a single network request's full details from the JS runtime.
+ */
+export function makeNetworkDetailReadScript(requestId: string): string {
+  return `(function() {
+  var byId = globalThis.__radon_network_by_id;
+  if (!byId) return JSON.stringify({ error: 'Network interceptor not installed' });
+  var entry = byId['${requestId.replace(/'/g, "\\'")}'];
+  if (!entry) return JSON.stringify({ error: 'Request not found' });
+
+  return JSON.stringify({
+    id: entry.id,
+    requestId: entry.requestId,
+    state: entry.state,
+    request: entry.request,
+    response: entry.response,
+    resourceType: entry.resourceType,
+    encodedDataLength: entry.encodedDataLength,
+    timestamp: entry.timestamp,
+    wallTime: entry.wallTime,
+    durationMs: entry.durationMs,
+    errorText: entry.errorText,
+    initiator: entry.initiator,
+    responseBody: entry.responseBody
+  });
+})()`;
+}

--- a/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
@@ -171,7 +171,7 @@ export function makeNetworkDetailReadScript(requestId: string): string {
   return `(function() {
   var byId = globalThis.__radon_network_by_id;
   if (!byId) return JSON.stringify({ error: 'Network interceptor not installed' });
-  var entry = byId['${requestId.replace(/'/g, "\\'")}'];
+  var entry = byId['${requestId.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'];
   if (!entry) return JSON.stringify({ error: 'Request not found' });
 
   return JSON.stringify({

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -1,6 +1,7 @@
 import { Registry } from "@argent/registry";
 import { simulatorServerBlueprint } from "../blueprints/simulator-server";
 import { jsRuntimeDebuggerBlueprint } from "../blueprints/js-runtime-debugger";
+import { networkInspectorBlueprint } from "../blueprints/network-inspector";
 import { profilerSessionBlueprint } from "../blueprints/profiler-session";
 import { listSimulatorsTool } from "../tools/simulator/list-simulators";
 import { bootSimulatorTool } from "../tools/simulator/boot-simulator";
@@ -29,6 +30,8 @@ import { debuggerComponentTreeTool } from "../tools/debugger/debugger-component-
 import { debuggerInspectElementTool } from "../tools/debugger/debugger-inspect-element";
 import { debuggerConsoleLogsTool } from "../tools/debugger/debugger-console-logs";
 import { debuggerConsoleListenTool } from "../tools/debugger/debugger-console-listen";
+import { networkLogsTool } from "../tools/network/network-logs";
+import { networkRequestTool } from "../tools/network/network-request";
 import { describeTool } from "../tools/interactions/describe";
 import { activateLicenseKeyTool } from "../tools/license/activate-license-key";
 import { activateSsoTool } from "../tools/license/activate-sso";
@@ -52,6 +55,7 @@ export function createRegistry(): Registry {
 
   registry.registerBlueprint(simulatorServerBlueprint);
   registry.registerBlueprint(jsRuntimeDebuggerBlueprint);
+  registry.registerBlueprint(networkInspectorBlueprint);
   registry.registerBlueprint(profilerSessionBlueprint);
 
   registry.registerTool(listSimulatorsTool);
@@ -81,6 +85,8 @@ export function createRegistry(): Registry {
   registry.registerTool(debuggerInspectElementTool);
   registry.registerTool(debuggerConsoleLogsTool);
   registry.registerTool(debuggerConsoleListenTool);
+  registry.registerTool(networkLogsTool);
+  registry.registerTool(networkRequestTool);
   registry.registerTool(describeTool);
   registry.registerTool(activateLicenseKeyTool);
   registry.registerTool(activateSsoTool);

--- a/packages/tool-server/test/network/network-inspector-blueprint.test.ts
+++ b/packages/tool-server/test/network/network-inspector-blueprint.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi } from "vitest";
+import { Registry, ServiceState } from "@argent/registry";
+import {
+  networkInspectorBlueprint,
+  NETWORK_INSPECTOR_NAMESPACE,
+} from "../../src/blueprints/network-inspector";
+
+describe("NetworkInspector blueprint", () => {
+  it("has namespace 'NetworkInspector'", () => {
+    expect(networkInspectorBlueprint.namespace).toBe("NetworkInspector");
+    expect(NETWORK_INSPECTOR_NAMESPACE).toBe("NetworkInspector");
+  });
+
+  it("getURN returns correct format", () => {
+    expect(networkInspectorBlueprint.getURN("8081")).toBe(
+      "NetworkInspector:8081"
+    );
+    expect(networkInspectorBlueprint.getURN("3000")).toBe(
+      "NetworkInspector:3000"
+    );
+  });
+
+  it("declares JsRuntimeDebugger as a dependency via getDependencies", () => {
+    expect(networkInspectorBlueprint.getDependencies).toBeDefined();
+    const deps = networkInspectorBlueprint.getDependencies!("8081");
+    expect(deps).toEqual({ debugger: "JsRuntimeDebugger:8081" });
+  });
+
+  it("getDependencies uses the port context for the JsRuntimeDebugger URN", () => {
+    const deps3000 = networkInspectorBlueprint.getDependencies!("3000");
+    expect(deps3000).toEqual({ debugger: "JsRuntimeDebugger:3000" });
+
+    const deps9090 = networkInspectorBlueprint.getDependencies!("9090");
+    expect(deps9090).toEqual({ debugger: "JsRuntimeDebugger:9090" });
+  });
+
+  it("factory reuses the CDP client from the debugger dependency (does NOT create its own)", async () => {
+    const mockEvaluate = vi.fn().mockResolvedValue(
+      JSON.stringify({ installed: true })
+    );
+    const mockCdp = {
+      evaluate: mockEvaluate,
+      events: { on: vi.fn() },
+    };
+    const mockDebuggerApi = {
+      port: 8081,
+      cdp: mockCdp,
+    };
+
+    const instance = await networkInspectorBlueprint.factory(
+      { debugger: mockDebuggerApi },
+      "8081"
+    );
+
+    // The API's cdp should be the SAME object as the debugger's cdp
+    expect(instance.api.cdp).toBe(mockCdp);
+    expect(instance.api.port).toBe(8081);
+  });
+
+  it("factory injects the network interceptor script via cdp.evaluate", async () => {
+    const mockEvaluate = vi.fn().mockResolvedValue(
+      JSON.stringify({ installed: true })
+    );
+    const mockCdp = {
+      evaluate: mockEvaluate,
+      events: { on: vi.fn() },
+    };
+    const mockDebuggerApi = {
+      port: 8081,
+      cdp: mockCdp,
+    };
+
+    await networkInspectorBlueprint.factory(
+      { debugger: mockDebuggerApi },
+      "8081"
+    );
+
+    expect(mockEvaluate).toHaveBeenCalledTimes(1);
+    // Verify it called evaluate with a string containing the interceptor guard
+    const script = mockEvaluate.mock.calls[0][0] as string;
+    expect(script).toContain("__radon_network_installed");
+    expect(script).toContain("globalThis.fetch");
+  });
+
+  it("factory does not fail if interceptor injection throws (catches error)", async () => {
+    const mockEvaluate = vi.fn().mockRejectedValue(new Error("eval failed"));
+    const mockCdp = {
+      evaluate: mockEvaluate,
+      events: { on: vi.fn() },
+    };
+    const mockDebuggerApi = {
+      port: 8081,
+      cdp: mockCdp,
+    };
+
+    // Should not throw
+    const instance = await networkInspectorBlueprint.factory(
+      { debugger: mockDebuggerApi },
+      "8081"
+    );
+    expect(instance.api).toBeDefined();
+    expect(instance.api.port).toBe(8081);
+  });
+
+  it("dispose does NOT disconnect the CDP client (owned by JsRuntimeDebugger)", async () => {
+    const mockDisconnect = vi.fn();
+    const mockCdp = {
+      evaluate: vi.fn().mockResolvedValue("{}"),
+      disconnect: mockDisconnect,
+      events: { on: vi.fn() },
+    };
+    const mockDebuggerApi = {
+      port: 8081,
+      cdp: mockCdp,
+    };
+
+    const instance = await networkInspectorBlueprint.factory(
+      { debugger: mockDebuggerApi },
+      "8081"
+    );
+
+    await instance.dispose();
+    expect(mockDisconnect).not.toHaveBeenCalled();
+  });
+
+  it("emits 'terminated' when the CDP connection disconnects", async () => {
+    let disconnectHandler: ((error?: Error) => void) | null = null;
+    const mockCdp = {
+      evaluate: vi.fn().mockResolvedValue("{}"),
+      events: {
+        on: vi.fn((event: string, handler: (error?: Error) => void) => {
+          if (event === "disconnected") {
+            disconnectHandler = handler;
+          }
+        }),
+      },
+    };
+    const mockDebuggerApi = {
+      port: 8081,
+      cdp: mockCdp,
+    };
+
+    const instance = await networkInspectorBlueprint.factory(
+      { debugger: mockDebuggerApi },
+      "8081"
+    );
+
+    const terminatedHandler = vi.fn();
+    instance.events.on("terminated", terminatedHandler);
+
+    // Simulate CDP disconnect
+    expect(disconnectHandler).not.toBeNull();
+    disconnectHandler!(new Error("connection lost"));
+
+    expect(terminatedHandler).toHaveBeenCalledOnce();
+    expect(terminatedHandler.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(terminatedHandler.mock.calls[0][0].message).toBe("connection lost");
+  });
+
+  it("registers in a Registry and resolves correctly with JsRuntimeDebugger dependency", async () => {
+    // Use the real Registry to verify wiring is correct at the registry level.
+    // We create a mock JsRuntimeDebugger blueprint that returns a fake API.
+    const registry = new Registry();
+
+    const mockCdp = {
+      evaluate: vi.fn().mockResolvedValue(JSON.stringify({ installed: true })),
+      events: { on: vi.fn() },
+    };
+
+    // Register a fake JsRuntimeDebugger blueprint
+    registry.registerBlueprint({
+      namespace: "JsRuntimeDebugger",
+      getURN(port: string) {
+        return `JsRuntimeDebugger:${port}`;
+      },
+      async factory() {
+        const { TypedEventEmitter } = await import("@argent/registry");
+        const events = new TypedEventEmitter();
+        return {
+          api: { port: 8081, cdp: mockCdp, projectRoot: "/test" },
+          dispose: async () => {},
+          events,
+        };
+      },
+    });
+
+    registry.registerBlueprint(networkInspectorBlueprint);
+
+    const api = (await registry.resolveService("NetworkInspector:8081")) as {
+      port: number;
+      cdp: unknown;
+    };
+
+    expect(api.port).toBe(8081);
+    expect(api.cdp).toBe(mockCdp);
+
+    // Both services should be RUNNING
+    expect(registry.getServiceState("JsRuntimeDebugger:8081")).toBe(
+      ServiceState.RUNNING
+    );
+    expect(registry.getServiceState("NetworkInspector:8081")).toBe(
+      ServiceState.RUNNING
+    );
+
+    await registry.dispose();
+  });
+
+  it("emits 'terminated' with fallback Error when disconnectHandler called with undefined", async () => {
+    let disconnectHandler: ((error?: Error) => void) | null = null;
+    const mockCdp = {
+      evaluate: vi.fn().mockResolvedValue("{}"),
+      events: {
+        on: vi.fn((event: string, handler: (error?: Error) => void) => {
+          if (event === "disconnected") {
+            disconnectHandler = handler;
+          }
+        }),
+      },
+    };
+    const mockDebuggerApi = {
+      port: 8081,
+      cdp: mockCdp,
+    };
+
+    const instance = await networkInspectorBlueprint.factory(
+      { debugger: mockDebuggerApi },
+      "8081"
+    );
+
+    const terminatedHandler = vi.fn();
+    instance.events.on("terminated", terminatedHandler);
+
+    // Simulate CDP disconnect with no error (undefined)
+    disconnectHandler!(undefined as unknown as Error);
+
+    expect(terminatedHandler).toHaveBeenCalledOnce();
+    const emittedError = terminatedHandler.mock.calls[0][0];
+    expect(emittedError).toBeInstanceOf(Error);
+    expect(emittedError.message).toBe("CDP disconnected");
+  });
+
+  it("does not import discovery, target-selection, or construct CDPClient", async () => {
+    // Read the source file to verify no dangerous imports exist.
+    // This is a static analysis check to catch regressions.
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const source = await fs.readFile(
+      path.resolve(
+        __dirname,
+        "../../src/blueprints/network-inspector.ts"
+      ),
+      "utf-8"
+    );
+
+    // Must NOT import from discovery or target-selection (that would mean it creates its own connection)
+    expect(source).not.toContain("from \"../utils/debugger/discovery\"");
+    expect(source).not.toContain("from \"../utils/debugger/target-selection\"");
+    // Must NOT construct new CDPClient (only imports the type)
+    expect(source).not.toContain("new CDPClient");
+    // Should use type-only import for CDPClient
+    expect(source).toContain("import type");
+  });
+});

--- a/packages/tool-server/test/network/network-integration.test.ts
+++ b/packages/tool-server/test/network/network-integration.test.ts
@@ -1,0 +1,593 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { WebSocketServer, WebSocket } from "ws";
+import * as http from "node:http";
+import { Registry } from "@argent/registry";
+import { jsRuntimeDebuggerBlueprint } from "../../src/blueprints/js-runtime-debugger";
+import { networkInspectorBlueprint } from "../../src/blueprints/network-inspector";
+import { networkLogsTool } from "../../src/tools/network/network-logs";
+import { networkRequestTool } from "../../src/tools/network/network-request";
+
+/**
+ * Integration test using a mock Metro HTTP + CDP WebSocket server.
+ * Verifies the network inspector blueprint depends on JsRuntimeDebugger
+ * (sharing the same CDP connection) and that network tools work end-to-end.
+ */
+
+let mockServer: http.Server;
+let wss: WebSocketServer;
+let mockPort: number;
+let registry: Registry;
+
+/**
+ * Track how many WebSocket connections the mock server receives.
+ * The key assertion: only ONE CDP connection should be opened even when
+ * both JsRuntimeDebugger and NetworkInspector are resolved.
+ */
+let wsConnectionCount = 0;
+
+/**
+ * Simulated network log state stored in the "JS runtime" (mock).
+ * When Runtime.evaluate runs the interceptor or log-read scripts,
+ * we return responses matching what the real runtime would produce.
+ */
+let interceptorInstalled = false;
+const networkLog: Array<{
+  id: number;
+  requestId: string;
+  state: string;
+  request: { url: string; method: string; headers: Record<string, string> };
+  response?: {
+    url: string;
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    mimeType: string;
+  };
+  resourceType: string;
+  encodedDataLength?: number;
+  timestamp: number;
+  durationMs?: number;
+  responseBody?: string;
+}> = [];
+
+function handleCDPMessage(ws: WebSocket, raw: string) {
+  const msg = JSON.parse(raw);
+  const { id, method, params } = msg;
+
+  switch (method) {
+    case "FuseboxClient.setClientMetadata":
+    case "ReactNativeApplication.enable":
+    case "Runtime.runIfWaitingForDebugger":
+      ws.send(JSON.stringify({ id, result: {} }));
+      break;
+
+    case "Runtime.enable":
+      ws.send(JSON.stringify({ id, result: {} }));
+      break;
+
+    case "Debugger.enable":
+      ws.send(
+        JSON.stringify({ id, result: { debuggerId: "mock-debugger" } })
+      );
+      ws.send(
+        JSON.stringify({
+          method: "Debugger.scriptParsed",
+          params: {
+            scriptId: "1",
+            url: "http://localhost/index.bundle?platform=ios&dev=true",
+            startLine: 0,
+            endLine: 50000,
+            sourceMapURL: "index.bundle.map",
+          },
+        })
+      );
+      break;
+
+    case "Debugger.setPauseOnExceptions":
+    case "Debugger.setAsyncCallStackDepth":
+      ws.send(JSON.stringify({ id, result: {} }));
+      break;
+
+    case "Runtime.addBinding":
+      ws.send(JSON.stringify({ id, result: {} }));
+      break;
+
+    case "Runtime.evaluate": {
+      const expr = params.expression as string;
+
+      // The interceptor script contains "globalThis.fetch =" (monkey-patching),
+      // while the log-read scripts never do.
+      if (expr.includes("globalThis.fetch =")) {
+        // This is the network interceptor installation script
+        interceptorInstalled = true;
+        ws.send(
+          JSON.stringify({
+            id,
+            result: {
+              result: {
+                type: "string",
+                value: JSON.stringify({ installed: true }),
+              },
+            },
+          })
+        );
+      } else if (
+        expr.includes("__radon_network_log") ||
+        expr.includes("__radon_network_by_id")
+      ) {
+        handleLogReadScript(ws, id, expr);
+      } else {
+        // Generic evaluate
+        ws.send(
+          JSON.stringify({
+            id,
+            result: {
+              result: { type: "string", value: "eval-result" },
+            },
+          })
+        );
+      }
+      break;
+    }
+
+    default:
+      ws.send(
+        JSON.stringify({
+          id,
+          error: {
+            code: -32601,
+            message: `Method not found: ${method}`,
+          },
+        })
+      );
+  }
+}
+
+function handleLogReadScript(ws: WebSocket, id: number, expr: string) {
+  if (expr.includes("__radon_network_by_id")) {
+    // Detail read script — extract the requestId
+    const match = expr.match(/byId\['([^']+)'\]/);
+    const requestId = match ? match[1] : null;
+    const entry = networkLog.find((e) => e.requestId === requestId);
+
+    if (!interceptorInstalled) {
+      ws.send(
+        JSON.stringify({
+          id,
+          result: {
+            result: {
+              type: "string",
+              value: JSON.stringify({
+                error: "Network interceptor not installed",
+              }),
+            },
+          },
+        })
+      );
+    } else if (!entry) {
+      ws.send(
+        JSON.stringify({
+          id,
+          result: {
+            result: {
+              type: "string",
+              value: JSON.stringify({ error: "Request not found" }),
+            },
+          },
+        })
+      );
+    } else {
+      ws.send(
+        JSON.stringify({
+          id,
+          result: {
+            result: {
+              type: "string",
+              value: JSON.stringify(entry),
+            },
+          },
+        })
+      );
+    }
+    return;
+  }
+
+  // List read script — extract start and limit from the script
+  const startMatch = expr.match(/var start = (\d+)/);
+  const limitMatch = expr.match(/var limit = (\d+)/);
+  const start = startMatch ? parseInt(startMatch[1], 10) : 0;
+  const limit = limitMatch ? parseInt(limitMatch[1], 10) : 50;
+
+  // Filter out Metro server requests (like the real interceptor does)
+  const filtered = networkLog.filter(
+    (e) =>
+      !e.request.url.includes(`localhost:${mockPort}`) &&
+      !e.request.url.includes(`127.0.0.1:${mockPort}`)
+  );
+
+  const slice = filtered.slice(start, limit > 0 ? start + limit : start);
+  const entries = slice.map((e) => ({
+    id: e.id,
+    requestId: e.requestId,
+    state: e.state,
+    request: { url: e.request.url, method: e.request.method },
+    response: e.response
+      ? {
+          status: e.response.status,
+          statusText: e.response.statusText,
+          mimeType: e.response.mimeType,
+        }
+      : undefined,
+    resourceType: e.resourceType,
+    encodedDataLength: e.encodedDataLength,
+    timestamp: e.timestamp,
+    durationMs: e.durationMs,
+  }));
+
+  ws.send(
+    JSON.stringify({
+      id,
+      result: {
+        result: {
+          type: "string",
+          value: JSON.stringify({
+            entries,
+            total: filtered.length,
+            interceptorInstalled,
+          }),
+        },
+      },
+    })
+  );
+}
+
+beforeAll(async () => {
+  // Seed mock network log with test data
+  networkLog.push(
+    {
+      id: 0,
+      requestId: "rn-net-1",
+      state: "finished",
+      request: {
+        url: "https://api.example.com/users",
+        method: "GET",
+        headers: { "content-type": "application/json" },
+      },
+      response: {
+        url: "https://api.example.com/users",
+        status: 200,
+        statusText: "OK",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer secret-token",
+        },
+        mimeType: "application/json",
+      },
+      resourceType: "Fetch",
+      encodedDataLength: 1234,
+      timestamp: Date.now() / 1000,
+      durationMs: 150,
+      responseBody: JSON.stringify([
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+      ]),
+    },
+    {
+      id: 1,
+      requestId: "rn-net-2",
+      state: "failed",
+      request: {
+        url: "https://api.example.com/broken",
+        method: "POST",
+        headers: {},
+      },
+      resourceType: "Fetch",
+      timestamp: Date.now() / 1000,
+      durationMs: 50,
+    }
+  );
+
+  await new Promise<void>((resolve) => {
+    mockServer = http.createServer((req, res) => {
+      if (req.url === "/status") {
+        res.setHeader("X-React-Native-Project-Root", "/mock/project");
+        res.end("packager-status:running");
+        return;
+      }
+      if (req.url === "/json/list") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify([
+            {
+              id: "page-1",
+              title: "React Native (mock)",
+              description: "[C++ connection]",
+              webSocketDebuggerUrl: `ws://localhost:${mockPort}/inspector/debug?device=0&page=1`,
+              deviceName: "MockDevice",
+              reactNative: {
+                capabilities: { prefersFuseboxFrontend: true },
+              },
+            },
+          ])
+        );
+        return;
+      }
+      res.statusCode = 404;
+      res.end("Not found");
+    });
+
+    wss = new WebSocketServer({ server: mockServer });
+    wss.on("connection", (ws) => {
+      wsConnectionCount++;
+      ws.on("message", (raw) => handleCDPMessage(ws, raw.toString()));
+    });
+
+    mockServer.listen(0, () => {
+      mockPort = (mockServer.address() as { port: number }).port;
+      resolve();
+    });
+  });
+
+  registry = new Registry();
+  registry.registerBlueprint(jsRuntimeDebuggerBlueprint);
+  registry.registerBlueprint(networkInspectorBlueprint);
+  registry.registerTool(networkLogsTool);
+  registry.registerTool(networkRequestTool);
+});
+
+afterAll(async () => {
+  await registry.dispose();
+  await new Promise<void>((resolve) => {
+    wss.close(() => {
+      mockServer.close(() => resolve());
+    });
+  });
+});
+
+describe("NetworkInspector integration (mock server)", () => {
+  it("shares the same CDP connection with JsRuntimeDebugger (only 1 WS connection)", async () => {
+    // Reset counter before this test group starts.
+    // The beforeAll already sets up the server but doesn't create any services yet.
+    wsConnectionCount = 0;
+
+    // Resolve the network inspector, which should trigger JsRuntimeDebugger first
+    await registry.resolveService(`NetworkInspector:${mockPort}`);
+
+    // Only ONE WebSocket connection should have been opened
+    expect(wsConnectionCount).toBe(1);
+
+    // Verify both services are running
+    expect(
+      registry.getServiceState(`JsRuntimeDebugger:${mockPort}`)
+    ).toBe("RUNNING");
+    expect(
+      registry.getServiceState(`NetworkInspector:${mockPort}`)
+    ).toBe("RUNNING");
+  });
+
+  it("view-network-logs returns paginated network entries", async () => {
+    const result = (await registry.invokeTool("view-network-logs", {
+      port: mockPort,
+    })) as string;
+
+    expect(result).toContain("NETWORK LOGS");
+    expect(result).toContain("rn-net-1");
+    expect(result).toContain("GET");
+    expect(result).toContain("/users");
+    expect(result).toContain("200 OK");
+    expect(result).toContain("rn-net-2");
+  });
+
+  it("view-network-logs returns 'no traffic' for empty log", async () => {
+    // Temporarily clear the log
+    const savedLog = networkLog.splice(0);
+    try {
+      const result = (await registry.invokeTool("view-network-logs", {
+        port: mockPort,
+      })) as string;
+
+      expect(result).toContain("No network traffic captured");
+    } finally {
+      // Restore the log
+      networkLog.push(...savedLog);
+    }
+  });
+
+  it("view-network-request-details returns full details for a known requestId", async () => {
+    const result = (await registry.invokeTool(
+      "view-network-request-details",
+      {
+        port: mockPort,
+        requestId: "rn-net-1",
+      }
+    )) as Record<string, unknown>;
+
+    expect(result.requestId).toBe("rn-net-1");
+    expect(result.state).toBe("finished");
+
+    const req = result.request as Record<string, unknown>;
+    expect(req.url).toBe("https://api.example.com/users");
+    expect(req.method).toBe("GET");
+
+    const resp = result.response as Record<string, unknown>;
+    expect(resp.status).toBe(200);
+    expect(resp.statusText).toBe("OK");
+
+    // Verify sensitive headers are redacted
+    const respHeaders = resp.headers as Record<string, string>;
+    expect(respHeaders.authorization).toBe("[REDACTED]");
+    expect(respHeaders["content-type"]).toBe("application/json");
+  });
+
+  it("view-network-request-details returns response body when includeBody is true", async () => {
+    const result = (await registry.invokeTool(
+      "view-network-request-details",
+      {
+        port: mockPort,
+        requestId: "rn-net-1",
+        includeBody: true,
+      }
+    )) as Record<string, unknown>;
+
+    const resp = result.response as Record<string, unknown>;
+    expect(resp.body).toBeDefined();
+    expect(resp.body).toContain("Alice");
+    expect(resp.body).toContain("Bob");
+  });
+
+  it("view-network-request-details returns error for unknown requestId", async () => {
+    const result = (await registry.invokeTool(
+      "view-network-request-details",
+      {
+        port: mockPort,
+        requestId: "rn-net-999",
+      }
+    )) as string;
+
+    expect(result).toContain("Request not found");
+  });
+
+  it("still only 1 WS connection when JsRuntimeDebugger is resolved before NetworkInspector", async () => {
+    // Dispose everything first so we can start fresh
+    await registry.disposeService(`JsRuntimeDebugger:${mockPort}`).catch(() => {});
+    wsConnectionCount = 0;
+
+    // Explicitly resolve JsRuntimeDebugger first
+    await registry.resolveService(`JsRuntimeDebugger:${mockPort}`);
+    expect(wsConnectionCount).toBe(1);
+
+    // Now resolve NetworkInspector — should NOT open a second connection
+    await registry.resolveService(`NetworkInspector:${mockPort}`);
+    expect(wsConnectionCount).toBe(1);
+  });
+
+  it("view-network-logs filters out requests to the Metro server port", async () => {
+    // Add a request that targets the Metro server itself
+    const metroEntry = {
+      id: networkLog.length,
+      requestId: "rn-net-metro",
+      state: "finished" as const,
+      request: {
+        url: `http://localhost:${mockPort}/symbolicate`,
+        method: "POST",
+        headers: {},
+      },
+      response: {
+        url: `http://localhost:${mockPort}/symbolicate`,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        mimeType: "application/json",
+      },
+      resourceType: "Fetch",
+      encodedDataLength: 100,
+      timestamp: Date.now() / 1000,
+      durationMs: 10,
+    };
+    networkLog.push(metroEntry);
+
+    try {
+      const result = (await registry.invokeTool("view-network-logs", {
+        port: mockPort,
+      })) as string;
+
+      // The Metro request should be filtered out
+      expect(result).not.toContain("rn-net-metro");
+      expect(result).not.toContain("/symbolicate");
+      // But non-Metro requests should still be present
+      expect(result).toContain("rn-net-1");
+    } finally {
+      // Remove the test entry
+      const idx = networkLog.findIndex((e) => e.requestId === "rn-net-metro");
+      if (idx >= 0) networkLog.splice(idx, 1);
+    }
+  });
+
+  it("view-network-logs returns page index out-of-range error", async () => {
+    const result = (await registry.invokeTool("view-network-logs", {
+      port: mockPort,
+      pageIndex: 999,
+    })) as string;
+
+    expect(result).toContain("Page index out of range");
+  });
+
+  it("view-network-request-details omits body when includeBody is false", async () => {
+    const result = (await registry.invokeTool(
+      "view-network-request-details",
+      {
+        port: mockPort,
+        requestId: "rn-net-1",
+        includeBody: false,
+      }
+    )) as Record<string, unknown>;
+
+    const resp = result.response as Record<string, unknown>;
+    expect(resp).toBeDefined();
+    expect(resp.status).toBe(200);
+    // Body should NOT be included
+    expect(resp.body).toBeUndefined();
+  });
+
+  it("view-network-request-details truncates large response bodies", async () => {
+    // Add a request with a very large body (> 1000 chars)
+    const largeBody = "x".repeat(2000);
+    const largeEntry = {
+      id: networkLog.length,
+      requestId: "rn-net-large",
+      state: "finished" as const,
+      request: {
+        url: "https://api.example.com/large",
+        method: "GET",
+        headers: {},
+      },
+      response: {
+        url: "https://api.example.com/large",
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        mimeType: "text/plain",
+      },
+      resourceType: "Fetch",
+      encodedDataLength: 2000,
+      timestamp: Date.now() / 1000,
+      durationMs: 100,
+      responseBody: largeBody,
+    };
+    networkLog.push(largeEntry);
+
+    try {
+      const result = (await registry.invokeTool(
+        "view-network-request-details",
+        {
+          port: mockPort,
+          requestId: "rn-net-large",
+          includeBody: true,
+        }
+      )) as Record<string, unknown>;
+
+      const resp = result.response as Record<string, unknown>;
+      expect(resp.body).toBeDefined();
+      const body = resp.body as string;
+      expect(body).toContain("TRUNCATED");
+      expect(body).toContain("2000 chars");
+      // Body should be shorter than original
+      expect(body.length).toBeLessThan(2000);
+    } finally {
+      const idx = networkLog.findIndex((e) => e.requestId === "rn-net-large");
+      if (idx >= 0) networkLog.splice(idx, 1);
+    }
+  });
+
+  it("NetworkInspector cascades teardown when JsRuntimeDebugger is disposed", async () => {
+    // Dispose JsRuntimeDebugger — NetworkInspector should also be torn down
+    await registry.disposeService(`JsRuntimeDebugger:${mockPort}`);
+
+    expect(
+      registry.getServiceState(`JsRuntimeDebugger:${mockPort}`)
+    ).toBe("IDLE");
+    expect(
+      registry.getServiceState(`NetworkInspector:${mockPort}`)
+    ).toBe("IDLE");
+  });
+});

--- a/packages/tool-server/test/network/network-interceptor.test.ts
+++ b/packages/tool-server/test/network/network-interceptor.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  makeNetworkLogReadScript,
+  makeNetworkDetailReadScript,
+} from "../../src/utils/debugger/scripts/network-interceptor";
+
+describe("makeNetworkLogReadScript", () => {
+  it("returns a string containing the start and limit values", () => {
+    const script = makeNetworkLogReadScript(10, 50, 8081);
+    expect(script).toContain("var start = 10");
+    expect(script).toContain("var limit = 50");
+  });
+
+  it("embeds the metro port for filtering", () => {
+    const script = makeNetworkLogReadScript(0, 50, 8081);
+    expect(script).toContain("localhost:8081");
+    expect(script).toContain("127.0.0.1:8081");
+  });
+
+  it("uses different metro port values correctly", () => {
+    const script3000 = makeNetworkLogReadScript(0, 50, 3000);
+    expect(script3000).toContain("localhost:3000");
+    expect(script3000).toContain("127.0.0.1:3000");
+    expect(script3000).not.toContain("localhost:8081");
+  });
+
+  it("reads from __radon_network_log", () => {
+    const script = makeNetworkLogReadScript(0, 50, 8081);
+    expect(script).toContain("globalThis.__radon_network_log");
+  });
+
+  it("returns interceptorInstalled: false when no log exists", () => {
+    const script = makeNetworkLogReadScript(0, 50, 8081);
+    expect(script).toContain("interceptorInstalled: false");
+  });
+
+  it("strips responseBody from list view entries", () => {
+    const script = makeNetworkLogReadScript(0, 50, 8081);
+    // The script builds entries without responseBody to avoid large payloads
+    expect(script).not.toContain("responseBody: s.responseBody");
+  });
+
+  it("is a valid IIFE", () => {
+    const script = makeNetworkLogReadScript(0, 50, 8081);
+    expect(script.trim()).toMatch(/^\(function\(\)/);
+    expect(script.trim()).toMatch(/\)\(\)$/);
+  });
+});
+
+describe("makeNetworkDetailReadScript", () => {
+  it("includes the requestId in the script", () => {
+    const script = makeNetworkDetailReadScript("rn-net-42");
+    expect(script).toContain("rn-net-42");
+  });
+
+  it("escapes single quotes in requestId to prevent injection", () => {
+    const script = makeNetworkDetailReadScript("rn-net-'test");
+    expect(script).toContain("rn-net-\\'test");
+    expect(script).not.toContain("rn-net-'test'");
+  });
+
+  it("escapes backslashes before quotes to prevent injection", () => {
+    // A requestId like rn-net-\' should become rn-net-\\' in the script,
+    // not rn-net-\\' which would terminate the string early.
+    const script = makeNetworkDetailReadScript("rn-net-\\'");
+    // The backslash should be doubled, then the quote escaped
+    expect(script).toContain("rn-net-\\\\\\'");
+  });
+
+  it("escapes standalone backslashes in requestId", () => {
+    const script = makeNetworkDetailReadScript("rn-net-\\test");
+    expect(script).toContain("rn-net-\\\\test");
+  });
+
+  it("reads from __radon_network_by_id", () => {
+    const script = makeNetworkDetailReadScript("rn-net-1");
+    expect(script).toContain("globalThis.__radon_network_by_id");
+  });
+
+  it("includes responseBody in the detail output", () => {
+    const script = makeNetworkDetailReadScript("rn-net-1");
+    expect(script).toContain("responseBody: entry.responseBody");
+  });
+
+  it("returns an error if interceptor is not installed", () => {
+    const script = makeNetworkDetailReadScript("rn-net-1");
+    expect(script).toContain("Network interceptor not installed");
+  });
+
+  it("returns an error if request is not found", () => {
+    const script = makeNetworkDetailReadScript("rn-net-1");
+    expect(script).toContain("Request not found");
+  });
+
+  it("is a valid IIFE", () => {
+    const script = makeNetworkDetailReadScript("rn-net-1");
+    expect(script.trim()).toMatch(/^\(function\(\)/);
+    expect(script.trim()).toMatch(/\)\(\)$/);
+  });
+});


### PR DESCRIPTION
This tool has been previously reverted in #18 due to a crash occuring when both the network inspector and js debugger were ran sequentially in a single tool-server session.

This PR reimplements `network-inspector` while resolving the aforementioned bug.