### PR TITLE
fix: rename skills install option to 'Automatic'

### DIFF
--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -363,7 +363,7 @@ export async function init(args: string[]): Promise<void> {
       options: [
         {
           value: "default" as const,
-          label: "Default (recommended)",
+          label: "Automatic",
           hint: "Installs all skills automatically with npx skills",
         },
         {


### PR DESCRIPTION
## Summary
- Renames the first skills config selection option from `Default (recommended)` to `Automatic` in the `argent init` flow
- The value (`"default"`) and behavior are unchanged; only the display label is updated