### PR TITLE
fix: add global uncaughtException and unhandledRejection handlers

### DIFF
--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -67,6 +67,17 @@ async function main(): Promise<void> {
   }
 }
 
+process.on("uncaughtException", (err) => {
+  process.stderr.write(`[argent] Uncaught exception: ${err.stack ?? err}\n`);
+  process.exit(1);
+});
+process.on("unhandledRejection", (reason) => {
+  process.stderr.write(
+    `[argent] Unhandled rejection: ${reason instanceof Error ? (reason.stack ?? reason.message) : reason}\n`
+  );
+  process.exit(1);
+});
+
 main().catch((err) => {
   console.error(err);
   process.exit(1);

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -6,6 +6,17 @@ import { DEFAULT_IDLE_TIMEOUT_MINUTES } from "./utils/idle-timer";
 import { startUpdateChecker } from "./utils/update-checker";
 
 export function start(): void {
+  process.on("uncaughtException", (err) => {
+    process.stderr.write(`[tool-server] Uncaught exception: ${err.stack ?? err}\n`);
+    process.exit(1);
+  });
+  process.on("unhandledRejection", (reason) => {
+    process.stderr.write(
+      `[tool-server] Unhandled rejection: ${reason instanceof Error ? (reason.stack ?? reason.message) : reason}\n`
+    );
+    process.exit(1);
+  });
+
   // ── Config ────────────────────────────────────────────────────────
   const PORT = parseInt(process.env.PORT ?? "3001", 10);
   const idleMinutes = parseInt(


### PR DESCRIPTION
## Summary

- Neither the tool-server nor the MCP CLI process registered global `uncaughtException` or `unhandledRejection` handlers.
- In Node.js 15+, an unhandled promise rejection terminates the process silently with no diagnostic output, making crashes hard to diagnose.
- Both processes now log the error/rejection to stderr before exiting with code 1.

## Changes

- `packages/tool-server/src/index.ts` — handlers added at the top of `start()`, before any other initialization.
- `packages/mcp/src/cli.ts` — handlers added just before the `main()` call at the bottom of the file.