### PR TITLE
feat: enhance debugger API with app and device context

### DIFF
--- a/packages/tool-server/src/blueprints/js-runtime-debugger.ts
+++ b/packages/tool-server/src/blueprints/js-runtime-debugger.ts
@@ -89,6 +89,8 @@ export interface JsRuntimeDebuggerApi {
   port: number;
   projectRoot: string;
   deviceName: string;
+  appName: string;
+  logicalDeviceId: string | undefined;
   isNewDebugger: boolean;
   cdp: CDPClient;
   sourceResolver: SourceResolver;
@@ -169,6 +171,8 @@ export const jsRuntimeDebuggerBlueprint: ServiceBlueprint<JsRuntimeDebuggerApi, 
       port,
       projectRoot: metro.projectRoot,
       deviceName: selected.deviceName,
+      appName: selected.target.title,
+      logicalDeviceId: selected.target.reactNative?.logicalDeviceId,
       isNewDebugger: selected.isNewDebugger,
       cdp,
       sourceResolver,

--- a/packages/tool-server/src/tools/debugger/debugger-component-tree.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-component-tree.ts
@@ -555,10 +555,18 @@ Use when you need tap coordinates for a React Native UI element. Returns a compa
       return `Error: ${parsed.error}`;
     }
 
-    return buildTextTree(parsed, {
+    const tree = buildTextTree(parsed, {
       onScreenOnly: params.onScreenOnly,
       maxNodes: params.maxNodes,
       includeSkipped: params.includeSkipped,
     });
+
+    const deviceLine = [
+      `device: ${api.deviceName}`,
+      `app: ${api.appName}`,
+      ...(api.logicalDeviceId ? [`udid: ${api.logicalDeviceId}`] : []),
+    ].join(" | ");
+
+    return `[${deviceLine}]\n${tree}`;
   },
 };

--- a/packages/tool-server/src/tools/debugger/debugger-connect.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-connect.ts
@@ -12,13 +12,15 @@ export const debuggerConnectTool: ToolDefinition<
     port: number;
     projectRoot: string;
     deviceName: string;
