### PR TITLE
feat: add dev mode script for local development without packing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "tsc --build",
     "start": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "start:tool-server": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
-    "pack:mcp": "npm run build -w @software-mansion/argent && npm pack -w @software-mansion/argent --pack-destination ."
+    "pack:mcp": "npm run build -w @software-mansion/argent && npm pack -w @software-mansion/argent --pack-destination .",
+    "dev": "node scripts/dev.cjs"
   }
 }

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// @ts-check
+"use strict";
+
+/**
+ * Full dev mode — no packing, no global install needed.
+ *
+ * What it does:
+ *   1. Builds MCP TypeScript (tsc only, no esbuild tool-server bundle)
+ *   2. Sets up packages/mcp/bin/ and packages/mcp/dist/ for local use
+ *   3. Patches ~/.claude.json to point the argent MCP at the local dist
+ *   4. Starts the tool-server from source via ts-node (no build needed)
+ *   5. Writes ~/.argent/tool-server.json so the local MCP picks it up
+ *   6. On exit: restores ~/.claude.json and stops the tool-server
+ *
+ * Usage:
+ *   npm run dev
+ *   PORT=4000 npm run dev
+ */
+
+const { execSync, spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const ROOT = path.resolve(__dirname, "..");
+const MCP_PKG = path.join(ROOT, "packages", "mcp");
+const TOOL_SERVER_PKG = path.join(ROOT, "packages", "tool-server");
+const STATE_DIR = path.join(os.homedir(), ".argent");
+const STATE_FILE = path.join(STATE_DIR, "tool-server.json");
+const CLAUDE_JSON = path.join(os.homedir(), ".claude.json");
+const PORT = parseInt(process.env.PORT ?? "3001", 10);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function readJson(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJson(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
+}
+
+function isProcessAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+async function waitForHttp(url, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(1000) });
+      if (res.ok) return true;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  return false;
+}
+
+// ── Step 1: Build MCP TypeScript ──────────────────────────────────────────────
+
+console.log("Building MCP TypeScript...");
+execSync("npm run build:mcp -w @software-mansion/argent", {
+  cwd: ROOT,
+  stdio: "inherit",
+});
+console.log("✓ MCP TypeScript built\n");
+
+// ── Step 2: Set up packages/mcp/bin/ and skills/rules/agents ─────────────────
+
+const BIN_DIR = path.join(MCP_PKG, "bin");
+const BIN_SRC = path.join(ROOT, "simulator-server");
+const BIN_DEST = path.join(BIN_DIR, "simulator-server");
+fs.mkdirSync(BIN_DIR, { recursive: true });
+if (fs.existsSync(BIN_SRC)) {
+  fs.copyFileSync(BIN_SRC, BIN_DEST);
+  fs.chmodSync(BIN_DEST, 0o755);
+  console.log("✓ Copied simulator-server binary");
+} else {
+  console.warn("⚠ simulator-server binary not found — gestures won't work");
+}
+
+for (const [srcName, destName] of [
+  ["skills/skills", "skills"],
+  ["skills/rules", "rules"],
+  ["skills/agents", "agents"],
+]) {
+  const src = path.join(ROOT, "packages", srcName);
+  const dest = path.join(MCP_PKG, destName);
+  if (fs.existsSync(src)) {
+    fs.rmSync(dest, { recursive: true, force: true });
+    fs.cpSync(src, dest, { recursive: true });
+  }
+}
+console.log("✓ Copied skills/rules/agents");
+
+// Stub tool-server.cjs — the launcher won't use it as long as the dev server
+// is registered in the state file, but it needs to exist to avoid a crash.
+const STUB = path.join(MCP_PKG, "dist", "tool-server.cjs");
+if (!fs.existsSync(STUB)) {
+  fs.mkdirSync(path.dirname(STUB), { recursive: true });
+  fs.writeFileSync(
+    STUB,
+    "throw new Error('dev mode: tool-server stub — start npm run dev first');\n"
+  );
+}
+
+// ── Step 3: Patch ~/.claude.json to use local MCP dist ───────────────────────
+
+const LOCAL_MCP_ENTRY = path.join(MCP_PKG, "dist", "cli.js");
+const LOG_FILE = path.join(STATE_DIR, "mcp-calls.log");
+
+const claudeConfig = readJson(CLAUDE_JSON);
+const originalArgentEntry = claudeConfig?.mcpServers?.argent ?? null;
+
+const devMcpEntry = {
+  type: "stdio",
+  command: "node",
+  args: [LOCAL_MCP_ENTRY, "mcp"],
+  env: { ARGENT_MCP_LOG: LOG_FILE },
+};
+
+if (!claudeConfig.mcpServers) claudeConfig.mcpServers = {};
+claudeConfig.mcpServers.argent = devMcpEntry;
+writeJson(CLAUDE_JSON, claudeConfig);
+console.log(`✓ Patched ~/.claude.json → node ${LOCAL_MCP_ENTRY} mcp\n`);
+
+// ── Cleanup on exit ───────────────────────────────────────────────────────────
+
+let toolServerPid = null;
+
+function cleanup() {
+  console.log("\nCleaning up...");
+
+  // Stop tool-server
+  if (toolServerPid && isProcessAlive(toolServerPid)) {
+    process.kill(toolServerPid, "SIGTERM");
+  }
+  try { fs.unlinkSync(STATE_FILE); } catch {}
+
+  // Restore ~/.claude.json
+  const config = readJson(CLAUDE_JSON);
+  if (config.mcpServers) {
+    if (originalArgentEntry) {
+      config.mcpServers.argent = originalArgentEntry;
+    } else {
+      delete config.mcpServers.argent;
+    }
+  }
+  writeJson(CLAUDE_JSON, config);
+  console.log("✓ Restored ~/.claude.json");
+  console.log("Done.");
+}
+
+process.on("SIGINT", () => { cleanup(); process.exit(0); });
+process.on("SIGTERM", () => { cleanup(); process.exit(0); });
+process.on("exit", cleanup);
+
+async function main() {
+  // ── Step 4: Kill any existing registered tool-server ───────────────────────
+
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  const existingState = readJson(STATE_FILE);
+  if (existingState.pid && isProcessAlive(existingState.pid)) {
+    console.log(`Stopping existing tool-server (PID ${existingState.pid})...`);
+    process.kill(existingState.pid, "SIGTERM");
+    await new Promise((r) => setTimeout(r, 600));
+  }
+  try { fs.unlinkSync(STATE_FILE); } catch {}
+
+  // ── Step 5: Start tool-server from source ──────────────────────────────────
+
+  console.log(`Starting dev tool-server on port ${PORT}...`);
+
+  const toolServer = spawn(
+    "npx",
+    ["ts-node", "src/index.ts"],
+    {
+      cwd: TOOL_SERVER_PKG,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, PORT: String(PORT) },
+    }
+  );
+
+  toolServerPid = toolServer.pid;
+
+  const logStream = fs.createWriteStream(
+    path.join(STATE_DIR, "tool-server.log"),
+    { flags: "a" }
+  );
+  toolServer.stdout.pipe(logStream);
+  toolServer.stderr.pipe(logStream);
+
+  toolServer.on("exit", (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(`\nTool-server exited with code ${code}. Check ~/.argent/tool-server.log`);
+    }
+  });
+
+  // ── Step 6: Wait for tool-server to be ready ───────────────────────────────
+
+  process.stdout.write("Waiting for tool-server");
+  const ready = await waitForHttp(`http://127.0.0.1:${PORT}/tools`);
+  if (!ready) {
+    console.error("\nTool-server failed to start. Check ~/.argent/tool-server.log");
+    cleanup();
+    process.exit(1);
+  }
+  console.log(" ready.");
+
+  // ── Step 7: Write state file ────────────────────────────────────────────────
+
+  writeJson(STATE_FILE, {
+    port: PORT,
+    pid: toolServerPid,
+    startedAt: new Date().toISOString(),
+    bundlePath: "dev",
+  });
+
+  // ── Done ────────────────────────────────────────────────────────────────────
+
+  console.log(`
+✓ Dev environment ready
+  Tool-server: http://127.0.0.1:${PORT}/tools
+  MCP:         ${LOCAL_MCP_ENTRY}
+  Logs:        ~/.argent/tool-server.log
+
+  Start a new Claude Code session to pick up the local MCP.
+
+  After tool-server code changes → Ctrl+C and re-run npm run dev
+  After MCP code changes         → re-run npm run dev (rebuilds MCP automatically)
+
+Press Ctrl+C to stop and restore global argent.
+`);
+
+  // Keep alive until tool-server exits or Ctrl+C
+  await new Promise((resolve) => {
+    toolServer.on("exit", resolve);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  cleanup();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `npm run dev` — a single command that sets up a full local dev environment without needing `npm run pack:mcp` or any global install
- Patches `~/.claude.json` to point the argent MCP at the local `dist/cli.js` for the session, restoring it on exit
- Starts the tool-server from source via `ts-node` and registers it in `~/.argent/tool-server.json` so the local MCP picks it up via the existing launcher health-check logic

## How it works

1. Builds MCP TypeScript (`tsc` only — skips the slow esbuild tool-server bundle)
2. Copies `simulator-server` binary and `skills/rules/agents` into `packages/mcp/`
3. Writes a stub `dist/tool-server.cjs` (never used while dev server is running)
4. Patches `~/.claude.json` → `node packages/mcp/dist/cli.js mcp`
5. Starts tool-server from source via `ts-node`, writes `~/.argent/tool-server.json`
6. On `Ctrl+C`: stops tool-server, removes state file, restores `~/.claude.json`

## Iteration speed

| What changed | What to do |
|---|---|
| Tool-server code (blueprints, tools) | `Ctrl+C` → `npm run dev` |
| MCP code (mcp-server, launcher) | `Ctrl+C` → `npm run dev` (rebuilds MCP automatically) |

Start a new Claude Code session after running `npm run dev` to pick up the local MCP.
