### PR TITLE
feat: add Codex CLI adapter for MCP config management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2562,6 +2562,18 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4205,7 +4217,8 @@
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.20.0",
-        "picocolors": "^1.1.1"
+        "picocolors": "^1.1.1",
+        "smol-toml": "^1.6.1"
       },
       "bin": {
         "argent": "dist/cli.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.20.0",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "smol-toml": "^1.6.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -7,7 +7,7 @@ import {
   PERMISSION_RULE,
   CURSOR_ALLOWLIST_PATTERN,
 } from "./constants.js";
-import { readJson, writeJson, dirExists } from "./utils.js";
+import { readJson, writeJson, dirExists, readToml, writeToml } from "./utils.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -426,6 +426,51 @@ const geminiAdapter: McpConfigAdapter = {
   },
 };
 
+// ── Codex CLI adapter ────────────────────────────────────────────────────────
+// Format (TOML): [mcp_servers.argent] command = "argent" args = ["mcp"] env = { ... }
+// Project: <root>/.codex/config.toml   Global: ~/.codex/config.toml
+
+const codexAdapter: McpConfigAdapter = {
+  name: "Codex",
+
+  detect(): boolean {
+    return (
+      dirExists(path.join(homedir(), ".codex")) ||
+      dirExists(path.join(process.cwd(), ".codex"))
+    );
+  },
+
+  projectPath(root: string): string | null {
+    return path.join(root, ".codex", "config.toml");
+  },
+
+  globalPath(): string | null {
+    return path.join(homedir(), ".codex", "config.toml");
+  },
+
+  write(configPath: string, entry: McpServerEntry): void {
+    const config = readToml(configPath);
+    const servers = (config.mcp_servers ?? {}) as Record<string, unknown>;
+    servers[MCP_SERVER_KEY] = {
+      command: entry.command,
+      args: entry.args,
+      env: entry.env,
+    };
+    config.mcp_servers = servers;
+    writeToml(configPath, config);
+  },
+
+  remove(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const config = readToml(configPath);
+    const servers = config.mcp_servers as Record<string, unknown> | undefined;
+    if (!servers?.[MCP_SERVER_KEY]) return false;
+    delete servers[MCP_SERVER_KEY];
+    writeToml(configPath, config);
+    return true;
+  },
+};
+
 // ── Registry ──────────────────────────────────────────────────────────────────
 
 export const ALL_ADAPTERS: McpConfigAdapter[] = [
@@ -435,6 +480,7 @@ export const ALL_ADAPTERS: McpConfigAdapter[] = [
   windsurfAdapter,
   zedAdapter,
   geminiAdapter,
+  codexAdapter,
 ];
 
 export function detectAdapters(): McpConfigAdapter[] {
@@ -542,6 +588,18 @@ function getCopyTargets(
           editorName: adapter.name,
           rulesDir: path.join(geminiBase, "rules"),
           agentsDir: path.join(geminiBase, "agents"),
+        });
+        break;
+      }
+      case "Codex": {
+        const codexBase =
+          scope === "global"
+            ? path.join(homedir(), ".codex")
+            : path.join(root, ".codex");
+        targets.push({
+          editorName: adapter.name,
+          rulesDir: path.join(codexBase, "rules"),
+          agentsDir: path.join(codexBase, "agents"),
         });
         break;
       }

--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -591,18 +591,9 @@ function getCopyTargets(
         });
         break;
       }
-      case "Codex": {
-        const codexBase =
-          scope === "global"
-            ? path.join(homedir(), ".codex")
-            : path.join(root, ".codex");
-        targets.push({
-          editorName: adapter.name,
-          rulesDir: path.join(codexBase, "rules"),
-          agentsDir: path.join(codexBase, "agents"),
-        });
-        break;
-      }
+      // Codex: .codex/rules/ is for execpolicy (Starlark security rules),
+      // not model instructions. Codex uses AGENTS.md files and
+      // .agents/skills/ for context injection — no directory copy target.
     }
   }
 

--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -591,14 +591,87 @@ function getCopyTargets(
         });
         break;
       }
-      // Codex: .codex/rules/ is for execpolicy (Starlark security rules),
-      // not model instructions. Codex uses AGENTS.md files and
-      // .agents/skills/ for context injection — no directory copy target.
     }
   }
 
   return targets;
 }
