### PR TITLE
feat: add MCP config adapter for Hermes Agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4195,9 +4195,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -4237,12 +4237,12 @@
       "name": "@swmansion/argent",
       "version": "0.5.2",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.20.0",
         "picocolors": "^1.1.1",
-        "smol-toml": "^1.6.1"
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "argent": "dist/cli.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -43,7 +43,8 @@
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.20.0",
     "picocolors": "^1.1.1",
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.6.1",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -206,11 +206,22 @@ export async function init(args: string[]): Promise<void> {
   if (nonInteractive) {
     selectedAdapters = detected.length > 0 ? detected : ALL_ADAPTERS;
   } else {
-    const choices = ALL_ADAPTERS.map((a) => ({
-      value: a,
-      label: a.name,
-      hint: detectedNames.includes(a.name) ? "detected" : undefined,
-    }));
+    const choices = ALL_ADAPTERS.map((a) => {
+      const parts: string[] = [];
+      if (detectedNames.includes(a.name)) parts.push("detected");
+      const hasProject = a.projectPath(process.cwd()) != null;
+      const hasGlobal = a.globalPath() != null;
+      if (!hasProject && hasGlobal) {
+        parts.push(pc.italic(pc.cyan(`ⓘ  will be installed into ${a.name}'s global config`)));
+      } else if (hasProject && !hasGlobal) {
+        parts.push(pc.italic(pc.cyan(`ⓘ  will be installed into ${a.name}'s project config`)));
+      }
+      return {
+        value: a,
+        label: a.name,
+        hint: parts.length > 0 ? parts.join(", ") : undefined,
+      };
+    });
 
     p.log.message(pc.dim("  Use arrow keys to move, space to toggle, enter to confirm."));
 

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -310,6 +310,16 @@ export async function init(args: string[]): Promise<void> {
         } catch (err) {
           mcpResults.push(`${pc.red("x")} ${adapter.name}: ${pc.dim(String(err))}`);
         }
+      } else if (scope !== "global" && adapter.globalPath()) {
+        const fallback = adapter.globalPath()!;
+        try {
+          adapter.write(fallback, mcpEntry);
+          mcpResults.push(
+            `${pc.green("+")} ${adapter.name} ${pc.dim(`(global fallback: ${fallback})`)}`
+          );
+        } catch (err) {
+          mcpResults.push(`${pc.red("x")} ${adapter.name}: ${pc.dim(String(err))}`);
+        }
       } else {
         mcpResults.push(
           `${pc.yellow("-")} ${adapter.name} ${pc.dim("(no config path for this scope)")}`

--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -8,7 +8,16 @@ import {
   PERMISSION_RULE,
   CURSOR_ALLOWLIST_PATTERN,
 } from "./constants.js";
-import { readJson, writeJson, dirExists, readToml, writeToml } from "./utils.js";
+import {
+  readJson,
+  writeJson,
+  dirExists,
+  readToml,
+  writeToml,
+  readYamlDocument,
+  writeYamlDocument,
+} from "./utils.js";
+import { isMap } from "yaml";
 
 const TOOL_SERVER_BUNDLE = path.join(import.meta.dirname, "..", "tool-server.cjs");
 
@@ -604,6 +613,63 @@ const codexAdapter: McpConfigAdapter = {
   },
 };
 
+// ── Hermes adapter ──────────────────────────────────────────────────────────
+// Format (YAML): mcp_servers: { argent: { command, args, env } }
+// Global only: ~/.hermes/config.yaml
+//
+// Uses the yaml Document API instead of POJO round-trip so user comments
+// and formatting in ~/.hermes/config.yaml survive every write. Refuses to
+// touch the file if mcp_servers exists but is not a YAML mapping (sequence
+// or scalar would otherwise be silently clobbered).
+
+const hermesAdapter: McpConfigAdapter = {
+  name: "Hermes",
+
+  detect(): boolean {
+    return dirExists(path.join(homedir(), ".hermes"));
+  },
+
+  projectPath(): string | null {
+    return null;
+  },
+
+  globalPath(): string | null {
+    return path.join(homedir(), ".hermes", "config.yaml");
+  },
+
+  write(configPath: string, entry: McpServerEntry): void {
+    const doc = readYamlDocument(configPath);
+    const existing = doc.get("mcp_servers");
+    if (existing != null && !isMap(existing)) {
+      throw new Error(`mcp_servers in ${configPath} is not a YAML mapping`);
+    }
+    if (existing == null) {
+      // Either absent or explicit null. Drop it so setIn creates a fresh map.
+      doc.delete("mcp_servers");
+    }
+    doc.setIn(["mcp_servers", MCP_SERVER_KEY], {
+      command: entry.command,
+      args: entry.args,
+      env: entry.env,
+    });
+    writeYamlDocument(configPath, doc);
+  },
+
+  remove(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const doc = readYamlDocument(configPath);
+    const servers = doc.get("mcp_servers");
+    if (!isMap(servers)) return false;
+    if (!servers.has(MCP_SERVER_KEY)) return false;
+    servers.delete(MCP_SERVER_KEY);
+    if (servers.items.length === 0) {
+      doc.delete("mcp_servers");
+    }
+    writeYamlDocument(configPath, doc);
+    return true;
+  },
+};
+
 // ── Registry ──────────────────────────────────────────────────────────────────
 // MARK: Registry
 
@@ -615,6 +681,7 @@ export const ALL_ADAPTERS: McpConfigAdapter[] = [
   zedAdapter,
   geminiAdapter,
   codexAdapter,
+  hermesAdapter,
 ];
 
 export function detectAdapters(): McpConfigAdapter[] {

--- a/packages/mcp/src/cli/mcp-configs.ts
+++ b/packages/mcp/src/cli/mcp-configs.ts
@@ -14,8 +14,8 @@ import {
   dirExists,
   readToml,
   writeToml,
-  readYamlDocument,
-  writeYamlDocument,
+  readYaml,
+  writeYaml,
 } from "./utils.js";
 import { isMap } from "yaml";
 
@@ -638,7 +638,7 @@ const hermesAdapter: McpConfigAdapter = {
   },
 
   write(configPath: string, entry: McpServerEntry): void {
-    const doc = readYamlDocument(configPath);
+    const doc = readYaml(configPath);
     const existing = doc.get("mcp_servers");
     if (existing != null && !isMap(existing)) {
       throw new Error(`mcp_servers in ${configPath} is not a YAML mapping`);
@@ -652,12 +652,12 @@ const hermesAdapter: McpConfigAdapter = {
       args: entry.args,
       env: entry.env,
     });
-    writeYamlDocument(configPath, doc);
+    writeYaml(configPath, doc);
   },
 
   remove(configPath: string): boolean {
     if (!fs.existsSync(configPath)) return false;
-    const doc = readYamlDocument(configPath);
+    const doc = readYaml(configPath);
     const servers = doc.get("mcp_servers");
     if (!isMap(servers)) return false;
     if (!servers.has(MCP_SERVER_KEY)) return false;
@@ -665,7 +665,7 @@ const hermesAdapter: McpConfigAdapter = {
     if (servers.items.length === 0) {
       doc.delete("mcp_servers");
     }
-    writeYamlDocument(configPath, doc);
+    writeYaml(configPath, doc);
     return true;
   },
 };

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { PACKAGE_NAME, NPM_REGISTRY } from "./constants.js";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
+import { Document, parseDocument, parse as parseYaml } from "yaml";
 
 // ── Package root resolution ───────────────────────────────────────────────────
 // tsc compiles src/cli/utils.ts -> dist/cli/utils.js.
@@ -79,6 +80,45 @@ export function readToml(filePath: string): Record<string, unknown> {
 export function writeToml(filePath: string, data: Record<string, unknown>): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, stringifyToml(data) + "\n");
+}
+
+// ── YAML helpers ────────────────────────────────────────────────────────────
+// Two flavors:
+//   readYaml — POJO round-trip, useful for read-only inspection.
+//     Throws on parse errors so callers never silently clobber a
+//     malformed user file.
+//   readYamlDocument/writeYamlDocument — Document API, preserves comments
+//     and formatting on round-trip. Required for hand-edited config files
+//     like ~/.hermes/config.yaml.
+
+export function readYaml(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) return {};
+  const text = fs.readFileSync(filePath, "utf8");
+  const parsed = parseYaml(text);
+  if (parsed === null || parsed === undefined) return {};
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`YAML at ${filePath} is not a mapping`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export function readYamlDocument(filePath: string): Document {
+  if (!fs.existsSync(filePath)) return new Document({});
+  const text = fs.readFileSync(filePath, "utf8");
+  const doc = parseDocument(text);
+  if (doc.errors.length > 0) {
+    const messages = doc.errors.map((e) => e.message).join("; ");
+    throw new Error(`Failed to parse YAML at ${filePath}: ${messages}`);
+  }
+  return doc;
+}
+
+export function writeYamlDocument(filePath: string, doc: Document): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  // lineWidth: 0 disables hard-wrap so long user strings (e.g. multi-line
+  // quoted personalities in ~/.hermes/config.yaml) stay on the lines they
+  // were on. Default would re-wrap at column 80.
+  fs.writeFileSync(filePath, doc.toString({ lineWidth: 0 }));
 }
 
 // ── JSON helpers ──────────────────────────────────────────────────────────────

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { PACKAGE_NAME, NPM_REGISTRY } from "./constants.js";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
-import { Document, parseDocument, parse as parseYaml } from "yaml";
+import { Document, parseDocument } from "yaml";
 
 // ── Package root resolution ───────────────────────────────────────────────────
 // tsc compiles src/cli/utils.ts -> dist/cli/utils.js.
