### PR TITLE
feat: add MCP config adapter for Aider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4195,9 +4195,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -4241,7 +4241,8 @@
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.20.0",
         "picocolors": "^1.1.1",
-        "smol-toml": "^1.6.1"
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "argent": "dist/cli.js",
@@ -4264,7 +4265,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "zod": "^3.23.0"
       },
@@ -4976,14 +4977,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
         "@argent/registry": "file:../registry",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -42,7 +42,8 @@
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.20.0",
     "picocolors": "^1.1.1",
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.6.1",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -7,7 +7,7 @@ import {
   PERMISSION_RULE,
   CURSOR_ALLOWLIST_PATTERN,
 } from "./constants.js";
-import { readJson, writeJson, dirExists, readToml, writeToml } from "./utils.js";
+import { readJson, writeJson, dirExists, readToml, writeToml, readYaml, writeYaml } from "./utils.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -466,6 +466,66 @@ const codexAdapter: McpConfigAdapter = {
   },
 };
 
+// ── Aider adapter ───────────────────────────────────────────────────────────
+// Format (YAML): servers: [{ name, command, envs }]
+// Project: <root>/.aider.mcp.yml   Global: ~/.aider.mcp.yml
+
+interface AiderServerEntry {
+  name: string;
+  command: string;
+  envs?: Record<string, string>;
+}
+
+const aiderAdapter: McpConfigAdapter = {
+  name: "Aider",
+
+  detect(): boolean {
+    return (
+      fs.existsSync(path.join(process.cwd(), ".aider.conf.yml")) ||
+      fs.existsSync(path.join(process.cwd(), ".aider.mcp.yml")) ||
+      fs.existsSync(path.join(homedir(), ".aider.conf.yml")) ||
+      fs.existsSync(path.join(homedir(), ".aider.mcp.yml"))
+    );
+  },
+
+  projectPath(root: string): string | null {
+    return path.join(root, ".aider.mcp.yml");
+  },
+
+  globalPath(): string | null {
+    return path.join(homedir(), ".aider.mcp.yml");
+  },
+
+  write(configPath: string, entry: McpServerEntry): void {
+    const config = readYaml(configPath);
+    const servers = (config.servers ?? []) as AiderServerEntry[];
+    // Build the command string from command + args
+    const command = [entry.command, ...entry.args].join(" ");
+    const idx = servers.findIndex((s) => s.name === MCP_SERVER_KEY);
+    const newEntry: AiderServerEntry = { name: MCP_SERVER_KEY, command, envs: entry.env };
+    if (idx >= 0) {
+      servers[idx] = newEntry;
+    } else {
+      servers.push(newEntry);
+    }
+    config.servers = servers;
+    writeYaml(configPath, config);
+  },
+
+  remove(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const config = readYaml(configPath);
+    const servers = config.servers as AiderServerEntry[] | undefined;
+    if (!Array.isArray(servers)) return false;
+    const idx = servers.findIndex((s) => s.name === MCP_SERVER_KEY);
+    if (idx < 0) return false;
+    servers.splice(idx, 1);
+    config.servers = servers;
+    writeYaml(configPath, config);
+    return true;
+  },
+};
+
 // ── Registry ──────────────────────────────────────────────────────────────────
 
 export const ALL_ADAPTERS: McpConfigAdapter[] = [
@@ -476,6 +536,7 @@ export const ALL_ADAPTERS: McpConfigAdapter[] = [
   zedAdapter,
   geminiAdapter,
   codexAdapter,
+  aiderAdapter,
 ];
 
 export function detectAdapters(): McpConfigAdapter[] {

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { PACKAGE_NAME, NPM_REGISTRY } from "./constants.js";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
 // ── Package root resolution ───────────────────────────────────────────────────
 // tsc compiles src/cli/utils.ts -> dist/cli/utils.js.
@@ -37,6 +38,22 @@ export function readToml(filePath: string): Record<string, unknown> {
 export function writeToml(filePath: string, data: Record<string, unknown>): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, stringifyToml(data) + "\n");
+}
+
+// ── YAML helpers ────────────────────────────────────────────────────────────
+
+export function readYaml(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) return {};
+  try {
+    return (parseYaml(fs.readFileSync(filePath, "utf8")) as Record<string, unknown>) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeYaml(filePath: string, data: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, stringifyYaml(data));
 }
 
 // ── JSON helpers ──────────────────────────────────────────────────────────────

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -63,7 +63,7 @@ describe("getMcpEntry", () => {
 // ── Adapter registry ──────────────────────────────────────────────────────────
 
 describe("ALL_ADAPTERS", () => {
-  it("contains all seven adapters", () => {
+  it("contains all eight adapters", () => {
     const names = ALL_ADAPTERS.map((a) => a.name);
     expect(names).toEqual([
       "Cursor",
@@ -73,6 +73,7 @@ describe("ALL_ADAPTERS", () => {
       "Zed",
       "Gemini",
       "Codex",
+      "Aider",
     ]);
   });
 });
@@ -457,6 +458,110 @@ describe("Codex adapter", () => {
     expect(content).toContain('model = "o3"');
     expect(content).toContain("[mcp_servers.other]");
     expect(content).toContain("[mcp_servers.argent]");
+  });
+});
+
+// ── Aider adapter ───────────────────────────────────────────────────────────
+
+describe("Aider adapter", () => {
+  const adapter = ALL_ADAPTERS.find((a) => a.name === "Aider")!;
+
+  function readYamlFile(filePath: string): Record<string, unknown> {
+    const { parse } = require("yaml") as typeof import("yaml");
+    return parse(fs.readFileSync(filePath, "utf8")) as Record<string, unknown>;
+  }
+
+  it("writes servers array in YAML format", () => {
+    const configPath = path.join(tmpDir, ".aider.mcp.yml");
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readYamlFile(configPath);
+    const servers = config.servers as Array<Record<string, unknown>>;
+    expect(servers).toHaveLength(1);
+    expect(servers[0].name).toBe("argent");
+    expect(servers[0].command).toBe("argent mcp");
+    expect(servers[0].envs).toHaveProperty("ARGENT_MCP_LOG");
+  });
+
+  it("removes argent entry and returns true", () => {
+    const configPath = path.join(tmpDir, ".aider.mcp.yml");
+    adapter.write(configPath, getMcpEntry());
+
+    const removed = adapter.remove(configPath);
+    expect(removed).toBe(true);
+
+    const config = readYamlFile(configPath);
+    const servers = config.servers as Array<Record<string, unknown>>;
+    expect(servers.find((s) => s.name === "argent")).toBeUndefined();
+  });
+
+  it("returns false when removing from non-existent file", () => {
+    expect(adapter.remove(path.join(tmpDir, "nope.yml"))).toBe(false);
+  });
+
+  it("returns false when removing from file without argent entry", () => {
+    const configPath = path.join(tmpDir, ".aider.mcp.yml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, "servers: []\n");
+    expect(adapter.remove(configPath)).toBe(false);
+  });
+
+  it("preserves other servers when writing", () => {
+    const configPath = path.join(tmpDir, ".aider.mcp.yml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      'servers:\n  - name: other\n    command: "npx other-tool"\n'
+    );
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readYamlFile(configPath);
+    const servers = config.servers as Array<Record<string, unknown>>;
+    expect(servers).toHaveLength(2);
+    expect(servers.find((s) => s.name === "other")).toBeDefined();
+    expect(servers.find((s) => s.name === "argent")).toBeDefined();
+  });
+
+  it("updates existing argent entry instead of duplicating", () => {
+    const configPath = path.join(tmpDir, ".aider.mcp.yml");
+    adapter.write(configPath, getMcpEntry());
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readYamlFile(configPath);
+    const servers = config.servers as Array<Record<string, unknown>>;
+    const argentEntries = servers.filter((s) => s.name === "argent");
+    expect(argentEntries).toHaveLength(1);
+  });
+
+  it("projectPath returns .aider.mcp.yml under project root", () => {
+    expect(adapter.projectPath("/foo")).toBe(path.join("/foo", ".aider.mcp.yml"));
+  });
+
+  it("globalPath returns ~/.aider.mcp.yml", () => {
+    expect(adapter.globalPath()).toBe(path.join(os.homedir(), ".aider.mcp.yml"));
+  });
+
+  it("detect() returns true when local .aider.conf.yml exists", () => {
+    const localConf = path.join(process.cwd(), ".aider.conf.yml");
+    const existed = fs.existsSync(localConf);
+    if (!existed) fs.writeFileSync(localConf, "");
+    try {
+      expect(adapter.detect()).toBe(true);
+    } finally {
+      if (!existed) fs.unlinkSync(localConf);
+    }
+  });
+
+  it("detect() returns true when local .aider.mcp.yml exists", () => {
+    const localMcp = path.join(process.cwd(), ".aider.mcp.yml");
+    const existed = fs.existsSync(localMcp);
+    if (!existed) fs.writeFileSync(localMcp, "");
+    try {
+      expect(adapter.detect()).toBe(true);
+    } finally {
+      if (!existed) fs.unlinkSync(localMcp);
+    }
   });
 });
 

--- a/packages/mcp/test/cli/uninstall.test.ts
+++ b/packages/mcp/test/cli/uninstall.test.ts
@@ -8,12 +8,13 @@ import {
   addClaudePermission,
   removeClaudePermission,
 } from "../../src/cli/mcp-configs.js";
-import { readToml } from "../../src/cli/utils.js";
+import { readToml, readYaml } from "../../src/cli/utils.js";
 
 let tmpDir: string;
 
 function readConfigFile(filePath: string): Record<string, unknown> {
   if (filePath.endsWith(".toml")) return readToml(filePath);
+  if (filePath.endsWith(".yml") || filePath.endsWith(".yaml")) return readYaml(filePath);
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 


### PR DESCRIPTION
## Summary

Closes ARG-105.

- Add an Aider MCP config adapter to `packages/mcp/src/cli/mcp-configs.ts`
- Aider's MCP server configuration uses a YAML file (`.aider.mcp.yml`) with a `servers` array containing `name`, `command`, and `envs` fields, following the format from [Aider's MCP PR](https://github.com/Aider-AI/aider/pull/3672)
- Add `yaml` package as a dependency and `readYaml`/`writeYaml` helpers to `utils.ts`
- Detection checks for `.aider.conf.yml` and `.aider.mcp.yml` in both project and home directories
- Update `uninstall.test.ts` to handle YAML config files

## Test plan

- [x] All 184 tests pass (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Adapter write/remove/detect/paths tested in `mcp-configs.test.ts`
- [x] Uninstall flow tested in `uninstall.test.ts`
- [ ] Verify adapter count updated from 7 to 8