+
+// ── Codex developer_instructions helpers ─────────────────────────────────────
+// Codex has no rules/ directory for model instructions. Instead we inject
+// rule content into the `developer_instructions` field of config.toml,
+// delimited by markers so we can update/remove without touching user content.
+
+const ARGENT_RULES_START = "# --- argent rules (managed by argent init — do not edit) ---";
+const ARGENT_RULES_END = "# --- end argent rules ---";
+
+function stripFrontmatter(content: string): string {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  return match ? content.slice(match[0].length).trim() : content.trim();
+}
+
+function readAndConcatRules(rulesDir: string): string | null {
+  if (!fs.existsSync(rulesDir)) return null;
+  const files = fs.readdirSync(rulesDir).filter((f) => f.endsWith(".md")).sort();
+  if (files.length === 0) return null;
+  const parts: string[] = [];
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(rulesDir, file), "utf8");
+    const stripped = stripFrontmatter(raw);
+    if (stripped) parts.push(stripped);
+  }
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+function injectArgentSection(existing: string | undefined, rules: string): string {
+  const section = `${ARGENT_RULES_START}\n${rules}\n${ARGENT_RULES_END}`;
+  if (!existing) return section;
+  // Replace existing argent section if present
+  const re = new RegExp(
+    `${escapeRegExp(ARGENT_RULES_START)}[\\s\\S]*?${escapeRegExp(ARGENT_RULES_END)}`,
+  );
+  if (re.test(existing)) return existing.replace(re, section);
+  // Append after user content
+  return `${existing}\n\n${section}`;
+}
+
+function removeArgentSection(existing: string): string {
+  const re = new RegExp(
+    `\\n*${escapeRegExp(ARGENT_RULES_START)}[\\s\\S]*?${escapeRegExp(ARGENT_RULES_END)}\\n*`,
+  );
+  return existing.replace(re, "").trim();
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function injectCodexRules(configPath: string, rulesDir: string): string | null {
+  const rules = readAndConcatRules(rulesDir);
+  if (!rules) return null;
+  const config = readToml(configPath);
+  const existing = config.developer_instructions as string | undefined;
+  config.developer_instructions = injectArgentSection(existing, rules);
+  writeToml(configPath, config);
+  return configPath;
+}
+
+export function removeCodexRules(configPath: string): boolean {
+  if (!fs.existsSync(configPath)) return false;
+  const config = readToml(configPath);
+  const existing = config.developer_instructions as string | undefined;
+  if (!existing || !existing.includes(ARGENT_RULES_START)) return false;
+  const cleaned = removeArgentSection(existing);
+  if (cleaned) {
+    config.developer_instructions = cleaned;
+  } else {
+    delete config.developer_instructions;
+  }
+  writeToml(configPath, config);
+  return true;
+}
+
+// ── Copy orchestrator ────────────────────────────────────────────────────────
 
 export function copyRulesAndAgents(
   adapters: McpConfigAdapter[],
@@ -631,6 +704,22 @@ export function copyRulesAndAgents(
       } catch (err) {
         results.push(`  Could not copy agents to ${target.agentsDir}: ${err}`);
       }
+    }
+  }
+
+  // Codex: inject rules into developer_instructions in config.toml
+  for (const adapter of adapters) {
+    if (adapter.name !== "Codex") continue;
+    const configPath =
+      scope === "global" ? adapter.globalPath() : adapter.projectPath(root);
+    if (!configPath) continue;
+    try {
+      const injected = injectCodexRules(configPath, rulesDir);
+      if (injected) {
+        results.push(`  Injected rules into ${configPath} (developer_instructions)`);
+      }
+    } catch (err) {
+      results.push(`  Could not inject rules into ${configPath}: ${err}`);
     }
   }
 

--- a/packages/mcp/src/cli/uninstall.ts
+++ b/packages/mcp/src/cli/uninstall.ts
@@ -6,6 +6,7 @@ import { execSync } from "node:child_process";
 import { homedir } from "node:os";
 import {
   ALL_ADAPTERS,
+  removeCodexRules,
 } from "./mcp-configs.js";
 import {
   detectPackageManager,
@@ -154,6 +155,20 @@ export async function uninstall(args: string[]): Promise<void> {
         }
       } catch (err) {
         pruneResults.push(`${pc.red("x")} Could not remove ${label}: ${err}`);
+      }
+    }
+
+    // Codex: remove argent rules from developer_instructions in config.toml
+    for (const configPath of [
+      path.join(projectRoot, ".codex", "config.toml"),
+      path.join(homedir(), ".codex", "config.toml"),
+    ]) {
+      try {
+        if (removeCodexRules(configPath)) {
+          pruneResults.push(`${pc.green("+")} Removed argent rules from ${configPath}`);
+        }
+      } catch (err) {
+        pruneResults.push(`${pc.red("x")} Could not clean ${configPath}: ${err}`);
       }
     }
 

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { PACKAGE_NAME, NPM_REGISTRY } from "./constants.js";
+import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 
 // ── Package root resolution ───────────────────────────────────────────────────
 // tsc compiles src/cli/utils.ts -> dist/cli/utils.js.
