### PR TITLE
chore: bump package versions to 0.5.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Branch, tag, or SHA to publish (e.g. v0.5.2)"
+        description: "Branch, tag, or SHA to publish (e.g. v0.5.3)"
         required: true
         type: string
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4235,8 +4235,9 @@
     },
     "packages/mcp": {
       "name": "@swmansion/argent",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.20.0",
@@ -4265,7 +4266,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "zod": "^3.23.0"
       },
@@ -4977,14 +4978,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
         "@argent/registry": "file:../registry",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "MCP server for iOS Simulator control",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -118,7 +118,7 @@ export async function startMcpServer(): Promise<void> {
   }
 
   const server = new Server(
-    { name: "argent", version: "0.5.2" },
+    { name: "argent", version: "0.5.3" },
     {
       capabilities: { tools: {} },
       instructions:

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "description": "Claude Code skills for iOS simulator interaction via argent",
   "scripts": {

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Framework-agnostic tool registry for iOS simulator control",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/download-native-binaries.sh
+++ b/scripts/download-native-binaries.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Downloads signed native binaries (dylibs + ax-service) from argent-private-releases.
 #
 # Usage: ./scripts/download-native-binaries.sh [release-tag]
-#   release-tag  Tag to download from (e.g. argent-v0.5.2). Defaults to argent-main.
+#   release-tag  Tag to download from (e.g. argent-v0.5.3). Defaults to argent-main.
 #
 # Requires:
 #   - gh CLI (no authentication needed — the repo is public)


### PR DESCRIPTION
## Summary
- Bump `@swmansion/argent`, `@argent/registry`, `@argent/skills`, and `@argent/tool-server` to 0.5.3
- Update version string reported by the MCP server
- Refresh example version tags in publish workflow and native-binaries download script

## Test plan
- [ ] CI passes
- [ ] Publish workflow dry-run validates new version