### PR TITLE
fix: npx init skips global install

### DIFF
--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -26,10 +26,13 @@ import { PACKAGE_NAME, MCP_BINARY_NAME } from "./constants.js";
 function isGloballyInstalled(): boolean {
   try {
     const cmd = process.platform === "win32" ? "where" : "which";
-    execSync(`${cmd} ${MCP_BINARY_NAME}`, {
+    const resolvedPath = execSync(`${cmd} ${MCP_BINARY_NAME}`, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
-    });
+    }).trim();
+    // When run via npx, the binary is on PATH temporarily inside the npx cache.
+    // That path disappears after npx exits, so it's not a real global install.
+    if (resolvedPath.includes("_npx")) return false;
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- When running `npx @swmansion/argent init`, npx temporarily puts the `argent` binary on PATH inside its cache (`_npx` directory)
- `isGloballyInstalled()` uses `which argent`, finds the npx-cached binary, and returns `true` — so the global install step is skipped entirely
- After npx exits, that PATH entry is gone and `argent` command is not found
- Fix: check if the resolved path contains `_npx` and treat it as not globally installed

## Test plan
- Run `npx @swmansion/argent init` on a machine without argent installed globally
- Verify it now prompts to install globally instead of skipping to the update check