@@ -83,26 +83,10 @@ export function writeToml(filePath: string, data: Record<string, unknown>): void
 }
 
 // ── YAML helpers ────────────────────────────────────────────────────────────
-// Two flavors:
-//   readYaml — POJO round-trip, useful for read-only inspection.
-//     Throws on parse errors so callers never silently clobber a
-//     malformed user file.
-//   readYamlDocument/writeYamlDocument — Document API, preserves comments
-//     and formatting on round-trip. Required for hand-edited config files
-//     like ~/.hermes/config.yaml.
+// Uses the Document API so comments and formatting survive round-trips,
+// which matters for hand-edited config files like ~/.hermes/config.yaml.
 
-export function readYaml(filePath: string): Record<string, unknown> {
-  if (!fs.existsSync(filePath)) return {};
-  const text = fs.readFileSync(filePath, "utf8");
-  const parsed = parseYaml(text);
-  if (parsed === null || parsed === undefined) return {};
-  if (typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`YAML at ${filePath} is not a mapping`);
-  }
-  return parsed as Record<string, unknown>;
-}
-
-export function readYamlDocument(filePath: string): Document {
+export function readYaml(filePath: string): Document {
   if (!fs.existsSync(filePath)) return new Document({});
   const text = fs.readFileSync(filePath, "utf8");
   const doc = parseDocument(text);
@@ -113,7 +97,7 @@ export function readYamlDocument(filePath: string): Document {
   return doc;
 }
 
-export function writeYamlDocument(filePath: string, doc: Document): void {
+export function writeYaml(filePath: string, doc: Document): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   // lineWidth: 0 disables hard-wrap so long user strings (e.g. multi-line
   // quoted personalities in ~/.hermes/config.yaml) stay on the lines they

--- a/packages/mcp/test/cli/mcp-configs.test.ts
+++ b/packages/mcp/test/cli/mcp-configs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { parse as parseYaml } from "yaml";
 import {
   ALL_ADAPTERS,
   getMcpEntry,
@@ -54,6 +55,10 @@ function readJsonFile(filePath: string): Record<string, unknown> {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
+function readYamlFile(filePath: string): Record<string, unknown> {
+  return parseYaml(fs.readFileSync(filePath, "utf8")) as Record<string, unknown>;
+}
+
 beforeEach(() => {
   tmpDir = setupTmpDir();
 });
@@ -76,7 +81,7 @@ describe("getMcpEntry", () => {
 // ── Adapter registry ──────────────────────────────────────────────────────────
 
 describe("ALL_ADAPTERS", () => {
-  it("contains all seven adapters", () => {
+  it("contains all eight adapters", () => {
     const names = ALL_ADAPTERS.map((a) => a.name);
     expect(names).toEqual([
       "Cursor",
@@ -86,6 +91,7 @@ describe("ALL_ADAPTERS", () => {
       "Zed",
       "Gemini",
       "Codex",
+      "Hermes",
     ]);
   });
 });
@@ -516,6 +522,234 @@ describe("Codex adapter", () => {
     expect(() => adapter.removeAllowlist!(tmpDir, "local")).not.toThrow();
     const content = fs.readFileSync(configPath, "utf8");
     expect(content).toContain('command = "argent"');
+  });
+});
+
+// ── Hermes adapter ──────────────────────────────────────────────────────────
+
+describe("Hermes adapter", () => {
+  const adapter = ALL_ADAPTERS.find((a) => a.name === "Hermes")!;
+
+  it("writes YAML format with mcp_servers key", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readYamlFile(configPath);
+    const servers = config.mcp_servers as Record<string, unknown>;
+    expect(servers).toHaveProperty("argent");
+    const argent = servers.argent as Record<string, unknown>;
+    expect(argent.command).toBe("argent");
+    expect(argent.args).toEqual(["mcp"]);
+    expect(argent.env).toHaveProperty("ARGENT_MCP_LOG");
+  });
+
+  it("removes argent entry and drops empty mcp_servers", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    adapter.write(configPath, getMcpEntry());
+
+    expect(adapter.remove(configPath)).toBe(true);
+    const config = readYamlFile(configPath);
+    expect(config).not.toHaveProperty("mcp_servers");
+  });
+
+  it("returns false when removing from non-existent file", () => {
+    expect(adapter.remove(path.join(tmpDir, "nope.yaml"))).toBe(false);
+  });
+
+  it("returns false when removing from file without argent entry", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, "mcp_servers: {}\n");
+
+    expect(adapter.remove(configPath)).toBe(false);
+  });
+
+  it("preserves other config and servers when writing", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, "model: test\nmcp_servers:\n  other:\n    command: other\n");
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readYamlFile(configPath);
+    expect(config.model).toBe("test");
+    const servers = config.mcp_servers as Record<string, unknown>;
+    expect(servers).toHaveProperty("other");
+    expect(servers).toHaveProperty("argent");
+  });
+
+  it("projectPath returns null", () => {
+    expect(adapter.projectPath("/foo")).toBeNull();
+  });
+
+  it("globalPath returns path in homedir", () => {
+    expect(adapter.globalPath()).toBe(path.join(os.homedir(), ".hermes", "config.yaml"));
+  });
+
+  it("preserves comments on write", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      [
+        "# top-of-file comment",
+        "model:",
+        "  default: claude-opus-4-6 # inline comment",
+        "  provider: anthropic",
+        "# section comment",
+        "agent:",
+        "  max_turns: 90",
+        "",
+      ].join("\n")
+    );
+
+    adapter.write(configPath, getMcpEntry());
+
+    const after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain("# top-of-file comment");
+    expect(after).toContain("# inline comment");
+    expect(after).toContain("# section comment");
+    const config = readYamlFile(configPath);
+    expect(config.mcp_servers as Record<string, unknown>).toHaveProperty("argent");
+    expect((config.model as Record<string, unknown>).default).toBe("claude-opus-4-6");
+  });
+
+  it("preserves comments around other keys on remove", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      [
+        "# header",
+        "model:",
+        "  default: claude-opus-4-6",
+        "mcp_servers:",
+        "  argent:",
+        "    command: argent",
+        "    args:",
+        "      - mcp",
+        "    env: {}",
+        "  filesystem:",
+        "    command: npx # keep me",
+        "",
+      ].join("\n")
+    );
+
+    expect(adapter.remove(configPath)).toBe(true);
+
+    const after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain("# header");
+    expect(after).toContain("# keep me");
+    const config = readYamlFile(configPath);
+    expect(config.mcp_servers as Record<string, unknown>).toHaveProperty("filesystem");
+    expect(config.mcp_servers as Record<string, unknown>).not.toHaveProperty("argent");
+  });
+
+  it("throws when config.yaml is malformed instead of silently overwriting", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const bogus = "model:\n  default: [unbalanced\nagent: : :\n";
+    fs.writeFileSync(configPath, bogus);
+
+    expect(() => adapter.write(configPath, getMcpEntry())).toThrow(/Failed to parse YAML/);
+    expect(fs.readFileSync(configPath, "utf8")).toBe(bogus);
+  });
+
+  it("throws when mcp_servers is a sequence instead of silently no-op", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, "mcp_servers:\n  - foo\n  - bar\n");
+
+    expect(() => adapter.write(configPath, getMcpEntry())).toThrow(/not a YAML mapping/);
+  });
+
+  it("handles mcp_servers explicitly null", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, "model: test\nmcp_servers:\n");
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readYamlFile(configPath);
+    expect(config.model).toBe("test");
+    expect(config.mcp_servers as Record<string, unknown>).toHaveProperty("argent");
+  });
+
+  it("write is idempotent", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    adapter.write(configPath, getMcpEntry());
+    const first = fs.readFileSync(configPath, "utf8");
+    adapter.write(configPath, getMcpEntry());
+    const second = fs.readFileSync(configPath, "utf8");
+    expect(second).toBe(first);
+  });
+
+  it("creates ~/.hermes/config.yaml when neither file nor directory exists", () => {
+    const configPath = path.join(tmpDir, ".hermes-fresh", "config.yaml");
+    expect(fs.existsSync(path.dirname(configPath))).toBe(false);
+
+    adapter.write(configPath, getMcpEntry());
+
+    expect(fs.existsSync(configPath)).toBe(true);
+    const config = readYamlFile(configPath);
+    expect(config.mcp_servers as Record<string, unknown>).toHaveProperty("argent");
+  });
+
+  it("does not hard-wrap long user strings (lineWidth disabled)", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const longLine =
+      "You are a kawaii assistant! Use cute expressions and be super enthusiastic about everything! Every response should feel warm and adorable.";
+    fs.writeFileSync(configPath, `agent:\n  personalities:\n    kawaii: "${longLine}"\n`);
+
+    adapter.write(configPath, getMcpEntry());
+
+    const after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain(longLine);
+    // The full long string must remain on a single content line — the yaml
+    // library would wrap at column 80 by default.
+    const kawaiiLine = after.split("\n").find((l) => l.includes("kawaii:"));
+    expect(kawaiiLine).toBeDefined();
+    expect(kawaiiLine!.length).toBeGreaterThan(80);
+  });
+
+  it("write+remove on a realistic seed is semantically lossless", () => {
+    const configPath = path.join(tmpDir, ".hermes", "config.yaml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const seed = [
+      "# managed by hermes",
+      "model:",
+      "  default: claude-opus-4-6 # selected via hermes model",
+      "  provider: anthropic",
+      "providers: {}",
+      "fallback_providers: []",
+      "toolsets:",
+      "  - hermes-cli",
+      "agent:",
+      "  max_turns: 90",
+      "  personalities:",
+      '    helpful: "You are a helpful assistant."',
+      '    kawaii: "You are a kawaii assistant! Use cute expressions and be super enthusiastic."',
+      "terminal:",
+      "  backend: local",
+      "",
+    ].join("\n");
+    fs.writeFileSync(configPath, seed);
+    const before = readYamlFile(configPath);
+
+    adapter.write(configPath, getMcpEntry());
+    expect(adapter.remove(configPath)).toBe(true);
+
+    const after = fs.readFileSync(configPath, "utf8");
+    const afterParsed = readYamlFile(configPath);
+    // Semantic check: parsed JS should equal the original parsed JS
+    expect(JSON.stringify(afterParsed)).toBe(JSON.stringify(before));
+    // Every comment line in the seed must still be in the output
+    const seedComments = seed.split("\n").filter((l) => l.includes("#"));
+    for (const c of seedComments) {
+      const stripped = c.trim();
+      expect(after).toContain(stripped);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `hermesAdapter` to `packages/mcp/src/cli/mcp-configs.ts` supporting Hermes (Nous Research AI coding agent CLI) with YAML-based config format (`mcp_servers` key)
- Add `readYaml`/`writeYaml` helpers to `packages/mcp/src/cli/utils.ts` using the `yaml` package
- Add full test coverage for write, remove, preserve-other-servers, path resolution, and edge cases


https://github.com/user-attachments/assets/62b2a24c-61c9-4453-8fc6-bc00cfbaecc7

<br>

https://github.com/user-attachments/assets/9125c0ec-cb20-462e-99ba-1f5e9555a0c1


Before this PR, adapters with only one config path (only local or only global) without were installing regardless of user's scope selection. This PR makes this fact more visible, allowing the user to disable the undesired installation targets. 

Would appreciate a UI opinion, i went with A because B was scary in my opinion, but something in between could also work:

A | B
---|---
<img width="617" height="251" alt="image" src="https://github.com/user-attachments/assets/241b8fe1-fdb1-47e6-9214-b1ce760203c8" />|<img width="617" height="251" alt="image" src="https://github.com/user-attachments/assets/d284c800-afc8-45d1-a12d-20e5211435a0" />


## Test plan
- [x] All 69 tests pass in `mcp-configs.test.ts` (7 new Hermes tests + updated adapter count test)
- [x] TypeScript compiles with `tsc --noEmit`