### PR TITLE
fix: omit Origin header in CDP WebSocket to support Expo apps

### DIFF
--- a/packages/tool-server/src/utils/debugger/cdp-client.ts
+++ b/packages/tool-server/src/utils/debugger/cdp-client.ts
@@ -65,9 +65,11 @@ export class CDPClient {
 
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const { protocol, host } = new URL(this.wsUrl);
-      const origin = (protocol === "wss:" ? "https://" : "http://") + host;
-      const ws = new WebSocket(this.wsUrl, { headers: { Origin: origin } });
+      // Do not send an Origin header — Expo's dev server rejects WebSocket
+      // connections whose Origin doesn't exactly match its serverBaseUrl
+      // (typically 127.0.0.1 vs localhost mismatch). Omitting Origin bypasses
+      // the check, which is safe since we only connect locally.
+      const ws = new WebSocket(this.wsUrl);
       this.ws = ws;
 
       const onOpen = () => {


### PR DESCRIPTION
## Summary
- Removes the explicit `Origin` header from the CDP WebSocket connection in `cdp-client.ts`
- Fixes debugger connection failures with Expo apps where Expo's dev server rejects WebSocket connections due to an `Origin` header mismatch (`localhost` vs `127.0.0.1`)

## Root Cause
Expo's `createDebugMiddleware` adds a security check (`isMatchingOrigin`) on the `/inspector/debug` WebSocket endpoint. Expo constructs its `serverBaseUrl` as `http://127.0.0.1:<port>` (via `getDefaultHostname` which converts `localhost` → `127.0.0.1`), but Argent was sending `Origin: http://localhost:<port>`. The host mismatch caused `socket.terminate()` — an immediate connection kill with WebSocket close code 1006.

When no `Origin` header is present, Expo's check returns `true` (bypass), which is safe since we only connect locally.

## Test plan
- [x] Verified debugger connects and evaluates JS on Expo app (Bluesky / Expo SDK 54)
- [x] Verified debugger connects and evaluates JS on regular RN app (Expensify)
- [x] Existing test suite passes (3 pre-existing failures unrelated to this change)