### PR TITLE
feat: add killArgentProcesses utility

### DIFF
--- a/packages/mcp/scripts/kill-argent.cjs
+++ b/packages/mcp/scripts/kill-argent.cjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// @ts-check
+"use strict";
+
+const { execFileSync } = require("child_process");
+
+/**
+ * Kill all node processes whose command line contains any of the given path segments.
+ * Silently ignores the case where no matching processes exist (pkill exits 1).
+ *
+ * @param {string | string[]} paths - One or more path substrings to match against running processes.
+ * @returns {string[]} The paths for which at least one process was killed.
+ */
+function killArgentProcesses(paths) {
+  const list = Array.isArray(paths) ? paths : [paths];
+  const killed = [];
+
+  if (process.platform === "win32") {
+    // Windows: use WMIC to find node PIDs whose CommandLine contains the path
+    for (const p of list) {
+      try {
+        const out = execFileSync(
+          "wmic",
+          ["process", "where", `Name='node.exe' and CommandLine like '%${p.replace(/'/g, "''")}%'`, "get", "ProcessId", "/format:list"],
+          { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }
+        );
+        const pids = out.match(/ProcessId=(\d+)/g)?.map((m) => parseInt(m.split("=")[1])) ?? [];
+        for (const pid of pids) {
+          try {
+            execFileSync("taskkill", ["/F", "/PID", String(pid)], { stdio: "pipe" });
+          } catch {
+            // Process may have already exited
+          }
+        }
+        if (pids.length > 0) killed.push(p);
+      } catch {
+        // WMIC not available or query failed
+      }
+    }
+  } else {
+    // macOS / Linux
+    for (const p of list) {
+      try {
+        execFileSync("pkill", ["-f", p], { stdio: "pipe" });
+        killed.push(p);
+      } catch {
+        // Exit code 1 means no matching processes — not an error
+      }
+    }
+  }
+
+  return killed;
+}
+
+module.exports = { killArgentProcesses };

--- a/packages/mcp/scripts/postinstall.cjs
+++ b/packages/mcp/scripts/postinstall.cjs
@@ -13,6 +13,7 @@ if (process.env.ARGENT_SKIP_POSTINSTALL === "1") {
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { killArgentProcesses } = require("./kill-argent.cjs");
 
 // npm sets this to the directory that ran `npm install`
 const projectRoot = process.env.npm_config_local_prefix;
@@ -22,6 +23,11 @@ if (!projectRoot) {
 }
 
 const distEntry = path.resolve(__dirname, "..", "dist", "index.js");
+const distDir = path.resolve(__dirname, "..", "dist");
+
+// Kill any running argent processes from this install location before updating
+const killedOnInstall = killArgentProcesses(distDir);
+
 const skillsSrc = path.resolve(__dirname, "..", "skills");
 const agentsSrc = path.resolve(__dirname, "..", "agents");
 const logFile = path.join(os.homedir(), ".argent", "mcp-calls.log");
@@ -77,6 +83,9 @@ function copySkills(srcDir, destDir) {
 }
 
 const results = [];
+if (killedOnInstall.length > 0) {
+  results.push("✓ Stopped running argent processes before update");
+}
 
 // Claude Code — .claude/mcp.json
 try {
@@ -148,3 +157,4 @@ for (const line of results) {
   console.log(" ", line);
 }
 console.log();
+

--- a/packages/mcp/scripts/uninstall.cjs
+++ b/packages/mcp/scripts/uninstall.cjs
@@ -5,6 +5,8 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { execSync } = require("child_process");
+const { killArgentProcesses } = require("./kill-argent.cjs");
 
 const userScope = process.argv.includes("--user");
 const allowPermissions = process.argv.includes("--allow");
@@ -40,6 +42,14 @@ function removePermissions(configPath) {
 }
 
 if (userScope) {
+  // Kill processes running from the global argent install
+  try {
+    const globalRoot = execSync("npm root -g", { encoding: "utf8" }).trim();
+    killArgentProcesses(path.join(globalRoot, "argent", "dist"));
+  } catch {
+    // npm root -g may fail in some environments — skip silently
+  }
+
   const userConfigPath = path.join(os.homedir(), ".claude.json");
   if (!fs.existsSync(userConfigPath)) {
     console.log("(not found, nothing to do)");
@@ -59,6 +69,9 @@ if (userScope) {
   }
 } else {
   const projectRoot = process.env.npm_config_local_prefix ?? process.cwd();
+
+  // Kill processes running from this project's argent installation
+  killArgentProcesses(path.join(projectRoot, "node_modules", "argent", "dist"));
 
   // Claude Code
   const claudeConfigPath = path.join(projectRoot, ".claude", "mcp.json");

--- a/scripts/reinstall-argent.sh
+++ b/scripts/reinstall-argent.sh
@@ -6,6 +6,7 @@ GLOBAL_ROOT="$(npm root -g)"
 echo "1. Killing existing Argent processes"
 
 pkill -f "$GLOBAL_ROOT/argent/dist" || true
+pkill -f "$REPO_ROOT/packages/mcp/dist" || true
 
 echo "2. Building and installing"
 

--- a/scripts/setup-project.cjs
+++ b/scripts/setup-project.cjs
@@ -10,6 +10,7 @@ const { execSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
+const { killArgentProcesses } = require(path.join(__dirname, "..", "packages", "mcp", "scripts", "kill-argent.cjs"));
 
 const args = process.argv.slice(2);
 const isGlobal = args.includes("--global");
@@ -82,9 +83,15 @@ function grantPermission(settingsPath) {
 // ---------------------------------------------------------------------------
 if (isGlobal) {
   console.log("\nInstalling argent globally...");
-  execSync(`npm install -g "${tarball}"`, { stdio: "inherit" });
 
+  // Kill processes from the current global install and any repo dev build
   const globalRoot = execSync("npm root -g", { encoding: "utf8" }).trim();
+  killArgentProcesses([
+    path.join(globalRoot, "argent", "dist"),
+    path.join(root, "packages", "mcp", "dist"),
+  ]);
+
+  execSync(`npm install -g "${tarball}"`, { stdio: "inherit" });
   const globalEntry = path.join(globalRoot, "argent", "dist", "index.js");
   const logFile = path.join(os.homedir(), ".argent", "mcp-calls.log");
   const mcpEntry = {
@@ -112,6 +119,12 @@ if (!fs.existsSync(projectRoot)) {
   console.error(`Error: ${projectRoot} does not exist.`);
   process.exit(1);
 }
+
+// Kill processes from the existing local install and any repo dev build
+killArgentProcesses([
+  path.join(projectRoot, "node_modules", "argent", "dist"),
+  path.join(root, "packages", "mcp", "dist"),
+]);
 
 console.log(`\nInstalling argent in ${projectRoot}...`);
 execSync(`npm install --force "${tarball}"`, {


### PR DESCRIPTION
## Summary

- Adds `kill-argent.cjs` utility that kills running Argent node processes by matching against path substrings (cross-platform: macOS/Linux via `pkill`, Windows via WMIC)
- Integrates the kill step into `postinstall.cjs` so any running Argent processes are stopped before the install updates the dist files
- Wires the kill step into `uninstall.cjs` and `reinstall-argent.sh` for clean teardown/reinstall flows