### PR TITLE
fix: correct pre-existing test failures in mcp package

### DIFF
--- a/packages/mcp/test/auto-screenshot.test.ts
+++ b/packages/mcp/test/auto-screenshot.test.ts
@@ -164,13 +164,13 @@ describe("getAutoScreenshotDelayMs", () => {
 
   it("uses env override as a floor", () => {
     process.env.ARGENT_AUTO_SCREENSHOT_DELAY_MS = "2000";
-    expect(getAutoScreenshotDelayMs("describe")).toBe(2000); // 1000 < 2000 → 2000
-    expect(getAutoScreenshotDelayMs("launch-app")).toBe(2000); // 1700 < 2000 → 2000
+    expect(getAutoScreenshotDelayMs("describe")).toBe(2000); // 100 < 2000 → 2000
+    expect(getAutoScreenshotDelayMs("keyboard")).toBe(2000); // 300 < 2000 → 2000
   });
 
   it("does not lower delay below the per-tool value", () => {
     process.env.ARGENT_AUTO_SCREENSHOT_DELAY_MS = "500";
-    expect(getAutoScreenshotDelayMs("launch-app")).toBe(1700); // 1700 > 500 → 1700
+    expect(getAutoScreenshotDelayMs("launch-app")).toBe(3000); // 3000 > 500 → 3000
   });
 
   it("ignores non-numeric env override", () => {

--- a/packages/mcp/test/cli/uninstall.test.ts
+++ b/packages/mcp/test/cli/uninstall.test.ts
@@ -8,10 +8,12 @@ import {
   addClaudePermission,
   removeClaudePermission,
 } from "../../src/cli/mcp-configs.js";
+import { readToml } from "../../src/cli/utils.js";
 
 let tmpDir: string;
 
-function readJsonFile(filePath: string): Record<string, unknown> {
+function readConfigFile(filePath: string): Record<string, unknown> {
+  if (filePath.endsWith(".toml")) return readToml(filePath);
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
@@ -34,7 +36,7 @@ describe("uninstall — MCP entry removal", () => {
       adapter.write(configPath, getMcpEntry());
       expect(adapter.remove(configPath)).toBe(true);
 
-      const config = readJsonFile(configPath);
+      const config = readConfigFile(configPath);
       // Check that argent is gone from whichever key this adapter uses
       const allValues = Object.values(config).filter(
         (v) => typeof v === "object" && v !== null
@@ -60,7 +62,7 @@ describe("uninstall — permissions cleanup", () => {
     removeClaudePermission(tmpDir, "local");
 
     const settingsPath = path.join(tmpDir, ".claude", "settings.json");
-    const config = readJsonFile(settingsPath);
+    const config = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
     const allow = (config.permissions as Record<string, unknown>).allow as string[];
     expect(allow).not.toContain("mcp__argent");
   });


### PR DESCRIPTION
## Summary
- **auto-screenshot tests**: `launch-app` delay was updated to 3000ms but two tests still expected the old 1700ms value. Updated assertions to match and switched to `keyboard` (base=300ms) for the env-override-as-floor test case.
- **uninstall test**: Codex adapter writes TOML configs, but the test used `JSON.parse` to read them back. Now uses `readToml` for `.toml` files.

## Test plan
- [x] All 168 mcp tests pass locally
- [x] CI unit tests pass (registry + tool-server already green)