### PR TITLE
feat: add MCP config adapter for Cline

### DIFF
--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -466,6 +466,73 @@ const codexAdapter: McpConfigAdapter = {
   },
 };
 
+// ── Cline adapter ───────────────────────────────────────────────────────────
+// Format: { mcpServers: { argent: { command, args, env } } }
+// Global only: ~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json (macOS)
+//              ~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json (Linux)
+
+function clineGlobalDir(): string {
+  const platform = process.platform;
+  if (platform === "darwin") {
+    return path.join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "Code",
+      "User",
+      "globalStorage",
+      "saoudrizwan.claude-dev"
+    );
+  }
+  // Linux (and fallback)
+  return path.join(
+    homedir(),
+    ".config",
+    "Code",
+    "User",
+    "globalStorage",
+    "saoudrizwan.claude-dev"
+  );
+}
+
+const clineAdapter: McpConfigAdapter = {
+  name: "Cline",
+
+  detect(): boolean {
+    return dirExists(clineGlobalDir());
+  },
+
+  projectPath(): string | null {
+    return null;
+  },
+
+  globalPath(): string | null {
+    return path.join(clineGlobalDir(), "settings", "cline_mcp_settings.json");
+  },
+
+  write(configPath: string, entry: McpServerEntry): void {
+    const config = readJson(configPath);
+    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+    servers[MCP_SERVER_KEY] = {
+      command: entry.command,
+      args: entry.args,
+      env: entry.env,
+    };
+    config.mcpServers = servers;
+    writeJson(configPath, config);
+  },
+
+  remove(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const config = readJson(configPath);
+    const servers = config.mcpServers as Record<string, unknown> | undefined;
+    if (!servers?.[MCP_SERVER_KEY]) return false;
+    delete servers[MCP_SERVER_KEY];
+    writeJson(configPath, config);
+    return true;
+  },
+};
+
 // ── Registry ──────────────────────────────────────────────────────────────────
 
 export const ALL_ADAPTERS: McpConfigAdapter[] = [
@@ -476,6 +543,7 @@ export const ALL_ADAPTERS: McpConfigAdapter[] = [
   zedAdapter,
   geminiAdapter,
   codexAdapter,
+  clineAdapter,
 ];
 
 export function detectAdapters(): McpConfigAdapter[] {

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -63,7 +63,7 @@ describe("getMcpEntry", () => {
 // ── Adapter registry ──────────────────────────────────────────────────────────
 
 describe("ALL_ADAPTERS", () => {
-  it("contains all seven adapters", () => {
+  it("contains all eight adapters", () => {
     const names = ALL_ADAPTERS.map((a) => a.name);
     expect(names).toEqual([
       "Cursor",
@@ -73,6 +73,7 @@ describe("ALL_ADAPTERS", () => {
       "Zed",
       "Gemini",
       "Codex",
+      "Cline",
     ]);
   });
 });
@@ -457,6 +458,75 @@ describe("Codex adapter", () => {
     expect(content).toContain('model = "o3"');
     expect(content).toContain("[mcp_servers.other]");
     expect(content).toContain("[mcp_servers.argent]");
+  });
+});
+
+// ── Cline adapter ───────────────────────────────────────────────────────────
+
+describe("Cline adapter", () => {
+  const adapter = ALL_ADAPTERS.find((a) => a.name === "Cline")!;
+
+  it("writes { mcpServers: { argent: ... } } without type", () => {
+    const configPath = path.join(tmpDir, "cline_mcp_settings.json");
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("argent");
+    const argent = servers.argent as Record<string, unknown>;
+    expect(argent.command).toBe("argent");
+    expect(argent).not.toHaveProperty("type");
+  });
+
+  it("removes argent entry and returns true", () => {
+    const configPath = path.join(tmpDir, "cline_mcp_settings.json");
+    adapter.write(configPath, getMcpEntry());
+
+    const removed = adapter.remove(configPath);
+    expect(removed).toBe(true);
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).not.toHaveProperty("argent");
+  });
+
+  it("returns false when removing from non-existent file", () => {
+    expect(adapter.remove(path.join(tmpDir, "nope.json"))).toBe(false);
+  });
+
+  it("returns false when removing from file without argent entry", () => {
+    const configPath = path.join(tmpDir, "cline_mcp_settings.json");
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: {} }));
+    expect(adapter.remove(configPath)).toBe(false);
+  });
+
+  it("projectPath returns null (global-only)", () => {
+    expect(adapter.projectPath("/foo")).toBeNull();
+  });
+
+  it("globalPath returns cline_mcp_settings.json in VS Code globalStorage", () => {
+    const globalPath = adapter.globalPath()!;
+    expect(globalPath).toContain("saoudrizwan.claude-dev");
+    expect(globalPath).toContain(
+      path.join("settings", "cline_mcp_settings.json")
+    );
+  });
+
+  it("preserves existing servers when writing", () => {
+    const configPath = path.join(tmpDir, "cline_mcp_settings.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: { "other-tool": { command: "npx" } },
+      })
+    );
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("other-tool");
+    expect(servers).toHaveProperty("argent");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a new `Cline` MCP config adapter for the Cline VS Code extension (`saoudrizwan.claude-dev`)
- Global-only adapter storing config at VS Code's `globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
- Uses standard `{ mcpServers: { ... } }` format (same as Cursor/Windsurf/Gemini)
- Cross-platform path resolution for macOS and Linux

## Test plan
- [x] All 69 existing + new tests pass (`npx vitest run test/cli/mcp-configs.test.ts`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Adapter registry updated from 7 to 8 adapters
- [x] Tests cover: write format, remove, non-existent remove, empty-server remove, projectPath (null), globalPath, preserve other servers

Resolves ARG-104