### PR TITLE
feat: Show offline banner during argent init

### DIFF
--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -459,11 +459,7 @@ export async function init(args: string[]): Promise<void> {
       "Manual Skills Installation"
     );
   } else {
-    // Offline with a cached skills CLI: --no-install prevents npx from
-    // hitting the registry for a newer version that it can't reach.
-    const skillsArgs = offlineWithCache
-      ? ["--no-install", "skills", "add", SKILLS_DIR]
-      : ["skills", "add", SKILLS_DIR];
+    const skillsArgs = ["skills", "add", SKILLS_DIR];
 
     if (scope === "global") {
       skillsArgs.push("-g");
@@ -473,7 +469,11 @@ export async function init(args: string[]): Promise<void> {
       skillsArgs.push("--skill", "*", "-y");
     }
 
-    p.log.info(`Running: ${pc.dim("npx")} ${pc.cyan(skillsArgs.join(" "))}`);
+    const npxArgs = offlineWithCache
+      ? ["--no-install", ...skillsArgs]
+      : skillsArgs;
+
+    p.log.info(`Running: ${pc.dim("npx")} ${pc.cyan(npxArgs.join(" "))}`);
 
     const spinner = p.spinner();
     if (skillsMethod === "default") {
@@ -482,7 +482,7 @@ export async function init(args: string[]): Promise<void> {
 
     try {
       const skillsCwd = scope === "custom" ? customRoot : undefined;
-      await runNpxSkills(skillsArgs, skillsMethod === "interactive", skillsCwd);
+      await runNpxSkills(npxArgs, skillsMethod === "interactive", skillsCwd);
       if (skillsMethod === "default") {
         spinner.stop("Skills installed.");
       }
@@ -491,11 +491,7 @@ export async function init(args: string[]): Promise<void> {
         spinner.stop(pc.red("Skills installation failed."));
       }
       p.log.error(`Failed to run npx skills: ${err}`);
-      // Strip `--no-install` from the manual-recovery hint: if the cached
-      // copy just failed, the user's actual recovery path is almost always
-      // re-running with network access, not forcing the same offline mode.
-      const manualArgs = skillsArgs[0] === "--no-install" ? skillsArgs.slice(1) : skillsArgs;
-      p.log.info(`You can install skills manually:\n  npx ${manualArgs.join(" ")}`);
+      p.log.info(`You can install skills manually:\n  npx ${skillsArgs.join(" ")}`);
     }
   }
 

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -77,12 +77,6 @@ export async function init(args: string[]): Promise<void> {
   let version = getInstalledVersion() ?? "unknown";
   p.log.info(`${pc.dim("Package:")} ${PACKAGE_NAME}@${version}`);
 
-  const online = await isOnline();
-  const skillsCached = !online && isSkillsCliAvailable();
-  if (!online) {
-    printOfflineBanner({ skillsCached });
-  }
-
   // ── Step 0: Install / Update Check ──────────────────────────────────────────
 
   const globallyInstalled = isGloballyInstalled();
@@ -143,7 +137,7 @@ export async function init(args: string[]): Promise<void> {
       p.log.info(`Install manually with: ${pc.cyan(cmdStr)}`);
       process.exit(1);
     }
-  } else if (online) {
+  } else {
     let latest: string | null = null;
     const spinner = p.spinner();
     spinner.start("Checking for updates...");
@@ -395,7 +389,16 @@ export async function init(args: string[]): Promise<void> {
   type SkillsMethod = "default" | "interactive" | "manual";
   let skillsMethod: SkillsMethod;
 
-  const skillsCliReady = online || skillsCached;
+  const online = await isOnline();
+  const offlineWithCache = !online && isSkillsCliAvailable();
+  const skillsCliReady = online || offlineWithCache;
+
+  if (!skillsCliReady) {
+    p.log.warn(
+      pc.yellow("You appear to be offline. ") +
+        "Automatic skills installation requires a network connection."
+    );
+  }
 
   if (nonInteractive) {
     skillsMethod = skillsCliReady ? "default" : "manual";
@@ -456,11 +459,9 @@ export async function init(args: string[]): Promise<void> {
       "Manual Skills Installation"
     );
   } else {
-    // When offline we rely on npx's own cache — pass --no-install so npx
-    // does not attempt to fetch a newer `skills` package from the registry,
-    // which would fail and mask the cached copy that `isSkillsCliAvailable`
-    // already confirmed is present.
-    const skillsArgs = skillsCached
+    // Offline with a cached skills CLI: --no-install prevents npx from
+    // hitting the registry for a newer version that it can't reach.
+    const skillsArgs = offlineWithCache
       ? ["--no-install", "skills", "add", SKILLS_DIR]
       : ["skills", "add", SKILLS_DIR];
 
@@ -527,22 +528,6 @@ export async function init(args: string[]): Promise<void> {
 
   p.note(summaryLines.join("\n"), "Summary");
   p.outro(pc.green("Argent is ready!"));
-}
-
-function printOfflineBanner({ skillsCached }: { skillsCached: boolean }): void {
-  const bullets = [`Installing or updating ${pc.cyan(PACKAGE_NAME)} from npm`];
-  if (!skillsCached) {
-    bullets.push(`Installing skills via ${pc.cyan("npx skills")}`);
-  }
-
-  const body = [
-    pc.red("You appear to be offline."),
-    "",
-    "You can continue, but the following will be skipped:",
-    ...bullets.map((b) => `  • ${b}`),
-  ].join("\n");
-
-  p.note(body, pc.red("Offline mode"));
 }
 
 export function printBanner(): void {

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -456,7 +456,13 @@ export async function init(args: string[]): Promise<void> {
       "Manual Skills Installation"
     );
   } else {
-    const skillsArgs = ["skills", "add", SKILLS_DIR];
+    // When offline we rely on npx's own cache — pass --no-install so npx
+    // does not attempt to fetch a newer `skills` package from the registry,
+    // which would fail and mask the cached copy that `isSkillsCliAvailable`
+    // already confirmed is present.
+    const skillsArgs = skillsCached
+      ? ["--no-install", "skills", "add", SKILLS_DIR]
+      : ["skills", "add", SKILLS_DIR];
 
     if (scope === "global") {
       skillsArgs.push("-g");
@@ -484,7 +490,11 @@ export async function init(args: string[]): Promise<void> {
         spinner.stop(pc.red("Skills installation failed."));
       }
       p.log.error(`Failed to run npx skills: ${err}`);
-      p.log.info(`You can install skills manually:\n  npx ${skillsArgs.join(" ")}`);
+      // Strip `--no-install` from the manual-recovery hint: if the cached
+      // copy just failed, the user's actual recovery path is almost always
+      // re-running with network access, not forcing the same offline mode.
+      const manualArgs = skillsArgs[0] === "--no-install" ? skillsArgs.slice(1) : skillsArgs;
+      p.log.info(`You can install skills manually:\n  npx ${manualArgs.join(" ")}`);
     }
   }
 

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -80,16 +80,7 @@ export async function init(args: string[]): Promise<void> {
   const online = await isOnline();
   const skillsCached = !online && isSkillsCliAvailable();
   if (!online) {
-    const lines = [
-      pc.red("You appear to be offline."),
-      ``,
-      `You can continue, but the following will be skipped:`,
-      `  • Installing or updating ${pc.cyan(PACKAGE_NAME)} from npm`,
-    ];
-    if (!skillsCached) {
-      lines.push(`  • Installing skills via ${pc.cyan("npx skills")} (use the manual option instead)`);
-    }
-    p.note(lines.join("\n"), pc.red("Offline mode"));
+    printOfflineBanner({ skillsCached });
   }
 
   // ── Step 0: Install / Update Check ──────────────────────────────────────────
@@ -526,6 +517,22 @@ export async function init(args: string[]): Promise<void> {
 
   p.note(summaryLines.join("\n"), "Summary");
   p.outro(pc.green("Argent is ready!"));
+}
+
+function printOfflineBanner({ skillsCached }: { skillsCached: boolean }): void {
+  const bullets = [`Installing or updating ${pc.cyan(PACKAGE_NAME)} from npm`];
+  if (!skillsCached) {
+    bullets.push(`Installing skills via ${pc.cyan("npx skills")} (use the manual option instead)`);
+  }
+
+  const body = [
+    pc.red("You appear to be offline."),
+    "",
+    "You can continue, but the following will be skipped:",
+    ...bullets.map((b) => `  • ${b}`),
+  ].join("\n");
+
+  p.note(body, pc.red("Offline mode"));
 }
 
 export function printBanner(): void {

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -400,8 +400,10 @@ export async function init(args: string[]): Promise<void> {
     );
   }
 
-  if (nonInteractive) {
-    skillsMethod = skillsCliReady ? "default" : "manual";
+  if (!skillsCliReady) {
+    skillsMethod = "manual";
+  } else if (nonInteractive) {
+    skillsMethod = "default";
   } else {
     p.log.message(pc.dim("  Use arrow keys to move, enter to confirm."));
 
@@ -411,16 +413,12 @@ export async function init(args: string[]): Promise<void> {
         {
           value: "default" as const,
           label: "Automatic",
-          hint: skillsCliReady
-            ? "Installs all skills automatically with npx skills"
-            : "Requires network - unavailable offline",
+          hint: "Installs all skills automatically with npx skills",
         },
         {
           value: "interactive" as const,
           label: "Interactive",
-          hint: skillsCliReady
-            ? "Full npx skills TUI - choose skills, agents, and method"
-            : "Requires network - unavailable offline",
+          hint: "Full npx skills TUI - choose skills, agents, and method",
         },
         {
           value: "manual" as const,

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -522,7 +522,7 @@ export async function init(args: string[]): Promise<void> {
 function printOfflineBanner({ skillsCached }: { skillsCached: boolean }): void {
   const bullets = [`Installing or updating ${pc.cyan(PACKAGE_NAME)} from npm`];
   if (!skillsCached) {
-    bullets.push(`Installing skills via ${pc.cyan("npx skills")} (use the manual option instead)`);
+    bullets.push(`Installing skills via ${pc.cyan("npx skills")}`);
   }
 
   const body = [

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -16,6 +16,7 @@ import {
   AGENTS_DIR,
   getInstalledVersion,
   getLatestVersion,
+  isOnline,
   detectPackageManager,
   globalInstallCommand,
   formatShellCommand,
@@ -74,6 +75,20 @@ export async function init(args: string[]): Promise<void> {
 
   let version = getInstalledVersion() ?? "unknown";
   p.log.info(`${pc.dim("Package:")} ${PACKAGE_NAME}@${version}`);
+
+  const online = await isOnline();
+  if (!online) {
+    p.note(
+      [
+        pc.red("You appear to be offline."),
+        ``,
+        `You can continue, but the following will be skipped:`,
+        `  • Installing or updating ${pc.cyan(PACKAGE_NAME)} from npm`,
+        `  • Installing skills via ${pc.cyan("npx skills")} (use the manual option instead)`,
+      ].join("\n"),
+      pc.red("Offline mode")
+    );
+  }
 
   // ── Step 0: Install / Update Check ──────────────────────────────────────────
 
@@ -135,7 +150,7 @@ export async function init(args: string[]): Promise<void> {
       p.log.info(`Install manually with: ${pc.cyan(cmdStr)}`);
       process.exit(1);
     }
-  } else {
+  } else if (online) {
     let latest: string | null = null;
     const spinner = p.spinner();
     spinner.start("Checking for updates...");
@@ -388,22 +403,27 @@ export async function init(args: string[]): Promise<void> {
   let skillsMethod: SkillsMethod;
 
   if (nonInteractive) {
-    skillsMethod = "default";
+    skillsMethod = online ? "default" : "manual";
   } else {
     p.log.message(pc.dim("  Use arrow keys to move, enter to confirm."));
 
     const choice = await p.select({
       message: "How would you like to install skills?",
+      initialValue: online ? "default" : "manual",
       options: [
         {
           value: "default" as const,
           label: "Automatic",
-          hint: "Installs all skills automatically with npx skills",
+          hint: online
+            ? "Installs all skills automatically with npx skills"
+            : "Requires network - unavailable offline",
         },
         {
           value: "interactive" as const,
           label: "Interactive",
-          hint: "Full npx skills TUI - choose skills, agents, and method",
+          hint: online
+            ? "Full npx skills TUI - choose skills, agents, and method"
+            : "Requires network - unavailable offline",
         },
         {
           value: "manual" as const,

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -468,9 +468,7 @@ export async function init(args: string[]): Promise<void> {
       skillsArgs.push("--skill", "*", "-y");
     }
 
-    const npxArgs = offlineWithCache
-      ? ["--no-install", ...skillsArgs]
-      : skillsArgs;
+    const npxArgs = offlineWithCache ? ["--no-install", ...skillsArgs] : skillsArgs;
 
     p.log.info(`Running: ${pc.dim("npx")} ${pc.cyan(npxArgs.join(" "))}`);
 

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -407,7 +407,6 @@ export async function init(args: string[]): Promise<void> {
 
     const choice = await p.select({
       message: "How would you like to install skills?",
-      initialValue: skillsCliReady ? "default" : "manual",
       options: [
         {
           value: "default" as const,

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -84,7 +84,7 @@ export async function init(args: string[]): Promise<void> {
         ``,
         `You can continue, but the following will be skipped:`,
         `  • Installing or updating ${pc.cyan(PACKAGE_NAME)} from npm`,
-        `  • Installing skills via ${pc.cyan("npx skills")} (use the manual option instead)`,
+        `  • Installing skills via ${pc.cyan("npx skills")} (unless already cached; manual install always works)`,
       ].join("\n"),
       pc.red("Offline mode")
     );
@@ -416,14 +416,14 @@ export async function init(args: string[]): Promise<void> {
           label: "Automatic",
           hint: online
             ? "Installs all skills automatically with npx skills"
-            : "Requires network - unavailable offline",
+            : "May require network if not already cached",
         },
         {
           value: "interactive" as const,
           label: "Interactive",
           hint: online
             ? "Full npx skills TUI - choose skills, agents, and method"
-            : "Requires network - unavailable offline",
+            : "May require network if not already cached",
         },
         {
           value: "manual" as const,

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -17,6 +17,7 @@ import {
   getInstalledVersion,
   getLatestVersion,
   isOnline,
+  isSkillsCliAvailable,
   detectPackageManager,
   globalInstallCommand,
   formatShellCommand,
@@ -77,17 +78,18 @@ export async function init(args: string[]): Promise<void> {
   p.log.info(`${pc.dim("Package:")} ${PACKAGE_NAME}@${version}`);
 
   const online = await isOnline();
+  const skillsCached = !online && isSkillsCliAvailable();
   if (!online) {
-    p.note(
-      [
-        pc.red("You appear to be offline."),
-        ``,
-        `You can continue, but the following will be skipped:`,
-        `  • Installing or updating ${pc.cyan(PACKAGE_NAME)} from npm`,
-        `  • Installing skills via ${pc.cyan("npx skills")} (unless already cached; manual install always works)`,
-      ].join("\n"),
-      pc.red("Offline mode")
-    );
+    const lines = [
+      pc.red("You appear to be offline."),
+      ``,
+      `You can continue, but the following will be skipped:`,
+      `  • Installing or updating ${pc.cyan(PACKAGE_NAME)} from npm`,
+    ];
+    if (!skillsCached) {
+      lines.push(`  • Installing skills via ${pc.cyan("npx skills")} (use the manual option instead)`);
+    }
+    p.note(lines.join("\n"), pc.red("Offline mode"));
   }
 
   // ── Step 0: Install / Update Check ──────────────────────────────────────────
@@ -402,28 +404,30 @@ export async function init(args: string[]): Promise<void> {
   type SkillsMethod = "default" | "interactive" | "manual";
   let skillsMethod: SkillsMethod;
 
+  const skillsCliReady = online || skillsCached;
+
   if (nonInteractive) {
-    skillsMethod = online ? "default" : "manual";
+    skillsMethod = skillsCliReady ? "default" : "manual";
   } else {
     p.log.message(pc.dim("  Use arrow keys to move, enter to confirm."));
 
     const choice = await p.select({
       message: "How would you like to install skills?",
-      initialValue: online ? "default" : "manual",
+      initialValue: skillsCliReady ? "default" : "manual",
       options: [
         {
           value: "default" as const,
           label: "Automatic",
-          hint: online
+          hint: skillsCliReady
             ? "Installs all skills automatically with npx skills"
-            : "May require network if not already cached",
+            : "Requires network - unavailable offline",
         },
         {
           value: "interactive" as const,
           label: "Interactive",
-          hint: online
+          hint: skillsCliReady
             ? "Full npx skills TUI - choose skills, agents, and method"
-            : "May require network if not already cached",
+            : "Requires network - unavailable offline",
         },
         {
           value: "manual" as const,

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -95,6 +95,17 @@ export function getLatestVersion(): string {
   return result.trim();
 }
 
+export function isSkillsCliAvailable(): boolean {
+  try {
+    execSync("npx --no-install skills --version", {
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function isOnline(timeoutMs = 1500): Promise<boolean> {
   const host = new URL(NPM_REGISTRY).hostname;
   const lookup = new Promise<boolean>((resolve) => {

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -133,6 +133,7 @@ export function getLatestVersion(): string {
   const result = execSync(`npm view ${PACKAGE_NAME} version --registry ${NPM_REGISTRY}`, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10_000,
   });
   return result.trim();
 }
@@ -141,6 +142,7 @@ export function isSkillsCliAvailable(): boolean {
   try {
     execSync("npx --no-install skills --version", {
       stdio: ["ignore", "ignore", "ignore"],
+      timeout: 2_000,
     });
     return true;
   } catch {

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as dns from "node:dns";
 import { execSync } from "node:child_process";
 import { PACKAGE_NAME, NPM_REGISTRY } from "./constants.js";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
@@ -89,8 +90,20 @@ export function getInstalledVersion(): string | null {
 export function getLatestVersion(): string {
   const result = execSync(`npm view ${PACKAGE_NAME} version --registry ${NPM_REGISTRY}`, {
     encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
   });
   return result.trim();
+}
+
+export async function isOnline(timeoutMs = 1500): Promise<boolean> {
+  const host = new URL(NPM_REGISTRY).hostname;
+  const lookup = new Promise<boolean>((resolve) => {
+    dns.lookup(host, (err) => resolve(!err));
+  });
+  const timeout = new Promise<boolean>((resolve) => {
+    setTimeout(() => resolve(false), timeoutMs);
+  });
+  return Promise.race([lookup, timeout]);
 }
 
 // ── Package manager detection ─────────────────────────────────────────────────

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -129,14 +129,15 @@ export function getInstalledVersion(): string | null {
   }
 }
 
+const PROBE_TIMEOUT_MS = 3_000;
+
 export function getLatestVersion(): string {
   const result = execSync(`npm view ${PACKAGE_NAME} version --registry ${NPM_REGISTRY}`, {
     encoding: "utf8",
+    timeout: PROBE_TIMEOUT_MS,
   });
   return result.trim();
 }
-
-const PROBE_TIMEOUT_MS = 8_000;
 
 export function isSkillsCliAvailable(): boolean {
   try {

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -132,8 +132,6 @@ export function getInstalledVersion(): string | null {
 export function getLatestVersion(): string {
   const result = execSync(`npm view ${PACKAGE_NAME} version --registry ${NPM_REGISTRY}`, {
     encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: 10_000,
   });
   return result.trim();
 }

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -149,14 +149,21 @@ export function isSkillsCliAvailable(): boolean {
 }
 
 export async function isOnline(timeoutMs = 1500): Promise<boolean> {
-  const host = new URL(NPM_REGISTRY).hostname;
-  const lookup = new Promise<boolean>((resolve) => {
-    dns.lookup(host, (err) => resolve(!err));
+  let host: string;
+  try {
+    host = new URL(NPM_REGISTRY).hostname;
+  } catch {
+    return false;
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    timer.unref();
+    dns.lookup(host, (err) => {
+      clearTimeout(timer);
+      resolve(!err);
+    });
   });
-  const timeout = new Promise<boolean>((resolve) => {
-    setTimeout(() => resolve(false), timeoutMs);
-  });
-  return Promise.race([lookup, timeout]);
 }
 
 // ── Package manager detection ─────────────────────────────────────────────────

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -136,11 +136,13 @@ export function getLatestVersion(): string {
   return result.trim();
 }
 
+const PROBE_TIMEOUT_MS = 8_000;
+
 export function isSkillsCliAvailable(): boolean {
   try {
     execSync("npx --no-install skills --version", {
       stdio: ["ignore", "ignore", "ignore"],
-      timeout: 2_000,
+      timeout: PROBE_TIMEOUT_MS,
     });
     return true;
   } catch {
@@ -148,7 +150,7 @@ export function isSkillsCliAvailable(): boolean {
   }
 }
 
-export async function isOnline(timeoutMs = 1500): Promise<boolean> {
+export async function isOnline(timeoutMs = PROBE_TIMEOUT_MS): Promise<boolean> {
   let host: string;
   try {
     host = new URL(NPM_REGISTRY).hostname;

--- a/packages/mcp/test/cli/utils.test.ts
+++ b/packages/mcp/test/cli/utils.test.ts
@@ -40,7 +40,6 @@ import {
   globalInstallCommand,
   globalUninstallCommand,
   formatShellCommand,
-  getLatestVersion,
   isOnline,
   isSkillsCliAvailable,
   resolveProjectRoot,
@@ -48,7 +47,7 @@ import {
   RULES_DIR,
   AGENTS_DIR,
 } from "../../src/cli/utils.js";
-import { NPM_REGISTRY, PACKAGE_NAME } from "../../src/cli/constants.js";
+import { NPM_REGISTRY } from "../../src/cli/constants.js";
 
 let tmpDir: string;
 
@@ -418,58 +417,3 @@ describe("isSkillsCliAvailable", () => {
   });
 });
 
-// ── getLatestVersion ─────────────────────────────────────────────────────────
-
-describe("getLatestVersion", () => {
-  beforeEach(() => {
-    execSyncMock.mockReset();
-  });
-
-  it("returns the trimmed version reported by `npm view`", () => {
-    execSyncMock.mockReturnValue("9.9.9\n");
-
-    expect(getLatestVersion()).toBe("9.9.9");
-  });
-
-  it("queries the package name and registry from constants", () => {
-    execSyncMock.mockReturnValue("1.0.0\n");
-
-    getLatestVersion();
-
-    const [cmd] = execSyncMock.mock.calls[0]!;
-    expect(cmd).toContain(`npm view ${PACKAGE_NAME} version`);
-    expect(cmd).toContain(`--registry ${NPM_REGISTRY}`);
-  });
-
-  it("pipes stderr so 404s do not leak to the terminal", () => {
-    // Regression guard for the previous behavior where `stdio: 'inherit'` let
-    // `npm view`'s 404 output bleed into the init UI on fresh/private
-    // packages. stderr must be captured (piped), not inherited.
-    execSyncMock.mockReturnValue("1.0.0\n");
-
-    getLatestVersion();
-
-    const opts = execSyncMock.mock.calls[0]![1] as
-      | { stdio?: [unknown, unknown, unknown] }
-      | undefined;
-    expect(opts?.stdio).toEqual(["ignore", "pipe", "pipe"]);
-  });
-
-  it("passes a timeout to bound the registry probe", () => {
-    execSyncMock.mockReturnValue("1.0.0\n");
-
-    getLatestVersion();
-
-    const opts = execSyncMock.mock.calls[0]![1] as { timeout?: number } | undefined;
-    expect(typeof opts?.timeout).toBe("number");
-    expect(opts!.timeout!).toBeGreaterThan(0);
-  });
-
-  it("propagates errors from `npm view` to the caller", () => {
-    execSyncMock.mockImplementation(() => {
-      throw new Error("E404");
-    });
-
-    expect(() => getLatestVersion()).toThrow("E404");
-  });
-});

--- a/packages/mcp/test/cli/utils.test.ts
+++ b/packages/mcp/test/cli/utils.test.ts
@@ -11,6 +11,7 @@ import {
   globalInstallCommand,
   globalUninstallCommand,
   formatShellCommand,
+  isOnline,
   SKILLS_DIR,
   RULES_DIR,
   AGENTS_DIR,
@@ -226,5 +227,17 @@ describe("bundled paths", () => {
 
   it("AGENTS_DIR is a string ending with agents", () => {
     expect(AGENTS_DIR).toMatch(/agents$/);
+  });
+});
+
+// ── isOnline ──────────────────────────────────────────────────────────────────
+
+describe("isOnline", () => {
+  it("resolves to false within the timeout when DNS does not respond", async () => {
+    const start = Date.now();
+    const result = await isOnline(50);
+    const elapsed = Date.now() - start;
+    expect(typeof result).toBe("boolean");
+    expect(elapsed).toBeLessThan(500);
   });
 });

--- a/packages/mcp/test/cli/utils.test.ts
+++ b/packages/mcp/test/cli/utils.test.ts
@@ -5,8 +5,8 @@ import * as os from "node:os";
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
 // These are hoisted so `vi.mock` can reference them. They let the network-
-// dependent helpers (`isOnline`, `isSkillsCliAvailable`, `getLatestVersion`)
-// be tested deterministically without touching DNS or spawning `npm`/`npx`.
+// dependent helpers (`isOnline`, `isSkillsCliAvailable`) be tested
+// deterministically without touching DNS or spawning `npx`.
 
 const { dnsLookupMock, execSyncMock } = vi.hoisted(() => ({
   dnsLookupMock: vi.fn(),

--- a/packages/mcp/test/cli/utils.test.ts
+++ b/packages/mcp/test/cli/utils.test.ts
@@ -416,4 +416,3 @@ describe("isSkillsCliAvailable", () => {
     expect(opts!.timeout!).toBeGreaterThan(0);
   });
 });
-

--- a/packages/mcp/test/cli/utils.test.ts
+++ b/packages/mcp/test/cli/utils.test.ts
@@ -1,7 +1,36 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+// These are hoisted so `vi.mock` can reference them. They let the network-
+// dependent helpers (`isOnline`, `isSkillsCliAvailable`, `getLatestVersion`)
+// be tested deterministically without touching DNS or spawning `npm`/`npx`.
+
+const { dnsLookupMock, execSyncMock } = vi.hoisted(() => ({
+  dnsLookupMock: vi.fn(),
+  execSyncMock: vi.fn(),
+}));
+
+vi.mock("node:dns", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:dns")>();
+  return {
+    ...actual,
+    default: { ...actual, lookup: dnsLookupMock },
+    lookup: dnsLookupMock,
+  };
+});
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    default: { ...actual, execSync: execSyncMock },
+    execSync: execSyncMock,
+  };
+});
+
 import {
   readJson,
   writeJson,
@@ -11,12 +40,15 @@ import {
   globalInstallCommand,
   globalUninstallCommand,
   formatShellCommand,
+  getLatestVersion,
   isOnline,
+  isSkillsCliAvailable,
   resolveProjectRoot,
   SKILLS_DIR,
   RULES_DIR,
   AGENTS_DIR,
 } from "../../src/cli/utils.js";
+import { NPM_REGISTRY, PACKAGE_NAME } from "../../src/cli/constants.js";
 
 let tmpDir: string;
 
@@ -272,13 +304,172 @@ describe("bundled paths", () => {
 });
 
 // ── isOnline ──────────────────────────────────────────────────────────────────
+// `isOnline` wraps `dns.lookup` with a timeout. All tests below run against
+// the mocked `dns.lookup` set up at the top of this file — they never touch
+// real DNS, which keeps them deterministic on offline runners and CI machines
+// that deny outbound network access.
 
 describe("isOnline", () => {
-  it("resolves to false within the timeout when DNS does not respond", async () => {
+  beforeEach(() => {
+    dnsLookupMock.mockReset();
+  });
+
+  it("returns true when DNS resolution succeeds", async () => {
+    dnsLookupMock.mockImplementation((_host: string, callback: (err: Error | null) => void) => {
+      setImmediate(() => callback(null));
+    });
+
+    await expect(isOnline()).resolves.toBe(true);
+    expect(dnsLookupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when DNS resolution errors", async () => {
+    dnsLookupMock.mockImplementation((_host: string, callback: (err: Error | null) => void) => {
+      setImmediate(() => callback(Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" })));
+    });
+
+    await expect(isOnline()).resolves.toBe(false);
+  });
+
+  it("returns false when DNS never responds before the timeout", async () => {
+    dnsLookupMock.mockImplementation(() => {
+      // Never invoke the callback — simulate a hanging DNS query.
+    });
+
     const start = Date.now();
-    const result = await isOnline(50);
+    const result = await isOnline(30);
     const elapsed = Date.now() - start;
-    expect(typeof result).toBe("boolean");
+
+    expect(result).toBe(false);
+    expect(elapsed).toBeGreaterThanOrEqual(25);
     expect(elapsed).toBeLessThan(500);
+  });
+
+  it("looks up the hostname from NPM_REGISTRY", async () => {
+    const expectedHost = new URL(NPM_REGISTRY).hostname;
+    dnsLookupMock.mockImplementation((_host: string, callback: (err: Error | null) => void) => {
+      setImmediate(() => callback(null));
+    });
+
+    await isOnline();
+
+    expect(dnsLookupMock).toHaveBeenCalledWith(expectedHost, expect.any(Function));
+  });
+
+  it("settles once even if DNS responds after the timeout has already fired", async () => {
+    let dnsCallback: ((err: Error | null) => void) | null = null;
+    dnsLookupMock.mockImplementation((_host: string, callback: (err: Error | null) => void) => {
+      dnsCallback = callback;
+    });
+
+    const result = await isOnline(10);
+    expect(result).toBe(false);
+
+    // Late DNS callback must not throw, log, or re-resolve the already-
+    // settled promise. This mirrors what happens when DNS responds after
+    // we have already given up waiting.
+    expect(() => dnsCallback?.(null)).not.toThrow();
+  });
+});
+
+// ── isSkillsCliAvailable ─────────────────────────────────────────────────────
+
+describe("isSkillsCliAvailable", () => {
+  beforeEach(() => {
+    execSyncMock.mockReset();
+  });
+
+  it("returns true when `npx --no-install skills --version` exits successfully", () => {
+    execSyncMock.mockReturnValue(Buffer.from("0.1.0\n"));
+
+    expect(isSkillsCliAvailable()).toBe(true);
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    const [cmd] = execSyncMock.mock.calls[0]!;
+    expect(cmd).toBe("npx --no-install skills --version");
+  });
+
+  it("returns false when the probe throws (skills CLI not in npx cache)", () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error("command failed");
+    });
+
+    expect(isSkillsCliAvailable()).toBe(false);
+  });
+
+  it("fully silences stdio so nothing leaks to the terminal", () => {
+    execSyncMock.mockReturnValue(Buffer.from(""));
+
+    isSkillsCliAvailable();
+
+    const opts = execSyncMock.mock.calls[0]![1] as
+      | { stdio?: [unknown, unknown, unknown] }
+      | undefined;
+    expect(opts?.stdio).toEqual(["ignore", "ignore", "ignore"]);
+  });
+
+  it("passes a timeout so a wedged npx cannot hang init forever", () => {
+    execSyncMock.mockReturnValue(Buffer.from(""));
+
+    isSkillsCliAvailable();
+
+    const opts = execSyncMock.mock.calls[0]![1] as { timeout?: number } | undefined;
+    expect(typeof opts?.timeout).toBe("number");
+    expect(opts!.timeout!).toBeGreaterThan(0);
+  });
+});
+
+// ── getLatestVersion ─────────────────────────────────────────────────────────
+
+describe("getLatestVersion", () => {
+  beforeEach(() => {
+    execSyncMock.mockReset();
+  });
+
+  it("returns the trimmed version reported by `npm view`", () => {
+    execSyncMock.mockReturnValue("9.9.9\n");
+
+    expect(getLatestVersion()).toBe("9.9.9");
+  });
+
+  it("queries the package name and registry from constants", () => {
+    execSyncMock.mockReturnValue("1.0.0\n");
+
+    getLatestVersion();
+
+    const [cmd] = execSyncMock.mock.calls[0]!;
+    expect(cmd).toContain(`npm view ${PACKAGE_NAME} version`);
+    expect(cmd).toContain(`--registry ${NPM_REGISTRY}`);
+  });
+
+  it("pipes stderr so 404s do not leak to the terminal", () => {
+    // Regression guard for the previous behavior where `stdio: 'inherit'` let
+    // `npm view`'s 404 output bleed into the init UI on fresh/private
+    // packages. stderr must be captured (piped), not inherited.
+    execSyncMock.mockReturnValue("1.0.0\n");
+
+    getLatestVersion();
+
+    const opts = execSyncMock.mock.calls[0]![1] as
+      | { stdio?: [unknown, unknown, unknown] }
+      | undefined;
+    expect(opts?.stdio).toEqual(["ignore", "pipe", "pipe"]);
+  });
+
+  it("passes a timeout to bound the registry probe", () => {
+    execSyncMock.mockReturnValue("1.0.0\n");
+
+    getLatestVersion();
+
+    const opts = execSyncMock.mock.calls[0]![1] as { timeout?: number } | undefined;
+    expect(typeof opts?.timeout).toBe("number");
+    expect(opts!.timeout!).toBeGreaterThan(0);
+  });
+
+  it("propagates errors from `npm view` to the caller", () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error("E404");
+    });
+
+    expect(() => getLatestVersion()).toThrow("E404");
   });
 });


### PR DESCRIPTION
## Summary
- Detects offline state during `argent init` and gracefully degrades
- Skills step: warns and skips to manual when offline; uses cached `npx skills` with `--no-install` when available
- Update check: bounded by a 3s timeout so it doesn't hang offline
