### PR TITLE
ci: add unit test workflow for all TypeScript packages

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,8 +27,10 @@ jobs:
       - name: Fix rollup native bindings
         run: npm install @rollup/rollup-linux-x64-gnu --no-save
 
-      - name: Build registry
-        run: npm run build -w packages/registry
+      - name: Build workspace dependencies
+        run: |
+          npm run build -w packages/registry
+          npm run build -w packages/native-devtools-ios
 
       - name: Run tests
         run: npm test --workspaces --if-present

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+      - name: Fix rollup native bindings
+        run: npm install @rollup/rollup-linux-x64-gnu --no-save
 
       - name: Build registry
         run: npm run build -w packages/registry

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Build registry
+        run: npm run build -w packages/registry
 
       - name: Run tests
         run: npm test --workspaces --if-present

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,32 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test --workspaces --if-present


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that runs Vitest unit tests across all workspace packages (mcp, registry, tool-server)
- Triggers on pushes to main and pull requests targeting main
- Builds the project first (required for cross-package references), then runs `npm test --workspaces --if-present`

## Test plan
- [ ] Verify the workflow runs successfully on this PR
- [ ] Confirm tests execute for mcp, registry, and tool-server packages
- [ ] Confirm packages without tests (skills) are skipped gracefully