### PR TITLE
feat: add update-argent tool and per-response update notification

### DIFF
--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -82,7 +82,7 @@ export async function startMcpServer(): Promise<void> {
   async function callTool(
     name: string,
     args: unknown
-  ): Promise<{ result: unknown; outputHint?: string }> {
+  ): Promise<{ result: unknown; outputHint?: string; note?: string }> {
     const tools = await fetchTools();
     const meta = tools.find((t) => t.name === name);
     const res = await fetchWithReconnect(() => `${TOOLS_URL}/tools/${name}`, {
@@ -94,9 +94,10 @@ export async function startMcpServer(): Promise<void> {
       data?: unknown;
       error?: string;
       message?: string;
+      note?: string;
     };
     if (!res.ok) throw new Error(json.error ?? json.message ?? res.statusText);
-    return { result: json.data, outputHint: meta?.outputHint };
+    return { result: json.data, outputHint: meta?.outputHint, note: json.note };
   }
 
   const server = new Server(
@@ -136,7 +137,14 @@ export async function startMcpServer(): Promise<void> {
       args: params.arguments,
     });
     try {
+<<<<<<< HEAD
       const { result, outputHint } = await callTool(params.name, params.arguments);
+=======
+      const { result, outputHint, note } = await callTool(
+        params.name,
+        params.arguments,
+      );
+>>>>>>> 322a369 (feat: add update notification and update-argent tool)
       await spyLog({
         ts: new Date().toISOString(),
         event: "tool_result",
@@ -180,6 +188,10 @@ export async function startMcpServer(): Promise<void> {
             },
           ];
         }
+      }
+
+      if (note) {
+        content = [{ type: "text" as const, text: note }, ...content];
       }
 
       return { content };

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -3,7 +3,13 @@ import type { Registry } from "@argent/registry";
 import { ToolNotFoundError } from "@argent/registry";
 import { createIdleTimer } from "./utils/idle-timer";
 import { formatErrorForAgent } from "./utils/format-error";
-import { getUpdateState } from "./utils/update-checker";
+import {
+  getUpdateState,
+  isUpdateNoteSuppressed,
+  suppressUpdateNote,
+} from "./utils/update-checker";
+
+const AUTO_SUPPRESS_MS = 30 * 60 * 1000; // 30 minutes
 
 function buildUpdateNote(currentVersion: string, latestVersion: string): string {
   return `NOTE: An update for Argent is available (${currentVersion} -> ${latestVersion}).
@@ -12,7 +18,10 @@ IMPORTANT — Updates must only be applied with the user's explicit, informed co
 
 How to update:
   - Manual (user-initiated): run \`npx @swmansion/argent update\` in the terminal
-  - Agent-assisted (requires explicit user consent): call the \`update-argent\` tool — only after the user has explicitly asked you to update Argent in this conversation`;
+  - Agent-assisted (requires explicit user consent): call the \`update-argent\` tool — only after the user has explicitly asked you to update Argent in this conversation
+  - To postpone this reminder: call the \`dismiss-update\` tool with the number of hours to suppress it
+
+ACTION REQUIRED: Save a note (via TODO, task list, or memory) that an Argent update to v${latestVersion} is available so you can remind the user about it later. This notification will not repeat for the next 30 minutes.`;
 }
 
 // ── HTTP app ────────────────────────────────────────────────────────
@@ -116,9 +125,13 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
           signal: controller.signal,
         });
         const { updateAvailable, currentVersion, latestVersion } = getUpdateState();
+        const shouldNotify = updateAvailable && !isUpdateNoteSuppressed();
+        if (shouldNotify) {
+          suppressUpdateNote(AUTO_SUPPRESS_MS);
+        }
         res.json({
           data,
-          ...(updateAvailable
+          ...(shouldNotify
             ? { note: buildUpdateNote(currentVersion, latestVersion ?? "unknown") }
             : {}),
         });

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -3,6 +3,17 @@ import type { Registry } from "@argent/registry";
 import { ToolNotFoundError } from "@argent/registry";
 import { createIdleTimer } from "./utils/idle-timer";
 import { formatErrorForAgent } from "./utils/format-error";
+import { getUpdateState } from "./utils/update-checker";
+
+function buildUpdateNote(currentVersion: string, latestVersion: string): string {
+  return `NOTE: An update for Argent is available (${currentVersion} -> ${latestVersion}).
+
+IMPORTANT — Updates must only be applied with the user's explicit, informed consent. Never initiate an update autonomously without the user explicitly requesting it in this conversation.
+
+How to update:
+  - Manual (user-initiated): run \`npx @swmansion/argent update\` in the terminal
+  - Agent-assisted (requires explicit user consent): call the \`update-argent\` tool — only after the user has explicitly asked you to update Argent in this conversation`;
+}
 
 // ── HTTP app ────────────────────────────────────────────────────────
 
@@ -104,7 +115,13 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
         const data = await registry.invokeTool(name, parsedData, {
           signal: controller.signal,
         });
-        res.json({ data });
+        const { updateAvailable, currentVersion, latestVersion } = getUpdateState();
+        res.json({
+          data,
+          ...(updateAvailable
+            ? { note: buildUpdateNote(currentVersion, latestVersion ?? "unknown") }
+            : {}),
+        });
       } catch (err: unknown) {
         if (err instanceof ToolNotFoundError) {
           res.status(404).json({ error: err.message });

--- a/packages/tool-server/src/tools/system/dismiss-update.ts
+++ b/packages/tool-server/src/tools/system/dismiss-update.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import type { ToolDefinition } from "@argent/registry";
+import { suppressUpdateNote } from "../../utils/update-checker";
+
+const zodSchema = z.object({
+  hours: z
+    .number()
+    .min(0)
+    .describe("Number of hours to suppress the update notification"),
+});
+
+export const dismissUpdateTool: ToolDefinition<{ hours: number }> = {
+  id: "dismiss-update",
+  description:
+    "Suppresses the Argent update notification for the given number of hours. Use when the user asks to postpone or silence update reminders.",
+  zodSchema,
+  services: () => ({}),
+  async execute(_services, params, _options) {
+    const durationMs = params.hours * 60 * 60 * 1000;
+    suppressUpdateNote(durationMs);
+    return {
+      message:
+        params.hours > 0
+          ? `Update notification dismissed for ${params.hours} hour(s).`
+          : "Update notification suppression cleared. The notification will appear on the next tool call if an update is still available.",
+    };
+  },
+};

--- a/packages/tool-server/src/tools/system/update-argent.ts
+++ b/packages/tool-server/src/tools/system/update-argent.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
 import type { ToolDefinition } from "@argent/registry";
+import { getUpdateState } from "../../utils/update-checker";
+
+let updateScheduled = false;
 
 export const updateArgentTool: ToolDefinition<void> = {
   id: "update-argent",
@@ -7,11 +10,28 @@ export const updateArgentTool: ToolDefinition<void> = {
     "Applies a pending Argent update. Only call this tool when the user has explicitly consented to updating Argent in this conversation. The tool server will restart automatically after the update.",
   services: () => ({}),
   async execute(_services, _params, _options) {
+    const { updateAvailable, currentVersion, latestVersion } = getUpdateState();
+
+    if (!updateAvailable) {
+      return {
+        message: `Argent is already up to date (v${currentVersion}). No update needed.`,
+      };
+    }
+
+    if (updateScheduled) {
+      return {
+        message:
+          "An Argent update is already in progress. Please wait for the tool server to restart.",
+      };
+    }
+
+    updateScheduled = true;
+
     // Delay the actual update spawn so the HTTP response can be flushed first.
     // The update process calls killToolServer() which sends SIGTERM — we need
     // the response to reach the MCP server before that happens.
     setTimeout(() => {
-      const child = spawn("npx", ["@swmansion/argent", "update", "--yes"], {
+      const child = spawn("argent", ["update", "--yes"], {
         detached: true,
         stdio: "ignore",
       });
@@ -19,8 +39,7 @@ export const updateArgentTool: ToolDefinition<void> = {
     }, 2000);
 
     return {
-      message:
-        "Argent update initiated. The tool server will stop and restart automatically once the update is installed. Subsequent tool calls will reconnect to the updated server.",
+      message: `Argent update initiated (v${currentVersion} -> v${latestVersion}). The tool server will stop and restart automatically once the update is installed. Subsequent tool calls will reconnect to the updated server.`,
     };
   },
 };

--- a/packages/tool-server/src/tools/system/update-argent.ts
+++ b/packages/tool-server/src/tools/system/update-argent.ts
@@ -1,0 +1,26 @@
+import { spawn } from "node:child_process";
+import type { ToolDefinition } from "@argent/registry";
+
+export const updateArgentTool: ToolDefinition<void> = {
+  id: "update-argent",
+  description:
+    "Applies a pending Argent update. Only call this tool when the user has explicitly consented to updating Argent in this conversation. The tool server will restart automatically after the update.",
+  services: () => ({}),
+  async execute(_services, _params, _options) {
+    // Delay the actual update spawn so the HTTP response can be flushed first.
+    // The update process calls killToolServer() which sends SIGTERM — we need
+    // the response to reach the MCP server before that happens.
+    setTimeout(() => {
+      const child = spawn("npx", ["@swmansion/argent", "update", "--yes"], {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+    }, 2000);
+
+    return {
+      message:
+        "Argent update initiated. The tool server will stop and restart automatically once the update is installed. Subsequent tool calls will reconnect to the updated server.",
+    };
+  },
+};

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -62,6 +62,7 @@ import { createRunFlowTool } from "../tools/flows/flow-run";
 import { flowReadPrerequisiteTool } from "../tools/flows/flow-read-prerequisite";
 import { gatherWorkspaceDataTool } from "../tools/workspace/gather-workspace-data";
 import { updateArgentTool } from "../tools/system/update-argent";
+import { dismissUpdateTool } from "../tools/system/dismiss-update";
 
 export function createRegistry(): Registry {
   const registry = new Registry();
@@ -136,6 +137,7 @@ export function createRegistry(): Registry {
 
   // System tools
   registry.registerTool(updateArgentTool);
+  registry.registerTool(dismissUpdateTool);
 
   return registry;
 }

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -61,6 +61,7 @@ import { flowFinishRecordingTool } from "../tools/flows/flow-finish-recording";
 import { createRunFlowTool } from "../tools/flows/flow-run";
 import { flowReadPrerequisiteTool } from "../tools/flows/flow-read-prerequisite";
 import { gatherWorkspaceDataTool } from "../tools/workspace/gather-workspace-data";
+import { updateArgentTool } from "../tools/system/update-argent";
 
 export function createRegistry(): Registry {
   const registry = new Registry();
@@ -132,6 +133,9 @@ export function createRegistry(): Registry {
   registry.registerTool(flowFinishRecordingTool);
   registry.registerTool(flowReadPrerequisiteTool);
   registry.registerTool(createRunFlowTool(registry));
+
+  // System tools
+  registry.registerTool(updateArgentTool);
 
   return registry;
 }

--- a/packages/tool-server/src/utils/update-checker.ts
+++ b/packages/tool-server/src/utils/update-checker.ts
@@ -39,17 +39,48 @@ export function suppressUpdateNote(durationMs: number): void {
 }
 
 /**
+ * Parses a semver string "major.minor.patch" into numeric components.
+ * Returns null for non-semver strings (pre-release tags, etc.).
+ */
+function parseSemver(v: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(v);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Returns true if `latest` is strictly greater than `current` by semver ordering.
+ * Returns false for non-semver strings (pre-release, local dev versions).
+ */
+function isNewerVersion(latest: string, current: string): boolean {
+  const l = parseSemver(latest);
+  const c = parseSemver(current);
+  if (!l || !c) return false;
+  if (l[0] !== c[0]) return l[0] > c[0];
+  if (l[1] !== c[1]) return l[1] > c[1];
+  return l[2] > c[2];
+}
+
+/**
  * Fetches the latest version of the package from the npm registry.
  * Returns `null` on any failure — update checks must never crash the server.
  */
 async function fetchLatestVersion(): Promise<string | null> {
   return new Promise((resolve) => {
+    let resolved = false;
+    const safeResolve = (value: string | null) => {
+      if (!resolved) {
+        resolved = true;
+        resolve(value);
+      }
+    };
+
     const url = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
 
     const req = https.get(url, { timeout: REQUEST_TIMEOUT_MS }, (res) => {
       if (res.statusCode !== 200) {
         res.resume();
-        resolve(null);
+        safeResolve(null);
         return;
       }
 
@@ -61,17 +92,18 @@ async function fetchLatestVersion(): Promise<string | null> {
       res.on("end", () => {
         try {
           const json = JSON.parse(body) as { version?: string };
-          resolve(json.version ?? null);
+          safeResolve(json.version ?? null);
         } catch {
-          resolve(null);
+          safeResolve(null);
         }
       });
+      res.on("error", () => safeResolve(null));
     });
 
-    req.on("error", () => resolve(null));
+    req.on("error", () => safeResolve(null));
     req.on("timeout", () => {
       req.destroy();
-      resolve(null);
+      safeResolve(null);
     });
   });
 }
@@ -82,7 +114,7 @@ async function check(): Promise<void> {
   if (latest === null) return; // network issue — keep previous state
 
   state = {
-    updateAvailable: latest !== currentVersion,
+    updateAvailable: isNewerVersion(latest, currentVersion),
     latestVersion: latest,
     currentVersion,
   };
@@ -97,6 +129,11 @@ async function check(): Promise<void> {
  * Safe to call once at startup. Returns a dispose function to clear the timer.
  */
 export function startUpdateChecker(): { dispose(): void } {
+  // Clear any leaked interval from a prior call.
+  if (interval) {
+    clearInterval(interval);
+  }
+
   // Fire-and-forget initial check — don't block startup.
   check();
 

--- a/packages/tool-server/src/utils/update-checker.ts
+++ b/packages/tool-server/src/utils/update-checker.ts
@@ -21,10 +21,21 @@ let state: UpdateState = {
 };
 
 let interval: ReturnType<typeof setInterval> | null = null;
+let suppressUntil = 0;
 
 /** Returns the current update state (read-only snapshot). */
 export function getUpdateState(): Readonly<UpdateState> {
   return { ...state };
+}
+
+/** Returns true if the update notification is currently suppressed. */
+export function isUpdateNoteSuppressed(): boolean {
+  return Date.now() < suppressUntil;
+}
+
+/** Suppress update notifications for the given duration (milliseconds). */
+export function suppressUpdateNote(durationMs: number): void {
+  suppressUntil = Date.now() + durationMs;
 }
 
 /**

--- a/packages/tool-server/src/utils/update-checker.ts
+++ b/packages/tool-server/src/utils/update-checker.ts
@@ -1,7 +1,7 @@
 import https from "node:https";
 import { version as currentVersion } from "../../package.json";
 
-const PACKAGE_NAME = "@argent/tool-server";
+const PACKAGE_NAME = "@software-mansion/argent";
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const REQUEST_TIMEOUT_MS = 10_000;
 

--- a/packages/tool-server/test/http-update-note.test.ts
+++ b/packages/tool-server/test/http-update-note.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createHttpApp, type HttpAppHandle } from "../src/http";
 import type { Registry } from "@argent/registry";
 
+let suppressed = false;
+
 // Mock update-checker before any imports that use it transitively.
 vi.mock("../src/utils/update-checker", () => ({
   getUpdateState: vi.fn(() => ({
@@ -9,11 +11,14 @@ vi.mock("../src/utils/update-checker", () => ({
     latestVersion: null,
     currentVersion: "1.0.0",
   })),
+  isUpdateNoteSuppressed: vi.fn(() => suppressed),
+  suppressUpdateNote: vi.fn(),
 }));
 
-import { getUpdateState } from "../src/utils/update-checker";
+import { getUpdateState, suppressUpdateNote } from "../src/utils/update-checker";
 
 const mockGetUpdateState = vi.mocked(getUpdateState);
+const mockSuppressUpdateNote = vi.mocked(suppressUpdateNote);
 
 function stubRegistry(toolResult: unknown = { ok: true }): Registry {
   return {
@@ -40,12 +45,13 @@ describe("HTTP update note injection", () => {
 
   beforeEach(async () => {
     request = await import("supertest").then((m) => m.default);
-    // Reset to "no update" default before each test.
+    suppressed = false;
     mockGetUpdateState.mockReturnValue({
       updateAvailable: false,
       latestVersion: null,
       currentVersion: "1.0.0",
     });
+    mockSuppressUpdateNote.mockClear();
   });
 
   afterEach(() => {
@@ -136,6 +142,40 @@ describe("HTTP update note injection", () => {
     expect(res.body.note).toContain("update-argent");
   });
 
+  it("note mentions `dismiss-update` tool", async () => {
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body.note).toContain("dismiss-update");
+  });
+
+  it("note instructs agent to persist the update info", async () => {
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body.note).toContain("Save a note");
+  });
+
   it("does NOT include a note on 500 error responses", async () => {
     const errorRegistry = {
       getSnapshot: vi.fn(() => ({ services: new Map(), namespaces: [], tools: ["test-tool"] })),
@@ -185,7 +225,6 @@ describe("HTTP update note injection", () => {
   });
 
   it("note says 'unknown' when latestVersion is null but updateAvailable is true", async () => {
-    // Edge case: updateAvailable is true but latestVersion somehow ended up null.
     mockGetUpdateState.mockReturnValue({
       updateAvailable: true,
       latestVersion: null,
@@ -202,5 +241,56 @@ describe("HTTP update note injection", () => {
     expect(res.body).toHaveProperty("note");
     expect(res.body.note).toContain("unknown");
     expect(res.body.note).not.toContain("null");
+  });
+
+  // ── Suppression behavior ──────────────────────────────────────────
+
+  it("calls suppressUpdateNote after delivering a note", async () => {
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(mockSuppressUpdateNote).toHaveBeenCalledOnce();
+    expect(mockSuppressUpdateNote).toHaveBeenCalledWith(30 * 60 * 1000);
+  });
+
+  it("does NOT include a note when suppressed", async () => {
+    suppressed = true;
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body).toHaveProperty("data");
+    expect(res.body).not.toHaveProperty("note");
+    expect(mockSuppressUpdateNote).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call suppressUpdateNote when no update is available", async () => {
+    handle = createHttpApp(stubRegistry());
+
+    await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(mockSuppressUpdateNote).not.toHaveBeenCalled();
   });
 });

--- a/packages/tool-server/test/http-update-note.test.ts
+++ b/packages/tool-server/test/http-update-note.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createHttpApp, type HttpAppHandle } from "../src/http";
+import type { Registry } from "@argent/registry";
+
+// Mock update-checker before any imports that use it transitively.
+vi.mock("../src/utils/update-checker", () => ({
+  getUpdateState: vi.fn(() => ({
+    updateAvailable: false,
+    latestVersion: null,
+    currentVersion: "1.0.0",
+  })),
+}));
+
+import { getUpdateState } from "../src/utils/update-checker";
+
+const mockGetUpdateState = vi.mocked(getUpdateState);
+
+function stubRegistry(toolResult: unknown = { ok: true }): Registry {
+  return {
+    getSnapshot: vi.fn(() => ({ services: new Map(), namespaces: [], tools: ["test-tool"] })),
+    getTool: vi.fn((name: string) => {
+      if (name === "test-tool") {
+        return {
+          id: "test-tool",
+          description: "A stub tool for testing",
+          inputSchema: { type: "object", properties: {} },
+          services: () => ({}),
+          execute: async () => toolResult,
+        };
+      }
+      return undefined;
+    }),
+    invokeTool: vi.fn(async (_name: string, _params: unknown) => toolResult),
+  } as unknown as Registry;
+}
+
+describe("HTTP update note injection", () => {
+  let handle: HttpAppHandle;
+  let request: typeof import("supertest").default;
+
+  beforeEach(async () => {
+    request = await import("supertest").then((m) => m.default);
+    // Reset to "no update" default before each test.
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: false,
+      latestVersion: null,
+      currentVersion: "1.0.0",
+    });
+  });
+
+  afterEach(() => {
+    handle?.dispose();
+    vi.clearAllMocks();
+  });
+
+  it("does NOT include a note when update is not available", async () => {
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body).toHaveProperty("data");
+    expect(res.body).not.toHaveProperty("note");
+  });
+
+  it("includes a note when update is available", async () => {
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body).toHaveProperty("data");
+    expect(res.body).toHaveProperty("note");
+    expect(typeof res.body.note).toBe("string");
+    expect(res.body.note.length).toBeGreaterThan(0);
+  });
+
+  it("note contains the current -> latest version string", async () => {
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body.note).toContain("1.0.0 -> 1.2.3");
+  });
+
+  it("note mentions `npx @swmansion/argent update`", async () => {
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body.note).toContain("npx @swmansion/argent update");
+  });
+
+  it("note mentions `update-argent` tool", async () => {
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body.note).toContain("update-argent");
+  });
+
+  it("does NOT include a note on 500 error responses", async () => {
+    const errorRegistry = {
+      getSnapshot: vi.fn(() => ({ services: new Map(), namespaces: [], tools: ["test-tool"] })),
+      getTool: vi.fn(() => ({
+        id: "test-tool",
+        description: "A stub tool",
+        inputSchema: {},
+        services: () => ({}),
+        execute: async () => { throw new Error("tool blew up"); },
+      })),
+      invokeTool: vi.fn(async () => { throw new Error("tool blew up"); }),
+    } as unknown as Registry;
+
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(errorRegistry);
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(500);
+
+    expect(res.body).toHaveProperty("error");
+    expect(res.body).not.toHaveProperty("note");
+  });
+
+  it("does NOT include a note on 404 (unknown tool) responses", async () => {
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/nonexistent-tool")
+      .send({})
+      .expect(404);
+
+    expect(res.body).toHaveProperty("error");
+    expect(res.body).not.toHaveProperty("note");
+  });
+
+  it("note says 'unknown' when latestVersion is null but updateAvailable is true", async () => {
+    // Edge case: updateAvailable is true but latestVersion somehow ended up null.
+    mockGetUpdateState.mockReturnValue({
+      updateAvailable: true,
+      latestVersion: null,
+      currentVersion: "1.0.0",
+    });
+
+    handle = createHttpApp(stubRegistry());
+
+    const res = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({})
+      .expect(200);
+
+    expect(res.body).toHaveProperty("note");
+    expect(res.body.note).toContain("unknown");
+    expect(res.body.note).not.toContain("null");
+  });
+});

--- a/packages/tool-server/test/update-argent-tool.test.ts
+++ b/packages/tool-server/test/update-argent-tool.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock child_process before importing the module under test.
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+import { updateArgentTool } from "../src/tools/system/update-argent";
+
+const mockSpawn = vi.mocked(spawn);
+
+function makeChild() {
+  return { unref: vi.fn() } as unknown as ReturnType<typeof spawn>;
+}
+
+describe("update-argent tool", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSpawn.mockReturnValue(makeChild());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("returns the expected message immediately", async () => {
+    const result = await updateArgentTool.execute({}, undefined, undefined);
+
+    expect(result).toEqual({
+      message:
+        "Argent update initiated. The tool server will stop and restart automatically once the update is installed. Subsequent tool calls will reconnect to the updated server.",
+    });
+  });
+
+  it("spawns the correct command after 2 seconds", async () => {
+    await updateArgentTool.execute({}, undefined, undefined);
+
+    // Not yet spawned before 2000 ms.
+    vi.advanceTimersByTime(1999);
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    // Now cross the threshold.
+    vi.advanceTimersByTime(1);
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "npx",
+      ["@swmansion/argent", "update", "--yes"],
+      { detached: true, stdio: "ignore" },
+    );
+  });
+
+  it("does NOT spawn before 2 seconds have elapsed", async () => {
+    await updateArgentTool.execute({}, undefined, undefined);
+
+    vi.advanceTimersByTime(1999);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("calls unref() on the child process", async () => {
+    const child = makeChild();
+    mockSpawn.mockReturnValue(child);
+
+    await updateArgentTool.execute({}, undefined, undefined);
+    vi.advanceTimersByTime(2000);
+
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/tool-server/test/update-argent-tool.test.ts
+++ b/packages/tool-server/test/update-argent-tool.test.ts
@@ -1,23 +1,51 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Mock child_process before importing the module under test.
+// Mock child_process and update-checker before importing the module under test.
 vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
 }));
 
+vi.mock("../src/utils/update-checker", () => ({
+  getUpdateState: vi.fn(),
+}));
+
 import { spawn } from "node:child_process";
-import { updateArgentTool } from "../src/tools/system/update-argent";
+import { getUpdateState } from "../src/utils/update-checker";
 
 const mockSpawn = vi.mocked(spawn);
+const mockGetUpdateState = vi.mocked(getUpdateState);
 
 function makeChild() {
   return { unref: vi.fn() } as unknown as ReturnType<typeof spawn>;
 }
 
+function stateWithUpdate(latestVersion = "99.0.0") {
+  return {
+    updateAvailable: true,
+    currentVersion: "1.0.0",
+    latestVersion,
+  };
+}
+
+function stateUpToDate() {
+  return {
+    updateAvailable: false,
+    currentVersion: "1.0.0",
+    latestVersion: "1.0.0",
+  };
+}
+
 describe("update-argent tool", () => {
-  beforeEach(() => {
+  // Re-import per test so the module-level `updateScheduled` flag resets.
+  let updateArgentTool: typeof import("../src/tools/system/update-argent").updateArgentTool;
+
+  beforeEach(async () => {
     vi.useFakeTimers();
+    vi.resetModules();
     mockSpawn.mockReturnValue(makeChild());
+    mockGetUpdateState.mockReturnValue(stateWithUpdate());
+    const mod = await import("../src/tools/system/update-argent");
+    updateArgentTool = mod.updateArgentTool;
   });
 
   afterEach(() => {
@@ -25,35 +53,29 @@ describe("update-argent tool", () => {
     vi.clearAllMocks();
   });
 
-  it("returns the expected message immediately", async () => {
+  it("returns a message with current and latest version on success", async () => {
     const result = await updateArgentTool.execute({}, undefined, undefined);
-
-    expect(result).toEqual({
-      message:
-        "Argent update initiated. The tool server will stop and restart automatically once the update is installed. Subsequent tool calls will reconnect to the updated server.",
-    });
+    expect((result as { message: string }).message).toContain("1.0.0 -> v99.0.0");
+    expect((result as { message: string }).message).toContain("restart");
   });
 
-  it("spawns the correct command after 2 seconds", async () => {
+  it("spawns `argent update --yes` (not npx) after 2 seconds", async () => {
     await updateArgentTool.execute({}, undefined, undefined);
 
-    // Not yet spawned before 2000 ms.
     vi.advanceTimersByTime(1999);
     expect(mockSpawn).not.toHaveBeenCalled();
 
-    // Now cross the threshold.
     vi.advanceTimersByTime(1);
     expect(mockSpawn).toHaveBeenCalledOnce();
     expect(mockSpawn).toHaveBeenCalledWith(
-      "npx",
-      ["@swmansion/argent", "update", "--yes"],
+      "argent",
+      ["update", "--yes"],
       { detached: true, stdio: "ignore" },
     );
   });
 
   it("does NOT spawn before 2 seconds have elapsed", async () => {
     await updateArgentTool.execute({}, undefined, undefined);
-
     vi.advanceTimersByTime(1999);
     expect(mockSpawn).not.toHaveBeenCalled();
   });
@@ -66,5 +88,25 @@ describe("update-argent tool", () => {
     vi.advanceTimersByTime(2000);
 
     expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it("returns 'already up to date' when no update is available", async () => {
+    mockGetUpdateState.mockReturnValue(stateUpToDate());
+
+    const result = await updateArgentTool.execute({}, undefined, undefined);
+    expect((result as { message: string }).message).toContain("already up to date");
+    vi.advanceTimersByTime(5000);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("returns 'already in progress' and does not double-spawn on second call", async () => {
+    await updateArgentTool.execute({}, undefined, undefined);
+    const second = await updateArgentTool.execute({}, undefined, undefined);
+
+    expect((second as { message: string }).message).toContain("already in progress");
+
+    vi.advanceTimersByTime(5000);
+    // Only one spawn despite two calls.
+    expect(mockSpawn).toHaveBeenCalledOnce();
   });
 });

--- a/packages/tool-server/test/update-checker.test.ts
+++ b/packages/tool-server/test/update-checker.test.ts
@@ -160,4 +160,109 @@ describe("update-checker", () => {
 
     handle.dispose();
   });
+
+  // ── Semver comparison ─────────────────────────────────────────────
+
+  it("does not flag update when running a newer local version", async () => {
+    const mockGet = vi.mocked(https.get);
+    // npm returns 0.1.0 but local is 0.3.3 — local is ahead
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      callback(createMockResponse(200, JSON.stringify({ version: "0.1.0" })));
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const state = getUpdateState();
+    expect(state.updateAvailable).toBe(false);
+    expect(state.latestVersion).toBe("0.1.0");
+
+    handle.dispose();
+  });
+
+  it("does not flag update for pre-release version strings", async () => {
+    const mockGet = vi.mocked(https.get);
+    // npm returns a pre-release tag — non-semver, should be treated safely
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      callback(
+        createMockResponse(200, JSON.stringify({ version: "1.0.0-beta.1" })),
+      );
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const state = getUpdateState();
+    expect(state.updateAvailable).toBe(false);
+
+    handle.dispose();
+  });
+
+  // ── Response stream error ─────────────────────────────────────────
+
+  it("handles response error event without crashing", async () => {
+    const mockGet = vi.mocked(https.get);
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      const res = new EventEmitter() as EventEmitter & {
+        statusCode: number;
+        setEncoding: ReturnType<typeof vi.fn>;
+        resume: ReturnType<typeof vi.fn>;
+      };
+      res.statusCode = 200;
+      res.setEncoding = vi.fn();
+      res.resume = vi.fn();
+
+      // Simulate a connection reset mid-stream
+      process.nextTick(() => {
+        res.emit("data", '{"ver');
+        res.emit("error", new Error("ECONNRESET"));
+      });
+
+      callback(res);
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const state = getUpdateState();
+    expect(state.updateAvailable).toBe(false);
+    expect(state.latestVersion).toBeNull();
+
+    handle.dispose();
+  });
+
+  // ── Double start guard ────────────────────────────────────────────
+
+  it("clears previous interval when startUpdateChecker is called twice", async () => {
+    const mockGet = vi.mocked(https.get);
+    let callCount = 0;
+    mockGet.mockImplementation((_url: unknown, _opts: unknown, cb: unknown) => {
+      callCount++;
+      const callback = cb as (res: ReturnType<typeof createMockResponse>) => void;
+      callback(createMockResponse(200, JSON.stringify({ version: "99.0.0" })));
+      return new EventEmitter() as ReturnType<typeof https.get>;
+    });
+
+    const handle1 = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(1);
+
+    // Start a second checker — should clear the first interval.
+    const handle2 = startUpdateChecker();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(2);
+
+    // Advance 1 hour — should trigger exactly 1 check (from handle2), not 2.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(callCount).toBe(3);
+
+    handle1.dispose();
+    handle2.dispose();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds an `update-argent` MCP tool that agents can call (with explicit user consent) to apply a pending update — spawns `npx @swmansion/argent update --yes` in a detached process with a 2-second grace period so the HTTP response flushes before SIGTERM arrives
- Injects a `note` field into every successful tool-server HTTP response when an update is available; the MCP server prepends this note as a text content block before the tool result, ensuring the AI sees the notice on its next tool call
- The note text is explicit about consent requirements: the AI must never apply an update without the user asking for it in the current conversation, and lists both the manual command (`npx @swmansion/argent update`) and the `update-argent` tool as the only two approved paths
- Includes the update-checker polling logic (hourly npm check, `getUpdateState()` runtime flag) that this feature builds on

## Note on scope

This PR includes the update-checker infrastructure (polling + runtime flag) as well as the two effectors. The notification mechanism has no user-facing impact until an actual update is available — the `note` field is omitted entirely when `updateAvailable` is false.