### PR TITLE
fix: publish private npm releases from GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,3 +32,5 @@ jobs:
       - run: npm pack --dry-run -w @swmansion/argent
 
       - run: npm publish -w @swmansion/argent --access restricted
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4235,7 +4235,7 @@
     },
     "packages/mcp": {
       "name": "@swmansion/argent",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "MCP server for iOS Simulator control",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- switch `@swmansion/argent` publishing from GitHub Packages to npm on tag pushes and manual dispatches
- validate the bundled native artifacts before publish, use `NPM_TOKEN` for the first restricted npm release from GitHub Actions, and point package metadata at the GitHub repo
- bump `@swmansion/argent` to `0.4.0` for the upcoming release

## Test plan
- [x] `npm install`
- [x] `npm pack --dry-run -w @swmansion/argent`
- [ ] add the `NPM_TOKEN` GitHub Actions secret before tagging the release
- [ ] merge to `main` and push tag `v0.4.0` to verify the publish workflow on npm


Made with [Cursor](https://cursor.com)