### PR TITLE
fix(tool-server): stop large source maps from blocking the event loop during debugger init

### DIFF
--- a/packages/tool-server/src/utils/debugger/source-maps.ts
+++ b/packages/tool-server/src/utils/debugger/source-maps.ts
@@ -149,12 +149,13 @@ export class SourceMapsRegistry {
       }
 
       const consumer = new SourceMapConsumer(rawData as any);
-      const sources: string[] = [];
-      consumer.eachMapping((mapping) => {
-        if (mapping.source && !sources.includes(mapping.source)) {
-          sources.push(mapping.source);
-        }
-      });
+      const consumerSources = (consumer as any).sources;
+      const rawSources = (rawData as any)?.sources;
+      const sources: string[] = Array.isArray(consumerSources)
+        ? Array.from(consumerSources)
+        : Array.isArray(rawSources)
+          ? rawSources.slice()
+          : [];
 
       this.maps.push({ scriptUrl, scriptId, consumer, sources });
     } catch {


### PR DESCRIPTION
## Summary

Replaces synchronous `SourceMapConsumer.eachMapping` iteration (used only to collect deduplicated source paths) with reading the precomputed `sources` list from `source-map-js`’s consumer (or the raw map JSON as a fallback). This removes a multi‑minute CPU spike on very large Metro bundles that was starving the Node event loop and causing Metro’s WebSocket heartbeat to time out—surfacing as `CDP connection closed` / `Service was terminated during initialization` during `JsRuntimeDebugger` initialization (for example when starting the React profiler against a 10k+ module app).

## Problem

On large React Native bundles, tools that depend on `JsRuntimeDebugger` could fail after roughly **60–70 seconds** with a cascade like:

- `Service was terminated during initialization`
- `Profiler.enable failed (non-fatal): CDP connection closed`
- Registry errors for `JsRuntimeDebugger` entering `ERROR` with `CDP disconnected`

The failure was **timing-bound and deterministic** for large bundles, while small apps behaved normally—so it was easy to misattribute to Fusebox / New Architecture handshake races. The actual bottleneck was **argent-side**: source map registration blocked the main thread for tens of seconds.

## Root cause

`SourceMapsRegistry.doRegister` (`packages/tool-server/src/utils/debugger/source-maps.ts`) constructed a `SourceMapConsumer`, then ran:

```ts
consumer.eachMapping((mapping) => {
  if (mapping.source && !sources.includes(mapping.source)) {
    sources.push(mapping.source);
  }
});
```

That loop is **synchronous** and, on huge maps, **O(mappings × sources)** in practice because of `Array.includes` inside the hot path. Example from analysis on a synthetic map comparable to a ~12k module app: **`eachMapping` alone ~72 s** for ~4.8M mappings.

While the tool-server held the Metro CDP WebSocket open, `js-runtime-debugger` awaited `sourceMaps.waitForPending()` during service initialization—so **no heartbeats / pong replies** were processed while the event loop stayed pegged in JSON parse / consumer work / `eachMapping`.

Metro’s `@react-native/dev-middleware` inspector proxy uses a WebSocket heartbeat (pings every 5s, **~60s pong timeout**). If the client never gets to reply, Metro **closes the socket**. The JS client often only observes the close after the loop unblocks—matching the observed ~70s wall clock.

## What changed

After `new SourceMapConsumer(rawData)`:

- **Before:** Build `sources` by walking every mapping and deduplicating with `includes`.
- **After:** Prefer `Array.from((consumer as any).sources)` when available; otherwise fall back to `rawData.sources` slice; otherwise `[]`.

The `consumer` instance is unchanged; **`toGeneratedPosition`**, **`findMatchingSource`**, and **`buildSourceCandidates`** still use `map.sources` for membership checks and then call `consumer.generatedPositionFor`, which already tolerates sources with no mappings (`null` / skipped). For Metro-generated bundles, `consumer.sources` aligns with the old deduped list in practice; in edge cases the list may be a slight superset, which only adds cheap candidate checks before `generatedPositionFor` filters.

## Impact

| Area | Effect |
|------|--------|
| **Large RN apps (many modules / huge source maps)** | Debugger-dependent tools should **complete initialization in seconds** (dominated by fetch + JSON parse + consumer construction) instead of **~70s + disconnect**. |
| **Small bundles** | **No meaningful behavior change**; path was already fast. |
| **CDP / Fusebox / handshake code** | **Unchanged**; fix is localized to source map registration. |
| **CPU during init** | Avoids **minutes of single-core pegging** per large map registration. |
| **Correctness of symbol resolution** | Intended to be **equivalent** for Metro maps; slightly more permissive candidate lists are handled by existing `generatedPositionFor` logic. |

## How to verify

1. **Unit / integration:** Exercise `SourceMapsRegistry` with a large fixture map and assert registration completes without multi‑second event-loop stall (optional follow-up).
2. **Manual:** On an RN app with a very large bundle, run a flow that starts `JsRuntimeDebugger` (e.g. `react-profiler-start`) and confirm **no ~60–70s stall** and **no Metro WS timeout** during init.
