### PR TITLE
fix: publish private npm releases from GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,30 +1,34 @@
-name: Publish to GitHub Packages
+name: Publish to npm
 
 on:
-  release:
-    types: [created]
   workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@swmansion"
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
 
       - run: npm run build -w @swmansion/argent
 
-      - run: npm publish --workspace packages/mcp
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: test -x packages/mcp/bin/simulator-server
+      - run: test -f packages/mcp/dylibs/libNativeDevtoolsIos.dylib
+      - run: test -f packages/mcp/dylibs/libKeyboardPatch.dylib
+      - run: test -f packages/mcp/dylibs/libInjectionBootstrap.dylib
+      - run: npm pack --dry-run -w @swmansion/argent
+
+      - run: npm publish -w @swmansion/argent --access restricted

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,6 +2,10 @@
   "name": "@swmansion/argent",
   "version": "0.3.5",
   "description": "MCP server for iOS Simulator control",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/argent.git"
+  },
   "type": "module",
   "bin": {
     "argent": "dist/cli.js",


### PR DESCRIPTION
## Summary
- switch the publish workflow from GitHub Packages to npm trusted publishing on npmjs.org
- publish the `@swmansion/argent` workspace privately with explicit native-artifact checks before release
- add repository metadata so npm can associate the package with this GitHub repo for trusted publishing

## Test plan
- [x] `npm run build -w @swmansion/argent`
- [x] `npm pack --dry-run -w @swmansion/argent`
- [ ] Configure the npm trusted publisher for `publish.yml` on `@swmansion/argent` before triggering a release


Made with [Cursor](https://cursor.com)