### PR TITLE
ci: add MCP tool and SKILL description quality checks

### DIFF
--- a/.github/workflows/description-quality.yml
+++ b/.github/workflows/description-quality.yml
@@ -1,0 +1,128 @@
+name: Description Quality
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/tool-server/src/tools/**'
+      - 'packages/skills/skills/**/SKILL.md'
+      - 'scripts/extract-tools.mjs'
+      - 'scripts/grade-skills.mjs'
+  pull_request:
+    paths:
+      - 'packages/tool-server/src/tools/**'
+      - 'packages/skills/skills/**/SKILL.md'
+      - 'scripts/extract-tools.mjs'
+      - 'scripts/grade-skills.mjs'
+
+jobs:
+  tool-descriptions:
+    name: Tool description quality (SpiderShield)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install SpiderShield
+        run: pip install spidershield==0.3.4
+
+      - name: Extract tool descriptions
+        run: node scripts/extract-tools.mjs > tools.json
+
+      - name: Run SpiderShield scan
+        run: spidershield scan packages/tool-server --tools-json tools.json --format json > spidershield-report.json
+
+      - name: Check description score (regression gate)
+        continue-on-error: false
+        run: |
+          python3 -c "
+          import json, sys
+
+          with open('spidershield-report.json') as f:
+              report = json.load(f)
+
+          description_score = report.get('description_score', 0)
+          tools = report.get('tools', [])
+
+          print()
+          print(f'  Description score: {description_score:.1f} / 10')
+          print(f'  Baseline:          3.3 / 10')
+          print()
+
+          # Per-tool table
+          col_name  = 36
+          col_score =  7
+          col_verb  = 17
+          col_trig  = 20
+
+          sep = (
+              '+' + '-' * (col_name  + 2) +
+              '+' + '-' * (col_score + 2) +
+              '+' + '-' * (col_verb  + 2) +
+              '+' + '-' * (col_trig  + 2) + '+'
+          )
+
+          def row(name, score, verb, trig):
+              return (
+                  '| ' + name[:col_name].ljust(col_name)   + ' '
+                  '| ' + str(score)[:col_score].rjust(col_score) + ' '
+                  '| ' + str(verb)[:col_verb].ljust(col_verb)   + ' '
+                  '| ' + str(trig)[:col_trig].ljust(col_trig)   + ' |'
+              )
+
+          print(sep)
+          print(row('Tool', 'Score', 'has_action_verb', 'has_scenario_trigger'))
+          print(sep)
+
+          for t in tools:
+              name  = t.get('tool_name', t.get('name', ''))
+              score = t.get('overall_score', t.get('score', 'n/a'))
+              verb  = t.get('has_action_verb', 'n/a')
+              trig  = t.get('has_scenario_trigger', 'n/a')
+              print(row(name, score, verb, trig))
+
+          print(sep)
+          print()
+
+          if description_score < 3.0:
+              print(f'ERROR: description_score {description_score:.1f} is below the regression threshold of 3.0')
+              print('       Baseline is 3.3 — a drop below 3.0 indicates a regression.')
+              sys.exit(1)
+          else:
+              print('OK: description score is at or above the regression threshold (3.0).')
+          "
+
+      - name: Upload SpiderShield report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: tool-description-report
+          path: spidershield-report.json
+
+  skill-descriptions:
+    name: Skill description quality (informational)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Grade skill descriptions
+        run: node scripts/grade-skills.mjs

--- a/.github/workflows/skill-description-quality.yml
+++ b/.github/workflows/skill-description-quality.yml
@@ -1,0 +1,30 @@
+name: Skill Description Quality
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/skills/skills/**/SKILL.md'
+      - 'scripts/grade-skills.mjs'
+  pull_request:
+    paths:
+      - 'packages/skills/skills/**/SKILL.md'
+      - 'scripts/grade-skills.mjs'
+
+jobs:
+  skill-descriptions:
+    name: Skill description quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Grade skill descriptions
+        run: node scripts/grade-skills.mjs

--- a/.github/workflows/tool-description-quality.yml
+++ b/.github/workflows/tool-description-quality.yml
@@ -1,4 +1,4 @@
-name: Description Quality
+name: Tool Description Quality
 
 on:
   push:
