### PR TITLE
fix: add node to types in tsconfig to resolve missing Node.js typing

### DIFF
--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
+    "types": ["node"],
     "strict": true,
     "composite": true,
     "sourceMap": true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "lib": ["ES2022"],
+    "types": ["node"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This PR fixes the linting issues visible on the attached pictures.

When lib is explicitly set in `tsconfig.json` (e.g., `"lib": ["ES2022"]`), TypeScript does not auto-resolve `@types/node` even if the package is installed. We need "types": ["node"] in `compilerOptions` to explicitly include it.

<img width="2294" height="288" alt="image" src="https://github.com/user-attachments/assets/04e26b8c-2361-42db-a105-a479cedf8e98" />

<img width="819" height="103" alt="image" src="https://github.com/user-attachments/assets/a7fecdc9-6660-473f-b9b2-185eae2d2af2" />

<img width="856" height="200" alt="image" src="https://github.com/user-attachments/assets/84077a7c-3ede-4552-95e0-40d1d40d5aa5" />
