### PR TITLE
chore: set npm publish access to public

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -27,7 +27,7 @@
   "private": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
-    "access": "restricted"
+    "access": "public"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
## Summary
- Changes `publishConfig.access` from `"restricted"` to `"public"` in `packages/mcp/package.json` to allow public npm publication of `@swmansion/argent`
- Registry is already correctly set to `https://registry.npmjs.org`
- Verified no workflows contain a `restricted` access setting