@@ -6,15 +6,11 @@ on:
       - main
     paths:
       - 'packages/tool-server/src/tools/**'
-      - 'packages/skills/skills/**/SKILL.md'
       - 'scripts/extract-tools.mjs'
-      - 'scripts/grade-skills.mjs'
   pull_request:
     paths:
       - 'packages/tool-server/src/tools/**'
-      - 'packages/skills/skills/**/SKILL.md'
       - 'scripts/extract-tools.mjs'
-      - 'scripts/grade-skills.mjs'
 
 jobs:
   tool-descriptions:
@@ -45,7 +41,6 @@ jobs:
         run: spidershield scan packages/tool-server --tools-json tools.json --format json > spidershield-report.json
 
       - name: Check description score (regression gate)
-        continue-on-error: false
         run: |
           python3 -c "
           import json, sys
@@ -54,14 +49,13 @@ jobs:
               report = json.load(f)
 
           description_score = report.get('description_score', 0)
-          tools = report.get('tools', [])
+          tools = report.get('tool_scores', [])
 
           print()
           print(f'  Description score: {description_score:.1f} / 10')
           print(f'  Baseline:          3.3 / 10')
           print()
 
-          # Per-tool table
           col_name  = 36
           col_score =  7
           col_verb  = 17
@@ -76,10 +70,10 @@ jobs:
 
           def row(name, score, verb, trig):
               return (
-                  '| ' + name[:col_name].ljust(col_name)   + ' '
+                  '| ' + name[:col_name].ljust(col_name)        + ' '
                   '| ' + str(score)[:col_score].rjust(col_score) + ' '
-                  '| ' + str(verb)[:col_verb].ljust(col_verb)   + ' '
-                  '| ' + str(trig)[:col_trig].ljust(col_trig)   + ' |'
+                  '| ' + str(verb)[:col_verb].ljust(col_verb)    + ' '
+                  '| ' + str(trig)[:col_trig].ljust(col_trig)    + ' |'
               )
 
           print(sep)
@@ -110,19 +104,3 @@ jobs:
         with:
           name: tool-description-report
           path: spidershield-report.json
-
-  skill-descriptions:
-    name: Skill description quality (informational)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Grade skill descriptions
-        run: node scripts/grade-skills.mjs

--- a/.github/workflows/tool-description-quality.yml
+++ b/.github/workflows/tool-description-quality.yml
@@ -53,7 +53,6 @@ jobs:
 
           print()
           print(f'  Description score: {description_score:.1f} / 10')
-          print(f'  Baseline:          3.3 / 10')
           print()
 
           col_name  = 36
@@ -90,12 +89,11 @@ jobs:
           print(sep)
           print()
 
-          if description_score < 3.0:
-              print(f'ERROR: description_score {description_score:.1f} is below the regression threshold of 3.0')
-              print('       Baseline is 3.3 — a drop below 3.0 indicates a regression.')
+          if description_score < 10.0:
+              print(f'ERROR: description_score {description_score:.1f} is below the required threshold of 10.0')
               sys.exit(1)
           else:
-              print('OK: description score is at or above the regression threshold (3.0).')
+              print('OK: description score is 10.0 / 10.')
           "
 
       - name: Upload SpiderShield report

--- a/packages/skills/skills/argent-react-native-profiler/SKILL.md
+++ b/packages/skills/skills/argent-react-native-profiler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: argent-react-native-profiler
-description: Profile a React Native Hermes app to measure re-render and CPU performance using argent profiler tools. Use during optimization to measure before/after, spot slow components, diagnose re-renders, check CPU hotspots, or produce a ranked issue report.
+description: Profile a React Native Hermes app to measure re-render and CPU performance using argent profiler tools. Use when optimizing for performance, measuring before/after a fix, spotting slow components, diagnosing re-renders, checking CPU hotspots, or producing a ranked issue report.
 ---
 
 This skill is complementary to `argent-react-native-optimization`, not a replacement for it.

