### PR TITLE
fix: add license field to package.json

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,6 +2,7 @@
   "name": "@swmansion/argent",
   "version": "0.5.1",
   "description": "MCP server for iOS Simulator control",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/software-mansion/argent.git"


### PR DESCRIPTION
## Summary
- Adds `"license": "Apache-2.0"` to `packages/mcp/package.json`
- npm shows "NONE" on the package page when this field is missing, even though a LICENSE file exists in the repo

## Test plan
- After next publish, verify https://www.npmjs.com/package/@swmansion/argent shows "Apache-2.0" instead of "NONE"