### PR TITLE
Enhance error handling in registry and tool server blueprints

### DIFF
--- a/packages/registry/src/logger.ts
+++ b/packages/registry/src/logger.ts
@@ -3,6 +3,42 @@ import type { Registry } from "./registry";
 const PREFIX = "[registry]";
 
 /**
+ * Walk the .cause chain and build a single string with all unique messages,
+ * then append the deepest available stack trace.
+ */
+function formatError(error: Error): string {
+  const parts: string[] = [];
+  let current: unknown = error;
+  while (current instanceof Error) {
+    if (!parts.some((p) => p.includes(current instanceof Error ? current.message : ""))) {
+      parts.push(current.message);
+    }
+    current = current.cause;
+  }
+
+  const fullMessage = parts.length === 1 ? parts[0]! : parts.join(" — caused by: ");
+
+  // Prefer the deepest stack in the chain (closest to the actual throw site)
+  let deepestStack: string | undefined;
+  let cursor: unknown = error;
+  while (cursor instanceof Error) {
+    if (cursor.stack) deepestStack = cursor.stack;
+    cursor = cursor.cause;
+  }
+
+  if (deepestStack) {
+    // Replace the first line of the stack (which repeats the message) with our
+    // full cause-chain message so the log line is self-contained.
+    const stackBody = deepestStack.includes("\n")
+      ? deepestStack.slice(deepestStack.indexOf("\n"))
+      : "";
+    return `${fullMessage}${stackBody}`;
+  }
+
+  return fullMessage;
+}
+
+/**
  * Subscribes to all registry lifetime events and logs them to the console.
  * Call this after creating the registry to observe service/tool lifecycle in the server.
  */
@@ -12,11 +48,7 @@ export function attachRegistryLogger(registry: Registry): void {
   });
 
   registry.events.on("serviceError", (serviceId, error) => {
-    console.error(
-      `${PREFIX} serviceError ${serviceId}:`,
-      error.message,
-      error.cause ? `(cause: ${error.cause})` : ""
-    );
+    console.error(`${PREFIX} serviceError ${serviceId}:\n${formatError(error)}`);
   });
 
   registry.events.on("serviceRegistered", (serviceId) => {
@@ -36,10 +68,6 @@ export function attachRegistryLogger(registry: Registry): void {
   });
 
   registry.events.on("toolFailed", (toolId, error) => {
-    console.error(
-      `${PREFIX} toolFailed ${toolId}:`,
-      error.message,
-      error.cause ? `(cause: ${error.cause})` : ""
-    );
+    console.error(`${PREFIX} toolFailed ${toolId}:\n${formatError(error)}`);
   });
 }

--- a/packages/registry/src/registry.ts
+++ b/packages/registry/src/registry.ts
@@ -247,32 +247,26 @@ export class Registry {
 
       return instance.api as T;
     } catch (error) {
-      this._transition(node, ServiceState.ERROR);
+      const cause = error instanceof Error ? error : new Error(String(error));
+      this._transition(node, ServiceState.ERROR, cause);
       node.initPromise = null;
 
       if (error instanceof ServiceInitializationError) {
         throw error;
       }
-      throw new ServiceInitializationError(
-        urn,
-        error instanceof Error ? error.message : String(error),
-        {
-          cause: error instanceof Error ? error : new Error(String(error)),
-        }
-      );
+      throw new ServiceInitializationError(urn, cause.message, { cause });
     }
   }
 
