### PR TITLE
feat: add MCP config adapter for Roo Code

### DIFF
--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -422,6 +422,75 @@ const geminiAdapter: McpConfigAdapter = {
   },
 };
 
+// ── Roo Code adapter ────────────────────────────────────────────────────────
+// Format: { mcpServers: { argent: { command, args, env } } }
+// Project: <root>/.roo/mcp.json
+// Global (macOS): ~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json
+
+function rooCodeGlobalDir(): string {
+  return path.join(
+    homedir(),
+    "Library",
+    "Application Support",
+    "Code",
+    "User",
+    "globalStorage",
+    "rooveterinaryinc.roo-cline",
+    "settings"
+  );
+}
+
+const rooCodeAdapter: McpConfigAdapter = {
+  name: "Roo Code",
+
+  detect(): boolean {
+    return (
+      dirExists(path.join(process.cwd(), ".roo")) ||
+      dirExists(
+        path.join(
+          homedir(),
+          "Library",
+          "Application Support",
+          "Code",
+          "User",
+          "globalStorage",
+          "rooveterinaryinc.roo-cline"
+        )
+      )
+    );
+  },
+
+  projectPath(root: string): string | null {
+    return path.join(root, ".roo", "mcp.json");
+  },
+
+  globalPath(): string | null {
+    return path.join(rooCodeGlobalDir(), "cline_mcp_settings.json");
+  },
+
+  write(configPath: string, entry: McpServerEntry): void {
+    const config = readJson(configPath);
+    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+    servers[MCP_SERVER_KEY] = {
+      command: entry.command,
+      args: entry.args,
+      env: entry.env,
+    };
+    config.mcpServers = servers;
+    writeJson(configPath, config);
+  },
+
+  remove(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const config = readJson(configPath);
+    const servers = config.mcpServers as Record<string, unknown> | undefined;
+    if (!servers?.[MCP_SERVER_KEY]) return false;
+    delete servers[MCP_SERVER_KEY];
+    writeJson(configPath, config);
+    return true;
+  },
+};
+
 // ── Codex CLI adapter ────────────────────────────────────────────────────────
 // Format (TOML): [mcp_servers.argent] command = "argent" args = ["mcp"] env = { ... }
 // Project: <root>/.codex/config.toml   Global: ~/.codex/config.toml
@@ -476,6 +545,7 @@ export const ALL_ADAPTERS: McpConfigAdapter[] = [
   zedAdapter,
   geminiAdapter,
   codexAdapter,
+  rooCodeAdapter,
 ];
 
 export function detectAdapters(): McpConfigAdapter[] {

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -63,7 +63,7 @@ describe("getMcpEntry", () => {
 // ── Adapter registry ──────────────────────────────────────────────────────────
 
 describe("ALL_ADAPTERS", () => {
-  it("contains all seven adapters", () => {
+  it("contains all eight adapters", () => {
     const names = ALL_ADAPTERS.map((a) => a.name);
     expect(names).toEqual([
       "Cursor",
@@ -73,6 +73,7 @@ describe("ALL_ADAPTERS", () => {
       "Zed",
       "Gemini",
       "Codex",
+      "Roo Code",
     ]);
   });
 });
@@ -457,6 +458,81 @@ describe("Codex adapter", () => {
     expect(content).toContain('model = "o3"');
     expect(content).toContain("[mcp_servers.other]");
     expect(content).toContain("[mcp_servers.argent]");
+  });
+});
+
+// ── Roo Code adapter ────────────────────────────────────────────────────────
+
+describe("Roo Code adapter", () => {
+  const adapter = ALL_ADAPTERS.find((a) => a.name === "Roo Code")!;
+
+  it("writes { mcpServers: { argent: ... } } without type", () => {
+    const configPath = path.join(tmpDir, ".roo", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("argent");
+    const argent = servers.argent as Record<string, unknown>;
+    expect(argent.command).toBe("argent");
+    expect(argent).not.toHaveProperty("type");
+  });
+
+  it("removes argent entry and returns true", () => {
+    const configPath = path.join(tmpDir, ".roo", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+
+    const removed = adapter.remove(configPath);
+    expect(removed).toBe(true);
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).not.toHaveProperty("argent");
+  });
+
+  it("returns false when removing from non-existent file", () => {
+    expect(adapter.remove(path.join(tmpDir, "nope.json"))).toBe(false);
+  });
+
+  it("returns false when removing from file without argent entry", () => {
+    const configPath = path.join(tmpDir, ".roo", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: {} }));
+
+    expect(adapter.remove(configPath)).toBe(false);
+  });
+
+  it("preserves other servers when writing", () => {
+    const configPath = path.join(tmpDir, ".roo", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: { other: { command: "other" } } }));
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("other");
+    expect(servers).toHaveProperty("argent");
+  });
+
+  it("projectPath returns .roo/mcp.json under project root", () => {
+    expect(adapter.projectPath("/foo")).toBe(path.join("/foo", ".roo", "mcp.json"));
+  });
+
+  it("globalPath returns VS Code globalStorage path", () => {
+    expect(adapter.globalPath()).toBe(
+      path.join(
+        os.homedir(),
+        "Library",
+        "Application Support",
+        "Code",
+        "User",
+        "globalStorage",
+        "rooveterinaryinc.roo-cline",
+        "settings",
+        "cline_mcp_settings.json"
+      )
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a new `McpConfigAdapter` for **Roo Code** (VS Code extension, fork of Cline)
- Project-level config: `.roo/mcp.json`
- Global config: VS Code `globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json`
- Uses standard `mcpServers` format (no `type` field), matching the Cline/Cursor convention
- Added to `ALL_ADAPTERS` registry with full test coverage (write, remove, paths, edge cases)

Resolves ARG-106

## Test plan
- [x] All 69 tests pass in `packages/mcp/test/cli/mcp-configs.test.ts`
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Adapter registry test updated from 7 to 8 adapters
- [x] Roo Code adapter tests cover: write format, remove, non-existent file removal, empty server removal, preserving other servers, projectPath, globalPath