### PR TITLE
fix: prime native devtools during simulator boot

### DIFF
--- a/packages/tool-server/src/tools/simulator/boot-simulator.ts
+++ b/packages/tool-server/src/tools/simulator/boot-simulator.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { z } from "zod";
-import type { ToolDefinition } from "@argent/registry";
+import type { Registry, ToolDefinition } from "@argent/registry";
+import { NATIVE_DEVTOOLS_NAMESPACE } from "../../blueprints/native-devtools";
 
 const execFileAsync = promisify(execFile);
 
@@ -9,32 +10,40 @@ const zodSchema = z.object({
   udid: z.string().describe("The UDID of the simulator to boot"),
 });
 
-export const bootSimulatorTool: ToolDefinition<{ udid: string }> = {
-  id: "boot-simulator",
-  description:
-    "Start an iOS simulator by UDID. Use when the target simulator is in Shutdown state before starting a session. Returns when the simulator is ready. Fails if the UDID is invalid or Xcode tools are not installed.",
-  zodSchema,
-  services: () => ({}),
-  async execute(_services, params, _options) {
-    const bootPromise = execFileAsync("xcrun", ["simctl", "boot", params.udid]).catch(
-      (err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        // xcrun simctl boot exits with an error if the device is already booted — treat as success
-        if (!message.includes("Unable to boot device in current state: Booted")) {
-          throw err;
+export function createBootSimulatorTool(
+  registry: Registry
+): ToolDefinition<{ udid: string }, { udid: string; booted: boolean }> {
+  return {
+    id: "boot-simulator",
+    description:
+      "Start an iOS simulator by UDID. Use when the target simulator is in Shutdown state before starting a session. Returns when the simulator is ready. Fails if the UDID is invalid or Xcode tools are not installed.",
+    zodSchema,
+    services: () => ({}),
+    async execute(_services, params, _options) {
+      const bootPromise = execFileAsync("xcrun", ["simctl", "boot", params.udid]).catch(
+        (err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          // xcrun simctl boot exits with an error if the device is already booted — treat as success
+          if (!message.includes("Unable to boot device in current state: Booted")) {
+            throw err;
+          }
         }
-      }
-    );
-    await bootPromise;
-    // Write the preference before opening so it applies to both fresh launches and
-    // already-running instances. `open --args` is ignored when the app is already running.
-    await execFileAsync("defaults", [
-      "write",
-      "com.apple.iphonesimulator",
-      "CurrentDeviceUDID",
-      params.udid,
-    ]);
-    await execFileAsync("open", ["-a", "Simulator.app"]);
-    return { udid: params.udid, booted: true };
-  },
-};
+      );
+      await bootPromise;
+      // `simctl bootstatus -b` blocks until the simulator has fully booted and can
+      // accept the launchd env setup performed by NativeDevtools service init.
+      await execFileAsync("xcrun", ["simctl", "bootstatus", params.udid, "-b"]);
+      await registry.resolveService(`${NATIVE_DEVTOOLS_NAMESPACE}:${params.udid}`);
+      // Write the preference before opening so it applies to both fresh launches and
+      // already-running instances. `open --args` is ignored when the app is already running.
+      await execFileAsync("defaults", [
+        "write",
+        "com.apple.iphonesimulator",
+        "CurrentDeviceUDID",
+        params.udid,
+      ]);
+      await execFileAsync("open", ["-a", "Simulator.app"]);
+      return { udid: params.udid, booted: true };
+    },
+  };
+}

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -12,7 +12,7 @@ import { jsRuntimeDebuggerBlueprint } from "../blueprints/js-runtime-debugger";
 import { networkInspectorBlueprint } from "../blueprints/network-inspector";
 import { reactProfilerSessionBlueprint } from "../blueprints/react-profiler-session";
 import { listSimulatorsTool } from "../tools/simulator/list-simulators";
-import { bootSimulatorTool } from "../tools/simulator/boot-simulator";
+import { createBootSimulatorTool } from "../tools/simulator/boot-simulator";
 import { simulatorServerTool } from "../tools/simulator/simulator-server";
 import { launchAppTool } from "../tools/simulator/launch-app";
 import { restartAppTool } from "../tools/simulator/restart-app";
@@ -78,7 +78,7 @@ export function createRegistry(): Registry {
   registry.registerBlueprint(nativeDevtoolsBlueprint);
 
   registry.registerTool(listSimulatorsTool);
-  registry.registerTool(bootSimulatorTool);
+  registry.registerTool(createBootSimulatorTool(registry));
   registry.registerTool(launchAppTool);
   registry.registerTool(restartAppTool);
   registry.registerTool(reinstallAppTool);

--- a/packages/tool-server/test/boot-simulator.test.ts
+++ b/packages/tool-server/test/boot-simulator.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Registry } from "@argent/registry";
+
+type ExecFileCallback = (error: Error | null, stdout?: string, stderr?: string) => void;
+
+const mockExecFile = vi.fn();
+
+function getCallback(args: unknown[]): ExecFileCallback {
+  const callback = args[args.length - 1];
+  if (typeof callback !== "function") {
+    throw new Error("Missing execFile callback");
+  }
+  return callback as ExecFileCallback;
+}
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => mockExecFile(...args),
+}));
+
+import { createBootSimulatorTool } from "../src/tools/simulator/boot-simulator";
+
+describe("boot-simulator tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      getCallback(args)(null, "", "");
+      return {} as never;
+    });
+  });
+
+  it("waits for boot completion and native-devtools init before returning", async () => {
+    const resolveService = vi.fn(async () => {});
+    const registry = {
+      resolveService,
+    } as unknown as Registry;
+
+    const tool = createBootSimulatorTool(registry);
+
+    await expect(tool.execute!({}, { udid: "SIM-1" })).resolves.toEqual({
+      udid: "SIM-1",
+      booted: true,
+    });
+
+    expect(mockExecFile.mock.calls.map(([file, args]) => [file, args])).toEqual([
+      ["xcrun", ["simctl", "boot", "SIM-1"]],
+      ["xcrun", ["simctl", "bootstatus", "SIM-1", "-b"]],
+      ["defaults", ["write", "com.apple.iphonesimulator", "CurrentDeviceUDID", "SIM-1"]],
+      ["open", ["-a", "Simulator.app"]],
+    ]);
+    expect(resolveService).toHaveBeenCalledWith("NativeDevtools:SIM-1");
+    expect(resolveService.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mockExecFile.mock.invocationCallOrder[1]
+    );
+    expect(resolveService.mock.invocationCallOrder[0]).toBeLessThan(
+      mockExecFile.mock.invocationCallOrder[2]
+    );
+  });
+
+  it("still primes native-devtools when simctl reports the simulator is already booted", async () => {
+    mockExecFile
+      .mockImplementationOnce((...args: unknown[]) => {
+        getCallback(args)(new Error("Unable to boot device in current state: Booted"));
+        return {} as never;
+      })
+      .mockImplementation((...args: unknown[]) => {
+        getCallback(args)(null, "", "");
+        return {} as never;
+      });
+
+    const resolveService = vi.fn(async () => {});
+    const registry = { resolveService } as unknown as Registry;
+
+    const tool = createBootSimulatorTool(registry);
+
+    await expect(tool.execute!({}, { udid: "SIM-2" })).resolves.toEqual({
+      udid: "SIM-2",
+      booted: true,
+    });
+
+    expect(mockExecFile.mock.calls[1]?.slice(0, 2)).toEqual([
+      "xcrun",
+      ["simctl", "bootstatus", "SIM-2", "-b"],
+    ]);
+    expect(resolveService).toHaveBeenCalledWith("NativeDevtools:SIM-2");
+  });
+});


### PR DESCRIPTION
## Summary
- wait for `simctl bootstatus -b` before `boot-simulator` returns so post-boot setup only runs once the simulator can accept it
- resolve `NativeDevtools:<udid>` during boot so immediate launches cannot beat the watcher and miss launchd env / accessibility setup
- add a focused regression test covering both fresh boots and the already-booted simulator case

## Test plan
- [x] `npm test -w @argent/tool-server -- boot-simulator.test.ts`
- [ ] `npm run build -w @argent/tool-server` *(currently fails on the base branch due missing `simulatorServerBinaryPath` / `simulatorServerBinaryDir` exports from `@argent/native-devtools-ios`)*


Made with [Cursor](https://cursor.com)