### PR TITLE
fix: log stdout/stderr errors instead of rethrowing

### DIFF
--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -63,10 +63,19 @@ export function start(): void {
   // When stdout is piped to a parent that stops reading (e.g. the MCP launcher
   // after it captures the startup line), writes via console.log emit EPIPE.
   process.stdout.on("error", (err: NodeJS.ErrnoException) => {
-    if (err.code !== "EPIPE") throw err;
+    if (err.code !== "EPIPE") {
+      process.stderr.write(`[tool-server] stdout error: ${err.message}\n`);
+    }
   });
   process.stderr.on("error", (err: NodeJS.ErrnoException) => {
-    if (err.code !== "EPIPE") throw err;
+    // stderr itself is broken — write to stdout as last resort
+    if (err.code !== "EPIPE") {
+      try {
+        process.stdout.write(`[tool-server] stderr error: ${err.message}\n`);
+      } catch {
+        /* both streams broken — nothing we can do */
+      }
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- Throwing inside a Node.js event listener creates an uncaught exception that crashes the process
- Non-EPIPE `stdout` errors are now logged to `stderr` instead of rethrowing
- Non-EPIPE `stderr` errors fall back to writing to `stdout` (wrapped in try/catch since both streams may be broken)

## Test plan

- [ ] Verify the tool-server still silently ignores EPIPE errors when the parent process stops reading
- [ ] Simulate a non-EPIPE stdout error and confirm it is logged to stderr without crashing
- [ ] Simulate both streams broken and confirm the process does not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)