@@ -21,6 +22,22 @@ export const PACKAGE_ROOT = resolvePackageRoot(import.meta.dirname);
 export const SKILLS_DIR = path.join(PACKAGE_ROOT, "skills");
 export const RULES_DIR = path.join(PACKAGE_ROOT, "rules");
 export const AGENTS_DIR = path.join(PACKAGE_ROOT, "agents");
+
+// ── TOML helpers ─────────────────────────────────────────────────────────────
+
+export function readToml(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) return {};
+  try {
+    return parseToml(fs.readFileSync(filePath, "utf8")) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function writeToml(filePath: string, data: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, stringifyToml(data) + "\n");
+}
 
 // ── JSON helpers ──────────────────────────────────────────────────────────────
 

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -644,7 +644,7 @@ describe("copyRulesAndAgents", () => {
     ).toBe(true);
   });
 
-  it("copies rules and agents to .codex/ for Codex adapter (local)", () => {
+  it("returns empty array for Codex adapter (no rules/agents dir support)", () => {
     const codexAdapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
     const results = copyRulesAndAgents(
       [codexAdapter],
@@ -653,44 +653,6 @@ describe("copyRulesAndAgents", () => {
       rulesDir,
       agentsDir,
     );
-    expect(results.some((r) => r.includes("rules"))).toBe(true);
-    expect(results.some((r) => r.includes("agents"))).toBe(true);
-    expect(
-      fs.existsSync(path.join(tmpDir, ".codex", "rules", "argent.md")),
-    ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(tmpDir, ".codex", "agents", "environment-inspector.md"),
-      ),
-    ).toBe(true);
-  });
-
-  it("copies rules and agents to ~/.codex/ for Codex adapter (global)", () => {
-    const codexAdapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
-    homedirOverride = path.join(tmpDir, "home");
-    const results = copyRulesAndAgents(
-      [codexAdapter],
-      tmpDir,
-      "global",
-      rulesDir,
-      agentsDir,
-    );
-    expect(results.some((r) => r.includes("rules"))).toBe(true);
-    expect(results.some((r) => r.includes("agents"))).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(homedirOverride, ".codex", "rules", "argent.md"),
-      ),
-    ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(
-          homedirOverride,
-          ".codex",
-          "agents",
-          "environment-inspector.md",
-        ),
-      ),
-    ).toBe(true);
+    expect(results).toHaveLength(0);
   });
 });

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -61,9 +61,9 @@ describe("getMcpEntry", () => {
 // ── Adapter registry ──────────────────────────────────────────────────────────
 
 describe("ALL_ADAPTERS", () => {
-  it("contains all six adapters", () => {
+  it("contains all seven adapters", () => {
     const names = ALL_ADAPTERS.map((a) => a.name);
-    expect(names).toEqual(["Cursor", "Claude Code", "VS Code", "Windsurf", "Zed", "Gemini"]);
+    expect(names).toEqual(["Cursor", "Claude Code", "VS Code", "Windsurf", "Zed", "Gemini", "Codex"]);
   });
 });
 
@@ -410,6 +410,80 @@ describe("Gemini adapter", () => {
   });
 });
 
+// ── Codex adapter ────────────────────────────────────────────────────────────
+
+describe("Codex adapter", () => {
+  const adapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
+
+  it("writes [mcp_servers.argent] in TOML format", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    adapter.write(configPath, getMcpEntry());
+
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).toContain("[mcp_servers.argent]");
+    expect(content).toContain('command = "argent"');
+  });
+
+  it("removes argent entry and returns true", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    adapter.write(configPath, getMcpEntry());
+
+    const removed = adapter.remove(configPath);
+    expect(removed).toBe(true);
+
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).not.toContain("[mcp_servers.argent]");
+  });
+
+  it("returns false when removing from non-existent file", () => {
+    expect(adapter.remove(path.join(tmpDir, "nope.toml"))).toBe(false);
+  });
+
+  it("returns false when removing from file without argent entry", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    fs.writeFileSync(configPath, "[mcp_servers]\n");
+    expect(adapter.remove(configPath)).toBe(false);
+  });
+
+  it("projectPath returns .codex/config.toml under project root", () => {
+    expect(adapter.projectPath("/foo")).toBe(
+      path.join("/foo", ".codex", "config.toml"),
+    );
+  });
+
+  it("detect() returns true when local .codex dir exists", () => {
+    const localCodex = path.join(process.cwd(), ".codex");
+    const existed = fs.existsSync(localCodex);
+    if (!existed) fs.mkdirSync(localCodex, { recursive: true });
+    try {
+      expect(adapter.detect()).toBe(true);
+    } finally {
+      if (!existed) fs.rmdirSync(localCodex);
+    }
+  });
+
+  it("globalPath returns ~/.codex/config.toml", () => {
+    expect(adapter.globalPath()).toBe(
+      path.join(os.homedir(), ".codex", "config.toml"),
+    );
+  });
+
+  it("preserves existing settings when writing", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      'model = "o3"\n\n[mcp_servers.other]\ncommand = "npx"\n',
+    );
+
+    adapter.write(configPath, getMcpEntry());
+
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).toContain('model = "o3"');
+    expect(content).toContain("[mcp_servers.other]");
+    expect(content).toContain("[mcp_servers.argent]");
+  });
+});
+
 // ── Claude permissions ────────────────────────────────────────────────────────
 
 describe("addClaudePermission / removeClaudePermission", () => {
@@ -563,6 +637,56 @@ describe("copyRulesAndAgents", () => {
         path.join(
           homedirOverride,
           ".gemini",
+          "agents",
+          "environment-inspector.md",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("copies rules and agents to .codex/ for Codex adapter (local)", () => {
+    const codexAdapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
+    const results = copyRulesAndAgents(
+      [codexAdapter],
+      tmpDir,
+      "local",
+      rulesDir,
+      agentsDir,
+    );
+    expect(results.some((r) => r.includes("rules"))).toBe(true);
+    expect(results.some((r) => r.includes("agents"))).toBe(true);
+    expect(
+      fs.existsSync(path.join(tmpDir, ".codex", "rules", "argent.md")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(tmpDir, ".codex", "agents", "environment-inspector.md"),
+      ),
+    ).toBe(true);
+  });
+
+  it("copies rules and agents to ~/.codex/ for Codex adapter (global)", () => {
+    const codexAdapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
+    homedirOverride = path.join(tmpDir, "home");
+    const results = copyRulesAndAgents(
+      [codexAdapter],
+      tmpDir,
+      "global",
+      rulesDir,
+      agentsDir,
+    );
+    expect(results.some((r) => r.includes("rules"))).toBe(true);
+    expect(results.some((r) => r.includes("agents"))).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(homedirOverride, ".codex", "rules", "argent.md"),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          homedirOverride,
+          ".codex",
           "agents",
           "environment-inspector.md",
         ),

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -8,6 +8,8 @@ import {
   addClaudePermission,
   removeClaudePermission,
   copyRulesAndAgents,
+  injectCodexRules,
+  removeCodexRules,
   type McpConfigAdapter,
 } from "../../src/cli/mcp-configs.js";
 
@@ -644,8 +646,13 @@ describe("copyRulesAndAgents", () => {
     ).toBe(true);
   });
 
-  it("returns empty array for Codex adapter (no rules/agents dir support)", () => {
+  it("injects Codex rules into developer_instructions in config.toml (local)", () => {
     const codexAdapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
+    // Pre-create the config.toml so the adapter can find it
+    const configPath = path.join(tmpDir, ".codex", "config.toml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, "");
+
     const results = copyRulesAndAgents(
       [codexAdapter],
       tmpDir,
@@ -653,6 +660,98 @@ describe("copyRulesAndAgents", () => {
       rulesDir,
       agentsDir,
     );
-    expect(results).toHaveLength(0);
+    expect(results.some((r) => r.includes("developer_instructions"))).toBe(true);
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).toContain("argent rules");
+    expect(content).toContain("developer_instructions");
+  });
+});
+
+// ── Codex developer_instructions injection ──────────────────────────────────
+
+describe("injectCodexRules / removeCodexRules", () => {
+  let rulesDir: string;
+
+  beforeEach(() => {
+    rulesDir = path.join(tmpDir, "src-rules");
+    fs.mkdirSync(rulesDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(rulesDir, "argent.md"),
+      "---\ndescription: Test rule\nalwaysApply: true\n---\n\nUse argent tools for simulator control.",
+    );
+  });
+
+  it("injects rules content with frontmatter stripped", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    injectCodexRules(configPath, rulesDir);
+
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).toContain("Use argent tools for simulator control.");
+    expect(content).not.toContain("alwaysApply");
+    expect(content).toContain("argent rules");
+  });
+
+  it("preserves existing developer_instructions", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    fs.writeFileSync(configPath, 'developer_instructions = "Always use TypeScript."\n');
+
+    injectCodexRules(configPath, rulesDir);
+
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).toContain("Always use TypeScript.");
+    expect(content).toContain("Use argent tools for simulator control.");
+  });
+
+  it("replaces existing argent section on re-inject", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    injectCodexRules(configPath, rulesDir);
+
+    // Update rule content and re-inject
+    fs.writeFileSync(path.join(rulesDir, "argent.md"), "Updated rule content.");
+    injectCodexRules(configPath, rulesDir);
+
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).toContain("Updated rule content.");
+    expect(content).not.toContain("Use argent tools for simulator control.");
+    // Should only have one pair of markers
+    expect(content.split("argent rules").length - 1).toBe(2); // start + end
+  });
+
+  it("removeCodexRules strips argent section", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    fs.writeFileSync(configPath, 'developer_instructions = "Always use TypeScript."\n');
+    injectCodexRules(configPath, rulesDir);
+
+    const removed = removeCodexRules(configPath);
+    expect(removed).toBe(true);
+
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).toContain("Always use TypeScript.");
+    expect(content).not.toContain("argent rules");
+  });
+
+  it("removeCodexRules deletes field when only argent content remains", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    injectCodexRules(configPath, rulesDir);
+
+    removeCodexRules(configPath);
+
+    const content = fs.readFileSync(configPath, "utf8");
+    expect(content).not.toContain("developer_instructions");
+  });
+
+  it("removeCodexRules returns false when no argent section exists", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    fs.writeFileSync(configPath, 'model = "o3"\n');
+    expect(removeCodexRules(configPath)).toBe(false);
+  });
+
+  it("removeCodexRules returns false for non-existent file", () => {
+    expect(removeCodexRules(path.join(tmpDir, "nope.toml"))).toBe(false);
+  });
+
+  it("returns null when rulesDir does not exist", () => {
+    const configPath = path.join(tmpDir, "config.toml");
+    expect(injectCodexRules(configPath, path.join(tmpDir, "nonexistent"))).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Adds OpenAI Codex CLI as a supported editor in the MCP config adapter system.

Codex uses TOML-based config (`~/.codex/config.toml`) instead of JSON, so this adds `smol-toml` for parsing/serialization and `readToml`/`writeToml` helpers.

### Rules injection via `developer_instructions`

Unlike Claude Code or Gemini, Codex has no `rules/` directory for model instructions (`.codex/rules/` is for execpolicy — Starlark security rules). Instead, we inject argent's rule content into the `developer_instructions` field in `config.toml`. This is a string injected as a `developer`-role message in the OpenAI API, which is always loaded and cannot be overridden by project-level `AGENTS.md` files.

The injected content is wrapped in markers (`# --- argent rules ---` / `# --- end argent rules ---`) so it can be cleanly updated or removed without touching the user's own `developer_instructions`.

### Single source of truth

All editors consume the same rule file (`packages/skills/rules/argent.md`). For directory-based editors (Claude Code, Cursor, Gemini) the file is copied as-is. For Codex, the YAML frontmatter is stripped and the content is injected into `developer_instructions`. There is no duplication — one source file, multiple delivery mechanisms.

## Changes
- `packages/mcp/src/cli/utils.ts` — `readToml`/`writeToml` helpers using `smol-toml`
- `packages/mcp/src/cli/mcp-configs.ts` — `codexAdapter`, `injectCodexRules`/`removeCodexRules`, Codex handling in `copyRulesAndAgents`
- `packages/mcp/src/cli/uninstall.ts` — cleanup of argent rules from Codex `config.toml` during prune
- `packages/mcp/test/cli/mcp-configs.test.ts` — 62 tests total (8 adapter + 8 injection + copy tests)
- `packages/mcp/package.json` — `smol-toml` dependency

## Test plan
- [x] All 62 tests pass (`npx vitest run test/cli/mcp-configs.test.ts`)
- [x] TOML output verified against existing `~/.codex/config.toml` format
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] End-to-end: `argent init` detects Codex, writes config, rules injected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)