### PR TITLE
fix: use launchctl getenv to avoid simctl 127-byte truncation of DYLD_INSERT_LIBRARIES

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "MCP server for iOS Simulator control",
   "repository": {
     "type": "git",

--- a/packages/tool-server/src/blueprints/native-devtools.ts
+++ b/packages/tool-server/src/blueprints/native-devtools.ts
@@ -97,8 +97,11 @@ function splitDyldInsertLibraries(value: string): string[] {
 }
 
 /**
- * Only strips Argent bootstrap dylibs (by basename, including the legacy pre-rename name).
- * All other entries are kept verbatim so third-party injectors (e.g. SimCam) are never dropped.
+ * Strips Argent bootstrap dylibs (by basename, including the legacy pre-rename name)
+ * and entries that don't exist on disk (truncated artifacts from the simctl getenv
+ * 127-byte bug, stale paths from old installs, etc.).
+ * Entries starting with '@' (loader-path references) are always preserved.
+ * Third-party dylibs present on disk (e.g. SimCam) are kept verbatim.
  */
 function shouldPreserveDyldInsertLibrariesEntry(entry: string, bootstrapPath: string): boolean {
   if (entry === bootstrapPath) {
@@ -109,7 +112,11 @@ function shouldPreserveDyldInsertLibrariesEntry(entry: string, bootstrapPath: st
     return false;
   }
 
-  return true;
+  if (entry.startsWith("@")) {
+    return true;
+  }
+
+  return fs.existsSync(entry);
 }
 
 export function buildDyldInsertLibraries(currentValue: string, bootstrapPath: string): string {
@@ -144,10 +151,15 @@ async function ensureAccessibilityEnabled(udid: string): Promise<void> {
 async function ensureEnv(udid: string, socketPath: string): Promise<void> {
   const bootstrapPath = bootstrapDylibPath();
 
-  // xcrun simctl getenv exits non-zero when the var is unset — suppress rejection
-  const result = await execFileAsync("xcrun", ["simctl", "getenv", udid, "DYLD_INSERT_LIBRARIES"], {
-    encoding: "utf8",
-  }).catch((e) => ({ stdout: (e as NodeJS.ErrnoException & { stdout?: string }).stdout ?? "" }));
+  // Read from launchctl inside the simulator (via simctl spawn) instead of
+  // `simctl getenv`. The latter silently truncates values longer than 127 bytes,
+  // which corrupts the colon-separated path list and causes stale entries to
+  // accumulate on every ensureEnv() cycle.
+  const result = await execFileAsync(
+    "xcrun",
+    ["simctl", "spawn", udid, "launchctl", "getenv", "DYLD_INSERT_LIBRARIES"],
+    { encoding: "utf8" }
+  ).catch((e) => ({ stdout: (e as NodeJS.ErrnoException & { stdout?: string }).stdout ?? "" }));
 
   const existing = (result.stdout ?? "").trim();
   const updated = buildDyldInsertLibraries(existing, bootstrapPath);

--- a/packages/tool-server/test/native-devtools-env.test.ts
+++ b/packages/tool-server/test/native-devtools-env.test.ts
@@ -21,7 +21,7 @@ describe("buildDyldInsertLibraries", () => {
     return filePath;
   }
 
-  it("replaces only stale bootstrap entries and keeps unrelated paths even if missing on disk", () => {
+  it("strips stale bootstrap entries and non-existent paths, keeps files present on disk", () => {
     const currentBootstrap = makeTempFile("libArgentInjectionBootstrap.dylib");
     const unrelated = makeTempFile("libOtherInspector.dylib");
     const staleBootstrap = "/tmp/old/location/libArgentInjectionBootstrap.dylib";
@@ -32,7 +32,8 @@ describe("buildDyldInsertLibraries", () => {
       currentBootstrap
     );
 
-    expect(result).toBe([truncatedEntry, unrelated, currentBootstrap].join(":"));
+    // staleBootstrap stripped (argent basename); truncatedEntry stripped (not on disk)
+    expect(result).toBe([unrelated, currentBootstrap].join(":"));
   });
 
   it("preserves valid non-bootstrap loader entries while deduplicating the active bootstrap", () => {
@@ -57,6 +58,33 @@ describe("buildDyldInsertLibraries", () => {
       currentBootstrap
     );
 
+    expect(result).toBe([thirdParty, currentBootstrap].join(":"));
+  });
+
+  it("is idempotent when called with its own output", () => {
+    const currentBootstrap = makeTempFile("libArgentInjectionBootstrap.dylib");
+    const thirdParty = makeTempFile("libSimCamLoader.dylib");
+
+    const first = buildDyldInsertLibraries(thirdParty, currentBootstrap);
+    const second = buildDyldInsertLibraries(first, currentBootstrap);
+
+    expect(second).toBe(first);
+  });
+
+  it("cleans up truncated entries from simctl getenv 127-byte corruption", () => {
+    const currentBootstrap = makeTempFile("libArgentInjectionBootstrap.dylib");
+    const thirdParty = makeTempFile("libSimCamLoader.dylib");
+    // Simulate the truncated entries that accumulate from the simctl getenv bug
+    const truncated1 = "/Users/mdk/.nvm/versions/node/v24.5.0/lib/nod";
+    const truncated2 =
+      "/Users/mdk/.nvm/versions/node/v24.5.0/lib/node_modules/@swmansion/argent/dylibs/l";
+
+    const result = buildDyldInsertLibraries(
+      [truncated1, truncated2, currentBootstrap, thirdParty].join(":"),
+      currentBootstrap
+    );
+
+    // Both truncated entries stripped (not on disk), bootstrap deduped, thirdParty preserved
     expect(result).toBe([thirdParty, currentBootstrap].join(":"));
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: `xcrun simctl getenv` silently truncates return values at exactly 127 bytes. The code read via `simctl getenv` but wrote via `simctl spawn ... launchctl setenv` (no limit), so each `ensureEnv()` cycle read a truncated value, preserved the unrecognized path fragments, and appended a fresh bootstrap — corrupting the variable and clobbering third-party dylibs like SimCam.
- **Fix read path**: switched to `simctl spawn <udid> launchctl getenv` which reads from the same launchd store we write to with no truncation.
- **Fix filter**: restored `fs.existsSync` guard (removed in faf6911) to strip truncated/stale entries while preserving third-party dylibs that actually exist on disk (e.g. SimCam's `libSimCamLoader.dylib`).
- Bump mcp version to 0.4.4.

## Test plan

- [x] Unit tests pass (5 tests including new idempotency and corruption-cleanup cases)
- [x] Verified on real simulator: set SimCam → run ensureEnv logic → SimCam preserved, bootstrap added once, idempotent on second call
- [x] Verified corruption cleanup: truncated entries from prior bug are stripped on first run
- [ ] Manual test with SimCam active: confirm camera injection still works after argent connects