-  private _transition(node: ServiceNode, to: ServiceState): void {
+  private _transition(node: ServiceNode, to: ServiceState, cause?: Error): void {
     const from = node.state;
     node.state = to;
     this.events.emit("serviceStateChange", node.urn, from, to);
     if (to === ServiceState.ERROR) {
-      this.events.emit(
-        "serviceError",
-        node.urn,
-        new Error(`Service "${node.urn}" entered ERROR state`)
-      );
+      const err = cause
+        ? new Error(`Service "${node.urn}" entered ERROR state: ${cause.message}`, { cause })
+        : new Error(`Service "${node.urn}" entered ERROR state`);
+      this.events.emit("serviceError", node.urn, err);
     }
   }
 
@@ -307,7 +301,7 @@ export class Registry {
     node.instance = null;
     node.initPromise = null;
     node.dependents.clear();
-    this._transition(node, error ? ServiceState.ERROR : ServiceState.IDLE);
+    this._transition(node, error ? ServiceState.ERROR : ServiceState.IDLE, error);
   }
 
   private async _teardown(urn: string, cause?: Error): Promise<void> {
@@ -341,6 +335,6 @@ export class Registry {
     node.instance = null;
     node.initPromise = null;
     node.dependents.clear();
-    this._transition(node, cause ? ServiceState.ERROR : ServiceState.IDLE);
+    this._transition(node, cause ? ServiceState.ERROR : ServiceState.IDLE, cause);
   }
 }

--- a/packages/registry/tests/logger.test.ts
+++ b/packages/registry/tests/logger.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Registry } from "../src/registry";
+import { attachRegistryLogger } from "../src/logger";
+import { createStaticBlueprint, createMockToolDef, staticUrn } from "./helpers";
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+describe("attachRegistryLogger — formatError via serviceError", () => {
+  it("logs a single error with message and stack", async () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    const err = new Error("connection refused");
+    registry.events.emit("serviceError", "svc:1", err);
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const output = errorSpy.mock.calls[0]![0] as string;
+    expect(output).toContain("[registry] serviceError svc:1:");
+    expect(output).toContain("connection refused");
+    // Stack trace lines should be present (V8/Node always attaches .stack)
+    expect(output).toContain("\n");
+  });
+
+  it("logs a 3-level cause chain joined by ' — caused by: '", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    const root = new Error("ECONNREFUSED");
+    const mid = new Error("WebSocket handshake failed", { cause: root });
+    const outer = new Error("Service init failed", { cause: mid });
+
+    registry.events.emit("serviceError", "svc:2", outer);
+
+    const output = errorSpy.mock.calls[0]![0] as string;
+    expect(output).toContain("Service init failed");
+    expect(output).toContain(" — caused by: ");
+    expect(output).toContain("WebSocket handshake failed");
+    expect(output).toContain("ECONNREFUSED");
+  });
+
+  it("deduplicates repeated messages in the cause chain", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    const inner = new Error("boom");
+    const outer = new Error("boom", { cause: inner });
+
+    registry.events.emit("serviceError", "svc:3", outer);
+
+    const output = errorSpy.mock.calls[0]![0] as string;
+    // "boom" should appear only once (no " — caused by: boom")
+    expect(output).not.toContain(" — caused by: ");
+    expect(output).toContain("boom");
+  });
+
+  it("falls back to message-only when stack is absent", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    const err = new Error("no stack");
+    // Simulate an error with no stack (e.g. from a non-V8 runtime)
+    err.stack = undefined;
+
+    registry.events.emit("serviceError", "svc:4", err);
+
+    const output = errorSpy.mock.calls[0]![0] as string;
+    expect(output).toContain("no stack");
+    // The output after the message should not have dangling newline + stack
+    expect(output).toBe("[registry] serviceError svc:4:\nno stack");
+  });
+
+  it("uses the deepest stack in the chain", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    const inner = new Error("root cause");
+    const outer = new Error("wrapper", { cause: inner });
+    // Delete the outer stack so only the inner stack is available
+    outer.stack = undefined;
+
+    registry.events.emit("serviceError", "svc:5", outer);
+
+    const output = errorSpy.mock.calls[0]![0] as string;
+    // Should contain the inner error's stack (which has "root cause" in its first line)
+    expect(output).toMatch(/at /);
+  });
+});
+
+describe("attachRegistryLogger — formatError via toolFailed", () => {
+  it("formats a cause chain for toolFailed the same way", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    const root = new Error("timeout");
+    const outer = new Error("evaluate failed", { cause: root });
+
+    registry.events.emit("toolFailed", "my-tool", outer);
+
+    const output = errorSpy.mock.calls[0]![0] as string;
+    expect(output).toContain("[registry] toolFailed my-tool:");
+    expect(output).toContain("evaluate failed");
+    expect(output).toContain("timeout");
+  });
+});
+
+describe("attachRegistryLogger — happy-path events", () => {
+  it("logs serviceStateChange", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    registry.events.emit("serviceStateChange", "svc:x", "IDLE" as any, "STARTING" as any);
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls[0]![0]).toContain("serviceStateChange svc:x: IDLE → STARTING");
+  });
+
+  it("logs toolRegistered", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    registry.events.emit("toolRegistered", "my-tool");
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls[0]![0]).toContain("toolRegistered my-tool");
+  });
+
+  it("logs toolInvoked", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    registry.events.emit("toolInvoked", "my-tool");
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls[0]![0]).toContain("toolInvoked my-tool");
+  });
+
+  it("logs toolCompleted with duration", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    registry.events.emit("toolCompleted", "my-tool", 123.456);
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls[0]![0]).toContain("toolCompleted my-tool (123.46ms)");
+  });
+
+  it("logs serviceRegistered", () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+
+    registry.events.emit("serviceRegistered", "svc:1");
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls[0]![0]).toContain("serviceRegistered svc:1");
+  });
+});
+
+describe("attachRegistryLogger — end-to-end with Registry", () => {
+  it("logs serviceError with cause when factory throws", async () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+    const { blueprint } = createStaticBlueprint("Fail", { failOnInit: true });
+    registry.registerBlueprint(blueprint);
+
+    await expect(registry.resolveService(staticUrn("Fail"))).rejects.toThrow();
+
+    const errorCalls = errorSpy.mock.calls.map((c) => c[0] as string);
+    const serviceErrorLog = errorCalls.find((c) => c.includes("serviceError"));
+    expect(serviceErrorLog).toBeDefined();
+    expect(serviceErrorLog).toContain("Fail factory failure");
+  });
+
+  it("logs toolFailed with cause when tool execution errors", async () => {
+    const registry = new Registry();
+    attachRegistryLogger(registry);
+    const { blueprint } = createStaticBlueprint("S");
+    registry.registerBlueprint(blueprint);
+    registry.registerTool(
+      createMockToolDef("bad-tool", () => ({ S: staticUrn("S") }), { fail: true })
+    );
+
+    await expect(registry.invokeTool("bad-tool")).rejects.toThrow();
+
+    const errorCalls = errorSpy.mock.calls.map((c) => c[0] as string);
+    const toolFailedLog = errorCalls.find((c) => c.includes("toolFailed bad-tool"));
+    expect(toolFailedLog).toBeDefined();
+    expect(toolFailedLog).toContain("bad-tool execution failure");
+  });
+});

