### PR TITLE
chore: Remove duplicate method

### DIFF
--- a/packages/registry/src/registry.ts
+++ b/packages/registry/src/registry.ts
@@ -242,7 +242,7 @@ export class Registry {
       node.instance = instance as ServiceInstance;
 
       instance.events.on("terminated", (error?: Error) => {
-        this._handleTermination(urn, error);
+        this._teardown(urn, error);
       });
 
       return instance.api as T;
@@ -268,40 +268,6 @@ export class Registry {
         : new Error(`Service "${node.urn}" entered ERROR state`);
       this.events.emit("serviceError", node.urn, err);
     }
-  }
-
-  private async _handleTermination(urn: string, error?: Error): Promise<void> {
-    const node = this.services.get(urn);
-    if (!node || node.state === ServiceState.TERMINATING || node.state === ServiceState.IDLE)
-      return;
-
-    this._transition(node, ServiceState.TERMINATING);
-
-    for (const depUrn of [...node.dependents]) {
-      await this._teardown(depUrn, error);
-    }
-
-    if (node.instance) {
-      node.instance.events.removeAllListeners();
-      try {
-        await node.instance.dispose();
-      } catch {
-        /* disposal errors are logged but not thrown */
-      }
-    }
-
-    const { payload } = parseURN(urn);
-    const depUrns = node.blueprint.getDependencies
-      ? Object.values(node.blueprint.getDependencies(payload))
-      : [];
-    for (const depUrn of depUrns) {
-      this.services.get(depUrn)?.dependents.delete(urn);
-    }
-
-    node.instance = null;
-    node.initPromise = null;
-    node.dependents.clear();
-    this._transition(node, error ? ServiceState.ERROR : ServiceState.IDLE, error);
   }
 
   private async _teardown(urn: string, cause?: Error): Promise<void> {


### PR DESCRIPTION
Both methods are identical. One checks for `IDLE || TERMINATING` the other for `TERMINATING || IDLE`.
I removed one of them.