### PR TITLE
fix: write profiler output to /tmp instead of project root

### DIFF
--- a/packages/skills/skills/argent-ios-profiler/SKILL.md
+++ b/packages/skills/skills/argent-ios-profiler/SKILL.md
@@ -48,7 +48,7 @@ You do not need to derive `app_process` manually — just make sure the app is l
 
 ### Step 1: Start recording
 
-Call `ios-profiler-start` with `device_id` (simulator UDID) and `project_root` (absolute path to the user's project root). The tool auto-detects the running app and saves the trace to `<project_root>/argent-profiler-cwd/` with a timestamped filename.
+Call `ios-profiler-start` with `device_id` (simulator UDID) and `project_root` (absolute path to the user's project root). The tool auto-detects the running app and saves the trace to `/tmp/argent-profiler-cwd/` with a timestamped filename.
 Let the user interact with the app or drive interaction via simulator tools (see `argent-simulator-interact` skill).
 
 ### Step 2: Stop and export

--- a/packages/skills/skills/argent-ios-profiler/SKILL.md
+++ b/packages/skills/skills/argent-ios-profiler/SKILL.md
@@ -48,7 +48,7 @@ You do not need to derive `app_process` manually — just make sure the app is l
 
 ### Step 1: Start recording
 
-Call `ios-profiler-start` with `device_id` (simulator UDID) and `project_root` (absolute path to the user's project root). The tool auto-detects the running app and saves the trace to `/tmp/argent-profiler-cwd/` with a timestamped filename.
+Call `ios-profiler-start` with `device_id` (simulator UDID). The tool auto-detects the running app and saves the trace to `/tmp/argent-profiler-cwd/` with a timestamped filename.
 Let the user interact with the app or drive interaction via simulator tools (see `argent-simulator-interact` skill).
 
 ### Step 2: Stop and export

--- a/packages/skills/skills/argent-ios-profiler/SKILL.md
+++ b/packages/skills/skills/argent-ios-profiler/SKILL.md
@@ -71,7 +71,7 @@ Use `profiler-stack-query` to investigate specific findings. See §3 Investigati
 
 To revisit a previous trace:
 
-1. Call `profiler-load` mode=`list` project_root=`<path>` to see available sessions.
+1. Call `profiler-load` mode=`list` to see available sessions.
 2. Call `profiler-load` mode=`load_instruments` session_id=`<timestamp>` device_id=`<UDID>` to re-parse the XML files.
 3. Use `profiler-stack-query` to investigate the reloaded data.
 

--- a/packages/skills/skills/argent-react-native-profiler/references/diagnostic-tools.md
+++ b/packages/skills/skills/argent-react-native-profiler/references/diagnostic-tools.md
@@ -82,12 +82,12 @@ Call `profiler-combined-report` when both React Profiler and iOS Instruments ran
 ## Session reload
 
 ```json
-{ "project_root": "/path/to/app", "mode": "list" }
+{ "mode": "list" }
 ```
 
 Call `profiler-load`. Modes:
 
-- `list` — show all saved profiling sessions (React + iOS) in the project's debug directory.
+- `list` — show all saved profiling sessions (React + iOS) in `/tmp/argent-profiler-cwd/`.
 - `load_react` — reload a React profiler session by `session_id`. Populates the in-memory cache for `profiler-cpu-query` and `profiler-commit-query`.
 - `load_instruments` — re-parse iOS Instruments XML by `session_id` and `device_id`. Populates session for `profiler-stack-query`.
 

--- a/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts
@@ -12,11 +12,6 @@ const DEFAULT_TEMPLATE_PATH = path.resolve(__dirname, "Argent.tracetemplate");
 
 const zodSchema = z.object({
   device_id: z.string().describe("iOS Simulator or device UDID"),
-  project_root: z
-    .string()
-    .describe(
-      "Absolute path to the user's project root directory. Output files will be saved to /tmp/argent-profiler-cwd/.",
-    ),
   app_process: z
     .string()
     .optional()
@@ -123,7 +118,7 @@ After starting, let the user interact with the app, then call ios-profiler-stop.
     const templatePath = params.template_path ?? DEFAULT_TEMPLATE_PATH;
     const appProcess = params.app_process ?? detectRunningApp(params.device_id);
 
-    const debugDir = await getDebugDir(params.project_root);
+    const debugDir = await getDebugDir();
     const timestamp = new Date()
       .toISOString()
       .replace(/[-:T]/g, (m) => (m === "T" ? "-" : ""))

--- a/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts
@@ -15,7 +15,7 @@ const zodSchema = z.object({
   project_root: z
     .string()
     .describe(
-      "Absolute path to the user's project root directory. Output files will be saved to <project_root>/argent-profiler-cwd/.",
+      "Absolute path to the user's project root directory. Output files will be saved to /tmp/argent-profiler-cwd/.",
     ),
   app_process: z
     .string()

--- a/packages/tool-server/src/tools/profiler/query/profiler-load.ts
+++ b/packages/tool-server/src/tools/profiler/query/profiler-load.ts
@@ -15,11 +15,6 @@ import { runIosProfilerPipeline } from "../../../utils/ios-profiler/pipeline/ind
 import { getDebugDir } from "../../../utils/react-profiler/debug/dump";
 
 const zodSchema = z.object({
-  project_root: z
-    .string()
-    .describe(
-      "Absolute path to the RN project root (debug files are in /tmp/argent-profiler-cwd/)",
-    ),
   mode: z
     .enum(["list", "load_react", "load_instruments"])
     .describe(
@@ -322,7 +317,7 @@ After loading, use profiler-cpu-query, profiler-commit-query, or profiler-stack-
     return svcs;
   },
   async execute(services, params) {
-    const debugDir = await getDebugDir(params.project_root);
+    const debugDir = await getDebugDir();
 
     switch (params.mode) {
       case "list":

--- a/packages/tool-server/src/tools/profiler/query/profiler-load.ts
+++ b/packages/tool-server/src/tools/profiler/query/profiler-load.ts
@@ -18,7 +18,7 @@ const zodSchema = z.object({
   project_root: z
     .string()
     .describe(
-      "Absolute path to the RN project root (debug files are in <project_root>/argent-profiler-cwd/)",
+      "Absolute path to the RN project root (debug files are in /tmp/argent-profiler-cwd/)",
     ),
   mode: z
     .enum(["list", "load_react", "load_instruments"])

--- a/packages/tool-server/src/tools/profiler/react/react-profiler-stop.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-stop.ts
@@ -247,7 +247,7 @@ Call react-profiler-start first, then exercise the app, then call this.`,
         .replace(/[-:T]/g, (m) => (m === "T" ? "-" : ""))
         .slice(0, 15);
 
-      const debugDir = await getDebugDir(api.projectRoot);
+      const debugDir = await getDebugDir();
 
       const cpuProfilePath = await writeDumpCompact(
         debugDir,

--- a/packages/tool-server/src/utils/react-profiler/PIPELINE_DESIGN.md
+++ b/packages/tool-server/src/utils/react-profiler/PIPELINE_DESIGN.md
@@ -54,7 +54,7 @@ Prevents the pipeline from always finding "something" even in perfectly smooth s
 
 ### Cap + persist full report
 
-Top 10 hot commits in inline response to stay token-efficient. Full markdown written to `argent-profiler-cwd/react-profiler-report.md` for agent to re-query without re-running profiling. Agent can use the Read tool directly on the file.
+Top 10 hot commits in inline response to stay token-efficient. Full markdown written to `/tmp/argent-profiler-cwd/react-profiler-report.md` for agent to re-query without re-running profiling. Agent can use the Read tool directly on the file.
 
 ### Findings threshold: renders ≥ 3 OR maxDuration ≥ 30ms
 

--- a/packages/tool-server/src/utils/react-profiler/debug/dump.ts
+++ b/packages/tool-server/src/utils/react-profiler/debug/dump.ts
@@ -7,10 +7,8 @@ const DEBUG_DIR_NAME = "argent-profiler-cwd";
 
 /**
  * Returns (and creates if needed) /tmp/argent-profiler-cwd/.
- * The projectRoot parameter is kept for API compatibility but is no longer
- * used to determine the output directory.
  */
-export async function getDebugDir(_projectRoot: string): Promise<string> {
+export async function getDebugDir(): Promise<string> {
   const dir = join(tmpdir(), DEBUG_DIR_NAME);
   await fs.mkdir(dir, { recursive: true });
   return dir;

--- a/packages/tool-server/src/utils/react-profiler/debug/dump.ts
+++ b/packages/tool-server/src/utils/react-profiler/debug/dump.ts
@@ -1,14 +1,17 @@
 import { promises as fs } from "fs";
 import { join } from "path";
+import { tmpdir } from "os";
 import type { HermesCpuProfile, DevToolsFiberCommit } from "../types/input";
 
 const DEBUG_DIR_NAME = "argent-profiler-cwd";
 
 /**
- * Returns (and creates if needed) <projectRoot>/argent-profiler-cwd/.
+ * Returns (and creates if needed) /tmp/argent-profiler-cwd/.
+ * The projectRoot parameter is kept for API compatibility but is no longer
+ * used to determine the output directory.
  */
-export async function getDebugDir(projectRoot: string): Promise<string> {
-  const dir = join(projectRoot, DEBUG_DIR_NAME);
+export async function getDebugDir(_projectRoot: string): Promise<string> {
+  const dir = join(tmpdir(), DEBUG_DIR_NAME);
   await fs.mkdir(dir, { recursive: true });
   return dir;
 }

--- a/packages/tool-server/src/utils/react-profiler/pipeline/index.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/index.ts
@@ -15,7 +15,7 @@ export async function runPipeline(
   options?: { debugDumps?: boolean },
 ): Promise<PipelineOutput> {
   const debugDumps = options?.debugDumps ?? false;
-  const debugDir = await getDebugDir(input.sessionMeta.projectRoot);
+  const debugDir = await getDebugDir();
 
   const sessionContext = await detectSessionContext(input);
 

--- a/packages/tool-server/test/react-profiler/dump.test.ts
+++ b/packages/tool-server/test/react-profiler/dump.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  getDebugDir,
+  writeDump,
+  writeDumpCompact,
+  readCpuProfile,
+  readCommitTree,
+} from "../../src/utils/react-profiler/debug/dump";
+
+const DEBUG_DIR = join(tmpdir(), "argent-profiler-cwd");
+
+afterEach(async () => {
+  // Clean up any files written during tests, but leave the directory itself
+  // (it may already exist on the system — don't remove it wholesale).
+  vi.restoreAllMocks();
+});
+
+// ── getDebugDir ────────────────────────────────────────────────────────
+
+describe("getDebugDir", () => {
+  it("takes no arguments", async () => {
+    // TypeScript would fail to compile if the signature required args,
+    // but verify at runtime too.
+    const dir = await getDebugDir();
+    expect(typeof dir).toBe("string");
+  });
+
+  it("returns a path inside os.tmpdir()", async () => {
+    const dir = await getDebugDir();
+    expect(dir).toBe(join(tmpdir(), "argent-profiler-cwd"));
+  });
+
+  it("creates the directory on disk", async () => {
+    const dir = await getDebugDir();
+    const stat = await fs.stat(dir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it("is idempotent — succeeds even if directory already exists", async () => {
+    await getDebugDir();
+    // Second call must not throw.
+    await expect(getDebugDir()).resolves.toBe(DEBUG_DIR);
+  });
+
+  it("never writes inside the current working directory", async () => {
+    const dir = await getDebugDir();
+    expect(dir.startsWith(process.cwd())).toBe(false);
+  });
+});
+
+// ── writeDump ─────────────────────────────────────────────────────────
+
+describe("writeDump", () => {
+  it("writes pretty-printed JSON and returns the file path", async () => {
+    const dir = await getDebugDir();
+    const data = { hello: "world", n: 42 };
+    const filePath = await writeDump(dir, "test-dump.json", data);
+
+    expect(filePath).toBe(join(dir, "test-dump.json"));
+    const raw = await fs.readFile(filePath!, "utf8");
+    expect(JSON.parse(raw)).toEqual(data);
+    // Pretty-printed: should contain newlines and indentation.
+    expect(raw).toContain("\n");
+    expect(raw).toContain("  ");
+
+    await fs.unlink(filePath!);
+  });
+
+  it("serialises Map values as plain objects", async () => {
+    const dir = await getDebugDir();
+    const data = { m: new Map([["a", 1], ["b", 2]]) };
+    const filePath = await writeDump(dir, "test-map.json", data);
+
+    const raw = await fs.readFile(filePath!, "utf8");
+    expect(JSON.parse(raw)).toEqual({ m: { a: 1, b: 2 } });
+
+    await fs.unlink(filePath!);
+  });
+
+  it("returns null and does not throw when the directory does not exist", async () => {
+    const result = await writeDump("/nonexistent/path", "out.json", {});
+    expect(result).toBeNull();
+  });
+});
+
+// ── writeDumpCompact ──────────────────────────────────────────────────
+
+describe("writeDumpCompact", () => {
+  it("writes compact JSON (no indentation) and returns the file path", async () => {
+    const dir = await getDebugDir();
+    const data = { hello: "world", n: 42 };
+    const filePath = await writeDumpCompact(dir, "test-compact.json", data);
+
+    expect(filePath).toBe(join(dir, "test-compact.json"));
+    const raw = await fs.readFile(filePath!, "utf8");
+    expect(JSON.parse(raw)).toEqual(data);
+    // Compact: single line, no indentation.
+    expect(raw.trim().split("\n")).toHaveLength(1);
+
+    await fs.unlink(filePath!);
+  });
+
+  it("compact output is smaller than pretty-printed for the same data", async () => {
+    const dir = await getDebugDir();
+    const data = { key: "value", nested: { a: 1, b: 2, c: [1, 2, 3] } };
+
+    const prettyPath = await writeDump(dir, "cmp-pretty.json", data);
+    const compactPath = await writeDumpCompact(dir, "cmp-compact.json", data);
+
+    const prettySize = (await fs.stat(prettyPath!)).size;
+    const compactSize = (await fs.stat(compactPath!)).size;
+    expect(compactSize).toBeLessThan(prettySize);
+
+    await fs.unlink(prettyPath!);
+    await fs.unlink(compactPath!);
+  });
+
+  it("serialises Map values as plain objects", async () => {
+    const dir = await getDebugDir();
+    const data = { m: new Map([["x", 10]]) };
+    const filePath = await writeDumpCompact(dir, "test-map-compact.json", data);
+
+    const raw = await fs.readFile(filePath!, "utf8");
+    expect(JSON.parse(raw)).toEqual({ m: { x: 10 } });
+
+    await fs.unlink(filePath!);
+  });
+
+  it("returns null and does not throw when the directory does not exist", async () => {
+    const result = await writeDumpCompact("/nonexistent/path", "out.json", {});
+    expect(result).toBeNull();
+  });
+});
+
+// ── readCpuProfile ────────────────────────────────────────────────────
+
+describe("readCpuProfile", () => {
+  it("reads and parses a CPU profile written by writeDumpCompact", async () => {
+    const dir = await getDebugDir();
+    const profile = {
+      nodes: [
+        {
+          id: 1,
+          callFrame: {
+            functionName: "foo",
+            scriptId: "1",
+            url: "index.js",
+            lineNumber: 1,
+            columnNumber: 0,
+          },
+          hitCount: 5,
+        },
+      ],
+      startTime: 1000,
+      endTime: 2000,
+      samples: [1],
+      timeDeltas: [1000],
+    };
+
+    const filePath = await writeDumpCompact(dir, "cpu-profile.json", profile);
+    const read = await readCpuProfile(filePath!);
+
+    expect(read.startTime).toBe(1000);
+    expect(read.endTime).toBe(2000);
+    expect(read.nodes[0]?.callFrame.functionName).toBe("foo");
+    expect(read.samples).toEqual([1]);
+
+    await fs.unlink(filePath!);
+  });
+
+  it("throws when the file does not exist", async () => {
+    await expect(
+      readCpuProfile("/nonexistent/cpu.json"),
+    ).rejects.toThrow();
+  });
+});
+
+// ── readCommitTree ────────────────────────────────────────────────────
+
+describe("readCommitTree", () => {
+  it("reads and parses a commit tree written by writeDumpCompact", async () => {
+    const dir = await getDebugDir();
+    const tree = {
+      commits: [
+        {
+          commitIndex: 0,
+          timestamp: 100,
+          componentName: "App",
+          actualDuration: 5,
+          selfDuration: 2,
+          commitDuration: 5,
+          didRender: true,
+          changeDescription: null,
+        },
+      ],
+      meta: {
+        detectedArchitecture: "bridgeless" as const,
+        anyCompilerOptimized: false,
+        hotCommitIndices: [0],
+        totalReactCommits: 1,
+      },
+    };
+
+    const filePath = await writeDumpCompact(dir, "commit-tree.json", tree);
+    const read = await readCommitTree(filePath!);
+
+    expect(read.commits).toHaveLength(1);
+    expect(read.commits[0]?.componentName).toBe("App");
+    expect(read.meta?.detectedArchitecture).toBe("bridgeless");
+    expect(read.meta?.hotCommitIndices).toEqual([0]);
+
+    await fs.unlink(filePath!);
+  });
+
+  it("handles a commit tree without meta", async () => {
+    const dir = await getDebugDir();
+    const tree = { commits: [] };
+    const filePath = await writeDumpCompact(dir, "commit-tree-bare.json", tree);
+    const read = await readCommitTree(filePath!);
+
+    expect(read.commits).toEqual([]);
+    expect(read.meta).toBeUndefined();
+
+    await fs.unlink(filePath!);
+  });
+
+  it("throws when the file does not exist", async () => {
+    await expect(
+      readCommitTree("/nonexistent/commits.json"),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- The profiler was creating `argent-profiler-cwd/` inside the user's project root on every profiling run, polluting their working tree
- Changed `getDebugDir` in `dump.ts` to use `os.tmpdir()` (resolves to `/tmp` on macOS) instead of `projectRoot`
- Updated all tool schema descriptions and documentation to reflect the new path

## Files changed

- `packages/tool-server/src/utils/react-profiler/debug/dump.ts` — core fix: use `/tmp/argent-profiler-cwd/` via `os.tmpdir()`
- `packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts` — update description string
- `packages/tool-server/src/tools/profiler/query/profiler-load.ts` — update description string
- `packages/tool-server/src/utils/react-profiler/PIPELINE_DESIGN.md` — update doc reference
- `packages/skills/skills/argent-ios-profiler/SKILL.md` — update skill doc reference

## Test plan

- [ ] Run the React profiler — verify no `argent-profiler-cwd/` folder appears in the project root
- [ ] Run the iOS profiler — verify trace files land in `/tmp/argent-profiler-cwd/`
- [ ] Run `profiler-load` with `list` mode — verify it finds sessions in `/tmp/argent-profiler-cwd/`