### PR TITLE
refactor: use __r.getModules() for safe Metro module scanning in debugger scripts

### DIFF
--- a/packages/tool-server/src/utils/debugger/scripts/component-tree.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/component-tree.ts
@@ -33,8 +33,16 @@ export function makeComponentTreeScript(opts: {
   var useFabric = typeof nativeFabricUIManager !== 'undefined';
   var UIManagerMod;
   if (!useFabric) {
-    for (var i = 0; i < 300; i++) {
-      try { var m = __r(i); if (m && m.UIManager) { UIManagerMod = m.UIManager; break; } } catch(e) {}
+    if (typeof __r.getModules === 'function') {
+      var _mods = __r.getModules();
+      for (var _entry of _mods) {
+        if (!_entry[1].isInitialized) continue;
+        try { var m = __r(_entry[0]); if (m && m.UIManager) { UIManagerMod = m.UIManager; break; } } catch(e) {}
+      }
+    } else {
+      for (var i = 0; i < 300; i++) {
+        try { var m = __r(i); if (m && m.UIManager) { UIManagerMod = m.UIManager; break; } } catch(e) {}
+      }
     }
     if (!UIManagerMod) return JSON.stringify({ error: 'Could not find UIManager' });
   }
@@ -136,18 +144,27 @@ export function makeComponentTreeScript(opts: {
   // --- Screen dimensions via Dimensions API (reliable fallback) ---
   var screenW = 0, screenH = 0;
   try {
-    for (var i = 0; i < 500; i++) {
-      try {
-        var m = __r(i);
-        if (m && m.Dimensions) {
-          var win = m.Dimensions.get('window');
-          if (win && win.width > 0 && win.height > 0) {
-            screenW = Math.round(win.width);
-            screenH = Math.round(win.height);
-            break;
-          }
+    function _findDimensions(mod) {
+      if (mod && mod.Dimensions) {
+        var win = mod.Dimensions.get('window');
+        if (win && win.width > 0 && win.height > 0) {
+          screenW = Math.round(win.width);
+          screenH = Math.round(win.height);
+          return true;
         }
-      } catch(e) {}
+      }
+      return false;
+    }
+    if (typeof __r.getModules === 'function') {
+      var _dMods = __r.getModules();
+      for (var _dEntry of _dMods) {
+        if (!_dEntry[1].isInitialized) continue;
+        try { if (_findDimensions(__r(_dEntry[0]))) break; } catch(e) {}
+      }
+    } else {
+      for (var i = 0; i < 500; i++) {
+        try { if (_findDimensions(__r(i))) break; } catch(e) {}
+      }
     }
   } catch(e) {}
 

--- a/packages/tool-server/src/utils/debugger/scripts/disable-logbox.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/disable-logbox.ts
@@ -1,20 +1,72 @@
 /**
  * IIFE that scans the Metro module registry for the LogBox module
- * and calls `ignoreAllLogs(true)` to suppress the yellow/red overlay.
+ * and calls `ignoreAllLogs(true)` to suppress the yellow/red overlay,
+ * then clears any already-queued LogBox entries (e.g. SegmentFetcher).
  *
- * Safe to call at any time — exits early when __r is unavailable
- * (e.g. the JS context hasn't finished loading yet).
+ * Uses `__r.getModules()` (available in DEV) to iterate only
+ * already-initialized modules, avoiding forced evaluation of unloaded
+ * modules. This prevents Metro's `guardedLoadModule` from reporting
+ * errors to LogBox when a module's top-level code throws (e.g.
+ * `TurboModuleRegistry.getEnforcing('SegmentFetcher')` in Expo builds).
+ *
+ * Falls back to the ErrorUtils-suppression approach when `getModules`
+ * is unavailable: temporarily nulls `global.ErrorUtils` so that any
+ * errors thrown during `__r(i)` scanning are caught by our try-catch
+ * instead of being routed to LogBox via `ErrorUtils.reportFatalError`.
+ *
+ * Safe to call at any time — exits early when __r is unavailable.
  */
 export const DISABLE_LOGBOX_SCRIPT = `(function() {
   if (typeof __r !== 'function') return;
-  for (var i = 0; i < 5000; i++) {
+
+  function findLogBox(mod) {
+    return mod && (mod.LogBox || (mod.default && mod.default.ignoreAllLogs && mod.default));
+  }
+
+  function findLogBoxData(mod) {
+    return mod
+      && typeof mod.clear === 'function'
+      && typeof mod.addLog === 'function'
+      && typeof mod.isMessageIgnored === 'function'
+      ? mod : null;
+  }
+
+  var LB = null;
+  var LBData = null;
+
+  if (typeof __r.getModules === 'function') {
+    var modules = __r.getModules();
+    for (var entry of modules) {
+      var id = entry[0], meta = entry[1];
+      if (!meta.isInitialized) continue;
+      try {
+        var mod = __r(id);
+        if (!LB) LB = findLogBox(mod);
+        if (!LBData) LBData = findLogBoxData(mod);
+        if (LB && LBData) break;
+      } catch(e) {}
+    }
+  } else {
+    var savedEU = global.ErrorUtils;
+    global.ErrorUtils = null;
     try {
-      var mod = __r(i);
-      var LB = mod && (mod.LogBox || (mod.default && mod.default.ignoreAllLogs && mod.default));
-      if (LB && typeof LB.ignoreAllLogs === 'function') {
-        LB.ignoreAllLogs(true);
-        return;
+      for (var i = 0; i < 5000; i++) {
+        try {
+          var mod = __r(i);
+          if (!LB) LB = findLogBox(mod);
+          if (!LBData) LBData = findLogBoxData(mod);
+          if (LB && LBData) break;
+        } catch(e) {}
       }
-    } catch(e) {}
+    } finally {
+      global.ErrorUtils = savedEU;
+    }
+  }
+
+  if (LB && typeof LB.ignoreAllLogs === 'function') {
+    LB.ignoreAllLogs(true);
+  }
+  if (LBData) {
+    LBData.clear();
   }
 })()`;

--- a/packages/tool-server/src/utils/debugger/scripts/render-hook.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/render-hook.ts
@@ -7,8 +7,16 @@ export const RENDER_HOOK_SCRIPT = `(function() {
   if (globalThis.__argent_render_patched) return 'already active';
   globalThis.__argent_render_patched = true;
   var UIManager;
-  for (var _i = 0; _i < 200; _i++) {
-    try { var _m = __r(_i); if (_m && _m.UIManager) { UIManager = _m.UIManager; break; } } catch(e) {}
+  if (typeof __r.getModules === 'function') {
+    var _mods = __r.getModules();
+    for (var _entry of _mods) {
+      if (!_entry[1].isInitialized) continue;
+      try { var _m = __r(_entry[0]); if (_m && _m.UIManager) { UIManager = _m.UIManager; break; } } catch(e) {}
+    }
+  } else {
+    for (var _i = 0; _i < 200; _i++) {
+      try { var _m = __r(_i); if (_m && _m.UIManager) { UIManager = _m.UIManager; break; } } catch(e) {}
+    }
   }
   var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
   var SKIP = new Set(['PerformanceLoggerContext','AppContainer','RootTagContext',


### PR DESCRIPTION
## Summary

- Replace blind numeric `__r(i)` loops in `component-tree.ts`, `render-hook.ts`, and `disable-logbox.ts` with `__r.getModules()`-based iteration that only visits already-initialized modules
- Prevents Metro's `guardedLoadModule` from triggering errors (e.g. `TurboModuleRegistry.getEnforcing('SegmentFetcher')`) when an unloaded module's top-level code throws during scanning
- `disable-logbox.ts` additionally clears already-queued LogBox entries after suppression, and falls back to temporarily nulling `global.ErrorUtils` on runtimes where `getModules` is unavailable