### PR TITLE
feat: add MCP config adapter for Trae

### DIFF
--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -466,6 +466,61 @@ const codexAdapter: McpConfigAdapter = {
   },
 };
 
+// ── Trae adapter ────────────────────────────────────────────────────────────
+// Format: { mcpServers: { argent: { command, args, env } } }
+// Project: <root>/.trae/mcp.json
+// Global (macOS): ~/Library/Application Support/Trae/User/mcp.json
+
+const traeAdapter: McpConfigAdapter = {
+  name: "Trae",
+
+  detect(): boolean {
+    return (
+      dirExists(path.join(process.cwd(), ".trae")) ||
+      dirExists(
+        path.join(homedir(), "Library", "Application Support", "Trae", "User")
+      )
+    );
+  },
+
+  projectPath(root: string): string | null {
+    return path.join(root, ".trae", "mcp.json");
+  },
+
+  globalPath(): string | null {
+    return path.join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "Trae",
+      "User",
+      "mcp.json"
+    );
+  },
+
+  write(configPath: string, entry: McpServerEntry): void {
+    const config = readJson(configPath);
+    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+    servers[MCP_SERVER_KEY] = {
+      command: entry.command,
+      args: entry.args,
+      env: entry.env,
+    };
+    config.mcpServers = servers;
+    writeJson(configPath, config);
+  },
+
+  remove(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const config = readJson(configPath);
+    const servers = config.mcpServers as Record<string, unknown> | undefined;
+    if (!servers?.[MCP_SERVER_KEY]) return false;
+    delete servers[MCP_SERVER_KEY];
+    writeJson(configPath, config);
+    return true;
+  },
+};
+
 // ── Registry ──────────────────────────────────────────────────────────────────
 
 export const ALL_ADAPTERS: McpConfigAdapter[] = [
@@ -476,6 +531,7 @@ export const ALL_ADAPTERS: McpConfigAdapter[] = [
   zedAdapter,
   geminiAdapter,
   codexAdapter,
+  traeAdapter,
 ];
 
 export function detectAdapters(): McpConfigAdapter[] {

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -63,7 +63,7 @@ describe("getMcpEntry", () => {
 // ── Adapter registry ──────────────────────────────────────────────────────────
 
 describe("ALL_ADAPTERS", () => {
-  it("contains all seven adapters", () => {
+  it("contains all eight adapters", () => {
     const names = ALL_ADAPTERS.map((a) => a.name);
     expect(names).toEqual([
       "Cursor",
@@ -73,6 +73,7 @@ describe("ALL_ADAPTERS", () => {
       "Zed",
       "Gemini",
       "Codex",
+      "Trae",
     ]);
   });
 });
@@ -457,6 +458,71 @@ describe("Codex adapter", () => {
     expect(content).toContain('model = "o3"');
     expect(content).toContain("[mcp_servers.other]");
     expect(content).toContain("[mcp_servers.argent]");
+  });
+});
+
+// ── Trae adapter ────────────────────────────────────────────────────────────
+
+describe("Trae adapter", () => {
+  const adapter = ALL_ADAPTERS.find((a) => a.name === "Trae")!;
+
+  it("writes { mcpServers: { argent: ... } } without type", () => {
+    const configPath = path.join(tmpDir, ".trae", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("argent");
+    const argent = servers.argent as Record<string, unknown>;
+    expect(argent.command).toBe("argent");
+    expect(argent).not.toHaveProperty("type");
+  });
+
+  it("removes argent entry and returns true", () => {
+    const configPath = path.join(tmpDir, ".trae", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+
+    const removed = adapter.remove(configPath);
+    expect(removed).toBe(true);
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).not.toHaveProperty("argent");
+  });
+
+  it("returns false when removing from non-existent file", () => {
+    expect(adapter.remove(path.join(tmpDir, "nope.json"))).toBe(false);
+  });
+
+  it("returns false when removing from file without argent entry", () => {
+    const configPath = path.join(tmpDir, ".trae", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: {} }));
+
+    expect(adapter.remove(configPath)).toBe(false);
+  });
+
+  it("preserves other servers when writing", () => {
+    const configPath = path.join(tmpDir, ".trae", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: { other: { command: "other" } } }));
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("other");
+    expect(servers).toHaveProperty("argent");
+  });
+
+  it("projectPath returns .trae/mcp.json under project root", () => {
+    expect(adapter.projectPath("/foo")).toBe(path.join("/foo", ".trae", "mcp.json"));
+  });
+
+  it("globalPath returns ~/Library/Application Support/Trae/User/mcp.json", () => {
+    expect(adapter.globalPath()).toBe(
+      path.join(os.homedir(), "Library", "Application Support", "Trae", "User", "mcp.json")
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Add MCP configuration adapter for Trae (ByteDance AI IDE) to the adapter registry
- Project-level config at `.trae/mcp.json`, global config at `~/Library/Application Support/Trae/User/mcp.json`
- Uses standard `mcpServers` object format (same as Cursor/Windsurf, no `type` field)
- Includes full test coverage following existing adapter test patterns

Resolves ARG-108

## Test plan
- [x] All 69 tests pass in `mcp-configs.test.ts` (7 new Trae-specific tests added)
- [x] TypeScript compiles cleanly with `tsc --noEmit`
- [ ] Manual verification: run `argent init` and confirm Trae is detected when `.trae/` directory exists