### PR TITLE
fix: handle rejected promises in update checker

### DIFF
--- a/packages/tool-server/src/utils/update-checker.ts
+++ b/packages/tool-server/src/utils/update-checker.ts
@@ -135,10 +135,10 @@ export function startUpdateChecker(): { dispose(): void } {
   }
 
   // Fire-and-forget initial check — don't block startup.
-  check();
+  check().catch(() => {});
 
   interval = setInterval(() => {
-    check();
+    check().catch(() => {});
   }, CHECK_INTERVAL_MS);
   interval.unref(); // don't keep the process alive for update checks
 


### PR DESCRIPTION
## Summary

- Fire-and-forget `check()` calls in `startUpdateChecker()` are async but were not guarded with `.catch()`. While `fetchLatestVersion()` is internally defensive, `check()` also calls `process.stderr.write()` which can throw if stderr is broken, producing an unhandled promise rejection.
- Added `.catch(() => {})` to both the initial `check()` call and the one inside `setInterval` to silently swallow any unexpected errors, since update checks must never crash the server.

## Test plan

- [ ] Verify the tool server starts without regressions
- [ ] Confirm no unhandled rejection warnings appear when stderr is unavailable