### PR TITLE
feat: pin native binaries to versioned release tags and publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,32 +1,41 @@
-name: Publish to GitHub Packages
+name: Publish to npm
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v*"
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to publish (e.g. v0.4.3)"
+        required: true
+        type: string
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: "https://registry.npmjs.org"
           scope: "@swmansion"
+
+      - name: Resolve native binaries tag
+        id: binaries_tag
+        run: |
+          REF="${{ inputs.ref }}"
+          echo "tag=argent-${REF//\//-}" >> $GITHUB_OUTPUT
 
       - name: Download signed simulator-server binary
         run: bash scripts/download-simulator-server.sh
 
       - name: Download signed native binaries (dylibs + ax-service)
-        run: bash scripts/download-native-binaries.sh
+        run: bash scripts/download-native-binaries.sh "${{ steps.binaries_tag.outputs.tag }}"
 
       - run: npm ci
 
@@ -39,6 +48,6 @@ jobs:
       - run: test -f packages/mcp/dylibs/libArgentInjectionBootstrap.dylib
       - run: npm pack --dry-run -w @swmansion/argent
 
-      - run: npm publish -w @swmansion/argent --registry https://npm.pkg.github.com
+      - run: npm publish -w @swmansion/argent
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "start:tool-server": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "download:simulator-server": "bash scripts/download-simulator-server.sh",
-    "download:native-binaries": "bash scripts/download-native-binaries.sh",
+    "download:native-binaries": "bash scripts/download-native-binaries.sh \"argent-v$(node -p 'require(\"./packages/mcp/package.json\").version')\"",
     "pack:mcp": "npm run download:simulator-server && npm run download:native-binaries && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
     "dev": "node scripts/dev.cjs",
     "format": "prettier --write ."

--- a/scripts/download-native-binaries.sh
+++ b/scripts/download-native-binaries.sh
@@ -3,14 +3,28 @@ set -euo pipefail
 
 # Downloads signed native binaries (dylibs + ax-service) from argent-private-releases.
 #
-# Usage: ./scripts/download-native-binaries.sh [release-tag]
-#   release-tag  Optional tag to download from. If omitted, downloads argent-main.
+# Usage: ./scripts/download-native-binaries.sh <release-tag>
+#   release-tag  Tag to download from (e.g. argent-v0.4.3). Required.
 #
 # Requires:
 #   - gh CLI (no authentication needed — the repo is public)
 
 REPO="software-mansion-labs/argent-private-releases"
-TAG="${1:-argent-main}"
+
+if [[ -z "${1:-}" ]]; then
+  echo "Error: release tag is required." >&2
+  echo "Usage: $0 <release-tag>  (e.g. argent-v0.4.3)" >&2
+  exit 1
+fi
+
+TAG="$1"
+
+# Verify the release exists before attempting downloads.
+if ! gh release view "${TAG}" --repo "${REPO}" &>/dev/null; then
+  echo "Error: release '${TAG}' not found in ${REPO}." >&2
+  echo "Build and publish the native binaries for this version first, then retry." >&2
+  exit 1
+fi
 DYLIBS_DIR="packages/native-devtools-ios/dylibs"
 BIN_DIR="packages/native-devtools-ios/bin"
 


### PR DESCRIPTION
## Summary

- **Versioned native binaries**: `download-native-binaries.sh` now requires an explicit release tag (e.g. `argent-v0.4.3`) instead of defaulting to `argent-main`. Fails fast with a clear error message if the release doesn't exist in `argent-private-releases`.
- **Manual publish with `ref` input**: `publish.yml` is now manual-only (`workflow_dispatch`) with a `ref` input (branch/tag/SHA). The binaries tag is derived as `argent-{ref}` and the repo is checked out at that ref.
- **npm instead of GitHub Packages**: publish target changed to `registry.npmjs.org` using `NPM_TOKEN` secret.
- **Local `pack:mcp`**: `download:native-binaries` npm script auto-derives the tag from `packages/mcp/package.json` version so local packaging always uses the version-pinned binaries.

## Release process going forward

1. Manually dispatch `build-native-binaries.yml` in `argent-private` with `ref: v0.4.3` → creates `argent-v0.4.3` in `argent-private-releases`
2. Manually dispatch this publish workflow with `ref: v0.4.3`

## Test plan

- [ ] Verify `download-native-binaries.sh` errors with a clear message when called without an argument
- [ ] Verify `download-native-binaries.sh` errors with a clear message when the release tag doesn't exist
- [ ] Verify `publish.yml` `workflow_dispatch` input is visible in GitHub Actions UI
- [ ] Add `NPM_TOKEN` secret to the repo before running the publish workflow