--- a/packages/registry/tests/registry-error-events.test.ts
+++ b/packages/registry/tests/registry-error-events.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { Registry } from "../src/registry";
+import { ServiceState } from "../src/types";
+import { ServiceInitializationError } from "../src/errors";
+import { createStaticBlueprint, staticUrn } from "./helpers";
+
+describe("Registry — serviceError events carry cause", () => {
+  it("emits serviceError with cause message when factory throws", async () => {
+    const registry = new Registry();
+    const { blueprint } = createStaticBlueprint("Broken", { failOnInit: true });
+    registry.registerBlueprint(blueprint);
+
+    const errors: { serviceId: string; error: Error }[] = [];
+    registry.events.on("serviceError", (serviceId, error) => {
+      errors.push({ serviceId, error });
+    });
+
+    await expect(registry.resolveService(staticUrn("Broken"))).rejects.toThrow();
+
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    const event = errors.find((e) => e.serviceId === staticUrn("Broken"))!;
+    expect(event).toBeDefined();
+    expect(event.error.message).toContain("entered ERROR state");
+    expect(event.error.message).toContain("Broken factory failure");
+    expect(event.error.cause).toBeInstanceOf(Error);
+    expect((event.error.cause as Error).message).toBe("Broken factory failure");
+  });
+
+  it("emits serviceError without cause message when no cause is provided", async () => {
+    const registry = new Registry();
+    const { blueprint } = createStaticBlueprint("A");
+    registry.registerBlueprint(blueprint);
+
+    const errors: { serviceId: string; error: Error }[] = [];
+    registry.events.on("serviceError", (serviceId, error) => {
+      errors.push({ serviceId, error });
+    });
+
+    await registry.resolveService(staticUrn("A"));
+
+    // Manually trigger termination without error — teardown to IDLE, no serviceError
+    await registry.disposeService(staticUrn("A"));
+    const errorForA = errors.find((e) => e.serviceId === staticUrn("A"));
+    expect(errorForA).toBeUndefined();
+  });
+
+  it("propagates cause through cascaded termination with error", async () => {
+    const registry = new Registry();
+    const { blueprint: bBlueprint, emitters: bEmitters } = createStaticBlueprint("B");
+    const { blueprint: aBlueprint } = createStaticBlueprint("A", { deps: ["B"] });
+    registry.registerBlueprint(bBlueprint);
+    registry.registerBlueprint(aBlueprint);
+
+    await registry.resolveService(staticUrn("A"));
+
+    const errors: { serviceId: string; error: Error }[] = [];
+    registry.events.on("serviceError", (serviceId, error) => {
+      errors.push({ serviceId, error });
+    });
+
+    const disconnectError = new Error("WebSocket closed unexpectedly");
+    bEmitters[0]!.emit("terminated", disconnectError);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Both A (dependent) and B should enter ERROR with cause info
+    const errorForB = errors.find((e) => e.serviceId === staticUrn("B"));
+    expect(errorForB).toBeDefined();
+    expect(errorForB!.error.message).toContain("WebSocket closed unexpectedly");
+
+    const errorForA = errors.find((e) => e.serviceId === staticUrn("A"));
+    expect(errorForA).toBeDefined();
+    expect(errorForA!.error.message).toContain("WebSocket closed unexpectedly");
+  });
+
+  it("preserves original cause in ServiceInitializationError through dep chain", async () => {
+    const registry = new Registry();
+    const { blueprint: bBlueprint } = createStaticBlueprint("DepFail", { failOnInit: true });
+    const { blueprint: aBlueprint } = createStaticBlueprint("Parent", { deps: ["DepFail"] });
+    registry.registerBlueprint(bBlueprint);
+    registry.registerBlueprint(aBlueprint);
+
+    try {
+      await registry.resolveService(staticUrn("Parent"));
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ServiceInitializationError);
+      // Walk the cause chain — the original "DepFail factory failure" should be reachable
+      let cursor: unknown = error;
+      const messages: string[] = [];
+      while (cursor instanceof Error) {
+        messages.push(cursor.message);
+        cursor = cursor.cause;
+      }
+      expect(messages.some((m) => m.includes("DepFail factory failure"))).toBe(true);
+    }
+
+    expect(registry.getServiceState(staticUrn("Parent"))).toBe(ServiceState.ERROR);
+    expect(registry.getServiceState(staticUrn("DepFail"))).toBe(ServiceState.ERROR);
+  });
+
+  it("emits serviceError with cause when teardown is triggered with an error", async () => {
+    const registry = new Registry();
+    const { blueprint, emitters } = createStaticBlueprint("Teardown");
+    registry.registerBlueprint(blueprint);
+
+    await registry.resolveService(staticUrn("Teardown"));
+
+    const errors: { serviceId: string; error: Error }[] = [];
+    registry.events.on("serviceError", (serviceId, error) => {
+      errors.push({ serviceId, error });
+    });
+
+    emitters[0]!.emit("terminated", new Error("process killed"));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(registry.getServiceState(staticUrn("Teardown"))).toBe(ServiceState.ERROR);
+    const event = errors.find((e) => e.serviceId === staticUrn("Teardown"));
+    expect(event).toBeDefined();
+    expect(event!.error.message).toContain("process killed");
+    expect(event!.error.cause).toBeInstanceOf(Error);
+  });
+
+  it("transitions to IDLE (not ERROR) when terminated without error", async () => {
+    const registry = new Registry();
+    const { blueprint, emitters } = createStaticBlueprint("Clean");
+    registry.registerBlueprint(blueprint);
+
+    await registry.resolveService(staticUrn("Clean"));
+
+    const errors: { serviceId: string; error: Error }[] = [];
+    registry.events.on("serviceError", (serviceId, error) => {
+      errors.push({ serviceId, error });
+    });
+
+    emitters[0]!.emit("terminated");
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(registry.getServiceState(staticUrn("Clean"))).toBe(ServiceState.IDLE);
+    expect(errors.find((e) => e.serviceId === staticUrn("Clean"))).toBeUndefined();
+  });
+});

