### PR TITLE
docs: make README images link to argent website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 <br/>
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/software-mansion/argent/blob/main/assets/banner_dark_mode.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://github.com/software-mansion/argent/blob/main/assets/banner_white_mode.png">
-    <img alt="banner" src="https://github.com/software-mansion/argent/blob/main/assets/banner_dark_mode.png" width="80%">
-  </picture>
+  <a href="https://argent.swmansion.com">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/software-mansion/argent/blob/main/assets/banner_dark_mode.png">
+      <source media="(prefers-color-scheme: light)" srcset="https://github.com/software-mansion/argent/blob/main/assets/banner_white_mode.png">
+      <img alt="banner" src="https://github.com/software-mansion/argent/blob/main/assets/banner_dark_mode.png" width="80%">
+    </picture>
+  </a>
 </p>
 <br/>
 
-**Argent** is an **agentic toolkit** that gives your AI assistant direct access to iOS Simulators. Ask it to tap a button, run a profiler or reproduce an issue manually - all from within your CLI, without switching context.
+**[Argent](https://argent.swmansion.com)** is an **agentic toolkit** that gives your AI assistant direct access to iOS Simulators. Ask it to tap a button, run a profiler or reproduce an issue manually - all from within your CLI, without switching context.
 
 ```bash
 npx @swmansion/argent init


### PR DESCRIPTION
## Summary
- Wrap the banner image and showcase GIF in the README with anchor tags linking to https://argent.swmansion.com so they're clickable