### PR TITLE
fix: restore GitHub Packages publishing fallback

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish to GitHub Packages
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-          registry-url: "https://registry.npmjs.org"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@swmansion"
 
       - run: npm ci
 
@@ -31,6 +32,6 @@ jobs:
       - run: test -f packages/mcp/dylibs/libInjectionBootstrap.dylib
       - run: npm pack --dry-run -w @swmansion/argent
 
-      - run: npm publish -w @swmansion/argent --access restricted
+      - run: npm publish -w @swmansion/argent --registry https://npm.pkg.github.com
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- switch the publish workflow back from npm to GitHub Packages so internal releases can keep shipping while npm private publishing is unavailable for the org
- keep the current tag-push/manual triggers and native artifact validation, but authenticate the publish step with `GITHUB_TOKEN`
- publish explicitly to `https://npm.pkg.github.com` so the workflow does not depend on the package's npm registry metadata

## Test plan
- [x] `npm install`
- [x] `npm run build -w @swmansion/argent && npm publish --dry-run -w @swmansion/argent --registry https://npm.pkg.github.com`
- [ ] merge to `main` and push a release tag to verify publishing to GitHub Packages


Made with [Cursor](https://cursor.com)