### PR TITLE
feat(tool-server): npm update checker (ARG-79)

### DIFF
--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -2,6 +2,7 @@ import { attachRegistryLogger } from "@argent/registry";
 import { createHttpApp } from "./http";
 import { createRegistry } from "./utils/setup-registry";
 import { DEFAULT_IDLE_TIMEOUT_MINUTES } from "./utils/idle-timer";
+import { startUpdateChecker } from "./utils/update-checker";
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -16,10 +17,12 @@ const idleTimeoutMs = idleMinutes > 0 ? idleMinutes * 60_000 : 0;
 
 const registry = createRegistry();
 attachRegistryLogger(registry);
+const updateChecker = startUpdateChecker();
 
 // `shutdown` captures `httpHandle` and `server` by closure; safe because it is
 // only invoked asynchronously after both are initialized.
 const shutdown = async () => {
+  updateChecker.dispose();
   httpHandle.dispose();
   await registry.dispose();
   server.close();

--- a/packages/tool-server/src/utils/update-checker.ts
+++ b/packages/tool-server/src/utils/update-checker.ts
@@ -1,0 +1,107 @@
+import https from "node:https";
+import { version as currentVersion } from "../../package.json";
+
+const PACKAGE_NAME = "@argent/tool-server";
+const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export interface UpdateState {
+  /** Whether a newer version is available on npm. */
+  updateAvailable: boolean;
+  /** The latest version on npm, or `null` if not yet checked / check failed. */
+  latestVersion: string | null;
+  /** The currently running version. */
+  currentVersion: string;
+}
+
+let state: UpdateState = {
+  updateAvailable: false,
+  latestVersion: null,
+  currentVersion,
+};
+
+let interval: ReturnType<typeof setInterval> | null = null;
+
+/** Returns the current update state (read-only snapshot). */
+export function getUpdateState(): Readonly<UpdateState> {
+  return { ...state };
+}
+
+/**
+ * Fetches the latest version of the package from the npm registry.
+ * Returns `null` on any failure — update checks must never crash the server.
+ */
+async function fetchLatestVersion(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const url = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+
+    const req = https.get(url, { timeout: REQUEST_TIMEOUT_MS }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        resolve(null);
+        return;
+      }
+
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        try {
+          const json = JSON.parse(body) as { version?: string };
+          resolve(json.version ?? null);
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(null);
+    });
+  });
+}
+
+/** Run a single check and update the runtime state. */
+async function check(): Promise<void> {
+  const latest = await fetchLatestVersion();
+  if (latest === null) return; // network issue — keep previous state
+
+  state = {
+    updateAvailable: latest !== currentVersion,
+    latestVersion: latest,
+    currentVersion,
+  };
+
+  if (state.updateAvailable) {
+    process.stderr.write(
+      `[argent] Update available: ${currentVersion} -> ${latest}\n`,
+    );
+  }
+}
+
+/**
+ * Start the update checker: runs an immediate check, then rechecks every hour.
+ * Safe to call once at startup. Returns a dispose function to clear the timer.
+ */
+export function startUpdateChecker(): { dispose(): void } {
+  // Fire-and-forget initial check — don't block startup.
+  check();
+
+  interval = setInterval(() => {
+    check();
+  }, CHECK_INTERVAL_MS);
+  interval.unref(); // don't keep the process alive for update checks
+
+  return {
+    dispose() {
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    },
+  };
+}

--- a/packages/tool-server/test/update-checker.test.ts
+++ b/packages/tool-server/test/update-checker.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import https from "node:https";
+import { EventEmitter } from "node:events";
+
+// We need to mock https before importing the module under test.
+vi.mock("node:https");
+
+let getUpdateState: typeof import("../src/utils/update-checker").getUpdateState;
+let startUpdateChecker: typeof import("../src/utils/update-checker").startUpdateChecker;
+
+function createMockResponse(statusCode: number, body: string) {
+  const res = new EventEmitter() as EventEmitter & {
+    statusCode: number;
+    setEncoding: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+  };
+  res.statusCode = statusCode;
+  res.setEncoding = vi.fn();
+  res.resume = vi.fn();
+
+  // Emit data + end on next tick so the handler can attach listeners first.
+  process.nextTick(() => {
+    res.emit("data", body);
+    res.emit("end");
+  });
+
+  return res;
+}
+
+describe("update-checker", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    // Re-import after module reset so each test gets fresh state.
+    const mod = await import("../src/utils/update-checker");
+    getUpdateState = mod.getUpdateState;
+    startUpdateChecker = mod.startUpdateChecker;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("detects an available update on startup", async () => {
+    const mockGet = vi.mocked(https.get);
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      callback(createMockResponse(200, JSON.stringify({ version: "99.0.0" })));
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle = startUpdateChecker();
+
+    // Let the fire-and-forget promise resolve.
+    await vi.advanceTimersByTimeAsync(0);
+
+    const state = getUpdateState();
+    expect(state.updateAvailable).toBe(true);
+    expect(state.latestVersion).toBe("99.0.0");
+
+    handle.dispose();
+  });
+
+  it("reports no update when versions match", async () => {
+    const { version: currentVersion } = await import("../../package.json");
+
+    const mockGet = vi.mocked(https.get);
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      callback(
+        createMockResponse(200, JSON.stringify({ version: currentVersion })),
+      );
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const state = getUpdateState();
+    expect(state.updateAvailable).toBe(false);
+    expect(state.latestVersion).toBe(currentVersion);
+
+    handle.dispose();
+  });
+
+  it("keeps previous state on network failure", async () => {
+    const mockGet = vi.mocked(https.get);
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, _cb: unknown) => {
+      const req = new EventEmitter() as ReturnType<typeof https.get>;
+      process.nextTick(() => req.emit("error", new Error("ENOTFOUND")));
+      return req;
+    });
+
+    const handle = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const state = getUpdateState();
+    expect(state.updateAvailable).toBe(false);
+    expect(state.latestVersion).toBeNull();
+
+    handle.dispose();
+  });
+
+  it("rechecks after the interval", async () => {
+    const mockGet = vi.mocked(https.get);
+    let callCount = 0;
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      callCount++;
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      callback(createMockResponse(200, JSON.stringify({ version: "99.0.0" })));
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(1);
+
+    // Advance 1 hour — should trigger another check.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(callCount).toBe(2);
+
+    handle.dispose();
+  });
+
+  it("stops checking after dispose", async () => {
+    const mockGet = vi.mocked(https.get);
+    let callCount = 0;
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      callCount++;
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      callback(createMockResponse(200, JSON.stringify({ version: "99.0.0" })));
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(1);
+
+    handle.dispose();
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(callCount).toBe(1); // No additional calls after dispose.
+  });
+
+  it("handles non-200 responses gracefully", async () => {
+    const mockGet = vi.mocked(https.get);
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      const res = createMockResponse(404, "Not Found");
+      callback(res);
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const state = getUpdateState();
+    expect(state.updateAvailable).toBe(false);
+    expect(state.latestVersion).toBeNull();
+
+    handle.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a background npm update checker
- On startup: queries the npm registry for the latest version of `@swmansion/argent`
- Every hour: re-checks for updates
- Stores the result in a runtime flag (`updateAvailable`, `latestVersion`) via `getUpdateState()`
- Silently fails on network errors — never crashes the server

## Scope
For now the changes **only the update-checking logic**. No user-facing behavior is wired up yet.

## Test plan
- [x] Unit tests cover: update detected, no update, network failure, periodic recheck, dispose cleanup, non-200 responses
- [x] All 6 tests pass
- [x] `getUpdateState()` returns correct values verified via mocked unit tests

Closes ARG-79