### PR TITLE
chore: update argent-private submodule URL to software-mansion org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packages/argent-private"]
 	path = packages/argent-private
-	url = git@github.com:software-mansion-labs/argent-private.git
+	url = git@github.com:software-mansion/argent-private.git
 	branch = main


### PR DESCRIPTION
## Summary
- Updates `.gitmodules` to point `packages/argent-private` at the new repo location under the `software-mansion` GitHub org (`git@github.com:software-mansion/argent-private.git`)
- The repo was previously under `software-mansion-labs`

## Test plan
- [ ] `git submodule sync && git submodule update --init` resolves correctly after merge