### PR TITLE
cli: kill tool-server on update/uninstall, add allowlist management and init improvements

### DIFF
--- a/packages/mcp/scripts/postinstall.cjs
+++ b/packages/mcp/scripts/postinstall.cjs
@@ -3,7 +3,21 @@
 "use strict";
 
 // Runs automatically after `npm install @software-mansion/argent`.
-// Set ARGENT_SKIP_POSTINSTALL=1 to suppress this message.
+// Set ARGENT_SKIP_POSTINSTALL=1 to suppress the init message (used by `argent update`).
+
+const os = require("os");
+const fs = require("fs");
+const path = require("path");
+
+// Always kill any running tool-server so the new binary takes effect on next use.
+const stateFile = path.join(os.homedir(), ".argent", "tool-server.json");
+try {
+  const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+  if (state && state.pid) {
+    try { process.kill(state.pid, "SIGTERM"); } catch {}
+  }
+  fs.unlinkSync(stateFile);
+} catch {}
 
 if (process.env.ARGENT_SKIP_POSTINSTALL === "1") {
   process.exit(0);

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -5,8 +5,10 @@
  * Usage:
  *   argent mcp          Start the MCP stdio server (used by editors)
  *   argent init         Set up argent in a workspace (MCP + skills + rules)
+ *   argent install      Alias for init
  *   argent update       Check for updates, refresh configuration
  *   argent uninstall    Remove argent from a workspace
+ *   argent remove       Alias for uninstall
  *   argent bridge       [future] Execute tool-server commands via CLI
  */
 
@@ -25,8 +27,10 @@ Usage: argent <command> [options]
 Commands:
   mcp         Start the MCP stdio server (used by editors)
   init        Initialize argent in the current workspace (MCP server + skills)
+  install     Alias for init
   update      Check for updates and refresh configuration
   uninstall   Remove argent configuration from the workspace
+  remove      Alias for uninstall
   bridge      [future] Execute tool-server commands via CLI
 
 Options:
@@ -44,10 +48,12 @@ async function main(): Promise<void> {
     case "mcp":
       return (await import("./mcp-server.js")).startMcpServer();
     case "init":
+    case "install":
       return (await import("./cli/init.js")).init(rest);
     case "update":
       return (await import("./cli/update.js")).update(rest);
     case "uninstall":
+    case "remove":
       return (await import("./cli/uninstall.js")).uninstall(rest);
     case "bridge":
       return (await import("./cli/bridge.js")).bridge(rest);

--- a/packages/mcp/src/cli/constants.ts
+++ b/packages/mcp/src/cli/constants.ts
@@ -10,3 +10,4 @@ export const NPM_REGISTRY = "https://npm.pkg.github.com";
 export const MCP_SERVER_KEY = "argent";
 export const MCP_BINARY_NAME = "argent";
 export const PERMISSION_RULE = "mcp__argent";
+export const CURSOR_ALLOWLIST_PATTERN = "argent:*";

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -5,7 +5,6 @@ import {
   detectAdapters,
   ALL_ADAPTERS,
   getMcpEntry,
-  addClaudePermission,
   copyRulesAndAgents,
   type McpConfigAdapter,
 } from "./mcp-configs.js";
@@ -287,22 +286,67 @@ export async function init(args: string[]): Promise<void> {
     }
   }
 
-  // Claude permissions
-  const hasClaudeCode = selectedAdapters.some((a) => a.name === "Claude Code");
-  if (hasClaudeCode) {
-    try {
-      addClaudePermission(projectRoot, scope);
-      mcpResults.push(
-        `${pc.green("+")} Claude Code permissions ${pc.dim("(mcp__argent)")}`,
+  p.note(mcpResults.join("\n"), "MCP Configuration");
+
+  // ── Tool Auto-Approval ────────────────────────────────────────────────────
+
+  const adaptersWithAllowlist = selectedAdapters.filter((a) => a.addAllowlist);
+  const adaptersWithoutAllowlist = selectedAdapters.filter(
+    (a) => !a.addAllowlist,
+  );
+
+  let allowlistEnabled = false;
+
+  if (adaptersWithAllowlist.length > 0) {
+    p.log.info(
+      `By default, editors ask for confirmation before running each MCP tool.\n` +
+      `  Adding argent to the auto-approve allowlist lets tools run without\n` +
+      `  repeated prompts. This is ${pc.cyan("recommended")} for a smooth experience.`,
+    );
+
+    if (nonInteractive) {
+      allowlistEnabled = true;
+    } else {
+      p.log.message(
+        pc.dim("  Press y for yes, n for no, enter to confirm."),
       );
-    } catch (err) {
-      mcpResults.push(
-        `${pc.red("x")} Claude permissions: ${pc.dim(String(err))}`,
-      );
+
+      const allowlistChoice = await p.confirm({
+        message: "Add argent tools to editor auto-approve lists? (recommended)",
+        initialValue: true,
+      });
+
+      if (p.isCancel(allowlistChoice)) {
+        p.cancel("Initialization cancelled.");
+        process.exit(0);
+      }
+
+      allowlistEnabled = allowlistChoice as boolean;
     }
   }
 
-  p.note(mcpResults.join("\n"), "MCP Configuration");
+  if (allowlistEnabled) {
+    const allowlistResults: string[] = [];
+
+    for (const adapter of adaptersWithAllowlist) {
+      try {
+        adapter.addAllowlist!(projectRoot, scope);
+        allowlistResults.push(`${pc.green("+")} ${adapter.name}`);
+      } catch (err) {
+        allowlistResults.push(
+          `${pc.red("x")} ${adapter.name}: ${pc.dim(String(err))}`,
+        );
+      }
+    }
+
+    for (const adapter of adaptersWithoutAllowlist) {
+      allowlistResults.push(
+        `${pc.yellow("-")} ${adapter.name} ${pc.dim("(no auto-approve API — configure manually)")}`,
+      );
+    }
+
+    p.note(allowlistResults.join("\n"), "Tool Auto-Approval");
+  }
 
   // ── Step 2: Skills Installation ─────────────────────────────────────────────
 
@@ -429,6 +473,7 @@ export async function init(args: string[]): Promise<void> {
 
   const summaryLines = [
     `${pc.green("MCP server")} configured for ${selectedAdapters.map((a) => a.name).join(", ")} (${scope})`,
+    `${pc.green("Auto-approve")} ${allowlistEnabled ? "enabled" : "skipped"}`,
     `${pc.green("Skills")} ${skillsMethod === "manual" ? "instructions printed" : "installed"}`,
     `${pc.green("Rules & agents")} ${copyResults.length > 0 ? "copied" : "n/a"}`,
   ];

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -9,8 +9,56 @@ import {
   copyRulesAndAgents,
   type McpConfigAdapter,
 } from "./mcp-configs.js";
-import { SKILLS_DIR, RULES_DIR, AGENTS_DIR, getInstalledVersion } from "./utils.js";
+import {
+  SKILLS_DIR,
+  RULES_DIR,
+  AGENTS_DIR,
+  getInstalledVersion,
+  getLatestVersion,
+  detectPackageManager,
+  globalInstallCommand,
+} from "./utils.js";
 import { PACKAGE_NAME } from "./constants.js";
+
+function isGloballyInstalled(): boolean {
+  try {
+    const raw = execSync(
+      `npm list -g ${PACKAGE_NAME} --depth=0 --json`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const data = JSON.parse(raw) as {
+      dependencies?: Record<string, unknown>;
+    };
+    return !!data?.dependencies?.[PACKAGE_NAME];
+  } catch {
+    return false;
+  }
+}
+
+function runShellCommand(cmd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const parts = cmd.split(" ");
+    const bin = parts[0]!;
+    const args = parts.slice(1);
+    const isWin = process.platform === "win32";
+    const child = spawn(isWin ? `${bin}.cmd` : bin, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: isWin,
+    });
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(stderr.trim() || `Command exited with code ${code}`));
+    });
+
+    child.on("error", reject);
+  });
+}
 
 export async function init(args: string[]): Promise<void> {
   const nonInteractive = args.includes("--yes") || args.includes("-y");
@@ -21,6 +69,109 @@ export async function init(args: string[]): Promise<void> {
 
   const version = getInstalledVersion() ?? "unknown";
   p.log.info(`${pc.dim("Package:")} ${PACKAGE_NAME}@${version}`);
+
+  // ── Step 0: Install / Update Check ──────────────────────────────────────────
+
+  const globallyInstalled = isGloballyInstalled();
+
+  if (!globallyInstalled) {
+    type InstallScope = "global" | "local";
+    let installScope: InstallScope;
+
+    if (nonInteractive) {
+      installScope = "global";
+    } else {
+      const installChoice = await p.select({
+        message: "argent needs to be installed. How would you like to install it?",
+        options: [
+          {
+            value: "global" as const,
+            label: "Install globally (recommended)",
+            hint: "Makes the argent command available everywhere",
+          },
+          {
+            value: "local" as const,
+            label: "Install locally",
+            hint: "Installs into the current project's node_modules only",
+          },
+        ],
+      });
+
+      if (p.isCancel(installChoice)) {
+        p.cancel("Installation cancelled.");
+        process.exit(0);
+      }
+
+      installScope = installChoice as InstallScope;
+    }
+
+    if (installScope === "local") {
+      p.log.warn(
+        pc.yellow("Local installation means the argent binary will only be available inside this project."),
+      );
+    }
+
+    const pm = detectPackageManager();
+    const cmd =
+      installScope === "global"
+        ? globalInstallCommand(pm, PACKAGE_NAME)
+        : `${pm} install ${PACKAGE_NAME}`;
+    const spinner = p.spinner();
+    spinner.start(`Installing ${PACKAGE_NAME} ${installScope === "global" ? "globally" : "locally"}...`);
+    try {
+      await runShellCommand(cmd);
+      spinner.stop(pc.green(`Installed ${installScope === "global" ? "globally" : "locally"}.`));
+    } catch (err) {
+      spinner.stop(pc.red("Installation failed."));
+      p.log.error(`${err}`);
+      p.log.info(`Install argent manually with: ${pc.cyan(cmd)}`);
+      process.exit(1);
+    }
+  } else {
+    let latest: string | null = null;
+    const spinner = p.spinner();
+    spinner.start("Checking for updates...");
+    try {
+      latest = getLatestVersion();
+    } catch {
+      // Registry unreachable — silently skip
+    }
+    spinner.stop(pc.dim("Version check complete."));
+
+    if (latest && latest !== version) {
+      if (!nonInteractive) {
+        const updateChoice = await p.select({
+          message: `Update available: ${pc.yellow(`v${version}`)} → ${pc.green(`v${latest}`)}`,
+          options: [
+            {
+              value: "update" as const,
+              label: `Update to v${latest} (recommended)`,
+            },
+            {
+              value: "skip" as const,
+              label: "Skip",
+              hint: "Continue with current version",
+            },
+          ],
+        });
+
+        if (!p.isCancel(updateChoice) && updateChoice === "update") {
+          const pm = detectPackageManager();
+          const cmd = globalInstallCommand(pm, `${PACKAGE_NAME}@${latest}`);
+          const updateSpinner = p.spinner();
+          updateSpinner.start(`Updating to v${latest}...`);
+          try {
+            await runShellCommand(cmd);
+            updateSpinner.stop(pc.green(`Updated to v${latest}.`));
+          } catch (err) {
+            updateSpinner.stop(pc.red("Update failed."));
+            p.log.error(`${err}`);
+            p.log.info(`You can update manually later: ${pc.cyan(cmd)}`);
+          }
+        }
+      }
+    }
+  }
 
   // ── Step 1: MCP Server Configuration ────────────────────────────────────────
 
@@ -286,7 +437,7 @@ export async function init(args: string[]): Promise<void> {
   p.outro(pc.green("argent is ready!"));
 }
 
-function printBanner(): void {
+export function printBanner(): void {
   const lines = [
     " █████╗ ██████╗  ██████╗ ███████╗███╗   ██╗████████╗",
     "██╔══██╗██╔══██╗██╔════╝ ██╔════╝████╗  ██║╚══██╔══╝",

--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { homedir } from "node:os";
-import { MCP_SERVER_KEY, MCP_BINARY_NAME, PERMISSION_RULE } from "./constants.js";
+import { MCP_SERVER_KEY, MCP_BINARY_NAME, PERMISSION_RULE, CURSOR_ALLOWLIST_PATTERN } from "./constants.js";
 import { readJson, writeJson, dirExists } from "./utils.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -19,6 +19,8 @@ export interface McpConfigAdapter {
   globalPath(): string | null;
   write(configPath: string, entry: McpServerEntry): void;
   remove(configPath: string): boolean;
+  addAllowlist?(root: string, scope: "local" | "global"): void;
+  removeAllowlist?(root: string, scope: "local" | "global"): void;
 }
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
@@ -78,6 +80,30 @@ const cursorAdapter: McpConfigAdapter = {
     writeJson(configPath, config);
     return true;
   },
+
+  addAllowlist(): void {
+    const permPath = path.join(homedir(), ".cursor", "permissions.json");
+    const config = readJson(permPath);
+    const list = (config.mcpAllowlist ?? []) as string[];
+    if (!list.includes(CURSOR_ALLOWLIST_PATTERN)) {
+      list.push(CURSOR_ALLOWLIST_PATTERN);
+      config.mcpAllowlist = list;
+      writeJson(permPath, config);
+    }
+  },
+
+  removeAllowlist(): void {
+    const permPath = path.join(homedir(), ".cursor", "permissions.json");
+    if (!fs.existsSync(permPath)) return;
+    const config = readJson(permPath);
+    const list = config.mcpAllowlist as string[] | undefined;
+    if (!Array.isArray(list)) return;
+    const idx = list.indexOf(CURSOR_ALLOWLIST_PATTERN);
+    if (idx === -1) return;
+    list.splice(idx, 1);
+    config.mcpAllowlist = list;
+    writeJson(permPath, config);
+  },
 };
 
 // ── Claude Code adapter ───────────────────────────────────────────────────────
@@ -126,6 +152,14 @@ const claudeAdapter: McpConfigAdapter = {
     delete servers[MCP_SERVER_KEY];
     writeJson(configPath, config);
     return true;
+  },
+
+  addAllowlist(root: string, scope: "local" | "global"): void {
+    addClaudePermission(root, scope);
+  },
+
+  removeAllowlist(root: string, scope: "local" | "global"): void {
+    removeClaudePermission(root, scope);
   },
 };
 
@@ -215,6 +249,27 @@ const windsurfAdapter: McpConfigAdapter = {
     writeJson(configPath, config);
     return true;
   },
+
+  addAllowlist(): void {
+    const configPath = path.join(homedir(), ".codeium", "windsurf", "mcp_config.json");
+    const config = readJson(configPath);
+    const servers = (config.mcpServers ?? {}) as Record<string, Record<string, unknown>>;
+    const entry = servers[MCP_SERVER_KEY];
+    if (!entry) return;
+    entry.alwaysAllow = ["*"];
+    writeJson(configPath, config);
+  },
+
+  removeAllowlist(): void {
+    const configPath = path.join(homedir(), ".codeium", "windsurf", "mcp_config.json");
+    if (!fs.existsSync(configPath)) return;
+    const config = readJson(configPath);
+    const servers = (config.mcpServers ?? {}) as Record<string, Record<string, unknown>>;
+    const entry = servers[MCP_SERVER_KEY];
+    if (!entry?.alwaysAllow) return;
+    delete entry.alwaysAllow;
+    writeJson(configPath, config);
+  },
 };
 
 // ── Zed adapter ──────────────────────────────────────────────────────────────
@@ -259,6 +314,38 @@ const zedAdapter: McpConfigAdapter = {
     delete servers[MCP_SERVER_KEY];
     writeJson(configPath, config);
     return true;
+  },
+
+  // Zed doesn't support server-level wildcards for MCP tools — each tool
+  // would need its own entry.  Setting the global default to "allow" is the
+  // documented opt-in; built-in security rules still protect against
+  // destructive operations.
+  addAllowlist(_root: string, scope: "local" | "global"): void {
+    const settingsPath =
+      scope === "global"
+        ? path.join(homedir(), ".config", "zed", "settings.json")
+        : path.join(process.cwd(), ".zed", "settings.json");
+    const config = readJson(settingsPath);
+    const agent = (config.agent ?? {}) as Record<string, unknown>;
+    const perms = (agent.tool_permissions ?? {}) as Record<string, unknown>;
+    perms.default = "allow";
+    agent.tool_permissions = perms;
+    config.agent = agent;
+    writeJson(settingsPath, config);
+  },
+
+  removeAllowlist(_root: string, scope: "local" | "global"): void {
+    const settingsPath =
+      scope === "global"
+        ? path.join(homedir(), ".config", "zed", "settings.json")
+        : path.join(process.cwd(), ".zed", "settings.json");
+    if (!fs.existsSync(settingsPath)) return;
+    const config = readJson(settingsPath);
+    const perms = (config.agent as Record<string, unknown>)
+      ?.tool_permissions as Record<string, unknown> | undefined;
+    if (!perms || perms.default !== "allow") return;
+    perms.default = "confirm";
+    writeJson(settingsPath, config);
   },
 };
 

