### PR TITLE
fix: pass GH_TOKEN to publish workflow download steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,9 +33,13 @@ jobs:
 
       - name: Download signed simulator-server binary
         run: bash scripts/download-simulator-server.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download signed native binaries (dylibs + ax-service)
         run: bash scripts/download-native-binaries.sh "${{ steps.binaries_tag.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary
- Adds `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the simulator-server and native binaries download steps in `publish.yml`
- `gh` CLI in GitHub Actions requires `GH_TOKEN` to be set even when accessing public repos — without it the command fails with exit code 4

## Test plan
- Re-run the publish workflow after merging — the download steps should succeed