### PR TITLE
fix: errors in Gemini `>=0.36` 

### DIFF
--- a/packages/skills/agents/argent-environment-inspector.md
+++ b/packages/skills/agents/argent-environment-inspector.md
@@ -12,7 +12,6 @@ description: >
   If subagent delegation is not available, run the steps in the main thread instead.
   The main agent is responsible for persisting the result to project memory.
 model: haiku
-max_turns: 25
 ---
 
 You are the **environment-inspector** subagent. Your job is to inspect a mobile app

--- a/packages/skills/agents/argent-environment-inspector.md
+++ b/packages/skills/agents/argent-environment-inspector.md
@@ -12,8 +12,7 @@ description: >
   If subagent delegation is not available, run the steps in the main thread instead.
   The main agent is responsible for persisting the result to project memory.
 model: haiku
-permissionMode: plan
-maxTurns: 25
+max_turns: 25
 ---
 
 You are the **environment-inspector** subagent. Your job is to inspect a mobile app


### PR DESCRIPTION
In Gemini `v0.36` they purposefully made themself incompatible with the rest of the ecosystem by renaming the standardised `maxTurns` prop  to `max_turns`, while causing both `maxTurns`  & `permissionMode` to throw an error. 

This is the only file in which we use these poorly supported properties, let's just not use them for now.