### PR TITLE
fix: add missing tsconfig project references

### DIFF
--- a/packages/tool-server/tsconfig.json
+++ b/packages/tool-server/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
+  "references": [{ "path": "../registry" }, { "path": "../native-devtools-ios" }],
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "files": [],
-  "references": [{ "path": "packages/tool-server" }, { "path": "packages/mcp" }]
+  "references": [
+    { "path": "packages/registry" },
+    { "path": "packages/native-devtools-ios" },
+    { "path": "packages/tool-server" },
+    { "path": "packages/mcp" }
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds `registry` and `native-devtools-ios` to root `tsconfig.json` references so `tsc --build` resolves all workspace packages
- Adds `references` to `packages/tool-server/tsconfig.json` for its dependencies (`@argent/registry`, `@argent/native-devtools-ios`)

Without this, `npm run build` and `npm run pack:mcp` fail with unresolved module errors after `native-devtools-ios` was introduced.

## Test plan
- [x] `npm run build` passes
- [x] `npm run pack:mcp` produces tarball
- [x] All registry and tool-server tests pass