### PR TITLE
feat: add accessibility permission gate during installation

### DIFF
--- a/packages/mcp/src/cli/accessibility.ts
+++ b/packages/mcp/src/cli/accessibility.ts
@@ -8,6 +8,15 @@ import pc from "picocolors";
  * Uses the CoreGraphics AXIsProcessTrusted() API via a one-liner Swift call.
  * Returns false on non-macOS platforms.
  */
+function isSwiftAvailable(): boolean {
+  try {
+    execSync("which swift", { stdio: "ignore", timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function isAccessibilityEnabled(): boolean {
   if (process.platform !== "darwin") return false;
   try {
@@ -159,6 +168,18 @@ export async function ensureAccessibilityPermission(
   // Already granted — nothing to do
   if (isAccessibilityEnabled()) return;
 
+  // Check that swift is available — we need it to query the Accessibility API
+  if (!isSwiftAvailable()) {
+    console.log(
+      pc.yellow(
+        "\n  Warning: `swift` is not available on your PATH.\n" +
+          "  Argent needs Swift to check Accessibility permissions.\n" +
+          "  Install Xcode Command Line Tools: xcode-select --install\n"
+      )
+    );
+    process.exit(1);
+  }
+
   // Show the warning banner
   printBannerBlock(PERM_BANNER_LINES, pc.yellow);
 
@@ -181,7 +202,7 @@ export async function ensureAccessibilityPermission(
     process.stdout.write(pc.yellow(pc.bold(`  Opening permission prompt in ${i}...`)) + "\r");
     await sleep(1000);
   }
-  process.stdout.write(" ".repeat(60) + "\r"); // Clear countdown line
+  process.stdout.write("\x1b[2K\r"); // Clear countdown line
 
   // Trigger the native prompt
   requestAccessibilityPermission();
@@ -236,18 +257,34 @@ export async function ensureAccessibilityPermission(
 
 /**
  * Poll for permission while listening for 's' keypress to open settings.
- * Returns true if permission is granted within the timeout.
+ * Uses recursive setTimeout (not setInterval) so that synchronous execSync
+ * calls in isAccessibilityEnabled() don't stack up and block key events.
+ * Handles Ctrl+C and ensures raw mode is always restored on exit.
  */
 function pollWithKeyboardHint(timeoutSeconds: number): Promise<boolean> {
   return new Promise((resolve) => {
     let resolved = false;
+    let rawModeSet = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
     const cleanup = () => {
-      if (process.stdin.isTTY) {
-        process.stdin.setRawMode(false);
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (rawModeSet && process.stdin.isTTY) {
+        try {
+          process.stdin.setRawMode(false);
+        } catch {
+          // Best effort
+        }
         process.stdin.pause();
         process.stdin.removeListener("data", onData);
+        rawModeSet = false;
       }
+      process.removeListener("exit", cleanup);
+      process.removeListener("SIGINT", onSigInt);
+      process.removeListener("SIGTERM", onSigInt);
     };
 
     const done = (result: boolean) => {
@@ -257,9 +294,25 @@ function pollWithKeyboardHint(timeoutSeconds: number): Promise<boolean> {
       resolve(result);
     };
 
-    // Set up keyboard listener for 's' to open settings
+    const onSigInt = () => {
+      cleanup();
+      process.exit(1);
+    };
+
+    // Ensure raw mode is always restored, even on unexpected exit
+    process.on("exit", cleanup);
+    process.on("SIGINT", onSigInt);
+    process.on("SIGTERM", onSigInt);
+
+    // Set up keyboard listener for 's' to open settings, Ctrl+C to abort
     const onData = (data: Buffer) => {
       const key = data.toString();
+      if (key === "\x03") {
+        // Ctrl+C
+        console.log();
+        done(false);
+        return;
+      }
       if (key === "s" || key === "S") {
         openAccessibilitySettings();
         console.log(pc.dim("  Opened System Settings → Accessibility"));
@@ -267,24 +320,35 @@ function pollWithKeyboardHint(timeoutSeconds: number): Promise<boolean> {
     };
 
     if (process.stdin.isTTY) {
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-      process.stdin.on("data", onData);
+      try {
+        process.stdin.setRawMode(true);
+        rawModeSet = true;
+        process.stdin.resume();
+        process.stdin.on("data", onData);
+      } catch {
+        // If raw mode fails, continue without keyboard hints
+      }
     }
 
-    // Poll every 1.5 seconds
-    let elapsed = 0;
-    const interval = setInterval(() => {
+    // Poll using recursive setTimeout so each check completes before scheduling the next
+    const startTime = Date.now();
+    const pollIntervalMs = 2000;
+
+    const check = () => {
+      if (resolved) return;
       if (isAccessibilityEnabled()) {
-        clearInterval(interval);
         done(true);
         return;
       }
-      elapsed += 1.5;
+      const elapsed = (Date.now() - startTime) / 1000;
       if (elapsed >= timeoutSeconds) {
-        clearInterval(interval);
         done(false);
+        return;
       }
-    }, 1500);
+      timer = setTimeout(check, pollIntervalMs);
+    };
+
+    // Start first check after a short delay to let the system prompt appear
+    timer = setTimeout(check, pollIntervalMs);
   });
 }

--- a/packages/mcp/src/cli/accessibility.ts
+++ b/packages/mcp/src/cli/accessibility.ts
@@ -1,0 +1,290 @@
+import { execSync } from "node:child_process";
+import pc from "picocolors";
+
+// ── macOS Accessibility Permission Helpers ───────────────────────────────────
+
+/**
+ * Check whether the current process has macOS Accessibility permissions.
+ * Uses the CoreGraphics AXIsProcessTrusted() API via a one-liner Swift call.
+ * Returns false on non-macOS platforms.
+ */
+export function isAccessibilityEnabled(): boolean {
+  if (process.platform !== "darwin") return false;
+  try {
+    const result = execSync(
+      `swift -e 'import Cocoa; print(AXIsProcessTrusted())'`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 15_000 }
+    );
+    return result.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Trigger the macOS Accessibility permission prompt via AXIsProcessTrustedWithOptions.
+ * This shows the native system dialog asking the user to grant access.
+ */
+function requestAccessibilityPermission(): void {
+  try {
+    execSync(
+      `swift -e 'import Cocoa; let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary; AXIsProcessTrustedWithOptions(opts)'`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 15_000 }
+    );
+  } catch {
+    // Prompt may still appear even if swift exits non-zero
+  }
+}
+
+/**
+ * Open System Settings directly to the Accessibility privacy pane.
+ */
+function openAccessibilitySettings(): void {
+  try {
+    execSync(
+      `open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"`,
+      { stdio: "ignore" }
+    );
+  } catch {
+    // Swallow — user can navigate manually
+  }
+}
+
+// ── Banner rendering ─────────────────────────────────────────────────────────
+
+const PERM_BANNER_LINES = [
+  "╔══════════════════════════════════════════════════════════════════════════════╗",
+  "║                                                                            ║",
+  "║       █████╗  ██████╗ ██████╗███████╗███████╗███████╗                      ║",
+  "║      ██╔══██╗██╔════╝██╔════╝██╔════╝██╔════╝██╔════╝                      ║",
+  "║      ███████║██║     ██║     █████╗  ███████╗███████╗                      ║",
+  "║      ██╔══██║██║     ██║     ██╔══╝  ╚════██║╚════██║                      ║",
+  "║      ██║  ██║╚██████╗╚██████╗███████╗███████║███████║                      ║",
+  "║      ╚═╝  ╚═╝ ╚═════╝ ╚═════╝╚══════╝╚══════╝╚══════╝                      ║",
+  "║                                                                            ║",
+  "║              ⚠  ACCESSIBILITY PERMISSION REQUIRED  ⚠                      ║",
+  "║                                                                            ║",
+  "║   Argent needs macOS Accessibility permissions to inspect simulator UI.    ║",
+  "║   Without this, the `describe` tool cannot read screen elements.           ║",
+  "║                                                                            ║",
+  "║   The system permission prompt will appear shortly.                        ║",
+  "║   Please click \"Allow\" when prompted.                                      ║",
+  "║                                                                            ║",
+  "╚══════════════════════════════════════════════════════════════════════════════╝",
+];
+
+const SUCCESS_BANNER_LINES = [
+  "╔══════════════════════════════════════════════════════════════════════════════╗",
+  "║                                                                            ║",
+  "║              ✓  ACCESSIBILITY PERMISSION GRANTED                           ║",
+  "║                                                                            ║",
+  "║   Thank you! Argent can now inspect simulator UI elements.                 ║",
+  "║                                                                            ║",
+  "╚══════════════════════════════════════════════════════════════════════════════╝",
+];
+
+const DENIED_BANNER_LINES = [
+  "╔══════════════════════════════════════════════════════════════════════════════╗",
+  "║                                                                            ║",
+  "║              ✗  ACCESSIBILITY PERMISSION DENIED                            ║",
+  "║                                                                            ║",
+  "║   Argent cannot function without Accessibility permissions.                ║",
+  "║   The `describe` tool requires access to the UI element tree.              ║",
+  "║                                                                            ║",
+  "║   To enable manually:                                                      ║",
+  "║                                                                            ║",
+  "║     1. Open System Settings                                                ║",
+  "║     2. Go to Privacy & Security → Accessibility                            ║",
+  "║     3. Find your terminal app (Terminal, iTerm2, etc.)                     ║",
+  "║     4. Toggle the switch ON                                                ║",
+  "║                                                                            ║",
+  "║   Then run `argent init` again.                                            ║",
+  "║                                                                            ║",
+  "╚══════════════════════════════════════════════════════════════════════════════╝",
+];
+
+function printBannerBlock(lines: string[], colorFn: (s: string) => string): void {
+  console.log();
+  for (const line of lines) {
+    console.log(colorFn(line));
+  }
+  console.log();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll for accessibility permission with retries.
+ * Returns true as soon as permission is detected, false after all attempts.
+ */
+function waitForPermission(attempts: number, intervalMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let count = 0;
+    const check = () => {
+      if (isAccessibilityEnabled()) {
+        resolve(true);
+        return;
+      }
+      count++;
+      if (count >= attempts) {
+        resolve(false);
+        return;
+      }
+      setTimeout(check, intervalMs);
+    };
+    check();
+  });
+}
+
+// ── Main gate ────────────────────────────────────────────────────────────────
+
+/**
+ * Ensure macOS Accessibility permissions are granted before continuing init.
+ * Shows a prominent banner, counts down, triggers the system prompt, and
+ * polls for the result. Exits the process if the user refuses.
+ *
+ * No-ops on non-macOS platforms or if permissions are already granted.
+ *
+ * In non-interactive mode (--yes), skips the countdown and interactive polling
+ * but still checks and exits if permissions are missing.
+ */
+export async function ensureAccessibilityPermission(
+  nonInteractive = false
+): Promise<void> {
+  // Only relevant on macOS
+  if (process.platform !== "darwin") return;
+
+  // Already granted — nothing to do
+  if (isAccessibilityEnabled()) return;
+
+  // Show the warning banner
+  printBannerBlock(PERM_BANNER_LINES, pc.yellow);
+
+  // In non-interactive mode (CI, --yes), we can't wait for user input.
+  // Trigger the prompt and do a quick poll, then fail if still denied.
+  if (nonInteractive) {
+    requestAccessibilityPermission();
+    // Give the system a few seconds to register the permission
+    const granted = await waitForPermission(5, 2000);
+    if (granted) {
+      printBannerBlock(SUCCESS_BANNER_LINES, pc.green);
+      return;
+    }
+    printBannerBlock(DENIED_BANNER_LINES, pc.red);
+    process.exit(1);
+  }
+
+  // Countdown
+  for (let i = 3; i > 0; i--) {
+    process.stdout.write(pc.yellow(pc.bold(`  Opening permission prompt in ${i}...`)) + "\r");
+    await sleep(1000);
+  }
+  process.stdout.write(" ".repeat(60) + "\r"); // Clear countdown line
+
+  // Trigger the native prompt
+  requestAccessibilityPermission();
+
+  console.log(pc.dim("  Waiting for you to grant Accessibility permission..."));
+  console.log(
+    pc.dim("  Press ") +
+      pc.cyan("s") +
+      pc.dim(" to open System Settings, or grant via the system dialog.")
+  );
+
+  // Poll for permission — give the user up to ~60 seconds
+  const granted = await pollWithKeyboardHint(60);
+
+  if (granted) {
+    printBannerBlock(SUCCESS_BANNER_LINES, pc.green);
+    return;
+  }
+
+  // Permission still denied
+  printBannerBlock(DENIED_BANNER_LINES, pc.red);
+
+  // Offer to open settings one more time
+  console.log(
+    pc.yellow("  Opening System Settings → Accessibility so you can enable it manually...")
+  );
+  openAccessibilitySettings();
+
+  console.log();
+  console.log(pc.dim("  Waiting for you to toggle the permission ON in System Settings..."));
+  console.log(pc.dim("  (checking every 2 seconds for up to 2 minutes)"));
+  console.log();
+
+  // Final extended poll — 2 minutes
+  const grantedAfterSettings = await waitForPermission(60, 2000);
+
+  if (grantedAfterSettings) {
+    printBannerBlock(SUCCESS_BANNER_LINES, pc.green);
+    return;
+  }
+
+  // User absolutely refuses — abort installation
+  console.log(
+    pc.red(pc.bold("  ✗ Accessibility permission is required. Installation aborted."))
+  );
+  console.log();
+  console.log(pc.dim("  Enable Accessibility for your terminal, then run:"));
+  console.log(pc.cyan("    argent init"));
+  console.log();
+  process.exit(1);
+}
+
+/**
+ * Poll for permission while listening for 's' keypress to open settings.
+ * Returns true if permission is granted within the timeout.
+ */
+function pollWithKeyboardHint(timeoutSeconds: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let resolved = false;
+
+    const cleanup = () => {
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdin.removeListener("data", onData);
+      }
+    };
+
+    const done = (result: boolean) => {
+      if (resolved) return;
+      resolved = true;
+      cleanup();
+      resolve(result);
+    };
+
+    // Set up keyboard listener for 's' to open settings
+    const onData = (data: Buffer) => {
+      const key = data.toString();
+      if (key === "s" || key === "S") {
+        openAccessibilitySettings();
+        console.log(pc.dim("  Opened System Settings → Accessibility"));
+      }
+    };
+
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+      process.stdin.on("data", onData);
+    }
+
+    // Poll every 1.5 seconds
+    let elapsed = 0;
+    const interval = setInterval(() => {
+      if (isAccessibilityEnabled()) {
+        clearInterval(interval);
+        done(true);
+        return;
+      }
+      elapsed += 1.5;
+      if (elapsed >= timeoutSeconds) {
+        clearInterval(interval);
+        done(false);
+      }
+    }, 1500);
+  });
+}

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -22,6 +22,7 @@ import {
   type ShellCommand,
 } from "./utils.js";
 import { PACKAGE_NAME, MCP_BINARY_NAME } from "./constants.js";
+import { ensureAccessibilityPermission } from "./accessibility.js";
 
 function isGloballyInstalled(): boolean {
   try {
@@ -69,6 +70,9 @@ export async function init(args: string[]): Promise<void> {
   const fromTar = extractFlag(args, "--from");
 
   printBanner();
+
+  // ── Accessibility Permission Gate (macOS only) ─────────────────────────────
+  await ensureAccessibilityPermission(nonInteractive);
 
   p.intro(pc.bgCyan(pc.black(" argent init ")));
 

--- a/packages/mcp/test/cli/accessibility-edge-cases.test.ts
+++ b/packages/mcp/test/cli/accessibility-edge-cases.test.ts
@@ -1,0 +1,702 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as child_process from "node:child_process";
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process"
+  );
+  return { ...actual, execSync: vi.fn() };
+});
+
+// picocolors is used in banners/output — let it pass through as identity so we
+// can assert on raw text content without color codes.
+vi.mock("picocolors", () => {
+  const identity = (s: string) => s;
+  return {
+    default: new Proxy(
+      {},
+      {
+        get: () => identity,
+      }
+    ),
+  };
+});
+
+const mockedExecSync = vi.mocked(child_process.execSync);
+
+// We re-import the module for each describe block that needs a fresh module
+// cache so platform overrides take effect at import time.
+async function freshImport() {
+  return await import("../../src/cli/accessibility.js");
+}
+
+/**
+ * Helper: create a standard execSync mock that routes by command string.
+ * `whichSwiftResult` — return value for `which swift`, or Error to throw.
+ * `accessibilityResults` — sequential return values for AXIsProcessTrusted() calls.
+ */
+function mockExecSyncRouted(opts: {
+  whichSwift?: string | Error;
+  accessibilityResults?: string[];
+  openThrows?: boolean;
+}) {
+  let accessIdx = 0;
+  const results = opts.accessibilityResults ?? ["false\n"];
+  mockedExecSync.mockImplementation(((cmd: string) => {
+    if (typeof cmd === "string" && cmd.includes("which swift")) {
+      if (opts.whichSwift instanceof Error) throw opts.whichSwift;
+      return opts.whichSwift ?? "/usr/bin/swift\n";
+    }
+    if (typeof cmd === "string" && cmd.startsWith("open ")) {
+      if (opts.openThrows) throw new Error("open command failed");
+      return "";
+    }
+    if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions")) {
+      return "";
+    }
+    if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted()")) {
+      const val = results[Math.min(accessIdx, results.length - 1)];
+      accessIdx++;
+      return val;
+    }
+    return "";
+  }) as typeof child_process.execSync);
+}
+
+// ---------------------------------------------------------------------------
+// 1. execSync edge cases for isAccessibilityEnabled
+// ---------------------------------------------------------------------------
+describe("isAccessibilityEnabled — execSync edge cases", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it('returns true when swift returns "true" with no trailing newline', async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    mockedExecSync.mockReturnValue("true");
+    expect(isAccessibilityEnabled()).toBe(true);
+  });
+
+  it('returns false when swift returns "TRUE" (uppercase) — comparison is case-sensitive', async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    mockedExecSync.mockReturnValue("TRUE");
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it('returns true when swift returns "true\\n\\n" (extra newlines) — .trim() handles it', async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    mockedExecSync.mockReturnValue("true\n\n");
+    expect(isAccessibilityEnabled()).toBe(true);
+  });
+
+  it("returns false when swift returns an empty string", async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    mockedExecSync.mockReturnValue("");
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it("returns false when execSync throws ETIMEDOUT", async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    const err = new Error("Command timed out");
+    (err as NodeJS.ErrnoException).code = "ETIMEDOUT";
+    mockedExecSync.mockImplementation(() => {
+      throw err;
+    });
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it("returns false when execSync throws ENOENT (swift not found)", async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    const err = new Error("spawn swift ENOENT");
+    (err as NodeJS.ErrnoException).code = "ENOENT";
+    mockedExecSync.mockImplementation(() => {
+      throw err;
+    });
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it('returns false when swift returns "True" (capitalised) — exact match only', async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    mockedExecSync.mockReturnValue("True\n");
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it("returns false when swift returns whitespace-only string", async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    mockedExecSync.mockReturnValue("   \n");
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it('returns true when swift returns "true" surrounded by whitespace', async () => {
+    const { isAccessibilityEnabled } = await freshImport();
+    mockedExecSync.mockReturnValue("  true  \n");
+    expect(isAccessibilityEnabled()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. isSwiftAvailable — tested indirectly via ensureAccessibilityPermission
+// ---------------------------------------------------------------------------
+describe("isSwiftAvailable — tested via ensureAccessibilityPermission", () => {
+  const originalPlatform = process.platform;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Use fake timers since ensureAccessibilityPermission may go past the
+    // exit(1) mock (which doesn't actually terminate) into countdown/polling.
+    vi.useFakeTimers();
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => {}) as unknown as (code?: number) => never);
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it('calls process.exit(1) and mentions "xcode-select --install" when swift is unavailable', async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // isAccessibilityEnabled -> false, then isSwiftAvailable (which swift) -> throws
+    // After the mocked exit(1), execution continues because the mock doesn't
+    // actually exit. It falls into the banner + nonInteractive/interactive path.
+    // We need to also handle the rest of the flow.
+    mockExecSyncRouted({
+      whichSwift: new Error("not found"),
+      // After exit(1) is mocked, the function continues and calls more stuff.
+      // All accessibility checks remain false.
+      accessibilityResults: ["false\n"],
+    });
+
+    const promise = ensureAccessibilityPermission(false);
+
+    // The function continues past the mocked exit(1) into the interactive flow
+    // (countdown 3s + polling). Advance past all of it.
+    // Countdown: 3 x 1s
+    await vi.advanceTimersByTimeAsync(3000);
+    // pollWithKeyboardHint: initial delay 2s + up to 60s worth of 2s polls
+    for (let i = 0; i < 31; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+    // After first poll phase fails: openAccessibilitySettings + second poll (60 attempts x 2s)
+    for (let i = 0; i < 61; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    await promise;
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const loggedOutput = consoleSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(loggedOutput).toContain("xcode-select --install");
+  });
+
+  it("does not exit when swift is available but permission is already granted", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    mockExecSyncRouted({
+      whichSwift: "/usr/bin/swift\n",
+      accessibilityResults: ["true\n"],
+    });
+
+    await ensureAccessibilityPermission(false);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Platform edge cases
+// ---------------------------------------------------------------------------
+describe("Platform edge cases", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it.each(["linux", "win32", "freebsd", "aix"] as const)(
+    "isAccessibilityEnabled returns false on %s without calling execSync",
+    async (platform) => {
+      Object.defineProperty(process, "platform", { value: platform });
+      const { isAccessibilityEnabled } = await freshImport();
+      mockedExecSync.mockClear();
+
+      expect(isAccessibilityEnabled()).toBe(false);
+      expect(mockedExecSync).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["linux", "win32", "freebsd"] as const)(
+    "ensureAccessibilityPermission returns immediately on %s — no side effects",
+    async (platform) => {
+      Object.defineProperty(process, "platform", { value: platform });
+      const { ensureAccessibilityPermission } = await freshImport();
+      const exitSpy = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => {}) as unknown as (code?: number) => never);
+      mockedExecSync.mockClear();
+
+      await ensureAccessibilityPermission(false);
+
+      expect(mockedExecSync).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+    }
+  );
+
+  it("runs the full flow on darwin", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const { isAccessibilityEnabled } = await freshImport();
+    mockedExecSync.mockReturnValue("true\n");
+
+    expect(isAccessibilityEnabled()).toBe(true);
+    expect(mockedExecSync).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Non-interactive mode edge cases
+// ---------------------------------------------------------------------------
+describe("Non-interactive mode edge cases", () => {
+  const originalPlatform = process.platform;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => {}) as unknown as (code?: number) => never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("nonInteractive=true with permission already granted — returns immediately, no banner printed", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+    const consoleSpy = vi.mocked(console.log);
+
+    mockExecSyncRouted({
+      accessibilityResults: ["true\n"],
+    });
+
+    await ensureAccessibilityPermission(true);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    // No banner lines should have been printed (no ACCESSIBILITY text)
+    const output = consoleSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).not.toContain("ACCESSIBILITY PERMISSION REQUIRED");
+  });
+
+  it("nonInteractive=true with permission denied — exits(1) quickly", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // Always denied
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n"],
+    });
+
+    const promise = ensureAccessibilityPermission(true);
+
+    // nonInteractive path: requestAccessibilityPermission called, then
+    // waitForPermission(5, 2000). check() runs immediately (attempt 0 = false),
+    // then 4 more setTimeout-based checks.
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    // After nonInteractive fails, mocked process.exit(1) doesn't actually exit,
+    // so execution falls through to the interactive path (countdown 3s + 2 poll phases).
+    // Countdown: 3 x 1s sleep
+    await vi.advanceTimersByTimeAsync(3000);
+    // pollWithKeyboardHint(60): initial 2s delay + up to 30 polls
+    for (let i = 0; i < 31; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+    // Second waitForPermission(60, 2000)
+    for (let i = 0; i < 61; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    await promise;
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("nonInteractive=undefined (default) — behaves as interactive (false), shows countdown", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+    const writeSpy = vi.mocked(process.stdout.write);
+
+    // Permission granted on 3rd AXIsProcessTrusted() call:
+    // call 1: initial guard check -> false
+    // call 2: first poll in pollWithKeyboardHint -> false
+    // call 3: second poll -> true
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n", "false\n", "true\n"],
+    });
+
+    const promise = ensureAccessibilityPermission();
+
+    // Advance through the 3-second countdown
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // pollWithKeyboardHint: initial delay (2s) then check, then 2s then check
+    await vi.advanceTimersByTimeAsync(2000); // first poll check -> false
+    await vi.advanceTimersByTimeAsync(2000); // second poll check -> true
+
+    await promise;
+
+    // Should have written countdown text (interactive mode indicator)
+    const writtenOutput = writeSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(writtenOutput).toContain("Opening permission prompt in");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Polling edge cases (waitForPermission behavior via nonInteractive path)
+// ---------------------------------------------------------------------------
+describe("Polling edge cases — waitForPermission via nonInteractive", () => {
+  const originalPlatform = process.platform;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => {}) as unknown as (code?: number) => never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("permission granted on first poll check — resolves immediately without extra polls", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // call 1: isAccessibilityEnabled guard -> false (enter flow)
+    // call 2: first poll check (waitForPermission) -> true (done!)
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n", "true\n"],
+    });
+
+    const promise = ensureAccessibilityPermission(true);
+
+    // waitForPermission check() runs synchronously first -> finds true -> resolves
+    await promise;
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("permission granted on last possible check (attempt 5 of 5) — still succeeds", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // call 1: guard -> false
+    // calls 2-5: poll checks 0-3 -> false
+    // call 6: poll check 4 (last) -> true
+    mockExecSyncRouted({
+      accessibilityResults: [
+        "false\n", // guard
+        "false\n", // poll 0
+        "false\n", // poll 1
+        "false\n", // poll 2
+        "false\n", // poll 3
+        "true\n",  // poll 4 (last possible)
+      ],
+    });
+
+    const promise = ensureAccessibilityPermission(true);
+
+    // Advance through 4 intervals (check 0 is immediate, checks 1-4 need timeouts)
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    await promise;
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("permission never granted — resolves false and exits after all attempts", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // All checks return false — never granted
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n"],
+    });
+
+    const promise = ensureAccessibilityPermission(true);
+
+    // waitForPermission(5, 2000): check 0 immediate, then 4 x setTimeout(2000)
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    // After nonInteractive exit(1) is mocked (no real exit), execution falls
+    // through to the interactive path. Drain the remaining timers.
+    // Countdown: 3s
+    await vi.advanceTimersByTimeAsync(3000);
+    // pollWithKeyboardHint(60): initial delay + polls
+    for (let i = 0; i < 31; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+    // Second waitForPermission(60, 2000)
+    for (let i = 0; i < 61; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    await promise;
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Raw mode / stdin edge cases (pollWithKeyboardHint via interactive path)
+// ---------------------------------------------------------------------------
+describe("Raw mode / stdin edge cases", () => {
+  const originalPlatform = process.platform;
+  const originalIsTTY = process.stdin.isTTY;
+  const originalSetRawMode = process.stdin.setRawMode;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => {}) as unknown as (code?: number) => never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      writable: true,
+      configurable: true,
+    });
+    // Restore setRawMode — it may not have existed originally
+    if (originalSetRawMode) {
+      process.stdin.setRawMode = originalSetRawMode;
+    }
+  });
+
+  it("skips raw mode setup when process.stdin.isTTY is false", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    // Install a setRawMode function so we can spy on whether it was called
+    const setRawModeMock = vi.fn(() => process.stdin);
+    process.stdin.setRawMode = setRawModeMock as unknown as typeof process.stdin.setRawMode;
+
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // guard -> false, first poll -> true
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n", "true\n"],
+    });
+
+    const promise = ensureAccessibilityPermission(false);
+
+    // Countdown
+    await vi.advanceTimersByTimeAsync(3000);
+    // First poll check (pollWithKeyboardHint initial delay)
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await promise;
+
+    expect(setRawModeMock).not.toHaveBeenCalled();
+  });
+
+  it("skips raw mode setup when process.stdin.isTTY is undefined", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+    const setRawModeMock = vi.fn(() => process.stdin);
+    process.stdin.setRawMode = setRawModeMock as unknown as typeof process.stdin.setRawMode;
+
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n", "true\n"],
+    });
+
+    const promise = ensureAccessibilityPermission(false);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await promise;
+
+    expect(setRawModeMock).not.toHaveBeenCalled();
+  });
+
+  it("catches and continues when setRawMode throws", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    // Make setRawMode throw when called
+    process.stdin.setRawMode = (() => {
+      throw new Error("raw mode not supported");
+    }) as unknown as typeof process.stdin.setRawMode;
+
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // guard -> false, first poll -> true
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n", "true\n"],
+    });
+
+    const promise = ensureAccessibilityPermission(false);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // Should not throw — raw mode error is caught
+    await expect(promise).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. openAccessibilitySettings edge cases (tested indirectly)
+// ---------------------------------------------------------------------------
+describe("openAccessibilitySettings — failure swallowed", () => {
+  const originalPlatform = process.platform;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => {}) as unknown as (code?: number) => never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("does not throw when the `open` command fails — error is swallowed", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // Permission always denied — forces the interactive path all the way through.
+    // The `open` command throws but should be caught.
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n"],
+      openThrows: true,
+    });
+
+    const promise = ensureAccessibilityPermission(false);
+
+    // Countdown: 3s
+    await vi.advanceTimersByTimeAsync(3000);
+
+    // pollWithKeyboardHint: 60s timeout, 2s intervals.
+    // Initial delay 2s, then checks. Need enough time to exhaust the timeout.
+    for (let i = 0; i < 31; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    // After first poll phase: openAccessibilitySettings (throws, caught) +
+    // second waitForPermission(60, 2000)
+    for (let i = 0; i < 61; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    // Should complete without throwing despite `open` failing
+    await expect(promise).resolves.toBeUndefined();
+    // Should still exit(1) since permission was never granted
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Concurrent / timing edge cases
+// ---------------------------------------------------------------------------
+describe("Concurrent / timing edge cases", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as unknown as (code?: number) => never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("ensureAccessibilityPermission called when already granted — idempotent, no side effects", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    mockExecSyncRouted({
+      accessibilityResults: ["true\n"],
+    });
+
+    // Call twice — both should succeed without any exit or banner
+    await ensureAccessibilityPermission(false);
+    await ensureAccessibilityPermission(true);
+
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it("permission changes from false to true mid-poll — detected on next check", async () => {
+    const { ensureAccessibilityPermission } = await freshImport();
+
+    // guard -> false, poll 0 -> false, poll 1 -> false, poll 2 -> true
+    mockExecSyncRouted({
+      accessibilityResults: ["false\n", "false\n", "false\n", "true\n"],
+    });
+
+    const promise = ensureAccessibilityPermission(true);
+
+    // waitForPermission(5, 2000): check 0 immediate -> false
+    // checks 1-2 via setTimeout
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await promise;
+
+    expect(process.exit).not.toHaveBeenCalled();
+    const logOutput = vi.mocked(console.log).mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logOutput).toContain("GRANTED");
+  });
+});

--- a/packages/mcp/test/cli/accessibility-integration.test.ts
+++ b/packages/mcp/test/cli/accessibility-integration.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as child_process from "node:child_process";
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, execSync: vi.fn() };
+});
+
+const mockedExecSync = vi.mocked(child_process.execSync);
+
+/**
+ * Helper: start an async function that may throw via process.exit, advance
+ * fake timers, and collect the result. We attach the catch handler *before*
+ * any timers fire so the rejection is never truly unhandled.
+ */
+async function driveToCompletion(
+  fn: () => Promise<void>,
+  timerSteps: Array<{ ms: number; count: number }>
+): Promise<{ exitCalled: boolean }> {
+  let exitCalled = false;
+  const promise = fn().catch((err: any) => {
+    if (err?.message === "process.exit") {
+      exitCalled = true;
+    } else {
+      throw err;
+    }
+  });
+
+  for (const step of timerSteps) {
+    for (let i = 0; i < step.count; i++) {
+      await vi.advanceTimersByTimeAsync(step.ms);
+    }
+  }
+
+  await promise;
+  return { exitCalled };
+}
+
+describe("accessibility integration", () => {
+  const originalPlatform = process.platform;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    processExitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error("process.exit");
+      }) as (code?: number) => never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  function allConsoleOutput(): string {
+    return consoleLogSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  }
+
+  function mockAlwaysDenied(): void {
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("which swift")) return "" as any;
+      if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+        return "" as any;
+      if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted"))
+        return "false\n" as any;
+      return "" as any;
+    });
+  }
+
+  // ── 1. Init integration ──────────────────────────────────────────────────
+
+  describe("init integration", () => {
+    it("ensureAccessibilityPermission is importable and callable", async () => {
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+      expect(typeof ensureAccessibilityPermission).toBe("function");
+    });
+
+    it("accepts a nonInteractive boolean parameter", async () => {
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+      Object.defineProperty(process, "platform", { value: "linux" });
+      await expect(ensureAccessibilityPermission(true)).resolves.toBeUndefined();
+      await expect(ensureAccessibilityPermission(false)).resolves.toBeUndefined();
+    });
+
+    it("on non-darwin, init flow proceeds without interruption", async () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+      await ensureAccessibilityPermission(false);
+      expect(mockedExecSync).not.toHaveBeenCalled();
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+
+    it("when accessibility is already granted, init flow proceeds without interruption", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted"))
+          return "true\n" as any;
+        return "" as any;
+      });
+
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+      await ensureAccessibilityPermission(false);
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── 2. Permission denial flow (non-interactive) ──────────────────────────
+
+  describe("permission denial flow (non-interactive)", () => {
+    it("prints banner, requests permission, prints denied banner, and exits", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      mockAlwaysDenied();
+
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+
+      const { exitCalled } = await driveToCompletion(
+        () => ensureAccessibilityPermission(true),
+        [{ ms: 2000, count: 6 }]
+      );
+
+      const output = allConsoleOutput();
+
+      expect(output).toContain("ACCESSIBILITY PERMISSION REQUIRED");
+
+      const execCalls = mockedExecSync.mock.calls.map((c) => String(c[0]));
+      expect(execCalls.some((c) => c.includes("AXIsProcessTrustedWithOptions"))).toBe(
+        true
+      );
+
+      expect(exitCalled).toBe(true);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+
+      expect(output).toContain("ACCESSIBILITY PERMISSION DENIED");
+    });
+  });
+
+  // ── 3. Permission grant flow (non-interactive) ───────────────────────────
+
+  describe("permission grant flow (non-interactive)", () => {
+    it("prints success banner when permission is granted during polling", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+
+      let axCallCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          axCallCount++;
+          return (axCallCount >= 3 ? "true\n" : "false\n") as any;
+        }
+        return "" as any;
+      });
+
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+
+      const { exitCalled } = await driveToCompletion(
+        () => ensureAccessibilityPermission(true),
+        [{ ms: 2000, count: 5 }]
+      );
+
+      expect(allConsoleOutput()).toContain("ACCESSIBILITY PERMISSION GRANTED");
+      expect(exitCalled).toBe(false);
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── 4. Banner content verification ───────────────────────────────────────
+
+  describe("banner content verification", () => {
+    it("warning banner contains required key text", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      mockAlwaysDenied();
+
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+
+      await driveToCompletion(
+        () => ensureAccessibilityPermission(true),
+        [{ ms: 2000, count: 6 }]
+      );
+
+      const output = allConsoleOutput();
+      expect(output).toContain("ACCESSIBILITY PERMISSION REQUIRED");
+      expect(output).toContain("describe");
+      expect(output).toContain("Allow");
+    });
+
+    it("success banner contains required key text", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+
+      let axCallCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          axCallCount++;
+          return (axCallCount >= 2 ? "true\n" : "false\n") as any;
+        }
+        return "" as any;
+      });
+
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+
+      await driveToCompletion(
+        () => ensureAccessibilityPermission(true),
+        [{ ms: 2000, count: 5 }]
+      );
+
+      const output = allConsoleOutput();
+      expect(output).toContain("ACCESSIBILITY PERMISSION GRANTED");
+      expect(output).toContain("Thank you");
+    });
+
+    it("denied banner contains required key text", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      mockAlwaysDenied();
+
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+
+      await driveToCompletion(
+        () => ensureAccessibilityPermission(true),
+        [{ ms: 2000, count: 6 }]
+      );
+
+      const output = allConsoleOutput();
+      expect(output).toContain("ACCESSIBILITY PERMISSION DENIED");
+      expect(output).toContain("System Settings");
+      expect(output).toContain("Privacy & Security");
+      expect(output).toContain("argent init");
+    });
+  });
+
+  // ── 5. Sequential flow verification ──────────────────────────────────────
+
+  describe("sequential flow verification", () => {
+    it("execSync calls follow correct order: swift check -> AXIsProcessTrustedWithOptions -> polling", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+
+      const callOrder: string[] = [];
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("which swift")) {
+          callOrder.push("which-swift");
+          return "" as any;
+        }
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions")) {
+          callOrder.push("request-permission");
+          return "" as any;
+        }
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callOrder.push("check-accessibility");
+          return "false\n" as any;
+        }
+        return "" as any;
+      });
+
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+
+      await driveToCompletion(
+        () => ensureAccessibilityPermission(true),
+        [{ ms: 2000, count: 6 }]
+      );
+
+      // isAccessibilityEnabled() is called first as the initial guard
+      expect(callOrder[0]).toBe("check-accessibility");
+      // Then isSwiftAvailable via "which swift"
+      expect(callOrder[1]).toBe("which-swift");
+      // Then requestAccessibilityPermission
+      expect(callOrder[2]).toBe("request-permission");
+      // Remaining calls are polling accessibility checks
+      const pollingChecks = callOrder.slice(3);
+      expect(pollingChecks.length).toBeGreaterThan(0);
+      expect(pollingChecks.every((c) => c === "check-accessibility")).toBe(true);
+    });
+
+    it("in interactive mode, countdown happens before permission request", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+
+      const events: string[] = [];
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("which swift")) {
+          events.push("which-swift");
+          return "" as any;
+        }
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions")) {
+          events.push("request-permission");
+          return "" as any;
+        }
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          events.push("check-ax");
+          return "false\n" as any;
+        }
+        if (typeof cmd === "string" && cmd.includes("x-apple.systempreferences")) {
+          events.push("open-settings");
+          return "" as any;
+        }
+        return "" as any;
+      });
+
+      stdoutWriteSpy.mockImplementation((data: any) => {
+        if (typeof data === "string" && data.includes("Opening permission prompt in")) {
+          events.push("countdown");
+        }
+        return true;
+      });
+
+      const originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+
+      const { ensureAccessibilityPermission } = await import(
+        "../../src/cli/accessibility.js"
+      );
+
+      await driveToCompletion(
+        () => ensureAccessibilityPermission(false),
+        [
+          // Countdown: 3 x 1s sleep
+          { ms: 1000, count: 3 },
+          // pollWithKeyboardHint: 60s timeout, 2s intervals
+          { ms: 2000, count: 35 },
+          // waitForPermission second phase: 60 attempts * 2s
+          { ms: 2000, count: 65 },
+        ]
+      );
+
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: originalIsTTY,
+        configurable: true,
+      });
+
+      const countdownIdx = events.indexOf("countdown");
+      const requestIdx = events.indexOf("request-permission");
+      expect(countdownIdx).toBeGreaterThanOrEqual(0);
+      expect(requestIdx).toBeGreaterThan(countdownIdx);
+    });
+  });
+});