--- a/packages/tool-server/src/blueprints/js-runtime-debugger.ts
+++ b/packages/tool-server/src/blueprints/js-runtime-debugger.ts
@@ -123,6 +123,11 @@ export const jsRuntimeDebuggerBlueprint: ServiceBlueprint<JsRuntimeDebuggerApi, 
     });
 
     const ignore = () => {};
+    const warnOnError = (label: string) => (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[JsRuntimeDebugger:${port}] ${label} failed (non-fatal): ${msg}\n`);
+    };
+
     await cdp.send("FuseboxClient.setClientMetadata", {}).catch(ignore);
     await cdp.send("ReactNativeApplication.enable", {}).catch(ignore);
     await cdp.send("Runtime.enable");
@@ -132,7 +137,7 @@ export const jsRuntimeDebuggerBlueprint: ServiceBlueprint<JsRuntimeDebuggerApi, 
     await cdp.send("Runtime.runIfWaitingForDebugger").catch(ignore);
     await cdp.addBinding("__argent_callback");
 
-    await cdp.evaluate(DISABLE_LOGBOX_SCRIPT).catch(ignore);
+    await cdp.evaluate(DISABLE_LOGBOX_SCRIPT).catch(warnOnError("DISABLE_LOGBOX_SCRIPT"));
 
     await sourceMaps.waitForPending();
 

--- a/packages/tool-server/src/blueprints/network-inspector.ts
+++ b/packages/tool-server/src/blueprints/network-inspector.ts
@@ -24,11 +24,15 @@ export const networkInspectorBlueprint: ServiceBlueprint<NetworkInspectorApi, st
   async factory(deps, _payload) {
     const debuggerApi = deps.debugger as JsRuntimeDebuggerApi;
     const cdp = debuggerApi.cdp;
-    const ignore = () => {};
 
     // Inject the fetch-level network interceptor. Idempotent — the script
     // guards itself with __argent_network_installed.
-    await cdp.evaluate(NETWORK_INTERCEPTOR_SCRIPT).catch(ignore);
+    await cdp.evaluate(NETWORK_INTERCEPTOR_SCRIPT).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[NetworkInspector:${debuggerApi.port}] NETWORK_INTERCEPTOR_SCRIPT failed (non-fatal): ${msg}\n`
+      );
+    });
 
     const api: NetworkInspectorApi = { port: debuggerApi.port, cdp };
 

