### PR TITLE
chore: bump packages to 0.4.0

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "MCP server for iOS Simulator control",
   "type": "module",
   "bin": {

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "type": "module",
   "description": "Claude Code skills for iOS simulator interaction via argent",
   "scripts": {

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Framework-agnostic tool registry for iOS simulator control",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps all workspace package versions from 0.3.x to 0.4.0 for the next internal release.

**Changed packages:**
- `@swmansion/argent` (packages/mcp): 0.3.5 -> 0.4.0
- `@argent/registry` (packages/registry): 0.3.3 -> 0.4.0
- `@argent/skills` (packages/skills): 0.3.3 -> 0.4.0
- `@argent/tool-server` (packages/tool-server): 0.3.3 -> 0.4.0