### PR TITLE
fix: handle rejected promises in simulator watcher

### DIFF
--- a/packages/tool-server/src/utils/simulator-watcher.ts
+++ b/packages/tool-server/src/utils/simulator-watcher.ts
@@ -58,7 +58,9 @@ export function startSimulatorWatcher(registry: Registry): {
       await Promise.all(newUdids.map((udid) => initSimulator(registry, watchedUdids, udid)));
     } else {
       // Subsequent polls: fire-and-forget to avoid blocking the interval tick.
-      newUdids.forEach((udid) => initSimulator(registry, watchedUdids, udid));
+      newUdids.forEach((udid) => {
+        initSimulator(registry, watchedUdids, udid).catch(() => {});
+      });
     }
 
     // Simulators that shut down: dispose service and clean up
@@ -75,7 +77,7 @@ export function startSimulatorWatcher(registry: Registry): {
   const ready = poll(true);
 
   // Subsequent polls are fire-and-forget.
-  const interval = setInterval(() => poll(false), POLL_INTERVAL_MS);
+  const interval = setInterval(() => poll(false).catch(() => {}), POLL_INTERVAL_MS);
 
   return { stop: () => clearInterval(interval), ready };
 }


### PR DESCRIPTION
## Summary
- Fire-and-forget `initSimulator` calls in `startSimulatorWatcher` could produce unhandled promise rejections if an unexpected error occurred before the internal try block.
- Added explicit `.catch(() => {})` to the `initSimulator` calls in the forEach loop and to the `poll(false)` call in setInterval.

## Test plan
- [ ] Verify the tool-server starts and polls for simulators without errors.
- [ ] Confirm that booting/shutting down simulators during polling does not surface unhandled rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)