+    appName: string;
+    logicalDeviceId: string | undefined;
     isNewDebugger: boolean;
     connected: boolean;
   }
 > = {
   id: "debugger-connect",
   description: `Connect to a running Metro dev server's CDP debugger endpoint.
-Returns connection info including port, projectRoot, deviceName, and isNewDebugger. If already connected, returns the existing connection.
+Returns connection info including port, projectRoot, deviceName, appName, logicalDeviceId, and isNewDebugger. If already connected, returns the existing connection.
 Use when starting a debug session or before calling other debugger-* tools. Fails if Metro is not running on the specified port.`,
   zodSchema,
   services: (params) => ({
@@ -30,6 +32,8 @@ Use when starting a debug session or before calling other debugger-* tools. Fail
       port: api.port,
       projectRoot: api.projectRoot,
       deviceName: api.deviceName,
+      appName: api.appName,
+      logicalDeviceId: api.logicalDeviceId,
       isNewDebugger: api.isNewDebugger,
       connected: api.cdp.isConnected(),
     };

--- a/packages/tool-server/src/tools/debugger/debugger-evaluate.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-evaluate.ts
@@ -9,11 +9,11 @@ const zodSchema = z.object({
 
 export const debuggerEvaluateTool: ToolDefinition<
   z.infer<typeof zodSchema>,
-  { result: unknown }
+  { result: unknown; deviceName: string; appName: string; logicalDeviceId: string | undefined }
 > = {
   id: "debugger-evaluate",
   description: `Execute arbitrary JavaScript in the React Native app's JS runtime via CDP.
-Returns the evaluation result as a JSON-serializable value. Use when you need to read app state, call app functions, or test logic at runtime. Fails if the expression throws or the runtime is not connected.`,
+Returns the evaluation result as a JSON-serializable value, along with deviceName, appName, and logicalDeviceId for context. Use when you need to read app state, call app functions, or test logic at runtime. Fails if the expression throws or the runtime is not connected.`,
   zodSchema,
   services: (params) => ({
     debugger: `JsRuntimeDebugger:${params.port}`,
@@ -21,6 +21,11 @@ Returns the evaluation result as a JSON-serializable value. Use when you need to
   async execute(services, params) {
     const api = services.debugger as JsRuntimeDebuggerApi;
     const result = await api.cdp.evaluate(params.expression);
-    return { result };
+    return {
+      result,
+      deviceName: api.deviceName,
+      appName: api.appName,
+      logicalDeviceId: api.logicalDeviceId,
+    };
   },
 };

--- a/packages/tool-server/src/tools/debugger/debugger-inspect-element.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-inspect-element.ts
@@ -148,6 +148,9 @@ export const debuggerInspectElementTool: ToolDefinition<
       truncated?: boolean;
       hiddenCount?: number;
       hint?: string;
+      deviceName: string;
+      appName: string;
+      logicalDeviceId: string | undefined;
     }
   | { error: string }
 > = {
@@ -269,6 +272,9 @@ Use when you need the source file and line for a component at a tap coordinate. 
             hint: `${hiddenCount} more parent components hidden (framework/navigation wrappers). Pass maxItems=${Math.min(totalKept, params.maxItems + 35)} to see more.`,
           }
         : {}),
+      deviceName: api.deviceName,
+      appName: api.appName,
+      logicalDeviceId: api.logicalDeviceId,
     };
   },
 };

--- a/packages/tool-server/src/tools/debugger/debugger-log-registry.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-log-registry.ts
@@ -5,6 +5,9 @@ import type { LogStats, MessageCluster } from "../../utils/debugger/log-file-wri
 
 interface LogRegistryResponse extends LogStats {
   clusters: MessageCluster[];
+  deviceName: string;
+  appName: string;
+  logicalDeviceId: string | undefined;
 }
 
 const zodSchema = z.object({
@@ -31,6 +34,9 @@ Use when investigating warnings, errors, or unexpected output — call this firs
     return {
       ...stats,
       clusters,
+      deviceName: api.deviceName,
+      appName: api.appName,
+      logicalDeviceId: api.logicalDeviceId,
     };
   },
 };

--- a/packages/tool-server/src/tools/debugger/debugger-reload-metro.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-reload-metro.ts
@@ -9,11 +9,18 @@ const zodSchema = z.object({
 
 export const debuggerReloadMetroTool: ToolDefinition<
   z.infer<typeof zodSchema>,
-  { reloaded: boolean; port: number; method: "cdp" | "http" }
+  {
+    reloaded: boolean;
+    port: number;
+    method: "cdp" | "http";
+    deviceName: string;
+    appName: string;
+    logicalDeviceId: string | undefined;
+  }
 > = {
   id: "debugger-reload-metro",
   description: `Restart the Metro JS bundle in the connected React Native app without restarting the native process.
-Use when you want to apply code changes or reset JS state. Returns { reloaded, port, method } indicating which reload path was used. Fails if Metro is not running on the given port.`,
+Use when you want to apply code changes or reset JS state. Returns { reloaded, port, method, deviceName, appName, logicalDeviceId } indicating which reload path was used and which device/app was targeted. Fails if Metro is not running on the given port.`,
   zodSchema,
   services: (params) => ({
     debugger: `JsRuntimeDebugger:${params.port}`,
@@ -29,10 +36,16 @@ Use when you want to apply code changes or reset JS state. Returns { reloaded, p
 
     // Primary: CDP Page.reload — works reliably with RN 0.76+ (Fusebox/Bridgeless).
     // Triggers a full JS execution context teardown and restart without touching the native shell.
+    const context = {
+      deviceName: api.deviceName,
+      appName: api.appName,
+      logicalDeviceId: api.logicalDeviceId,
+    };
+
     try {
       await api.cdp.send("Page.reload");
       disableLogBox();
-      return { reloaded: true, port, method: "cdp" };
+      return { reloaded: true, port, method: "cdp", ...context };
     } catch {
       // Fall through to HTTP fallback
     }
@@ -48,6 +61,6 @@ Use when you want to apply code changes or reset JS state. Returns { reloaded, p
       );
     }
     disableLogBox();
-    return { reloaded: true, port, method: "http" };
+    return { reloaded: true, port, method: "http", ...context };
   },
 };

--- a/packages/tool-server/src/tools/debugger/debugger-status.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-status.ts
@@ -12,6 +12,8 @@ export const debuggerStatusTool: ToolDefinition<
     port: number;
     projectRoot: string;
     deviceName: string;
+    appName: string;
+    logicalDeviceId: string | undefined;
     isNewDebugger: boolean;
     connected: boolean;
     loadedScripts: number;
@@ -21,7 +23,7 @@ export const debuggerStatusTool: ToolDefinition<
 > = {
   id: "debugger-status",
   description: `Get JS runtime debugger connection status and diagnostic info.
-Use when you need to verify connectivity before using other debugger tools. Returns port, projectRoot, deviceName, connected flag, loadedScripts count, and sourceMapReady (always true — waits for pending source maps before returning). Fails if Metro is unreachable.`,
+Use when you need to verify connectivity before using other debugger tools. Returns port, projectRoot, deviceName, appName, logicalDeviceId, connected flag, loadedScripts count, and sourceMapReady (always true — waits for pending source maps before returning). Fails if Metro is unreachable.`,
   zodSchema,
   services: (params) => ({
     debugger: `JsRuntimeDebugger:${params.port}`,
@@ -33,6 +35,8 @@ Use when you need to verify connectivity before using other debugger tools. Retu
       port: api.port,
       projectRoot: api.projectRoot,
       deviceName: api.deviceName,
+      appName: api.appName,
+      logicalDeviceId: api.logicalDeviceId,
       isNewDebugger: api.isNewDebugger,
       connected: api.cdp.isConnected(),
       loadedScripts: api.cdp.getLoadedScripts().size,


### PR DESCRIPTION
## Summary

- Added `appName` and `logicalDeviceId` fields to `JsRuntimeDebuggerApi` interface, populated from the selected Metro target's title and React Native logical device ID
- Propagated `appName` and `logicalDeviceId` to all debugger tool responses: `debugger-connect`, `debugger-status`, `debugger-evaluate`, `debugger-inspect-element`, `debugger-log-registry`, `debugger-reload-metro`
- `debugger-component-tree` now prepends a device context header line (`device | app | udid`) to the returned tree string

This was added because of the observation I made - when trying to reload a metro server with two available servers running, the agent sometimes mixes up some ports. This change is the best-effort approach to deal with this edge-case.