### PR TITLE
feat: default local MCP/skills install with custom path support

### DIFF
--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -16,31 +16,28 @@ import {
   getLatestVersion,
   detectPackageManager,
   globalInstallCommand,
+  formatShellCommand,
+  type ShellCommand,
 } from "./utils.js";
-import { PACKAGE_NAME } from "./constants.js";
+import { PACKAGE_NAME, MCP_BINARY_NAME } from "./constants.js";
 
 function isGloballyInstalled(): boolean {
   try {
-    const raw = execSync(`npm list -g ${PACKAGE_NAME} --depth=0 --json`, {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    execSync(`${cmd} ${MCP_BINARY_NAME}`, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
-    const data = JSON.parse(raw) as {
-      dependencies?: Record<string, unknown>;
-    };
-    return !!data?.dependencies?.[PACKAGE_NAME];
+    return true;
   } catch {
     return false;
   }
 }
 
-function runShellCommand(cmd: string): Promise<void> {
+function runShellCommand(cmd: ShellCommand): Promise<void> {
   return new Promise((resolve, reject) => {
-    const parts = cmd.split(" ");
-    const bin = parts[0]!;
-    const args = parts.slice(1);
     const isWin = process.platform === "win32";
-    const child = spawn(isWin ? `${bin}.cmd` : bin, args, {
+    const child = spawn(isWin ? `${cmd.bin}.cmd` : cmd.bin, cmd.args, {
       stdio: ["ignore", "pipe", "pipe"],
       shell: isWin,
     });
@@ -73,7 +70,7 @@ export async function init(args: string[]): Promise<void> {
 
   p.intro(pc.bgCyan(pc.black(" argent init ")));
 
-  const version = getInstalledVersion() ?? "unknown";
+  let version = getInstalledVersion() ?? "unknown";
   p.log.info(`${pc.dim("Package:")} ${PACKAGE_NAME}@${version}`);
 
   // ── Step 0: Install / Update Check ──────────────────────────────────────────
@@ -106,15 +103,34 @@ export async function init(args: string[]): Promise<void> {
     const pm = detectPackageManager();
     const installTarget = fromTar ?? PACKAGE_NAME;
     const cmd = globalInstallCommand(pm, installTarget);
+    const cmdStr = formatShellCommand(cmd);
     const spinner = p.spinner();
     spinner.start(`Installing ${PACKAGE_NAME} globally...`);
     try {
       await runShellCommand(cmd);
       spinner.stop(pc.green("Installed globally."));
+      version = getInstalledVersion() ?? version;
     } catch (err) {
       spinner.stop(pc.red("Installation failed."));
       p.log.error(`${err}`);
-      p.log.info(`Install argent manually with: ${pc.cyan(cmd)}`);
+      p.log.info(`Install argent manually with: ${pc.cyan(cmdStr)}`);
+      process.exit(1);
+    }
+  } else if (fromTar) {
+    // --from flag: reinstall from the specified tarball/path
+    const pm = detectPackageManager();
+    const cmd = globalInstallCommand(pm, fromTar);
+    const cmdStr = formatShellCommand(cmd);
+    const spinner = p.spinner();
+    spinner.start(`Installing from ${fromTar}...`);
+    try {
+      await runShellCommand(cmd);
+      spinner.stop(pc.green("Installed from tarball."));
+      version = getInstalledVersion() ?? version;
+    } catch (err) {
+      spinner.stop(pc.red("Installation failed."));
+      p.log.error(`${err}`);
+      p.log.info(`Install manually with: ${pc.cyan(cmdStr)}`);
       process.exit(1);
     }
   } else {
@@ -124,7 +140,7 @@ export async function init(args: string[]): Promise<void> {
     try {
       latest = getLatestVersion();
     } catch {
-      // Registry unreachable — silently skip
+      // Registry unreachable - silently skip
     }
     spinner.stop(pc.dim("Version check complete."));
 
@@ -148,15 +164,17 @@ export async function init(args: string[]): Promise<void> {
         if (!p.isCancel(updateChoice) && updateChoice === "update") {
           const pm = detectPackageManager();
           const cmd = globalInstallCommand(pm, `${PACKAGE_NAME}@${latest}`);
+          const cmdStr = formatShellCommand(cmd);
           const updateSpinner = p.spinner();
           updateSpinner.start(`Updating to v${latest}...`);
           try {
             await runShellCommand(cmd);
             updateSpinner.stop(pc.green(`Updated to v${latest}.`));
+            version = getInstalledVersion() ?? version;
           } catch (err) {
             updateSpinner.stop(pc.red("Update failed."));
             p.log.error(`${err}`);
-            p.log.info(`You can update manually later: ${pc.cyan(cmd)}`);
+            p.log.info(`You can update manually later: ${pc.cyan(cmdStr)}`);
           }
         }
       }
@@ -200,11 +218,12 @@ export async function init(args: string[]): Promise<void> {
 
   p.log.info(`Editors: ${selectedAdapters.map((a) => pc.cyan(a.name)).join(", ")}`);
 
-  // Ask scope: global or local
-  let scope: "local" | "global";
+  // Ask scope: global, local, or custom path
+  let scope: "local" | "global" | "custom";
+  let customRoot: string | undefined;
 
   if (nonInteractive) {
-    scope = "global";
+    scope = "local";
   } else {
     p.log.message(pc.dim("  Use arrow keys to move, enter to confirm."));
 
@@ -212,14 +231,19 @@ export async function init(args: string[]): Promise<void> {
       message: "Install MCP server globally or locally?",
       options: [
         {
-          value: "global" as const,
-          label: "Global",
-          hint: "Available across all projects (~/.*/mcp.json)",
-        },
-        {
           value: "local" as const,
           label: "Local",
-          hint: "Current project only (.cursor/mcp.json, .mcp.json, ...)",
+          hint: "Current project only - .cursor/mcp.json, .mcp.json, ...",
+        },
+        {
+          value: "global" as const,
+          label: "Global",
+          hint: "Available across all projects - ~/.*/mcp.json",
+        },
+        {
+          value: "custom" as const,
+          label: "Specify installation path",
+          hint: "Specify a directory to use as the project root",
         },
       ],
     });
@@ -229,15 +253,34 @@ export async function init(args: string[]): Promise<void> {
       process.exit(0);
     }
 
-    scope = scopeChoice as "local" | "global";
+    scope = scopeChoice as "local" | "global" | "custom";
+
+    if (scope === "custom") {
+      const customPathInput = await p.text({
+        message: "Enter the path to use as the project root for MCP config:",
+        placeholder: process.cwd(),
+        validate(value) {
+          if (!value?.trim()) return "Path cannot be empty.";
+        },
+      });
+
+      if (p.isCancel(customPathInput)) {
+        p.cancel("Initialization cancelled.");
+        process.exit(0);
+      }
+
+      customRoot = customPathInput as string;
+    }
   }
 
   const projectRoot = process.cwd();
+  const effectiveRoot = scope === "custom" ? customRoot! : projectRoot;
+  const normalizedScope: "local" | "global" = scope === "global" ? "global" : "local";
   const mcpEntry = getMcpEntry();
   const mcpResults: string[] = [];
 
   for (const adapter of selectedAdapters) {
-    const configPath = scope === "global" ? adapter.globalPath() : adapter.projectPath(projectRoot);
+    const configPath = scope === "global" ? adapter.globalPath() : adapter.projectPath(effectiveRoot);
 
     if (!configPath) {
       if (scope === "global" && adapter.projectPath(projectRoot)) {
@@ -288,7 +331,7 @@ export async function init(args: string[]): Promise<void> {
       p.log.message(pc.dim("  Press y for yes, n for no, enter to confirm."));
 
       const allowlistChoice = await p.confirm({
-        message: "Add argent tools to editor auto-approve lists? (recommended)",
+        message: "Add argent tools to editor auto-approve lists? - recommended",
         initialValue: true,
       });
 
@@ -306,7 +349,7 @@ export async function init(args: string[]): Promise<void> {
 
     for (const adapter of adaptersWithAllowlist) {
       try {
-        adapter.addAllowlist!(projectRoot, scope);
+        adapter.addAllowlist!(effectiveRoot, normalizedScope);
         allowlistResults.push(`${pc.green("+")} ${adapter.name}`);
       } catch (err) {
         allowlistResults.push(`${pc.red("x")} ${adapter.name}: ${pc.dim(String(err))}`);
@@ -315,7 +358,7 @@ export async function init(args: string[]): Promise<void> {
 
     for (const adapter of adaptersWithoutAllowlist) {
       allowlistResults.push(
-        `${pc.yellow("-")} ${adapter.name} ${pc.dim("(no auto-approve API — configure manually)")}`
+        `${pc.yellow("-")} ${adapter.name} ${pc.dim("(no auto-approve API - configure manually)")}`
       );
     }
 
@@ -346,7 +389,7 @@ export async function init(args: string[]): Promise<void> {
         {
           value: "interactive" as const,
           label: "Interactive",
-          hint: "Full npx skills TUI — choose skills, agents, and method",
+          hint: "Full npx skills TUI - choose skills, agents, and method",
         },
         {
           value: "manual" as const,
@@ -373,10 +416,10 @@ export async function init(args: string[]): Promise<void> {
         `To install manually, copy them to your editor's skills directory:`,
         ``,
         `  ${pc.dim("# Claude Code")}`,
-        `  cp -r ${SKILLS_DIR}/* ${scope === "global" ? "~/.claude/skills/" : ".claude/skills/"}`,
+        `  cp -r ${SKILLS_DIR}/* ${scope === "global" ? "~/.claude/skills/" : `${scope === "custom" ? customRoot! : "."}/.claude/skills/`}`,
         ``,
         `  ${pc.dim("# Cursor")}`,
-        `  cp -r ${SKILLS_DIR}/* ${scope === "global" ? "~/.cursor/skills/" : ".cursor/skills/"}`,
+        `  cp -r ${SKILLS_DIR}/* ${scope === "global" ? "~/.cursor/skills/" : `${scope === "custom" ? customRoot! : "."}/.cursor/skills/`}`,
         ``,
         `  ${pc.dim("# Or use npx skills directly:")}`,
         `  npx skills add ${SKILLS_DIR}`,
@@ -402,7 +445,8 @@ export async function init(args: string[]): Promise<void> {
     }
 
     try {
-      await runNpxSkills(skillsArgs, skillsMethod === "interactive");
+      const skillsCwd = scope === "custom" ? customRoot : undefined;
+      await runNpxSkills(skillsArgs, skillsMethod === "interactive", skillsCwd);
       if (skillsMethod === "default") {
         spinner.stop("Skills installed.");
       }
@@ -421,8 +465,8 @@ export async function init(args: string[]): Promise<void> {
 
   const copyResults = copyRulesAndAgents(
     selectedAdapters,
-    projectRoot,
-    scope,
+    effectiveRoot,
+    normalizedScope,
     RULES_DIR,
     AGENTS_DIR
   );
@@ -468,12 +512,13 @@ export function printBanner(): void {
   console.log();
 }
 
-function runNpxSkills(args: string[], interactive: boolean): Promise<void> {
+function runNpxSkills(args: string[], interactive: boolean, cwd?: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const npxCmd = process.platform === "win32" ? "npx.cmd" : "npx";
     const child = spawn(npxCmd, args, {
       stdio: interactive ? "inherit" : ["ignore", "pipe", "pipe"],
       shell: process.platform === "win32",
+      ...(cwd ? { cwd } : {}),
     });
 
     let stdout = "";

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -82,7 +82,7 @@ export async function init(args: string[]): Promise<void> {
   if (!globallyInstalled) {
     if (!nonInteractive) {
       const installChoice = await p.select({
-        message: "argent is not installed globally. Would you like to install it?",
+        message: "Argent is not installed globally. Would you like to install it?",
         options: [
           {
             value: "global" as const,
@@ -115,7 +115,7 @@ export async function init(args: string[]): Promise<void> {
     } catch (err) {
       spinner.stop(pc.red("Installation failed."));
       p.log.error(`${err}`);
-      p.log.info(`Install argent manually with: ${pc.cyan(cmdStr)}`);
+      p.log.info(`Install Argent manually with: ${pc.cyan(cmdStr)}`);
       process.exit(1);
     }
   } else if (fromTar) {
@@ -204,7 +204,7 @@ export async function init(args: string[]): Promise<void> {
     p.log.message(pc.dim("  Use arrow keys to move, space to toggle, enter to confirm."));
 
     const selected = await p.multiselect({
-      message: "Which editors should argent be configured for?",
+      message: "Which editors should Argent be configured for?",
       options: choices,
       initialValues: detected,
       required: true,
@@ -326,7 +326,7 @@ export async function init(args: string[]): Promise<void> {
   if (adaptersWithAllowlist.length > 0) {
     p.log.info(
       `By default, editors ask for confirmation before running each MCP tool.\n` +
-        `  Adding argent to the auto-approve allowlist lets tools run without\n` +
+        `  Adding Argent to the auto-approve allowlist lets tools run without\n` +
         `  repeated prompts. This is ${pc.cyan("recommended")} for a smooth experience.`
     );
 
@@ -336,7 +336,7 @@ export async function init(args: string[]): Promise<void> {
       p.log.message(pc.dim("  Press y for yes, n for no, enter to confirm."));
 
       const allowlistChoice = await p.confirm({
-        message: "Add argent tools to editor auto-approve lists? - recommended",
+        message: "Add Argent tools to editor auto-approve lists? - recommended",
         initialValue: true,
       });
 
@@ -373,7 +373,7 @@ export async function init(args: string[]): Promise<void> {
   // ── Step 2: Skills Installation ─────────────────────────────────────────────
 
   p.log.step(pc.bold("Step 2: Skills Installation"));
-  p.log.warn(pc.yellow("Skills installation is required for argent to function properly."));
+  p.log.warn(pc.yellow("Skills installation is required for Argent to function properly."));
 
   type SkillsMethod = "default" | "interactive" | "manual";
   let skillsMethod: SkillsMethod;
@@ -492,7 +492,7 @@ export async function init(args: string[]): Promise<void> {
   ];
 
   p.note(summaryLines.join("\n"), "Summary");
-  p.outro(pc.green("argent is ready!"));
+  p.outro(pc.green("Argent is ready!"));
 }
 
 export function printBanner(): void {

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -244,7 +244,7 @@ export async function init(args: string[]): Promise<void> {
         },
         {
           value: "custom" as const,
-          label: "Specify installation path",
+          label: "Specify installation directory",
           hint: "Specify a directory to use as the project root",
         },
       ],
@@ -274,7 +274,7 @@ export async function init(args: string[]): Promise<void> {
         process.exit(0);
       }
 
-      customRoot = customPathInput as string;
+      customRoot = resolve((customPathInput as string).trim());
     }
   }
 
@@ -353,6 +353,16 @@ export async function init(args: string[]): Promise<void> {
     const allowlistResults: string[] = [];
 
     for (const adapter of adaptersWithAllowlist) {
+      const hasPath =
+        normalizedScope === "global"
+          ? adapter.globalPath()
+          : adapter.projectPath(effectiveRoot);
+      if (!hasPath) {
+        allowlistResults.push(
+          `${pc.yellow("-")} ${adapter.name} ${pc.dim("(no config for this scope)")}`
+        );
+        continue;
+      }
       try {
         adapter.addAllowlist!(effectiveRoot, normalizedScope);
         allowlistResults.push(`${pc.green("+")} ${adapter.name}`);

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -1,5 +1,7 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { execSync, spawn } from "node:child_process";
 import {
   detectAdapters,
@@ -261,6 +263,9 @@ export async function init(args: string[]): Promise<void> {
         placeholder: process.cwd(),
         validate(value) {
           if (!value?.trim()) return "Path cannot be empty.";
+          const resolved = resolve(value.trim());
+          if (!existsSync(resolved))
+            return `Path does not exist: ${resolved}. Please verify and enter a valid path.`;
         },
       });
 

--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -321,11 +321,11 @@ const zedAdapter: McpConfigAdapter = {
   // would need its own entry.  Setting the global default to "allow" is the
   // documented opt-in; built-in security rules still protect against
   // destructive operations.
-  addAllowlist(_root: string, scope: "local" | "global"): void {
+  addAllowlist(root: string, scope: "local" | "global"): void {
     const settingsPath =
       scope === "global"
         ? path.join(homedir(), ".config", "zed", "settings.json")
-        : path.join(process.cwd(), ".zed", "settings.json");
+        : path.join(root, ".zed", "settings.json");
     const config = readJson(settingsPath);
     const agent = (config.agent ?? {}) as Record<string, unknown>;
     const perms = (agent.tool_permissions ?? {}) as Record<string, unknown>;
@@ -335,11 +335,11 @@ const zedAdapter: McpConfigAdapter = {
     writeJson(settingsPath, config);
   },
 
-  removeAllowlist(_root: string, scope: "local" | "global"): void {
+  removeAllowlist(root: string, scope: "local" | "global"): void {
     const settingsPath =
       scope === "global"
         ? path.join(homedir(), ".config", "zed", "settings.json")
-        : path.join(process.cwd(), ".zed", "settings.json");
+        : path.join(root, ".zed", "settings.json");
     if (!fs.existsSync(settingsPath)) return;
     const config = readJson(settingsPath);
     const perms = (config.agent as Record<string, unknown>)?.tool_permissions as

--- a/packages/mcp/src/cli/uninstall.ts
+++ b/packages/mcp/src/cli/uninstall.ts
@@ -2,10 +2,10 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { ALL_ADAPTERS, removeCodexRules } from "./mcp-configs.js";
-import { detectPackageManager, globalUninstallCommand } from "./utils.js";
+import { detectPackageManager, globalUninstallCommand, formatShellCommand } from "./utils.js";
 import { PACKAGE_NAME } from "./constants.js";
 import { killToolServer } from "../launcher.js";
 
@@ -180,12 +180,12 @@ export async function uninstall(args: string[]): Promise<void> {
   if (shouldUninstallPackage) {
     const pm = detectPackageManager();
     const cmd = globalUninstallCommand(pm, PACKAGE_NAME);
-    p.log.info(`Running: ${pc.dim(cmd)}`);
+    p.log.info(`Running: ${pc.dim(formatShellCommand(cmd))}`);
 
     await killToolServer();
 
     try {
-      execSync(cmd, { stdio: "inherit" });
+      execFileSync(cmd.bin, cmd.args, { stdio: "inherit" });
       p.log.success("Package uninstalled.");
     } catch (err) {
       p.log.error(`Uninstall failed: ${err}`);

--- a/packages/mcp/src/cli/update.ts
+++ b/packages/mcp/src/cli/update.ts
@@ -1,12 +1,13 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { detectAdapters, getMcpEntry, copyRulesAndAgents } from "./mcp-configs.js";
 import {
   getInstalledVersion,
   getLatestVersion,
   detectPackageManager,
   globalInstallCommand,
+  formatShellCommand,
   RULES_DIR,
   AGENTS_DIR,
 } from "./utils.js";
@@ -46,6 +47,7 @@ export async function update(args: string[]): Promise<void> {
 
     const pm = detectPackageManager();
     const cmd = globalInstallCommand(pm, `${PACKAGE_NAME}@${latest}`);
+    const cmdStr = formatShellCommand(cmd);
 
     if (!nonInteractive) {
       p.log.message(pc.dim("  Press y for yes, n for no, enter to confirm."));
@@ -61,12 +63,12 @@ export async function update(args: string[]): Promise<void> {
       }
     }
 
-    p.log.info(`Running: ${pc.dim(cmd)}`);
+    p.log.info(`Running: ${pc.dim(cmdStr)}`);
 
     await killToolServer();
 
     try {
-      execSync(cmd, {
+      execFileSync(cmd.bin, cmd.args, {
         stdio: "inherit",
         env: { ...process.env, ARGENT_SKIP_POSTINSTALL: "1" },
       });
@@ -133,7 +135,7 @@ export async function update(args: string[]): Promise<void> {
     p.log.message(pc.dim("  Press y for yes, n for no, enter to confirm."));
 
     const checkSkills = await p.confirm({
-      message: "Check if skills have updates? (runs npx skills check)",
+      message: "Check if skills have updates? — runs npx skills check",
       initialValue: true,
     });
 

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -103,7 +103,8 @@ export interface ShellCommand {
 }
 
 export function formatShellCommand(cmd: ShellCommand): string {
-  return [cmd.bin, ...cmd.args].join(" ");
+  const parts = [cmd.bin, ...cmd.args.map((a) => (a.includes(" ") ? `"${a}"` : a))];
+  return parts.join(" ");
 }
 
 export function detectPackageManager(): PackageManager {

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -97,6 +97,15 @@ export function getLatestVersion(): string {
 
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 
+export interface ShellCommand {
+  bin: string;
+  args: string[];
+}
+
+export function formatShellCommand(cmd: ShellCommand): string {
+  return [cmd.bin, ...cmd.args].join(" ");
+}
+
 export function detectPackageManager(): PackageManager {
   const agent = process.env.npm_config_user_agent ?? "";
   if (agent.startsWith("yarn")) return "yarn";
@@ -105,28 +114,28 @@ export function detectPackageManager(): PackageManager {
   return "npm";
 }
 
-export function globalInstallCommand(pm: PackageManager, pkg: string): string {
+export function globalInstallCommand(pm: PackageManager, pkg: string): ShellCommand {
   switch (pm) {
     case "yarn":
-      return `yarn global add ${pkg}`;
+      return { bin: "yarn", args: ["global", "add", pkg] };
     case "pnpm":
-      return `pnpm add -g ${pkg}`;
+      return { bin: "pnpm", args: ["add", "-g", pkg] };
     case "bun":
-      return `bun add -g ${pkg}`;
+      return { bin: "bun", args: ["add", "-g", pkg] };
     default:
-      return `npm install -g ${pkg}`;
+      return { bin: "npm", args: ["install", "-g", pkg] };
   }
 }
 
-export function globalUninstallCommand(pm: PackageManager, pkg: string): string {
+export function globalUninstallCommand(pm: PackageManager, pkg: string): ShellCommand {
   switch (pm) {
     case "yarn":
-      return `yarn global remove ${pkg}`;
+      return { bin: "yarn", args: ["global", "remove", pkg] };
     case "pnpm":
-      return `pnpm remove -g ${pkg}`;
+      return { bin: "pnpm", args: ["remove", "-g", pkg] };
     case "bun":
-      return `bun remove -g ${pkg}`;
+      return { bin: "bun", args: ["remove", "-g", pkg] };
     default:
-      return `npm uninstall -g ${pkg}`;
+      return { bin: "npm", args: ["uninstall", "-g", pkg] };
   }
 }

--- a/packages/mcp/test/cli/update.test.ts
+++ b/packages/mcp/test/cli/update.test.ts
@@ -3,6 +3,7 @@ import {
   getInstalledVersion,
   detectPackageManager,
   globalInstallCommand,
+  formatShellCommand,
 } from "../../src/cli/utils.js";
 import { PACKAGE_NAME, NPM_REGISTRY } from "../../src/cli/constants.js";
 
@@ -27,17 +28,19 @@ describe("update — install command generation", () => {
     delete process.env.npm_config_user_agent;
     const pm = detectPackageManager();
     const cmd = globalInstallCommand(pm, `${PACKAGE_NAME}@1.0.0`);
-    expect(cmd).toContain("npm install -g");
-    expect(cmd).toContain(PACKAGE_NAME);
-    expect(cmd).not.toContain("--registry");
+    const cmdStr = formatShellCommand(cmd);
+    expect(cmdStr).toContain("npm install -g");
+    expect(cmdStr).toContain(PACKAGE_NAME);
+    expect(cmdStr).not.toContain("--registry");
   });
 
   it("generates correct pnpm update command", () => {
     process.env.npm_config_user_agent = "pnpm/9.0.0";
     const pm = detectPackageManager();
     const cmd = globalInstallCommand(pm, `${PACKAGE_NAME}@1.0.0`);
-    expect(cmd).toContain("pnpm add -g");
-    expect(cmd).toContain(PACKAGE_NAME);
+    const cmdStr = formatShellCommand(cmd);
+    expect(cmdStr).toContain("pnpm add -g");
+    expect(cmdStr).toContain(PACKAGE_NAME);
   });
 });
 
@@ -55,7 +58,8 @@ describe("update — registry safety", () => {
   it("globalInstallCommand never includes --registry (relies on .npmrc scoped registry)", () => {
     for (const pm of ["npm", "yarn", "pnpm", "bun"] as const) {
       const cmd = globalInstallCommand(pm, `${PACKAGE_NAME}@1.0.0`);
-      expect(cmd).not.toContain("--registry");
+      const cmdStr = formatShellCommand(cmd);
+      expect(cmdStr).not.toContain("--registry");
     }
   });
 });

--- a/packages/mcp/test/cli/utils.test.ts
+++ b/packages/mcp/test/cli/utils.test.ts
@@ -10,6 +10,7 @@ import {
   detectPackageManager,
   globalInstallCommand,
   globalUninstallCommand,
+  formatShellCommand,
   SKILLS_DIR,
   RULES_DIR,
   AGENTS_DIR,
@@ -172,6 +173,22 @@ describe("globalUninstallCommand", () => {
   });
   it("bun", () => {
     expect(globalUninstallCommand("bun", "pkg")).toEqual({ bin: "bun", args: ["remove", "-g", "pkg"] });
+  });
+});
+
+// ── formatShellCommand ───────────────────────────────────────────────────────
+
+describe("formatShellCommand", () => {
+  it("joins bin and args", () => {
+    expect(formatShellCommand({ bin: "npm", args: ["install", "-g", "pkg"] })).toBe(
+      "npm install -g pkg"
+    );
+  });
+
+  it("quotes args that contain spaces", () => {
+    expect(
+      formatShellCommand({ bin: "npm", args: ["install", "-g", "/path/with spaces/pkg.tgz"] })
+    ).toBe('npm install -g "/path/with spaces/pkg.tgz"');
   });
 });
 

--- a/packages/mcp/test/cli/utils.test.ts
+++ b/packages/mcp/test/cli/utils.test.ts
@@ -143,31 +143,35 @@ describe("detectPackageManager", () => {
 
 describe("globalInstallCommand", () => {
   it("npm", () => {
-    expect(globalInstallCommand("npm", "pkg")).toBe("npm install -g pkg");
+    expect(globalInstallCommand("npm", "pkg")).toEqual({ bin: "npm", args: ["install", "-g", "pkg"] });
   });
   it("yarn", () => {
-    expect(globalInstallCommand("yarn", "pkg")).toBe("yarn global add pkg");
+    expect(globalInstallCommand("yarn", "pkg")).toEqual({ bin: "yarn", args: ["global", "add", "pkg"] });
   });
   it("pnpm", () => {
-    expect(globalInstallCommand("pnpm", "pkg")).toBe("pnpm add -g pkg");
+    expect(globalInstallCommand("pnpm", "pkg")).toEqual({ bin: "pnpm", args: ["add", "-g", "pkg"] });
   });
   it("bun", () => {
-    expect(globalInstallCommand("bun", "pkg")).toBe("bun add -g pkg");
+    expect(globalInstallCommand("bun", "pkg")).toEqual({ bin: "bun", args: ["add", "-g", "pkg"] });
+  });
+  it("preserves paths with spaces", () => {
+    const cmd = globalInstallCommand("npm", "/path/with spaces/pkg.tgz");
+    expect(cmd.args[2]).toBe("/path/with spaces/pkg.tgz");
   });
 });
 
 describe("globalUninstallCommand", () => {
   it("npm", () => {
-    expect(globalUninstallCommand("npm", "pkg")).toBe("npm uninstall -g pkg");
+    expect(globalUninstallCommand("npm", "pkg")).toEqual({ bin: "npm", args: ["uninstall", "-g", "pkg"] });
   });
   it("yarn", () => {
-    expect(globalUninstallCommand("yarn", "pkg")).toBe("yarn global remove pkg");
+    expect(globalUninstallCommand("yarn", "pkg")).toEqual({ bin: "yarn", args: ["global", "remove", "pkg"] });
   });
   it("pnpm", () => {
-    expect(globalUninstallCommand("pnpm", "pkg")).toBe("pnpm remove -g pkg");
+    expect(globalUninstallCommand("pnpm", "pkg")).toEqual({ bin: "pnpm", args: ["remove", "-g", "pkg"] });
   });
   it("bun", () => {
-    expect(globalUninstallCommand("bun", "pkg")).toBe("bun remove -g pkg");
+    expect(globalUninstallCommand("bun", "pkg")).toEqual({ bin: "bun", args: ["remove", "-g", "pkg"] });
   });
 });
 


### PR DESCRIPTION
## Summary

- Changes CLI `init` to default to local installation of MCP and skills, with an option for a custom path
- Adds path validation in the `init` function, resolving and checking paths before use
- Improves `isGloballyInstalled` check using `which`/`where` instead of `npm list -g --json`
- Refactors `runShellCommand` to accept a structured `ShellCommand` object instead of a raw string
- Renames "argent" to "Argent" (capitalized) in installer-facing user messages (where it does not refer to `argent` command but the branding name itself)