### PR TITLE
chore: bump workspace packages to 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4235,7 +4235,7 @@
     },
     "packages/mcp": {
       "name": "@swmansion/argent",
-      "version": "0.4.5",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "dependencies": {
         "@clack/prompts": "^1.1.0",
@@ -4256,7 +4256,7 @@
     },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
-      "version": "1.0.0",
+      "version": "0.5.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.5.0"
@@ -4264,7 +4264,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.4.5",
+      "version": "0.5.1",
       "dependencies": {
         "zod": "^3.23.0"
       },
@@ -4976,14 +4976,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.4.5",
+      "version": "0.5.1",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.4.5",
+      "version": "0.5.1",
       "dependencies": {
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
         "@argent/registry": "file:../registry",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.4.5",
+  "version": "0.5.1",
   "description": "MCP server for iOS Simulator control",
   "repository": {
     "type": "git",

--- a/packages/native-devtools-ios/package.json
+++ b/packages/native-devtools-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-ios",
-  "version": "1.0.0",
+  "version": "0.5.1",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.4.5",
+  "version": "0.5.1",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.4.5",
+  "version": "0.5.1",
   "type": "module",
   "description": "Claude Code skills for iOS simulator interaction via argent",
   "scripts": {

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.4.5",
+  "version": "0.5.1",
   "description": "Framework-agnostic tool registry for iOS simulator control",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This change bumps all workspace `package.json` versions to `0.5.1` and refreshes `package-lock.json` so the lockfile matches.

Packages updated:
- `@swmansion/argent` (packages/mcp)
- `@argent/tool-server`
- `@argent/registry`
- `@argent/skills`
- `@argent/native-devtools-ios` (aligned from 1.0.0 to the shared release line)

Made with [Cursor](https://cursor.com)