--- a/packages/mcp/src/cli/uninstall.ts
+++ b/packages/mcp/src/cli/uninstall.ts
@@ -14,6 +14,7 @@ import {
   globalUninstallCommand,
 } from "./utils.js";
 import { PACKAGE_NAME } from "./constants.js";
+import { killToolServer } from "../launcher.js";
 
 export async function uninstall(args: string[]): Promise<void> {
   const nonInteractive = args.includes("--yes") || args.includes("-y");
@@ -196,6 +197,8 @@ export async function uninstall(args: string[]): Promise<void> {
     const pm = detectPackageManager();
     const cmd = globalUninstallCommand(pm, PACKAGE_NAME);
     p.log.info(`Running: ${pc.dim(cmd)}`);
+
+    await killToolServer();
 
     try {
       execSync(cmd, { stdio: "inherit" });

--- a/packages/mcp/src/cli/uninstall.ts
+++ b/packages/mcp/src/cli/uninstall.ts
@@ -5,9 +5,7 @@ import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { homedir } from "node:os";
 import {
-  detectAdapters,
   ALL_ADAPTERS,
-  removeClaudePermission,
 } from "./mcp-configs.js";
 import {
   detectPackageManager,
@@ -65,24 +63,20 @@ export async function uninstall(args: string[]): Promise<void> {
     }
   }
 
-  // ── Remove Claude permissions ───────────────────────────────────────────────
+  // ── Remove allowlists ──────────────────────────────────────────────────────
 
-  try {
-    removeClaudePermission(projectRoot, "local");
-    results.push(
-      `${pc.green("+")} Removed Claude Code permissions ${pc.dim("(local)")}`,
-    );
-  } catch {
-    // non-fatal
-  }
-
-  try {
-    removeClaudePermission(projectRoot, "global");
-    results.push(
-      `${pc.green("+")} Removed Claude Code permissions ${pc.dim("(global)")}`,
-    );
-  } catch {
-    // non-fatal
+  for (const adapter of ALL_ADAPTERS) {
+    if (!adapter.removeAllowlist) continue;
+    for (const s of ["local", "global"] as const) {
+      try {
+        adapter.removeAllowlist(projectRoot, s);
+        results.push(
+          `${pc.green("+")} Removed ${adapter.name} allowlist ${pc.dim(`(${s})`)}`,
+        );
+      } catch {
+        // non-fatal
+      }
+    }
   }
 
   if (results.length > 0) {

--- a/packages/mcp/src/cli/update.ts
+++ b/packages/mcp/src/cli/update.ts
@@ -4,7 +4,6 @@ import { execSync } from "node:child_process";
 import {
   detectAdapters,
   getMcpEntry,
-  addClaudePermission,
   copyRulesAndAgents,
 } from "./mcp-configs.js";
 import {
@@ -110,18 +109,15 @@ export async function update(args: string[]): Promise<void> {
     }
   }
 
-  // Refresh Claude permissions
-  const hasClaude = detected.some((a) => a.name === "Claude Code");
-  if (hasClaude) {
-    try {
-      addClaudePermission(projectRoot, "global");
-    } catch {
-      // non-fatal
-    }
-    try {
-      addClaudePermission(projectRoot, "local");
-    } catch {
-      // non-fatal
+  // Refresh allowlists
+  for (const adapter of detected) {
+    if (!adapter.addAllowlist) continue;
+    for (const s of ["global", "local"] as const) {
+      try {
+        adapter.addAllowlist(projectRoot, s);
+      } catch {
+        // non-fatal
+      }
     }
   }
 

--- a/packages/mcp/src/cli/update.ts
+++ b/packages/mcp/src/cli/update.ts
@@ -16,6 +16,7 @@ import {
   AGENTS_DIR,
 } from "./utils.js";
 import { PACKAGE_NAME } from "./constants.js";
+import { killToolServer } from "../launcher.js";
 
 export async function update(args: string[]): Promise<void> {
   const nonInteractive = args.includes("--yes") || args.includes("-y");
@@ -68,6 +69,8 @@ export async function update(args: string[]): Promise<void> {
     }
 
     p.log.info(`Running: ${pc.dim(cmd)}`);
+
+    await killToolServer();
 
     try {
       execSync(cmd, {

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -101,7 +101,7 @@ export function globalInstallCommand(pm: PackageManager, pkg: string): string {
     case "bun":
       return `bun add -g ${pkg}`;
     default:
-      return `npm install -g --force ${pkg}`;
+      return `npm install -g ${pkg}`;
   }
 }
 

--- a/packages/mcp/src/launcher.ts
+++ b/packages/mcp/src/launcher.ts
@@ -157,6 +157,17 @@ async function clearState(): Promise<void> {
   }
 }
 
+export async function killToolServer(): Promise<void> {
+  const state = await readState();
+  if (!state) return;
+  try {
+    process.kill(state.pid, "SIGTERM");
+  } catch {
+    // already gone
+  }
+  await clearState();
+}
+
 export async function ensureToolsServer(): Promise<string> {
   const state = await readState();
 


### PR DESCRIPTION
## Summary

- **Kill tool-server on update/uninstall**: exports `killToolServer()` from `launcher.ts` and calls it in `argent update` (before installing new binary) and `argent uninstall` (before removing the package), ensuring the running daemon is replaced/cleaned up immediately
- **Postinstall kill**: `postinstall.cjs` now also terminates any running tool-server so a plain `npm install -g` picks up the new binary on next use
- **Generic allowlist management**: replaces the Claude-only `addClaudePermission` calls with a per-adapter `addAllowlist`/`removeAllowlist` interface, implemented for Cursor (`~/.cursor/permissions.json`), Claude Code, Windsurf, and Zed
- **`argent init` improvements**: adds a Step 0 that detects whether argent is globally installed and offers to install/update it before proceeding; also surfaces an update prompt if already installed but outdated
- **Command aliases**: `argent install` → `init`, `argent remove` → `uninstall`