### PR TITLE
fix: Fix `query-documentation` tool edge-cases

### DIFF
--- a/packages/tool-server/src/tools/ai/query-documentation.ts
+++ b/packages/tool-server/src/tools/ai/query-documentation.ts
@@ -79,9 +79,12 @@ export const queryDocumentationTool: ToolDefinition<
         const newToken = await readToken();
         response = await fetchDocumentation(params.text, newToken, signal);
       } else {
-        // SSO Login aborted, failed to open, either way the following response is universal to all these cases.
+        const loginMessage = ssoResult.ssoUrl
+          ? ` Open ${ssoResult.ssoUrl} to sign in to your account.`
+          : "";
+
         throw new Error(
-          `Argent license required. Login or activate your license to continue. Open ${ssoResult.ssoUrl} to sign in to your account.`,
+          `Argent license required. Login or activate your license to continue.${loginMessage}`,
         );
       }
     }

--- a/packages/tool-server/src/tools/ai/query-documentation.ts
+++ b/packages/tool-server/src/tools/ai/query-documentation.ts
@@ -77,7 +77,24 @@ export const queryDocumentationTool: ToolDefinition<
       const ssoResult = await activateWithSSO();
       if (ssoResult.success) {
         const newToken = await readToken();
-        response = await fetchDocumentation(params.text, newToken, signal);
+        // New timeout for the retry - the original signal may have
+        // been consumed while the user was completing the SSO flow.
+        const retryTimeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+        const retrySignal = options?.signal
+          ? AbortSignal.any([options.signal, retryTimeout])
+          : retryTimeout;
+        try {
+          response = await fetchDocumentation(
+            params.text,
+            newToken,
+            retrySignal,
+          );
+        } catch (cause) {
+          throw new Error(
+            "Network failure contacting Radon AI backend on retry after SSO",
+            { cause: cause as Error },
+          );
+        }
       } else {
         const loginMessage = ssoResult.ssoUrl
           ? ` Open ${ssoResult.ssoUrl} to sign in to your account.`


### PR DESCRIPTION
The merged #16 PR was a stale branch. This PR pushes the remaining updates that should've been pushed in #16

Fixed:
- Edge case for `ssoResult.ssoUrl` being `null`
- Edge case for one of the promises becoming stale before resolving.