### PR TITLE
fix: simplify local installation flow and add --from tarball support

### DIFF
--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -59,8 +59,15 @@ function runShellCommand(cmd: string): Promise<void> {
   });
 }
 
+function extractFlag(args: string[], flag: string): string | null {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1]!;
+}
+
 export async function init(args: string[]): Promise<void> {
   const nonInteractive = args.includes("--yes") || args.includes("-y");
+  const fromTar = extractFlag(args, "--from");
 
   printBanner();
 
@@ -97,7 +104,8 @@ export async function init(args: string[]): Promise<void> {
     }
 
     const pm = detectPackageManager();
-    const cmd = globalInstallCommand(pm, PACKAGE_NAME);
+    const installTarget = fromTar ?? PACKAGE_NAME;
+    const cmd = globalInstallCommand(pm, installTarget);
     const spinner = p.spinner();
     spinner.start(`Installing ${PACKAGE_NAME} globally...`);
     try {

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -74,52 +74,35 @@ export async function init(args: string[]): Promise<void> {
   const globallyInstalled = isGloballyInstalled();
 
   if (!globallyInstalled) {
-    type InstallScope = "global" | "local";
-    let installScope: InstallScope;
-
-    if (nonInteractive) {
-      installScope = "global";
-    } else {
+    if (!nonInteractive) {
       const installChoice = await p.select({
-        message: "argent needs to be installed. How would you like to install it?",
+        message: "argent is not installed globally. Would you like to install it?",
         options: [
           {
             value: "global" as const,
-            label: "Install globally (recommended)",
+            label: "Install globally",
             hint: "Makes the argent command available everywhere",
           },
           {
-            value: "local" as const,
-            label: "Install locally",
-            hint: "Installs into the current project's node_modules only",
+            value: "cancel" as const,
+            label: "Cancel",
           },
         ],
       });
 
-      if (p.isCancel(installChoice)) {
+      if (p.isCancel(installChoice) || installChoice === "cancel") {
         p.cancel("Installation cancelled.");
         process.exit(0);
       }
-
-      installScope = installChoice as InstallScope;
-    }
-
-    if (installScope === "local") {
-      p.log.warn(
-        pc.yellow("Local installation means the argent binary will only be available inside this project."),
-      );
     }
 
     const pm = detectPackageManager();
-    const cmd =
-      installScope === "global"
-        ? globalInstallCommand(pm, PACKAGE_NAME)
-        : `${pm} install ${PACKAGE_NAME}`;
+    const cmd = globalInstallCommand(pm, PACKAGE_NAME);
     const spinner = p.spinner();
-    spinner.start(`Installing ${PACKAGE_NAME} ${installScope === "global" ? "globally" : "locally"}...`);
+    spinner.start(`Installing ${PACKAGE_NAME} globally...`);
     try {
       await runShellCommand(cmd);
-      spinner.stop(pc.green(`Installed ${installScope === "global" ? "globally" : "locally"}.`));
+      spinner.stop(pc.green("Installed globally."));
     } catch (err) {
       spinner.stop(pc.red("Installation failed."));
       p.log.error(`${err}`);

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -92,7 +92,7 @@ export async function init(args: string[]): Promise<void> {
           },
           {
             value: "cancel" as const,
-            label: "Cancel",
+            label: "Cancel installation",
           },
         ],
       });


### PR DESCRIPTION
## Summary

- Removes the local install option from the CLI init prompt, making global install the only path
- Adds `--from <tarball>` flag support so users can install directly from a `.tgz` file (useful for testing local builds)
- Cleans up related prompt copy and spinner messages for clarity