### PR TITLE
fix: Reduce component tree output by ~95% for heavy RN apps

### DIFF
--- a/packages/tool-server/src/tools/debugger/debugger-component-tree.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-component-tree.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import * as crypto from "node:crypto";
 import type { ToolDefinition } from "@argent/registry";
 import type { JsRuntimeDebuggerApi } from "../../blueprints/js-runtime-debugger";
 import { makeComponentTreeScript } from "../../utils/debugger/scripts/component-tree";
@@ -52,6 +53,9 @@ export function buildTextTree(
     offScreen: { count: 0 },
     sameTestID: { count: 0 },
     fullScreenWrapper: { count: 0 },
+    ancestorText: { count: 0 },
+    contentFreeWrapper: { count: 0 },
+    soleChildLeaf: { count: 0 },
   };
 
   // Collapse parent→child when both have the same name and nearly identical rects.
@@ -80,8 +84,30 @@ export function buildTextTree(
     }
   }
 
-  // Remove components that are entirely off-screen (scrolled away, off-canvas overlays)
+  // Remove components that are entirely off-screen and prune their entire subtree.
+  // This catches off-canvas navigation stacks (drawer, hidden tabs) whose children
+  // would otherwise survive because they lack rects.
   if (canNormalize && opts.onScreenOnly) {
+    // Build a quick parent→children index for subtree pruning
+    const tempChildren = new Map<number, number[]>();
+    for (const c of components) {
+      if (c.parentIdx >= 0) {
+        let list = tempChildren.get(c.parentIdx);
+        if (!list) {
+          list = [];
+          tempChildren.set(c.parentIdx, list);
+        }
+        list.push(c.id);
+      }
+    }
+
+    function removeSubtree(id: number) {
+      removed.add(id);
+      filterStats.offScreen.count++;
+      const ch = tempChildren.get(id);
+      if (ch) for (const cid of ch) removeSubtree(cid);
+    }
+
     for (const c of components) {
       if (removed.has(c.id) || !c.rect) continue;
       const centerY = c.rect.y + c.rect.h / 2;
@@ -89,9 +115,23 @@ export function buildTextTree(
       if (
         centerY < -screenH * 0.1 ||
         centerY > screenH * 1.05 ||
-        centerX < -screenW * 0.5 ||
-        centerX > screenW * 1.5
+        centerX < -screenW * 0.05 ||
+        centerX > screenW * 1.05
       ) {
+        removeSubtree(c.id);
+      }
+    }
+
+    // Also remove rectless components whose entire ancestor chain is removed.
+    // These are children of off-screen containers that have no rect themselves.
+    for (const c of components) {
+      if (removed.has(c.id) || c.rect) continue;
+      let ancestor = c.parentIdx;
+      while (ancestor >= 0 && !components[ancestor].rect) {
+        if (removed.has(ancestor)) break;
+        ancestor = components[ancestor].parentIdx;
+      }
+      if (ancestor >= 0 && removed.has(ancestor)) {
         removed.add(c.id);
         filterStats.offScreen.count++;
       }
@@ -134,6 +174,54 @@ export function buildTextTree(
     }
   }
 
+  // Remove components whose display text (text or accLabel) is already present
+  // in an ancestor's display text. Handles chains like:
+  //   Link "Browse topic X" → Button "Browse topic X" → Text "X"
+  // where children repeat or subset the parent's label. Up to 6 levels deep.
+  for (const c of components) {
+    const cDisplay = c.text ?? c.accLabel;
+    if (removed.has(c.id) || !cDisplay || c.testID) continue;
+    let ancestor = c.parentIdx;
+    let depth = 0;
+    while (ancestor >= 0 && depth < 6) {
+      if (removed.has(ancestor)) {
+        ancestor = components[ancestor].parentIdx;
+        continue;
+      }
+      const a = components[ancestor];
+      const aDisplay = a.text ?? a.accLabel;
+      if (
+        aDisplay &&
+        aDisplay.length >= cDisplay.length &&
+        aDisplay.includes(cDisplay)
+      ) {
+        removed.add(c.id);
+        filterStats.ancestorText.count++;
+        break;
+      }
+      ancestor = a.parentIdx;
+      depth++;
+    }
+  }
+
+  // Collapse content-free wrappers with same rect as their effective parent.
+  // A component that has no text, testID, or accLabel and overlaps its parent's
+  // rect is a layout wrapper that adds indentation noise without navigation value.
+  for (const c of components) {
+    if (removed.has(c.id) || c.text || c.testID || c.accLabel) continue;
+    if (!c.rect) continue;
+    let effectiveParentIdx = c.parentIdx;
+    while (effectiveParentIdx >= 0 && removed.has(effectiveParentIdx)) {
+      effectiveParentIdx = components[effectiveParentIdx].parentIdx;
+    }
+    const parent =
+      effectiveParentIdx >= 0 ? components[effectiveParentIdx] : null;
+    if (parent && parent.rect && rectsOverlap(parent.rect, c.rect)) {
+      removed.add(c.id);
+      filterStats.contentFreeWrapper.count++;
+    }
+  }
+
   const childrenOf = new Map<number, number[]>();
   const roots: number[] = [];
   for (const c of components) {
@@ -155,6 +243,51 @@ export function buildTextTree(
         childrenOf.set(effectiveParent, list);
       }
       list.push(c.id);
+    }
+  }
+
+  // Remove single-child leaf nodes that add no navigation value: the component
+  // has no testID, is the sole child of a parent that already has text/testID,
+  // and has no children of its own. Catches patterns like:
+  //   WebOnlyInlineLinkText "Rachel Maddow" → UITextView "View profile"
+  //   ShareMenuButton [testID=postShareBtn] → Trigger "Open share menu"
+  {
+    const toRemove: number[] = [];
+    for (const [parentId, children] of childrenOf) {
+      if (children.length !== 1) continue;
+      const childId = children[0];
+      const child = components[childId];
+      const parent = components[parentId];
+      if (child.testID) continue;
+      if (!parent.text && !parent.accLabel && !parent.testID) continue;
+      if (childrenOf.has(childId)) continue; // not a leaf
+      toRemove.push(childId);
+    }
+    if (toRemove.length > 0) {
+      for (const id of toRemove) {
+        removed.add(id);
+        filterStats.soleChildLeaf.count++;
+      }
+      // Rebuild childrenOf after removals
+      childrenOf.clear();
+      roots.length = 0;
+      for (const c of components) {
+        if (removed.has(c.id)) continue;
+        let effectiveParent = c.parentIdx;
+        while (effectiveParent >= 0 && removed.has(effectiveParent)) {
+          effectiveParent = components[effectiveParent].parentIdx;
+        }
+        if (effectiveParent === -1) {
+          roots.push(c.id);
+        } else {
+          let list = childrenOf.get(effectiveParent);
+          if (!list) {
+            list = [];
+            childrenOf.set(effectiveParent, list);
+          }
+          list.push(c.id);
+        }
+      }
     }
   }
 
@@ -306,7 +439,10 @@ export function buildTextTree(
       filterStats.sameNameDedup.count +
       filterStats.offScreen.count +
       filterStats.sameTestID.count +
-      filterStats.fullScreenWrapper.count;
+      filterStats.fullScreenWrapper.count +
+      filterStats.ancestorText.count +
+      filterStats.contentFreeWrapper.count +
+      filterStats.soleChildLeaf.count;
 
     lines.push("");
     lines.push("--- Filtered ---");
@@ -348,6 +484,19 @@ export function buildTextTree(
       }
       if (filterStats.sameTestID.count > 0) {
         lines.push(`  Same-testID chain: ${filterStats.sameTestID.count}`);
+      }
+      if (filterStats.ancestorText.count > 0) {
+        lines.push(`  Ancestor text dedup: ${filterStats.ancestorText.count}`);
+      }
+      if (filterStats.contentFreeWrapper.count > 0) {
+        lines.push(
+          `  Content-free wrapper: ${filterStats.contentFreeWrapper.count}`,
+        );
+      }
+      if (filterStats.soleChildLeaf.count > 0) {
+        lines.push(
+          `  Sole-child leaf: ${filterStats.soleChildLeaf.count}`,
+        );
       }
     }
   }
