### PR TITLE
fix: catch errors in TypedEventEmitter listeners

### DIFF
--- a/packages/registry/src/event-emitter.ts
+++ b/packages/registry/src/event-emitter.ts
@@ -15,7 +15,15 @@ export class TypedEventEmitter<
   }
 
   emit<K extends keyof T>(event: K, ...args: Parameters<T[K]>): void {
-    this.listeners.get(event)?.forEach((fn) => fn(...args));
+    this.listeners.get(event)?.forEach((fn) => {
+      try {
+        fn(...args);
+      } catch (err) {
+        process.stderr.write(
+          `[registry] Event listener error (${String(event)}): ${err instanceof Error ? err.message : err}\n`
+        );
+      }
+    });
   }
 
   removeAllListeners(): void {


### PR DESCRIPTION
## Summary

- A throwing listener in `TypedEventEmitter.emit()` would stop iteration of remaining listeners and propagate the error to the caller.
- During service teardown this could skip cleanup steps and leak resources.
- Each listener is now isolated with a try/catch so all listeners run even if one throws. Errors are logged to stderr rather than swallowed silently.

## Test plan

- [ ] Verify that when one listener throws, subsequent listeners still execute
- [ ] Verify error messages appear on stderr with event name and error details
- [ ] Confirm existing emit behavior is unchanged when no listeners throw