--- a/scripts/extract-tools.mjs
+++ b/scripts/extract-tools.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Extracts tool id + description from all ToolDefinition objects in
+ * packages/tool-server/src/tools/**\/*.ts and outputs MCP tools/list JSON
+ * suitable for `spidershield scan . --tools-json <file>`.
+ *
+ * Usage:
+ *   node scripts/extract-tools.mjs > tools.json
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dir = dirname(__filename);
+const toolsRoot = join(__dir, "..", "packages", "tool-server", "src", "tools");
+
+function walk(dir) {
+  const entries = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      entries.push(...walk(full));
+    } else if (extname(name) === ".ts" && !name.endsWith(".d.ts")) {
+      entries.push(full);
+    }
+  }
+  return entries;
+}
+
+function extractFromFile(filePath) {
+  const src = readFileSync(filePath, "utf8");
+  const tools = [];
+
+  // Match: id: "...", followed anywhere by description: `...` or "..."
+  // We iterate over all id: occurrences in the file.
+  const idPattern = /\bid:\s*["']([^"']+)["']/g;
+  let idMatch;
+  while ((idMatch = idPattern.exec(src)) !== null) {
+    const id = idMatch[1];
+    const afterId = src.slice(idMatch.index);
+
+    // Look for description within the next 2000 chars (handles multi-line)
+    const descWindow = afterId.slice(0, 2000);
+
+    // Template literal description
+    let descMatch = descWindow.match(/\bdescription:\s*`([\s\S]*?)`/);
+    if (!descMatch) {
+      // Double-quoted description
+      descMatch = descWindow.match(/\bdescription:\s*"((?:[^"\\]|\\.)*)"/);
+    }
+    if (!descMatch) {
+      // Single-quoted description
+      descMatch = descWindow.match(/\bdescription:\s*'((?:[^'\\]|\\.)*)'/);
+    }
+
+    if (descMatch) {
+      tools.push({
+        name: id,
+        description: descMatch[1].trim(),
+      });
+    }
+  }
+
+  return tools;
+}
+
+const files = walk(toolsRoot);
+const tools = [];
+for (const f of files) {
+  tools.push(...extractFromFile(f));
+}
+
+// Deduplicate by name (take first occurrence)
+const seen = new Set();
+const unique = tools.filter((t) => {
+  if (seen.has(t.name)) return false;
+  seen.add(t.name);
+  return true;
+});
+
+// MCP tools/list format
+console.log(JSON.stringify({ tools: unique }, null, 2));

--- a/scripts/grade-skills.mjs
+++ b/scripts/grade-skills.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * Grades all packages/skills/skills/*\/SKILL.md files on description quality.
+ *
+ * Criteria (each 0 or 1, normalized to 0–10):
+ *   1. Has `description` in frontmatter
+ *   2. Description contains "Use when" trigger (case-insensitive)
+ *   3. Description starts with capital letter + verb OR describes a workflow
+ *   4. Content body has at least 2 ## headings
+ *   5. Content body has numbered steps (1., 2., …) or bullet lists (- / *)
+ *   6. Content length > 300 characters
+ *   7. Description length > 50 characters
+ *
+ * Usage:
+ *   node scripts/grade-skills.mjs
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dir = dirname(__filename);
+const skillsRoot = join(__dir, "..", "packages", "skills", "skills");
+
+// ─── YAML frontmatter parser (no deps) ────────────────────────────────────────
+
+function parseFrontmatter(src) {
+  const match = src.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return { frontmatter: {}, body: src };
+
+  const rawFm = match[1];
+  const body = src.slice(match[0].length).trimStart();
+
+  const frontmatter = {};
+  // Simple key: value parser; handles multi-line values indented with spaces
+  const lines = rawFm.split(/\r?\n/);
+  let currentKey = null;
+  let currentVal = [];
+
+  function flush() {
+    if (currentKey !== null) {
+      frontmatter[currentKey] = currentVal.join(" ").trim();
+    }
+  }
+
+  for (const line of lines) {
+    const kvMatch = line.match(/^(\w[\w-]*):\s*(.*)/);
+    if (kvMatch) {
+      flush();
+      currentKey = kvMatch[1];
+      currentVal = [kvMatch[2]];
+    } else if (currentKey && /^\s+/.test(line)) {
+      currentVal.push(line.trim());
+    } else {
+      flush();
+      currentKey = null;
+      currentVal = [];
+    }
+  }
+  flush();
+
+  return { frontmatter, body };
+}
+
+// ─── Scoring ──────────────────────────────────────────────────────────────────
+
+const CRITERIA = [
+  {
+    id: "has_description",
+    label: "Has description",
+    check: ({ description }) => Boolean(description && description.length > 0),
+  },
+  {
+    id: "use_when_trigger",
+    label: '"Use when" trigger',
+    check: ({ description }) =>
+      Boolean(description && /use when/i.test(description)),
+  },
+  {
+    id: "capital_verb",
+    label: "Starts with capital + verb / workflow",
+    check: ({ description }) => {
+      if (!description) return false;
+      // Starts with a capital letter followed by a word (verb-like) or "workflow"
+      return /^[A-Z][a-z]/.test(description) || /workflow/i.test(description);
+    },
+  },
+  {
+    id: "two_headings",
+    label: "≥2 ## headings in body",
+    check: ({ body }) => {
+      const matches = body.match(/^##\s+/gm);
+      return Boolean(matches && matches.length >= 2);
+    },
+  },
+  {
+    id: "has_steps_or_bullets",
+    label: "Has numbered steps or bullets",
+    check: ({ body }) =>
+      /^\s*\d+\.\s+/m.test(body) || /^\s*[-*]\s+/m.test(body),
+  },
+  {
+    id: "body_length",
+    label: "Body > 300 chars",
+    check: ({ body }) => body.length > 300,
+  },
+  {
+    id: "desc_length",
+    label: "Description > 50 chars",
+    check: ({ description }) => Boolean(description && description.length > 50),
+  },
+];
+
+const MAX_SCORE = CRITERIA.length; // 7
+
+function grade(skillPath) {
+  const src = readFileSync(skillPath, "utf8");
+  const { frontmatter, body } = parseFrontmatter(src);
+  const description = frontmatter.description || "";
+
+  const ctx = { description, body, frontmatter };
+  const results = CRITERIA.map((c) => ({ ...c, pass: c.check(ctx) }));
+  const raw = results.filter((r) => r.pass).length;
+  const score = ((raw / MAX_SCORE) * 10).toFixed(1);
+
+  return { description, body, results, raw, score };
+}
+
+// ─── Table rendering ──────────────────────────────────────────────────────────
+
+function pad(str, width, align = "left") {
+  const s = String(str);
+  if (s.length >= width) return s.slice(0, width);
+  const spaces = " ".repeat(width - s.length);
+  return align === "right" ? spaces + s : s + spaces;
+}
+
+function renderTable(rows, columns) {
+  // columns: [{ key, label, width, align }]
+  const widths = columns.map((c) => c.width);
+
+  const top = "┌" + widths.map((w) => "─".repeat(w + 2)).join("┬") + "┐";
+  const mid = "├" + widths.map((w) => "─".repeat(w + 2)).join("┼") + "┤";
+  const bot = "└" + widths.map((w) => "─".repeat(w + 2)).join("┴") + "┘";
+
+  const header =
+    "│" +
+    columns.map((c) => " " + pad(c.label, c.width, c.align) + " ").join("│") +
+    "│";
+
+  const body = rows.map((row) => {
+    return (
+      "│" +
+      columns
+        .map((c) => " " + pad(row[c.key] ?? "", c.width, c.align) + " ")
+        .join("│") +
+      "│"
+    );
+  });
+
+  return [top, header, mid, ...body, bot].join("\n");
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+const skillDirs = readdirSync(skillsRoot).filter((name) => {
+  const full = join(skillsRoot, name);
+  return statSync(full).isDirectory();
+});
+
+const allResults = [];
+
+for (const dir of skillDirs.sort()) {
+  const skillPath = join(skillsRoot, dir, "SKILL.md");
+  try {
+    const result = grade(skillPath);
+    allResults.push({ name: dir, ...result });
+  } catch (err) {
+    console.error(`  Error reading ${dir}: ${err.message}`);
+  }
+}
+
+// ─── Per-skill table ──────────────────────────────────────────────────────────
+
+const criteriaColumns = [
+  { key: "name", label: "Skill", width: 38, align: "left" },
+  { key: "score", label: "Score", width: 5, align: "right" },
+  ...CRITERIA.map((c) => ({
+    key: c.id,
+    label: c.label.slice(0, 22),
+    width: Math.max(c.label.length, 4),
+    align: "left",
+  })),
+];
+
+const tableRows = allResults.map((r) => {
+  const row = { name: r.name, score: r.score };
+  for (const cr of r.results) {
+    row[cr.id] = cr.pass ? "✓" : "✗";
+  }
+  return row;
+});
+
+console.log("\n Skill Description Quality Report\n");
+console.log(renderTable(tableRows, criteriaColumns));
+
+// ─── Average ──────────────────────────────────────────────────────────────────
+
+const avg =
+  allResults.reduce((sum, r) => sum + parseFloat(r.score), 0) /
+  allResults.length;
+
+console.log(`\n Average score: ${avg.toFixed(1)} / 10  (${allResults.length} skills)\n`);
+
+// ─── Per-criterion summary ────────────────────────────────────────────────────
+
+const summaryRows = CRITERIA.map((c) => {
+  const passing = allResults.filter((r) =>
+    r.results.find((cr) => cr.id === c.id && cr.pass)
+  ).length;
+  return {
+    criterion: c.label,
+    passing: `${passing} / ${allResults.length}`,
+    pct: ((passing / allResults.length) * 100).toFixed(0) + "%",
+  };
+});
+
+const summaryColumns = [
+  { key: "criterion", label: "Criterion", width: 36, align: "left" },
+  { key: "passing", label: "Passing", width: 9, align: "right" },
+  { key: "pct", label: "%", width: 5, align: "right" },
+];
+
+console.log(" Criterion breakdown:\n");
+console.log(renderTable(summaryRows, summaryColumns));
+console.log();
+
+// Always exit 0 — informational only
+process.exit(0);

--- a/scripts/grade-skills.mjs
+++ b/scripts/grade-skills.mjs
@@ -236,5 +236,13 @@ console.log(" Criterion breakdown:\n");
 console.log(renderTable(summaryRows, summaryColumns));
 console.log();
 
-// Always exit 0 — informational only
+// Fail if any skill scores below 10.0
+const failing = allResults.filter((r) => parseFloat(r.score) < 10.0);
+if (failing.length > 0) {
+  console.error(
+    ` ✗ ${failing.length} skill(s) scored below 10.0: ${failing.map((r) => r.name).join(", ")}`
+  );
+  process.exit(1);
+}
+console.log(" ✓ All skills scored 10.0 / 10\n");
 process.exit(0);


### PR DESCRIPTION
Adds two focused CI workflows that gate on description quality — one for MCP tool definitions, one for SKILL.md files.

## `.github/workflows/tool-description-quality.yml`

Triggers on changes to `packages/tool-server/src/tools/**` or `scripts/extract-tools.mjs`.

- Runs `scripts/extract-tools.mjs` to extract all tool `id` + `description` pairs from TypeScript source into `--tools-json` format (SpiderShield's static regex scanner does not support Argent's `ToolDefinition` wrapper pattern)
- Feeds the JSON to `spidershield scan --tools-json` for description quality scoring
- Fails if `description_score < 10.0`
- Uploads `spidershield-report.json` as a build artifact

## `.github/workflows/skill-description-quality.yml`

Triggers on changes to `packages/skills/skills/**/SKILL.md` or `scripts/grade-skills.mjs`.

- Runs `scripts/grade-skills.mjs`, a self-contained Node.js grader (no deps) that parses SKILL.md frontmatter and scores each file against 7 criteria: has `description`, "Use when" trigger, capital+verb start, ≥2 `##` headings, numbered steps/bullets, body >300 chars, description >50 chars
- Fails if any skill scores below 10.0

## `scripts/extract-tools.mjs`

Walks `packages/tool-server/src/tools/**/*.ts`, extracts `id` + `description` from every `ToolDefinition` object via regex, deduplicates, and outputs `{ tools: [...] }` JSON.

## `scripts/grade-skills.mjs`

Reads all `packages/skills/skills/*/SKILL.md`, parses YAML frontmatter, scores against the 7 criteria above, prints a unicode table, and exits 1 if any skill scores below 10.0.