### PR TITLE
chore: bump packages to 0.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4235,7 +4235,7 @@
     },
     "packages/mcp": {
       "name": "@swmansion/argent",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "hasInstallScript": true,
       "dependencies": {
         "@clack/prompts": "^1.1.0",
@@ -4264,7 +4264,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "zod": "^3.23.0"
       },
@@ -4976,14 +4976,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
         "@argent/registry": "file:../registry",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "Claude Code skills for iOS simulator interaction via argent",
   "scripts": {

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Framework-agnostic tool registry for iOS simulator control",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps all workspace package versions to 0.4.4 for the next internal release.

**Changed packages:**
- `@swmansion/argent` (packages/mcp): lockfile catch-up (package.json already at 0.4.4)
- `@argent/registry` (packages/registry): 0.4.3 -> 0.4.4
- `@argent/skills` (packages/skills): 0.4.3 -> 0.4.4
- `@argent/tool-server` (packages/tool-server): 0.4.3 -> 0.4.4

Note: `packages/mcp/package.json` was bumped out-of-band in c990e98 alongside the DYLD_INSERT_LIBRARIES fix; this PR brings the rest of the workspace and the lockfile in line.