### PR TITLE
feat: add MCP config adapter for Continue

### DIFF
--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -466,6 +466,61 @@ const codexAdapter: McpConfigAdapter = {
   },
 };
 
+// ── Continue adapter ─────────────────────────────────────────────────────────
+// Format: { mcpServers: [ { name: "argent", command, args, env } ] }
+// Global: ~/.continue/config.json   Project: .continue/config.json
+
+const continueAdapter: McpConfigAdapter = {
+  name: "Continue",
+
+  detect(): boolean {
+    return (
+      dirExists(path.join(homedir(), ".continue")) ||
+      dirExists(path.join(process.cwd(), ".continue"))
+    );
+  },
+
+  projectPath(root: string): string | null {
+    return path.join(root, ".continue", "config.json");
+  },
+
+  globalPath(): string | null {
+    return path.join(homedir(), ".continue", "config.json");
+  },
+
+  write(configPath: string, entry: McpServerEntry): void {
+    const config = readJson(configPath);
+    const servers = (config.mcpServers ?? []) as Array<Record<string, unknown>>;
+    const idx = servers.findIndex((s) => s.name === MCP_SERVER_KEY);
+    const newEntry = {
+      name: MCP_SERVER_KEY,
+      command: entry.command,
+      args: entry.args,
+      env: entry.env,
+    };
+    if (idx >= 0) {
+      servers[idx] = newEntry;
+    } else {
+      servers.push(newEntry);
+    }
+    config.mcpServers = servers;
+    writeJson(configPath, config);
+  },
+
+  remove(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const config = readJson(configPath);
+    const servers = config.mcpServers as Array<Record<string, unknown>> | undefined;
+    if (!Array.isArray(servers)) return false;
+    const idx = servers.findIndex((s) => s.name === MCP_SERVER_KEY);
+    if (idx < 0) return false;
+    servers.splice(idx, 1);
+    config.mcpServers = servers;
+    writeJson(configPath, config);
+    return true;
+  },
+};
+
 // ── Registry ──────────────────────────────────────────────────────────────────
 
 export const ALL_ADAPTERS: McpConfigAdapter[] = [
@@ -476,6 +531,7 @@ export const ALL_ADAPTERS: McpConfigAdapter[] = [
   zedAdapter,
   geminiAdapter,
   codexAdapter,
+  continueAdapter,
 ];
 
 export function detectAdapters(): McpConfigAdapter[] {

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -63,7 +63,7 @@ describe("getMcpEntry", () => {
 // ── Adapter registry ──────────────────────────────────────────────────────────
 
 describe("ALL_ADAPTERS", () => {
-  it("contains all seven adapters", () => {
+  it("contains all eight adapters", () => {
     const names = ALL_ADAPTERS.map((a) => a.name);
     expect(names).toEqual([
       "Cursor",
@@ -73,6 +73,7 @@ describe("ALL_ADAPTERS", () => {
       "Zed",
       "Gemini",
       "Codex",
+      "Continue",
     ]);
   });
 });
@@ -457,6 +458,101 @@ describe("Codex adapter", () => {
     expect(content).toContain('model = "o3"');
     expect(content).toContain("[mcp_servers.other]");
     expect(content).toContain("[mcp_servers.argent]");
+  });
+});
+
+// ── Continue adapter ─────────────────────────────────────────────────────────
+
+describe("Continue adapter", () => {
+  const adapter = ALL_ADAPTERS.find((a) => a.name === "Continue")!;
+
+  it("writes { mcpServers: [{ name: 'argent', ... }] } array format", () => {
+    const configPath = path.join(tmpDir, ".continue", "config.json");
+    const entry = getMcpEntry();
+
+    adapter.write(configPath, entry);
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Array<Record<string, unknown>>;
+    expect(Array.isArray(servers)).toBe(true);
+    expect(servers).toHaveLength(1);
+    expect(servers[0].name).toBe("argent");
+    expect(servers[0].command).toBe("argent");
+    expect(servers[0]).not.toHaveProperty("type");
+  });
+
+  it("removes argent entry and returns true", () => {
+    const configPath = path.join(tmpDir, ".continue", "config.json");
+    adapter.write(configPath, getMcpEntry());
+
+    const removed = adapter.remove(configPath);
+    expect(removed).toBe(true);
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Array<Record<string, unknown>>;
+    expect(servers).toHaveLength(0);
+  });
+
+  it("returns false when removing from non-existent file", () => {
+    expect(adapter.remove(path.join(tmpDir, "nope.json"))).toBe(false);
+  });
+
+  it("returns false when removing from file without argent entry", () => {
+    const configPath = path.join(tmpDir, ".continue", "config.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: [] }));
+
+    expect(adapter.remove(configPath)).toBe(false);
+  });
+
+  it("preserves other servers when writing", () => {
+    const configPath = path.join(tmpDir, ".continue", "config.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: [{ name: "other", command: "other" }] })
+    );
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Array<Record<string, unknown>>;
+    expect(servers).toHaveLength(2);
+    expect(servers.find((s) => s.name === "other")).toBeDefined();
+    expect(servers.find((s) => s.name === "argent")).toBeDefined();
+  });
+
+  it("updates existing argent entry instead of duplicating", () => {
+    const configPath = path.join(tmpDir, ".continue", "config.json");
+    adapter.write(configPath, getMcpEntry());
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Array<Record<string, unknown>>;
+    expect(servers.filter((s) => s.name === "argent")).toHaveLength(1);
+  });
+
+  it("preserves existing config keys when writing", () => {
+    const configPath = path.join(tmpDir, ".continue", "config.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ models: [{ title: "GPT-4" }], mcpServers: [] })
+    );
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    expect(config.models).toBeDefined();
+    expect((config.mcpServers as unknown[]).length).toBe(1);
+  });
+
+  it("projectPath returns .continue/config.json under project root", () => {
+    expect(adapter.projectPath("/foo")).toBe(path.join("/foo", ".continue", "config.json"));
+  });
+
+  it("globalPath returns ~/.continue/config.json", () => {
+    expect(adapter.globalPath()).toBe(path.join(os.homedir(), ".continue", "config.json"));
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a `Continue` adapter to the MCP configuration system in `packages/mcp/src/cli/mcp-configs.ts`
- Continue (by continuedev) uses an array-based `mcpServers` format in `~/.continue/config.json` where each server entry is identified by a `name` field, unlike the object-map format used by Cursor/Claude/Windsurf
- The adapter supports both project-level (`.continue/config.json`) and global (`~/.continue/config.json`) configuration paths
- Includes comprehensive tests covering write format, remove, idempotent writes, preservation of existing config, project/global paths

Resolves ARG-107

## Test plan

- [x] All 71 tests pass in `packages/mcp/test/cli/mcp-configs.test.ts`
- [x] TypeScript compiles cleanly with `tsc --noEmit`
- [ ] Verify adapter is detected when `~/.continue` directory exists
- [ ] Verify `argent init` writes correct array-format entry to Continue config