--- a/packages/mcp/test/cli/accessibility-smoke.test.ts
+++ b/packages/mcp/test/cli/accessibility-smoke.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// ── 1. Module exports ────────────────────────────────────────────────────────
+
+describe("accessibility module exports", () => {
+  it("exports isAccessibilityEnabled as a function", async () => {
+    const mod = await import("../../src/cli/accessibility.js");
+    expect(typeof mod.isAccessibilityEnabled).toBe("function");
+  });
+
+  it("exports ensureAccessibilityPermission as a function", async () => {
+    const mod = await import("../../src/cli/accessibility.js");
+    expect(typeof mod.ensureAccessibilityPermission).toBe("function");
+  });
+
+  it("does not leak internal helpers", async () => {
+    const mod = await import("../../src/cli/accessibility.js");
+    const exportedKeys = Object.keys(mod);
+
+    const internalNames = [
+      "isSwiftAvailable",
+      "requestAccessibilityPermission",
+      "openAccessibilitySettings",
+      "printBannerBlock",
+      "sleep",
+      "waitForPermission",
+      "pollWithKeyboardHint",
+    ];
+
+    for (const name of internalNames) {
+      expect(exportedKeys).not.toContain(name);
+    }
+  });
+
+  it("exports exactly two public symbols", async () => {
+    const mod = await import("../../src/cli/accessibility.js");
+    const exportedKeys = Object.keys(mod);
+    expect(exportedKeys).toHaveLength(2);
+    expect(exportedKeys).toContain("isAccessibilityEnabled");
+    expect(exportedKeys).toContain("ensureAccessibilityPermission");
+  });
+});
+
+// ── 2. Import chain ──────────────────────────────────────────────────────────
+
+describe("import chain", () => {
+  it("init.ts re-exports ensureAccessibilityPermission from accessibility", async () => {
+    // Verify the import path resolves without error
+    const accessibilityMod = await import("../../src/cli/accessibility.js");
+    expect(accessibilityMod.ensureAccessibilityPermission).toBeDefined();
+  });
+
+  it("dynamic import of accessibility module resolves successfully", async () => {
+    await expect(
+      import("../../src/cli/accessibility.js")
+    ).resolves.toBeDefined();
+  });
+});
+
+// ── 3. Type contracts ────────────────────────────────────────────────────────
+
+describe("type contracts", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("isAccessibilityEnabled() returns a boolean", async () => {
+    // Force non-darwin so it short-circuits without calling execSync
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { isAccessibilityEnabled } = await import(
+      "../../src/cli/accessibility.js"
+    );
+    const result = isAccessibilityEnabled();
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("ensureAccessibilityPermission() returns a Promise (thenable)", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { ensureAccessibilityPermission } = await import(
+      "../../src/cli/accessibility.js"
+    );
+    const result = ensureAccessibilityPermission();
+    expect(result).toBeInstanceOf(Promise);
+    expect(typeof result.then).toBe("function");
+    await result; // resolve to avoid unhandled rejection
+  });
+
+  it("ensureAccessibilityPermission(true) accepts boolean arg without error", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { ensureAccessibilityPermission } = await import(
+      "../../src/cli/accessibility.js"
+    );
+    await expect(ensureAccessibilityPermission(true)).resolves.toBeUndefined();
+  });
+
+  it("ensureAccessibilityPermission(false) accepts boolean arg without error", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { ensureAccessibilityPermission } = await import(
+      "../../src/cli/accessibility.js"
+    );
+    await expect(
+      ensureAccessibilityPermission(false)
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ── 4. Platform guard smoke test ─────────────────────────────────────────────
+
+describe("platform guard", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("isAccessibilityEnabled() does not throw on any platform", async () => {
+    // Force linux to avoid side effects from execSync on darwin
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { isAccessibilityEnabled } = await import(
+      "../../src/cli/accessibility.js"
+    );
+    expect(() => isAccessibilityEnabled()).not.toThrow();
+  });
+
+  it("ensureAccessibilityPermission() does not throw on any platform", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { ensureAccessibilityPermission } = await import(
+      "../../src/cli/accessibility.js"
+    );
+    await expect(ensureAccessibilityPermission()).resolves.not.toThrow();
+  });
+
+  it("isAccessibilityEnabled() returns a boolean, not undefined or null", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const { isAccessibilityEnabled } = await import(
+      "../../src/cli/accessibility.js"
+    );
+    const result = isAccessibilityEnabled();
+    expect(result).not.toBeUndefined();
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe("boolean");
+  });
+});
+
+// ── 5. No side effects on import ─────────────────────────────────────────────
+
+describe("no side effects on import", () => {
+  it("importing the module does not trigger execSync calls", async () => {
+    // The module only calls execSync inside function bodies, never at the
+    // top level. We verify this by checking that the module loads and all
+    // exports are functions (not eagerly-computed values from execSync).
+    const mod = await import("../../src/cli/accessibility.js");
+    for (const [key, value] of Object.entries(mod)) {
+      expect(typeof value).toBe("function");
+    }
+    // If execSync were called at import time on non-darwin, the module
+    // would either throw or produce side effects. The fact that the
+    // module loads cleanly with only function exports confirms no
+    // top-level execSync calls.
+    expect(Object.keys(mod)).toHaveLength(2);
+  });
+
+  it("importing the module does not write to stdout", async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(
+      () => true
+    );
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(
+      () => {}
+    );
+
+    const mod = await import("../../src/cli/accessibility.js");
+    expect(mod).toBeDefined();
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+
+    stdoutSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  it("importing the module does not write to stderr", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(
+      () => true
+    );
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(
+      () => {}
+    );
+
+    const mod = await import("../../src/cli/accessibility.js");
+    expect(mod).toBeDefined();
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    stderrSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/mcp/test/cli/accessibility.test.ts
+++ b/packages/mcp/test/cli/accessibility.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isAccessibilityEnabled } from "../../src/cli/accessibility.js";
+import * as child_process from "node:child_process";
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, execSync: vi.fn() };
+});
+
+const mockedExecSync = vi.mocked(child_process.execSync);
+
+describe("isAccessibilityEnabled", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("returns false on non-darwin platforms", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(isAccessibilityEnabled()).toBe(false);
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
+  it("returns true when swift reports true", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockedExecSync.mockReturnValue("true\n");
+    expect(isAccessibilityEnabled()).toBe(true);
+  });
+
+  it("returns false when swift reports false", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockedExecSync.mockReturnValue("false\n");
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it("returns false when swift throws", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockedExecSync.mockImplementation(() => {
+      throw new Error("swift not found");
+    });
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+});

--- a/packages/mcp/test/cli/accessibility.test.ts
+++ b/packages/mcp/test/cli/accessibility.test.ts
@@ -1,45 +1,643 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isAccessibilityEnabled } from "../../src/cli/accessibility.js";
 import * as child_process from "node:child_process";
 
 vi.mock("node:child_process", async () => {
-  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return { ...actual, execSync: vi.fn() };
 });
 
 const mockedExecSync = vi.mocked(child_process.execSync);
 