--- a/packages/tool-server/src/blueprints/react-profiler-session.ts
+++ b/packages/tool-server/src/blueprints/react-profiler-session.ts
@@ -70,7 +70,12 @@ export const reactProfilerSessionBlueprint: ServiceBlueprint<ReactProfilerSessio
   async factory(deps, _payload) {
     const debuggerApi = deps.debugger as JsRuntimeDebuggerApi;
     const cdp = debuggerApi.cdp;
+    const port = debuggerApi.port;
     const ignore = () => {};
+    const warnOnError = (label: string) => (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[ReactProfilerSession:${port}] ${label} failed (non-fatal): ${msg}\n`);
+    };
 
     const events = new TypedEventEmitter<ServiceEvents>();
 
@@ -91,7 +96,7 @@ export const reactProfilerSessionBlueprint: ServiceBlueprint<ReactProfilerSessio
     };
 
     // Enable Profiler domain
-    await cdp.send("Profiler.enable").catch(ignore);
+    await cdp.send("Profiler.enable").catch(warnOnError("Profiler.enable"));
 
     // Track script sources for source map resolution in analyze_profile
     cdp.events.on("scriptParsed", (script) => {
@@ -104,7 +109,7 @@ export const reactProfilerSessionBlueprint: ServiceBlueprint<ReactProfilerSessio
     });
 
     // Inject fiber root tracker (idempotent — guarded in JS)
-    await cdp.evaluate(FIBER_ROOT_TRACKER_SCRIPT).catch(ignore);
+    await cdp.evaluate(FIBER_ROOT_TRACKER_SCRIPT).catch(warnOnError("FIBER_ROOT_TRACKER_SCRIPT"));
 
     // Detect RN architecture
     try {
@@ -132,8 +137,8 @@ export const reactProfilerSessionBlueprint: ServiceBlueprint<ReactProfilerSessio
           state.detectedArchitecture = "bridge";
         }
       }
-    } catch {
-      // non-fatal
+    } catch (err) {
+      warnOnError("architecture detection")(err);
     }
 
     // Get Hermes version
@@ -146,8 +151,8 @@ export const reactProfilerSessionBlueprint: ServiceBlueprint<ReactProfilerSessio
         const props = JSON.parse(propsJson) as Record<string, unknown>;
         state.hermesVersion = (props["OSS Release Version"] as string) ?? "unknown";
       }
-    } catch {
-      // non-fatal
+    } catch (err) {
+      warnOnError("Hermes version probe")(err);
     }
 
     cdp.events.on("disconnected", (error) => {

--- a/packages/tool-server/src/utils/debugger/cdp-client.ts
+++ b/packages/tool-server/src/utils/debugger/cdp-client.ts
@@ -53,9 +53,7 @@ interface CDPExceptionDetails {
 function formatExceptionDetails(details: CDPExceptionDetails): string {
   // exception.description already contains the JS Error message + its own JS stack
   const description =
-    details.exception?.description ??
-    details.text ??
-    "Script evaluation threw an exception";
+    details.exception?.description ?? details.text ?? "Script evaluation threw an exception";
 
   // If the description already embeds a stack trace (Error: msg\n  at ...) use it as-is.
   // Otherwise append the CDP-reported call frames.

--- a/packages/tool-server/src/utils/debugger/cdp-client.ts
+++ b/packages/tool-server/src/utils/debugger/cdp-client.ts
@@ -34,6 +34,48 @@ export type CDPClientEvents = {
   consoleAPICalled: (params: ConsoleAPICalledParams) => void;
 };
 
+interface CDPExceptionDetails {
+  text?: string;
+  exception?: { description?: string; value?: unknown };
+  stackTrace?: {
+    callFrames: Array<{
+      functionName: string;
+      url: string;
+      lineNumber: number;
+      columnNumber: number;
+    }>;
+  };
+  lineNumber?: number;
+  columnNumber?: number;
+  url?: string;
+}
+
+function formatExceptionDetails(details: CDPExceptionDetails): string {
+  // exception.description already contains the JS Error message + its own JS stack
+  const description =
+    details.exception?.description ??
+    details.text ??
+    "Script evaluation threw an exception";
+
+  // If the description already embeds a stack trace (Error: msg\n  at ...) use it as-is.
+  // Otherwise append the CDP-reported call frames.
+  if (description.includes("\n    at ") || description.includes("\n  at ")) {
+    return description;
+  }
+
+  const frames = details.stackTrace?.callFrames ?? [];
+  if (frames.length === 0) return description;
+
+  const frameLines = frames
+    .map((f) => {
+      const loc = `${f.url || "<anonymous>"}:${f.lineNumber + 1}:${f.columnNumber + 1}`;
+      return `  at ${f.functionName || "<anonymous>"} (${loc})`;
+    })
+    .join("\n");
+
+  return `${description}\n${frameLines}`;
+}
+
 interface PendingRequest {
   resolve: (result: unknown) => void;
   reject: (error: Error) => void;
@@ -155,11 +197,11 @@ export class CDPClient {
   async evaluate(expression: string, options?: { timeout?: number }): Promise<unknown> {
     const result = (await this.send("Runtime.evaluate", { expression }, options?.timeout)) as {
       result?: { type?: string; value?: unknown; description?: string };
-      exceptionDetails?: unknown;
+      exceptionDetails?: CDPExceptionDetails;
     };
 
     if (result.exceptionDetails) {
-      throw new Error(`Evaluation error: ${JSON.stringify(result.exceptionDetails)}`);
+      throw new Error(formatExceptionDetails(result.exceptionDetails));
     }
 
     return result.result?.value;

--- a/packages/tool-server/test/blueprints/warnOnError.test.ts
+++ b/packages/tool-server/test/blueprints/warnOnError.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The blueprints (js-runtime-debugger, network-inspector, react-profiler-session)
+ * all define an inline `warnOnError` closure with the same shape:
+ *
+ *   const warnOnError = (label: string) => (err: unknown) => {
+ *     const msg = err instanceof Error ? err.message : String(err);
+ *     process.stderr.write(`[Namespace:${port}] ${label} failed (non-fatal): ${msg}\n`);
+ *   };
+ *
+ * Since invoking the real blueprint factories requires a live Metro/CDP connection,
+ * we test the pattern directly by replicating the closure and capturing stderr.
+ */
+
+function createWarnOnError(namespace: string, port: number) {
+  return (label: string) => (err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[${namespace}:${port}] ${label} failed (non-fatal): ${msg}\n`);
+  };
+}
+
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+});
+
+describe("warnOnError pattern", () => {
+  it("writes formatted warning to stderr for an Error object", () => {
+    const warnOnError = createWarnOnError("JsRuntimeDebugger", 8081);
+    warnOnError("DISABLE_LOGBOX_SCRIPT")(new Error("expression evaluation timed out"));
+
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    const output = stderrSpy.mock.calls[0]![0] as string;
+    expect(output).toBe(
+      "[JsRuntimeDebugger:8081] DISABLE_LOGBOX_SCRIPT failed (non-fatal): expression evaluation timed out\n"
+    );
+  });
+
+  it("coerces non-Error values to string", () => {
+    const warnOnError = createWarnOnError("NetworkInspector", 8081);
+    warnOnError("NETWORK_INTERCEPTOR_SCRIPT")("string error");
+
+    const output = stderrSpy.mock.calls[0]![0] as string;
+    expect(output).toBe(
+      "[NetworkInspector:8081] NETWORK_INTERCEPTOR_SCRIPT failed (non-fatal): string error\n"
+    );
+  });
+
+  it("handles undefined/null coercion", () => {
+    const warnOnError = createWarnOnError("ReactProfilerSession", 3000);
+    warnOnError("Profiler.enable")(undefined);
+
+    const output = stderrSpy.mock.calls[0]![0] as string;
+    expect(output).toContain("failed (non-fatal): undefined");
+  });
+
+  it("works as a .catch() handler (receives single argument)", async () => {
+    const warnOnError = createWarnOnError("JsRuntimeDebugger", 8081);
+
+    await Promise.reject(new Error("CDP not connected")).catch(
+      warnOnError("Runtime.enable")
+    );
+
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    const output = stderrSpy.mock.calls[0]![0] as string;
+    expect(output).toContain("[JsRuntimeDebugger:8081] Runtime.enable failed (non-fatal):");
+    expect(output).toContain("CDP not connected");
+  });
+
+  it("ignore pattern swallows silently (no stderr output)", async () => {
+    const ignore = () => {};
+    await Promise.reject(new Error("not important")).catch(ignore);
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("matches the exact format used by each blueprint namespace", () => {
+    const namespaces = [
+      { ns: "JsRuntimeDebugger", label: "DISABLE_LOGBOX_SCRIPT" },
+      { ns: "NetworkInspector", label: "NETWORK_INTERCEPTOR_SCRIPT" },
+      { ns: "ReactProfilerSession", label: "FIBER_ROOT_TRACKER_SCRIPT" },
+    ];
+
+    for (const { ns, label } of namespaces) {
+      stderrSpy.mockClear();
+      const warnOnError = createWarnOnError(ns, 8081);
+      warnOnError(label)(new Error("test"));
+
+      const output = stderrSpy.mock.calls[0]![0] as string;
+      const expected = `[${ns}:8081] ${label} failed (non-fatal): test\n`;
+      expect(output).toBe(expected);
+    }
+  });
+});

--- a/packages/tool-server/test/blueprints/warnOnError.test.ts
+++ b/packages/tool-server/test/blueprints/warnOnError.test.ts
@@ -63,9 +63,7 @@ describe("warnOnError pattern", () => {
   it("works as a .catch() handler (receives single argument)", async () => {
     const warnOnError = createWarnOnError("JsRuntimeDebugger", 8081);
 
-    await Promise.reject(new Error("CDP not connected")).catch(
-      warnOnError("Runtime.enable")
-    );
+    await Promise.reject(new Error("CDP not connected")).catch(warnOnError("Runtime.enable"));
 
     expect(stderrSpy).toHaveBeenCalledOnce();
     const output = stderrSpy.mock.calls[0]![0] as string;

--- a/packages/tool-server/test/debugger/cdp-exception-format.test.ts
+++ b/packages/tool-server/test/debugger/cdp-exception-format.test.ts
@@ -89,9 +89,7 @@ describe("CDPClient.evaluate — formatExceptionDetails", () => {
       exception: { value: null },
     });
 
-    await expect(client.evaluate("null()")).rejects.toThrow(
-      "Script evaluation threw an exception"
-    );
+    await expect(client.evaluate("null()")).rejects.toThrow("Script evaluation threw an exception");
     await client.disconnect();
   });
 

--- a/packages/tool-server/test/debugger/cdp-exception-format.test.ts
+++ b/packages/tool-server/test/debugger/cdp-exception-format.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { WebSocketServer, WebSocket } from "ws";
+import { CDPClient } from "../../src/utils/debugger/cdp-client";
+
+let wss: WebSocketServer;
+let port: number;
+let serverWs: WebSocket | null = null;
+
+beforeEach(async () => {
+  serverWs = null;
+  await new Promise<void>((resolve) => {
+    wss = new WebSocketServer({ port: 0 }, () => {
+      port = (wss.address() as { port: number }).port;
+      resolve();
+    });
+  });
+  wss.on("connection", (ws) => {
+    serverWs = ws;
+  });
+});
+
+afterEach(async () => {
+  if (serverWs) serverWs.close();
+  await new Promise<void>((resolve) => wss.close(() => resolve()));
+});
+
+function waitForServer(): Promise<WebSocket> {
+  return new Promise((resolve) => {
+    if (serverWs) return resolve(serverWs);
+    wss.once("connection", (ws) => resolve(ws));
+  });
+}
+
+/**
+ * Helper: set up the mock WS to reply with a given exceptionDetails payload
+ * when it receives a Runtime.evaluate request.
+ */
+function replyWithException(ws: WebSocket, exceptionDetails: Record<string, unknown>) {
+  ws.on("message", (raw) => {
+    const msg = JSON.parse(raw.toString());
+    if (msg.method === "Runtime.evaluate") {
+      ws.send(
+        JSON.stringify({
+          id: msg.id,
+          result: { exceptionDetails },
+        })
+      );
+    }
+  });
+}
+
+describe("CDPClient.evaluate — formatExceptionDetails", () => {
+  it("returns description as-is when it contains an embedded stack trace", async () => {
+    const client = new CDPClient(`ws://localhost:${port}`);
+    await client.connect();
+    const ws = await waitForServer();
+
+    const embeddedStack =
+      "ReferenceError: foo is not defined\n    at render (http://localhost:8081/src/App.tsx:10:5)";
+    replyWithException(ws, {
+      exception: { description: embeddedStack },
+    });
+
+    await expect(client.evaluate("foo()")).rejects.toThrow(embeddedStack);
+    await client.disconnect();
+  });
+
+  it("uses .text when .exception.description is absent", async () => {
+    const client = new CDPClient(`ws://localhost:${port}`);
+    await client.connect();
+    const ws = await waitForServer();
+
+    replyWithException(ws, {
+      text: "Uncaught SyntaxError: Unexpected token",
+    });
+
+    await expect(client.evaluate("bad syntax")).rejects.toThrow(
+      "Uncaught SyntaxError: Unexpected token"
+    );
+    await client.disconnect();
+  });
+
+  it("falls back to default message when both description and text are missing", async () => {
+    const client = new CDPClient(`ws://localhost:${port}`);
+    await client.connect();
+    const ws = await waitForServer();
+
+    replyWithException(ws, {
+      exception: { value: null },
+    });
+
+    await expect(client.evaluate("null()")).rejects.toThrow(
+      "Script evaluation threw an exception"
+    );
+    await client.disconnect();
+  });
+
+  it("appends formatted call frames when description has no embedded stack", async () => {
+    const client = new CDPClient(`ws://localhost:${port}`);
+    await client.connect();
+    const ws = await waitForServer();
+
+    replyWithException(ws, {
+      exception: { description: "TypeError: x is not a function" },
+      stackTrace: {
+        callFrames: [
+          {
+            functionName: "handlePress",
+            url: "http://localhost:8081/src/Button.tsx",
+            lineNumber: 19,
+            columnNumber: 4,
+          },
+          {
+            functionName: "",
+            url: "http://localhost:8081/src/App.tsx",
+            lineNumber: 41,
+            columnNumber: 0,
+          },
+        ],
+      },
+    });
+
+    try {
+      await client.evaluate("x()");
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      const msg = (error as Error).message;
+      expect(msg).toContain("TypeError: x is not a function");
+      expect(msg).toContain("  at handlePress (http://localhost:8081/src/Button.tsx:20:5)");
+      expect(msg).toContain("  at <anonymous> (http://localhost:8081/src/App.tsx:42:1)");
+    }
+
+    await client.disconnect();
+  });
+
+  it("returns description without frames when callFrames array is empty", async () => {
+    const client = new CDPClient(`ws://localhost:${port}`);
+    await client.connect();
+    const ws = await waitForServer();
+
+    replyWithException(ws, {
+      exception: { description: "RangeError: Maximum call stack size exceeded" },
+      stackTrace: { callFrames: [] },
+    });
+
+    await expect(client.evaluate("recurse()")).rejects.toThrow(
+      "RangeError: Maximum call stack size exceeded"
+    );
+    await client.disconnect();
+  });
+
+  it("uses <anonymous> for missing function names and URLs in frames", async () => {
+    const client = new CDPClient(`ws://localhost:${port}`);
+    await client.connect();
+    const ws = await waitForServer();
+
+    replyWithException(ws, {
+      text: "Uncaught error",
+      stackTrace: {
+        callFrames: [
+          {
+            functionName: "",
+            url: "",
+            lineNumber: 0,
+            columnNumber: 0,
+          },
+        ],
+      },
+    });
+
+    try {
+      await client.evaluate("anon()");
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      const msg = (error as Error).message;
+      expect(msg).toContain("Uncaught error");
+      expect(msg).toContain("  at <anonymous> (<anonymous>:1:1)");
+    }
+
+    await client.disconnect();
+  });
+});


### PR DESCRIPTION
## Summary

Improves how errors are surfaced and handled across the registry logger, registry events, tool-server debugger/CDP client, and related blueprints (JS runtime debugger, network inspector, React profiler session).

## Changes

- **Registry**: Logger and registry updates for clearer error handling and event behavior.
- **Tool server**: CDP client and blueprint adjustments for more consistent error paths.
- **Tests**: New coverage for logger, registry error events, blueprint `warnOnError` behavior, and CDP exception formatting.

The new output should be more verbose inside the `tool-server.log` file, while also providing just enough information to the agent:

<img width="1830" height="556" alt="image" src="https://github.com/user-attachments/assets/a998bbdc-e914-48aa-96c6-574f3f2e0ad1" />


