### PR TITLE
feat: add download:native-binaries script and include it in pack:mcp

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "start:tool-server": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "download:simulator-server": "bash scripts/download-simulator-server.sh",
-    "pack:mcp": "npm run download:simulator-server && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
+    "download:native-binaries": "bash scripts/download-native-binaries.sh",
+    "pack:mcp": "npm run download:simulator-server && npm run download:native-binaries && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
     "dev": "node scripts/dev.cjs",
     "format": "prettier --write ."
   },


### PR DESCRIPTION
## Summary

- Adds `download:native-binaries` npm script that calls `scripts/download-native-binaries.sh`
- Includes it in `pack:mcp` so both simulator-server and native binaries (dylibs + ax-service) are downloaded before building

## Test plan
- [ ] Run `npm run pack:mcp` and verify ax-service and dylibs are present in the tarball