-describe("isAccessibilityEnabled", () => {
-  const originalPlatform = process.platform;
+const originalPlatform = process.platform;
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-    Object.defineProperty(process, "platform", { value: originalPlatform });
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  Object.defineProperty(process, "platform", { value: originalPlatform });
+});
+
+// ── isAccessibilityEnabled ──────────────────────────────────────────────────
+
+describe("isAccessibilityEnabled", () => {
+  let isAccessibilityEnabled: typeof import("../../src/cli/accessibility.js").isAccessibilityEnabled;
+
+  beforeEach(async () => {
+    const mod = await import("../../src/cli/accessibility.js");
+    isAccessibilityEnabled = mod.isAccessibilityEnabled;
   });
 
-  it("returns false on non-darwin platforms", () => {
+  it("returns false on linux", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
     expect(isAccessibilityEnabled()).toBe(false);
     expect(mockedExecSync).not.toHaveBeenCalled();
   });
 
-  it("returns true when swift reports true", () => {
+  it("returns false on win32", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(isAccessibilityEnabled()).toBe(false);
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
+  it("returns true when swift outputs 'true\\n'", () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
     mockedExecSync.mockReturnValue("true\n");
     expect(isAccessibilityEnabled()).toBe(true);
   });
 
-  it("returns false when swift reports false", () => {
+  it("returns true when swift outputs 'true' without newline", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockedExecSync.mockReturnValue("true");
+    expect(isAccessibilityEnabled()).toBe(true);
+  });
+
+  it("returns false when swift outputs 'false\\n'", () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
     mockedExecSync.mockReturnValue("false\n");
     expect(isAccessibilityEnabled()).toBe(false);
   });
 
-  it("returns false when swift throws", () => {
+  it("returns false when swift outputs unexpected string", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockedExecSync.mockReturnValue("something unexpected\n");
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it("returns false when swift outputs empty string", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockedExecSync.mockReturnValue("");
+    expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it("returns false when execSync throws", () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
     mockedExecSync.mockImplementation(() => {
       throw new Error("swift not found");
     });
     expect(isAccessibilityEnabled()).toBe(false);
+  });
+
+  it("calls execSync with the correct swift command", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockedExecSync.mockReturnValue("false\n");
+    isAccessibilityEnabled();
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      `swift -e 'import Cocoa; print(AXIsProcessTrusted())'`,
+      expect.objectContaining({
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 15_000,
+      })
+    );
+  });
+
+  it("passes timeout of 15_000 to execSync", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockedExecSync.mockReturnValue("true\n");
+    isAccessibilityEnabled();
+    const callOptions = mockedExecSync.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(callOptions.timeout).toBe(15_000);
+  });
+});
+
+// ── ensureAccessibilityPermission ───────────────────────────────────────────
+
+describe("ensureAccessibilityPermission", () => {
+  let ensureAccessibilityPermission: typeof import("../../src/cli/accessibility.js").ensureAccessibilityPermission;
+
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  // Sentinel error class so we can distinguish process.exit throws
+  class ProcessExitError extends Error {
+    code: number;
+    constructor(code: number) {
+      super(`process.exit(${code})`);
+      this.code = code;
+    }
+  }
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    const mod = await import("../../src/cli/accessibility.js");
+    ensureAccessibilityPermission = mod.ensureAccessibilityPermission;
+
+    // Mock process.exit to throw so execution halts at call site
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new ProcessExitError(code ?? 0);
+    }) as never);
+
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  function setDarwin() {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+  }
+
+  function mockSwiftAvailableAndAccessibility(accessibilityResults: (boolean | Error)[]) {
+    let callIdx = 0;
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.startsWith("which swift")) {
+        return "" as any;
+      }
+      if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions")) {
+        return "" as any;
+      }
+      if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+        const result =
+          accessibilityResults[callIdx] ?? accessibilityResults[accessibilityResults.length - 1];
+        callIdx++;
+        if (result instanceof Error) throw result;
+        return result ? "true\n" : ("false\n" as any);
+      }
+      if (typeof cmd === "string" && cmd.startsWith("open ")) {
+        return "" as any;
+      }
+      return "" as any;
+    });
+  }
+
+  function mockSwiftUnavailable() {
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+        return "false\n" as any;
+      }
+      if (typeof cmd === "string" && cmd.startsWith("which swift")) {
+        throw new Error("not found");
+      }
+      return "" as any;
+    });
+  }
+
+  /**
+   * Run a test where ensureAccessibilityPermission is expected to eventually
+   * call process.exit (which throws). This helper eagerly attaches a .catch()
+   * so the rejection is never "unhandled", then advances timers, then returns
+   * the caught error (or null if it resolved normally).
+   */
+  async function runExpectingExit(
+    nonInteractive: boolean | undefined,
+    advanceFn: () => Promise<void>
+  ): Promise<{ error: ProcessExitError | null }> {
+    let caughtError: ProcessExitError | null = null;
+
+    const promise = ensureAccessibilityPermission(nonInteractive).catch((err) => {
+      if (err instanceof ProcessExitError) {
+        caughtError = err;
+      } else {
+        throw err;
+      }
+    });
+
+    await advanceFn();
+    await promise;
+
+    return { error: caughtError };
+  }
+
+  /**
+   * Run a test where ensureAccessibilityPermission is expected to resolve normally
+   * (no process.exit). Advances timers via the provided function.
+   */
+  async function runExpectingSuccess(
+    nonInteractive: boolean | undefined,
+    advanceFn: () => Promise<void>
+  ): Promise<void> {
+    const promise = ensureAccessibilityPermission(nonInteractive);
+    await advanceFn();
+    await promise;
+  }
+
+  async function advanceAndFlush(ms: number) {
+    await vi.advanceTimersByTimeAsync(ms);
+  }
+
+  // ── Non-darwin platforms ──────────────────────────────────────────────
+
+  describe("on non-darwin platforms", () => {
+    it("returns immediately on linux", async () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      mockedExecSync.mockClear();
+      await ensureAccessibilityPermission();
+      expect(mockedExecSync).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns immediately on win32", async () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      mockedExecSync.mockClear();
+      await ensureAccessibilityPermission();
+      expect(mockedExecSync).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Already granted ──────────────────────────────────────────────────
+
+  describe("when accessibility is already granted", () => {
+    it("returns immediately without showing banner", async () => {
+      setDarwin();
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          return "true\n" as any;
+        }
+        return "" as any;
+      });
+
+      await ensureAccessibilityPermission();
+      expect(exitSpy).not.toHaveBeenCalled();
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).not.toContain("ACCESSIBILITY PERMISSION REQUIRED");
+    });
+  });
+
+  // ── Swift not available ──────────────────────────────────────────────
+
+  describe("when swift is not available", () => {
+    it("prints warning and exits with code 1", async () => {
+      setDarwin();
+      mockSwiftUnavailable();
+
+      // process.exit throws synchronously inside the async function,
+      // rejecting the returned promise immediately — no timers needed.
+      const { error } = await runExpectingExit(undefined, async () => {});
+
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe(1);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("swift");
+      expect(allLogs).toContain("xcode-select --install");
+    });
+  });
+
+  // ── Non-interactive mode ─────────────────────────────────────────────
+
+  describe("non-interactive mode", () => {
+    it("shows the permission-required banner", async () => {
+      setDarwin();
+      mockSwiftAvailableAndAccessibility([false]);
+
+      const { error } = await runExpectingExit(true, async () => {
+        for (let i = 0; i < 6; i++) await advanceAndFlush(2000);
+      });
+
+      expect(error).not.toBeNull();
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("ACCESSIBILITY PERMISSION REQUIRED");
+    });
+
+    it("triggers permission request via AXIsProcessTrustedWithOptions", async () => {
+      setDarwin();
+      mockSwiftAvailableAndAccessibility([false, true]);
+
+      await runExpectingSuccess(true, async () => {
+        for (let i = 0; i < 6; i++) await advanceAndFlush(2000);
+      });
+
+      const calls = mockedExecSync.mock.calls.map((c) => c[0]);
+      const hasPromptCall = calls.some(
+        (cmd) => typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions")
+      );
+      expect(hasPromptCall).toBe(true);
+    });
+
+    it("exits with code 1 if denied after polling", async () => {
+      setDarwin();
+      mockSwiftAvailableAndAccessibility([false]);
+
+      const { error } = await runExpectingExit(true, async () => {
+        for (let i = 0; i < 6; i++) await advanceAndFlush(2000);
+      });
+
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe(1);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("shows denied banner when permission stays denied", async () => {
+      setDarwin();
+      mockSwiftAvailableAndAccessibility([false]);
+
+      const { error } = await runExpectingExit(true, async () => {
+        for (let i = 0; i < 6; i++) await advanceAndFlush(2000);
+      });
+
+      expect(error).not.toBeNull();
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("ACCESSIBILITY PERMISSION DENIED");
+    });
+
+    it("succeeds if permission is granted during quick poll", async () => {
+      setDarwin();
+      mockSwiftAvailableAndAccessibility([false, false, true]);
+
+      await runExpectingSuccess(true, async () => {
+        for (let i = 0; i < 6; i++) await advanceAndFlush(2000);
+      });
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("ACCESSIBILITY PERMISSION GRANTED");
+    });
+
+    it("does not show countdown (skips directly to prompt)", async () => {
+      setDarwin();
+      mockSwiftAvailableAndAccessibility([false]);
+
+      const { error } = await runExpectingExit(true, async () => {
+        for (let i = 0; i < 6; i++) await advanceAndFlush(2000);
+      });
+
+      expect(error).not.toBeNull();
+      const stdoutCalls = stdoutWriteSpy.mock.calls.map((c) => String(c[0]));
+      const countdownMessages = stdoutCalls.filter((s) =>
+        s.includes("Opening permission prompt in")
+      );
+      expect(countdownMessages).toHaveLength(0);
+    });
+  });
+
+  // ── Interactive mode ─────────────────────────────────────────────────
+
+  describe("interactive mode", () => {
+    let originalIsTTY: boolean | undefined;
+
+    beforeEach(() => {
+      originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: false,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    });
+
+    /** Advance through the 3-second countdown */
+    async function advanceCountdown() {
+      for (let i = 0; i < 3; i++) await advanceAndFlush(1000);
+    }
+
+    it("shows the permission-required banner", async () => {
+      setDarwin();
+      let callCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.startsWith("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callCount++;
+          return callCount >= 3 ? ("true\n" as any) : ("false\n" as any);
+        }
+        return "" as any;
+      });
+
+      await runExpectingSuccess(false, async () => {
+        await advanceCountdown();
+        for (let i = 0; i < 4; i++) await advanceAndFlush(2000);
+      });
+
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("ACCESSIBILITY PERMISSION REQUIRED");
+    });
+
+    it("performs countdown writing to stdout", async () => {
+      setDarwin();
+      let callCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.startsWith("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callCount++;
+          return callCount >= 3 ? ("true\n" as any) : ("false\n" as any);
+        }
+        return "" as any;
+      });
+
+      await runExpectingSuccess(false, async () => {
+        await advanceCountdown();
+        for (let i = 0; i < 4; i++) await advanceAndFlush(2000);
+      });
+
+      const stdoutCalls = stdoutWriteSpy.mock.calls.map((c) => String(c[0]));
+      const countdownMessages = stdoutCalls.filter((s) =>
+        s.includes("Opening permission prompt in")
+      );
+      expect(countdownMessages.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("triggers requestAccessibilityPermission after countdown", async () => {
+      setDarwin();
+      let callCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.startsWith("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callCount++;
+          return callCount >= 3 ? ("true\n" as any) : ("false\n" as any);
+        }
+        return "" as any;
+      });
+
+      await runExpectingSuccess(false, async () => {
+        await advanceCountdown();
+        for (let i = 0; i < 4; i++) await advanceAndFlush(2000);
+      });
+
+      const calls = mockedExecSync.mock.calls.map((c) => c[0]);
+      expect(
+        calls.some(
+          (cmd) => typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions")
+        )
+      ).toBe(true);
+    });
+
+    it("displays hint about pressing s for settings", async () => {
+      setDarwin();
+      let callCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.startsWith("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callCount++;
+          return callCount >= 3 ? ("true\n" as any) : ("false\n" as any);
+        }
+        return "" as any;
+      });
+
+      await runExpectingSuccess(false, async () => {
+        await advanceCountdown();
+        for (let i = 0; i < 4; i++) await advanceAndFlush(2000);
+      });
+
+      const allLogs = consoleLogSpy.mock.calls
+        .map((c) => (c as unknown[]).map(String).join(" "))
+        .join("\n");
+      expect(allLogs).toContain("Waiting for you to grant Accessibility permission");
+    });
+
+    it("succeeds when permission is granted during pollWithKeyboardHint", async () => {
+      setDarwin();
+      let callCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.startsWith("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callCount++;
+          // 1st=initial check (false), 2nd=first poll (false), 3rd=second poll (true)
+          return callCount >= 3 ? ("true\n" as any) : ("false\n" as any);
+        }
+        return "" as any;
+      });
+
+      await runExpectingSuccess(false, async () => {
+        await advanceCountdown();
+        for (let i = 0; i < 4; i++) await advanceAndFlush(2000);
+      });
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("ACCESSIBILITY PERMISSION GRANTED");
+    });
+
+    it("shows denied banner after pollWithKeyboardHint timeout and opens settings", async () => {
+      setDarwin();
+      let callCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.startsWith("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.startsWith("open ")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callCount++;
+          // Grant on 35th check (during final waitForPermission, after denied banner)
+          return callCount >= 35 ? ("true\n" as any) : ("false\n" as any);
+        }
+        return "" as any;
+      });
+
+      await runExpectingSuccess(false, async () => {
+        await advanceCountdown();
+        // pollWithKeyboardHint: 60s timeout, 2s interval
+        for (let i = 0; i < 32; i++) await advanceAndFlush(2000);
+        // final waitForPermission
+        for (let i = 0; i < 40; i++) await advanceAndFlush(2000);
+      });
+
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("ACCESSIBILITY PERMISSION DENIED");
+      expect(allLogs).toContain("Opening System Settings");
+
+      const openCalls = mockedExecSync.mock.calls.filter(
+        (c) => typeof c[0] === "string" && (c[0] as string).startsWith("open ")
+      );
+      expect(openCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("succeeds when permission is granted during final extended poll", async () => {
+      setDarwin();
+      let callCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.startsWith("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.startsWith("open ")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callCount++;
+          return callCount >= 35 ? ("true\n" as any) : ("false\n" as any);
+        }
+        return "" as any;
+      });
+
+      await runExpectingSuccess(false, async () => {
+        await advanceCountdown();
+        for (let i = 0; i < 32; i++) await advanceAndFlush(2000);
+        for (let i = 0; i < 40; i++) await advanceAndFlush(2000);
+      });
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("ACCESSIBILITY PERMISSION GRANTED");
+    });
+
+    it("calls process.exit(1) when permission denied after all attempts", async () => {
+      setDarwin();
+      mockSwiftAvailableAndAccessibility([false]);
+
+      const { error } = await runExpectingExit(false, async () => {
+        await advanceCountdown();
+        // pollWithKeyboardHint
+        for (let i = 0; i < 32; i++) await advanceAndFlush(2000);
+        // final waitForPermission
+        for (let i = 0; i < 62; i++) await advanceAndFlush(2000);
+      });
+
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe(1);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("shows final abort message when permission is permanently denied", async () => {
+      setDarwin();
+      mockSwiftAvailableAndAccessibility([false]);
+
+      const { error } = await runExpectingExit(false, async () => {
+        await advanceCountdown();
+        for (let i = 0; i < 32; i++) await advanceAndFlush(2000);
+        for (let i = 0; i < 62; i++) await advanceAndFlush(2000);
+      });
+
+      expect(error).not.toBeNull();
+      const allLogs = consoleLogSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+      expect(allLogs).toContain("Accessibility permission is required");
+      expect(allLogs).toContain("argent init");
+    });
+  });
+
+  // ── Default parameter ────────────────────────────────────────────────
+
+  describe("default parameter", () => {
+    it("defaults to interactive mode (nonInteractive = false)", async () => {
+      setDarwin();
+
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: false,
+        configurable: true,
+      });
+
+      let callCount = 0;
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.startsWith("which swift")) return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrustedWithOptions"))
+          return "" as any;
+        if (typeof cmd === "string" && cmd.includes("AXIsProcessTrusted")) {
+          callCount++;
+          return callCount >= 2 ? ("true\n" as any) : ("false\n" as any);
+        }
+        return "" as any;
+      });
+
+      await runExpectingSuccess(undefined, async () => {
+        // countdown (proves interactive mode)
+        for (let i = 0; i < 3; i++) await advanceAndFlush(1000);
+        await advanceAndFlush(2000);
+      });
+
+      const stdoutCalls = stdoutWriteSpy.mock.calls.map((c) => String(c[0]));
+      const hasCountdown = stdoutCalls.some((s) => s.includes("Opening permission prompt in"));
+      expect(hasCountdown).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Require macOS Accessibility permissions before proceeding with argent init. 
Shows a prominent banner, counts down 3 seconds, triggers the native system permission dialog, and polls for the result. 

- If the user accepts, a green success banner is shown. 
- If denied, installation is refused with manual instructions and an option to auto-open System Settings. In non-interactive mode (--yes), performs a quick check and exits if permissions are missing.