### PR TITLE
feat: versioned native binaries in CI, npm publish, argent-main default locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "start:tool-server": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "download:simulator-server": "bash scripts/download-simulator-server.sh",
-    "download:native-binaries": "bash scripts/download-native-binaries.sh \"argent-v$(node -p 'require(\"./packages/mcp/package.json\").version')\"",
+    "download:native-binaries": "bash scripts/download-native-binaries.sh",
     "pack:mcp": "npm run download:simulator-server && npm run download:native-binaries && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
     "dev": "node scripts/dev.cjs",
     "format": "prettier --write ."


### PR DESCRIPTION
Fixes the mistake in #125 — local downloads should always use `argent-main`, only CI should care about the version.

## Changes

**`scripts/download-native-binaries.sh`**
- Keeps `argent-main` as the default when no argument is passed (local `npm run download:native-binaries` / `pack:mcp` unchanged)
- Adds an upfront `gh release view` existence check — fails fast with a clear error if the tag doesn't exist in `argent-private-releases`

**`.github/workflows/publish.yml`**
- Manual-only (`workflow_dispatch`) with a `ref` input (branch/tag/SHA)
- Derives the binaries tag as `argent-{ref}` and checks out the repo at that ref
- Publishes to npm (`registry.npmjs.org`) using `NPM_TOKEN` instead of GitHub Packages

**`package.json`** — no change (unlike #125)

## Release process

1. Manually dispatch `build-native-binaries.yml` in `argent-private` with `ref: v0.4.3` → creates `argent-v0.4.3` in `argent-private-releases`
2. Manually dispatch this publish workflow with `ref: v0.4.3`

## Test plan
- [ ] `npm run download:native-binaries` locally still fetches `argent-main`
- [ ] Running publish workflow with `ref: v0.4.3` fetches `argent-v0.4.3`
- [ ] Running publish workflow with a tag that doesn't exist fails with a clear error
- [ ] Add `NPM_TOKEN` secret before running the publish workflow