@@ -410,11 +559,16 @@ Set includeSkipped=true to see a summary of all filtered components.`,
   }),
   async execute(services, params) {
     const api = services.debugger as JsRuntimeDebuggerApi;
+    const requestId = crypto.randomUUID();
     const script = makeComponentTreeScript({
       includeSkipped: params.includeSkipped,
+      requestId,
     });
-    const raw = await api.cdp.evaluate(script);
+    const response = await api.cdp.evaluateWithBinding(script, requestId, {
+      timeout: 15_000,
+    });
 
+    const raw = response.result;
     if (typeof raw !== "string") {
       return "Error: no result from component tree script";
     }

--- a/packages/tool-server/src/utils/debugger/scripts/component-tree.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/component-tree.ts
@@ -8,14 +8,21 @@
  * On Fabric, uses nativeFabricUIManager.measure with the shadow node.
  * On Paper, falls back to UIManager.measureInWindow with native tags.
  *
+ * Measurement is async-safe: on Paper (where measureInWindow is async),
+ * the script collects all candidates first, then batch-measures them via
+ * Promise.all, with a per-host-tag cache to avoid redundant bridge calls.
+ *
  * When includeSkipped is true, the script also tracks totalFibers walked
  * and a per-name count of JS-side skipped components.
  */
-export function makeComponentTreeScript(opts?: {
+export function makeComponentTreeScript(opts: {
   includeSkipped?: boolean;
+  requestId: string;
 }): string {
   const trackSkipped = opts?.includeSkipped ? "true" : "false";
-  return `(function() {
+  const requestId = JSON.stringify(opts.requestId);
+  return `(async function() {
+  var REQUEST_ID = ${requestId};
   var TRACK_SKIPPED = ${trackSkipped};
   var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
   if (!hook) return JSON.stringify({ error: 'No DevTools hook' });
@@ -110,8 +117,12 @@ export function makeComponentTreeScript(opts?: {
   function getHostInfo(fiber) {
     if (typeof fiber.type !== 'string' || !fiber.stateNode) return null;
     if (useFabric && fiber.stateNode.node) return { f: true, n: fiber.stateNode.node };
-    if (!useFabric && fiber.stateNode.canonical && typeof fiber.stateNode.canonical.nativeTag === 'number')
-      return { f: false, n: fiber.stateNode.canonical.nativeTag };
+    if (!useFabric) {
+      if (fiber.stateNode.canonical && typeof fiber.stateNode.canonical.nativeTag === 'number')
+        return { f: false, n: fiber.stateNode.canonical.nativeTag };
+      if (typeof fiber.stateNode._nativeTag === 'number')
+        return { f: false, n: fiber.stateNode._nativeTag };
+    }
     return null;
   }
 
@@ -122,39 +133,47 @@ export function makeComponentTreeScript(opts?: {
     return findHostNode(fiber.child, d + 1);
   }
 
-  function measureRect(info) {
-    var rect = null;
-    try {
-      if (info.f) {
-        nativeFabricUIManager.measure(info.n, function(x, y, w, h, px, py) {
-          if (w > 0 && h > 0) rect = { x: Math.round(px), y: Math.round(py), w: Math.round(w), h: Math.round(h) };
-        });
-      } else {
-        UIManagerMod.measureInWindow(info.n, function(x, y, w, h) {
-          if (w > 0 && h > 0) rect = { x: Math.round(x), y: Math.round(y), w: Math.round(w), h: Math.round(h) };
-        });
-      }
-    } catch(e) {}
-    return rect;
-  }
-
+  // --- Screen dimensions via Dimensions API (reliable fallback) ---
   var screenW = 0, screenH = 0;
-  (function findScreenDims(fiber) {
-    if (!fiber || screenW > 0) return;
-    var info = getHostInfo(fiber);
-    if (info) {
-      var r = measureRect(info);
-      if (r && r.x === 0 && r.y === 0 && r.w > 0 && r.h > 0) { screenW = r.w; screenH = r.h; return; }
+  try {
+    for (var i = 0; i < 500; i++) {
+      try {
+        var m = __r(i);
+        if (m && m.Dimensions) {
+          var win = m.Dimensions.get('window');
+          if (win && win.width > 0 && win.height > 0) {
+            screenW = Math.round(win.width);
+            screenH = Math.round(win.height);
+            break;
+          }
+        }
+      } catch(e) {}
     }
-    findScreenDims(fiber.child);
-  })(root.current);
+  } catch(e) {}
 
-  var components = [];
+  // --- Phase 1: Walk tree, collect candidates (no measurement yet) ---
+  var candidates = [];
   var totalFibers = 0;
   var skippedCounts = {};
 
-  function collectAll(fiber, parentIdx) {
+  function collectAll(fiber, parentCandidateIdx) {
     if (!fiber) return;
+
+    // Skip entire subtrees of inactive screens/pages. react-native-screens uses
+    // activityState (0=inactive, 2=active) and pagers use isPageFocused.
+    // This prunes off-screen navigation stacks and inactive tab pages.
+    if (fiber.memoizedProps) {
+      var as = fiber.memoizedProps.activityState;
+      if (as === 0 || as === 1) {
+        collectAll(fiber.sibling, parentCandidateIdx);
+        return;
+      }
+      if (fiber.memoizedProps.isPageFocused === false) {
+        collectAll(fiber.sibling, parentCandidateIdx);
+        return;
+      }
+    }
+
     var name = getCompName(fiber);
     var emittedIdx = -1;
 
@@ -175,38 +194,129 @@ export function makeComponentTreeScript(opts?: {
 
       if (skip && testID && !isHardSkip(name)) skip = false;
 
+      // Skip host components (native views) with no testID — their parent React
+      // component carries the semantic info and inherits their rect via findHostNode.
+      // This removes rendering internals like UITextView, UITextViewInner, etc.
+      if (!skip && typeof fiber.type === 'string' && !testID) {
+        skip = true;
+      }
+
       if (!skip) {
         var hostInfo = getHostInfo(fiber) || findHostNode(fiber, 0);
-        var rect = hostInfo ? measureRect(hostInfo) : null;
-
-        var isTextNode = name === 'Text' || name === 'RCTText';
-        if (isTextNode && !text && !testID) {
-        } else if (rect || testID || accLabel || text) {
-          if (isTextNode && text && parentIdx >= 0 && components[parentIdx].text === text) {
-          } else {
-            var entry = { id: components.length, name: name, rect: rect, parentIdx: parentIdx };
-            if (testID) entry.testID = testID;
-            if (accLabel) entry.accLabel = accLabel;
-            if (text) entry.text = text;
-            emittedIdx = components.length;
-            components.push(entry);
-          }
-        }
+        emittedIdx = candidates.length;
+        candidates.push({
+          name: name,
+          hostInfo: hostInfo,
+          parentIdx: parentCandidateIdx,
+          testID: testID,
+          accLabel: accLabel,
+          text: text,
+          rect: null
+        });
       } else if (TRACK_SKIPPED) {
         skippedCounts[name] = (skippedCounts[name] || 0) + 1;
       }
     }
 
-    collectAll(fiber.child, emittedIdx >= 0 ? emittedIdx : parentIdx);
-    collectAll(fiber.sibling, parentIdx);
+    collectAll(fiber.child, emittedIdx >= 0 ? emittedIdx : parentCandidateIdx);
+    collectAll(fiber.sibling, parentCandidateIdx);
   }
 
   collectAll(root.current.child, -1);
+
+  // --- Phase 2: Batch measure with per-host-tag caching ---
+  var rectCache = {};
+  var uniqueHosts = [];
+  var hostKeyMap = {};
+
+  for (var ci = 0; ci < candidates.length; ci++) {
+    var hi = candidates[ci].hostInfo;
+    if (!hi) continue;
+    var key = (hi.f ? 'f' : 'p') + hi.n;
+    if (!(key in hostKeyMap)) {
+      hostKeyMap[key] = uniqueHosts.length;
+      uniqueHosts.push(hi);
+    }
+  }
+
+  function measureOne(info) {
+    return new Promise(function(resolve) {
+      try {
+        if (info.f) {
+          nativeFabricUIManager.measure(info.n, function(x, y, w, h, px, py) {
+            if (w > 0 && h > 0) resolve({ x: Math.round(px), y: Math.round(py), w: Math.round(w), h: Math.round(h) });
+            else resolve(null);
+          });
+        } else {
+          UIManagerMod.measureInWindow(info.n, function(x, y, w, h) {
+            if (w > 0 && h > 0) resolve({ x: Math.round(x), y: Math.round(y), w: Math.round(w), h: Math.round(h) });
+            else resolve(null);
+          });
+        }
+      } catch(e) { resolve(null); }
+    });
+  }
+
+  var rects = await Promise.all(uniqueHosts.map(measureOne));
+
+  for (var ri = 0; ri < uniqueHosts.length; ri++) {
+    var rKey = (uniqueHosts[ri].f ? 'f' : 'p') + uniqueHosts[ri].n;
+    rectCache[rKey] = rects[ri];
+  }
+
+  // Assign rects to candidates
+  for (var ai = 0; ai < candidates.length; ai++) {
+    var h = candidates[ai].hostInfo;
+    if (h) {
+      var rk = (h.f ? 'f' : 'p') + h.n;
+      candidates[ai].rect = rectCache[rk] || null;
+    }
+  }
+
+  // --- Phase 3: Filter and build final components array ---
+  var components = [];
+  var candidateToComp = {};
+
+  for (var fi = 0; fi < candidates.length; fi++) {
+    var c = candidates[fi];
+    var isTextNode = c.name === 'Text' || c.name === 'RCTText';
+
+    // Skip empty text nodes with no testID
+    if (isTextNode && !c.text && !c.testID) continue;
+
+    // Must have a rect or a testID. Components with only text/accLabel but no
+    // rect and no testID are unmeasurable and untappable — they add context noise
+    // without enabling any interaction.
+    if (!c.rect && !c.testID) continue;
+
+    // Find effective parent in the components array
+    var effectiveParent = c.parentIdx;
+    while (effectiveParent >= 0 && !(effectiveParent in candidateToComp)) {
+      effectiveParent = candidates[effectiveParent].parentIdx;
+    }
+    var parentCompIdx = effectiveParent >= 0 ? candidateToComp[effectiveParent] : -1;
+
+    // Generalized text dedup: skip ANY component whose display text (text or
+    // accLabel) matches its effective parent's display text and has no testID.
+    var displayText = c.text || c.accLabel;
+    if (displayText && !c.testID && parentCompIdx >= 0) {
+      var parentDisplay = components[parentCompIdx].text || components[parentCompIdx].accLabel;
+      if (parentDisplay === displayText) continue;
+    }
+
+    var entry = { id: components.length, name: c.name, rect: c.rect, parentIdx: parentCompIdx };
+    if (c.testID) entry.testID = c.testID;
+    if (c.accLabel) entry.accLabel = c.accLabel;
+    if (c.text) entry.text = c.text;
+    candidateToComp[fi] = components.length;
+    components.push(entry);
+  }
+
   var result = { screenW: screenW, screenH: screenH, components: components };
   if (TRACK_SKIPPED) {
     result.totalFibers = totalFibers;
     result.skippedCounts = skippedCounts;
   }
-  return JSON.stringify(result);
+  __radon_lite_callback(JSON.stringify({ requestId: REQUEST_ID, result: JSON.stringify(result) }));
 })()`;
 }

--- a/packages/tool-server/test/debugger/component-tree.test.ts
+++ b/packages/tool-server/test/debugger/component-tree.test.ts
@@ -51,13 +51,31 @@ describe("buildTextTree — same-name dedup (B fix)", () => {
     expect(result).toContain('Text "Content"');
   });
 
-  it("does NOT collapse different-name parent/child", () => {
+  it("collapses different-name content-free child with same rect", () => {
     const rect = { x: 0, y: 62, w: 400, h: 738 };
     const data: RawResult = {
       ...SCREEN,
       components: [
         entry(0, "Wrapper", -1, rect),
         entry(1, "ScrollView", 0, rect),
+        entry(2, "Text", 1, { x: 50, y: 100, w: 300, h: 30 }, { text: "Hi" }),
+      ],
+    };
+    const result = buildTextTree(data, { onScreenOnly: true });
+    // ScrollView is content-free (no text/testID/accLabel) and overlaps parent → collapsed
+    expect(result).not.toContain("ScrollView");
+    // Child text gets reparented to Wrapper
+    expect(result).toContain("Wrapper");
+    expect(result).toContain('Text "Hi"');
+  });
+
+  it("keeps different-name child with same rect when it has testID", () => {
+    const rect = { x: 0, y: 62, w: 400, h: 738 };
+    const data: RawResult = {
+      ...SCREEN,
+      components: [
+        entry(0, "Wrapper", -1, rect),
+        entry(1, "ScrollView", 0, rect, { testID: "myScroll" }),
         entry(2, "Text", 1, { x: 50, y: 100, w: 300, h: 30 }, { text: "Hi" }),
       ],
     };


### PR DESCRIPTION
## Summary

The `debugger-component-tree` tool produced 102KB+ output on heavy React Native apps (e.g. Bluesky), exceeding the MCP response limit and cluttering agent context. This PR reduces output by ~95% (102KB → ~5KB) while preserving all information needed for navigation.

### Bugs fixed
- **Paper architecture measurement broken**: `getHostInfo` only checked `stateNode.canonical.nativeTag` — many RN versions use `stateNode._nativeTag`. All measurements returned null on affected apps (zero tap coordinates, no screen dimensions).
- **Async measurement on Paper**: `measureInWindow` is async on Paper arch (callback fires on next tick). The script assumed synchronous callbacks. Now uses `evaluateWithBinding` with `Promise.all` batch measurement and per-host-tag caching.
- **Screen dimensions**: Replaced fragile root-view measurement with `Dimensions.get('window')` API.

### New JS-side filters (during fiber walk)
- **Skip inactive screens** (`activityState === 0|1` from react-native-screens) — prunes entire subtrees of off-screen navigation stacks.
- **Skip inactive pager pages** (`isPageFocused === false`) — prunes unfocused tab content.
- **Skip host components without testID** — native views (UITextView, etc.) are rendering internals; parent React components carry the semantic info.
- **Generalized text dedup** — any component (not just Text/RCTText) whose display text matches its parent's is skipped. Checks both `text` and `accLabel`.
- **Require rect or testID** — unmeasurable, untappable components without testID are dropped.

### New TS-side filters (post-processing)
- **Off-screen subtree pruning** — removes entire descendant trees of off-screen components (not just individual nodes). Tighter X bounds (±5% vs ±50%) to catch drawers.
- **Ancestor text containment** — removes nodes whose text is a substring of an ancestor's text (up to 6 levels).
- **Content-free wrapper collapse** — removes nodes with no content that overlap their parent's rect, regardless of name.
- **Sole-child leaf removal** — removes leaf nodes that are sole children when parent already has text/testID.

## Test plan

- [x] Unit tests: 17/17 pass (updated test for new content-free wrapper behavior, added test for testID preservation)
- [x] Tested on Bluesky (Expo, Paper arch, heavy app with 16K+ fibers) across 5 screens:
  - **Explore**: trending topics, feeds, search bar — all visible with correct tap coords
  - **Home feed**: posts with controls, tab switching — Following tab content pruned when inactive
  - **Notifications**: empty state, All/Mentions tabs
  - **Profile**: user info, 6 sub-tabs, edit button — tap coordinates verified
  - **Chat**: empty state, FAB button
- [x] Verified tap coordinates by tapping 5 elements using only tree-provided coords (Home tab, Following tab, Notifications tab, Profile tab, Edit Profile button) — all landed correctly
- [x] Pre-existing integration test failures confirmed unrelated (debugger breakpoint/pause/step tests fail on main)