### PR TITLE
fix: only prompt for update when remote version is strictly newer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1038,6 +1038,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "dev": true,
@@ -2445,6 +2452,18 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -4237,10 +4256,12 @@
       "name": "@swmansion/argent",
       "version": "0.5.2",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.20.0",
         "picocolors": "^1.1.1",
+        "semver": "^7.7.4",
         "smol-toml": "^1.6.1",
         "yaml": "^2.8.3"
       },
@@ -4250,6 +4271,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/semver": "^7.7.1",
         "esbuild": "^0.27.3",
         "typescript": "^5.5.0",
         "vitest": "^4.0.18"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -43,11 +43,13 @@
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.20.0",
     "picocolors": "^1.1.1",
+    "semver": "^7.7.4",
     "smol-toml": "^1.6.1",
     "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/semver": "^7.7.1",
     "esbuild": "^0.27.3",
     "typescript": "^5.5.0",
     "vitest": "^4.0.18"

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -16,6 +16,7 @@ import {
   AGENTS_DIR,
   getInstalledVersion,
   getLatestVersion,
+  isNewerVersion,
   isOnline,
   isSkillsCliAvailable,
   detectPackageManager,
@@ -159,7 +160,7 @@ export async function init(args: string[]): Promise<void> {
     }
     spinner.stop(pc.dim("Version check complete."));
 
-    if (latest && latest !== version) {
+    if (latest && isNewerVersion(latest, version)) {
       if (!nonInteractive) {
         const updateChoice = await p.select({
           message: `Update available: ${pc.yellow(`v${version}`)} → ${pc.green(`v${latest}`)}`,

--- a/packages/mcp/src/cli/utils.ts
+++ b/packages/mcp/src/cli/utils.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as dns from "node:dns";
 import { execSync } from "node:child_process";
+import semver from "semver";
 import { PACKAGE_NAME, NPM_REGISTRY } from "./constants.js";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 import { Document, parseDocument } from "yaml";
@@ -161,6 +162,14 @@ export function getLatestVersion(): string {
     timeout: PROBE_TIMEOUT_MS,
   });
   return result.trim();
+}
+
+// Returns true only when `candidate` is a strictly newer semver than
+// `current`. Unparseable versions never report as newer, so a local
+// prerelease build with a non-semver tag does not trigger a downgrade prompt.
+export function isNewerVersion(candidate: string, current: string): boolean {
+  if (!semver.valid(candidate) || !semver.valid(current)) return false;
+  return semver.gt(candidate, current);
 }
 
 export function isSkillsCliAvailable(): boolean {

--- a/packages/mcp/test/cli/utils.test.ts
+++ b/packages/mcp/test/cli/utils.test.ts
@@ -40,6 +40,7 @@ import {
   globalInstallCommand,
   globalUninstallCommand,
   formatShellCommand,
+  isNewerVersion,
   isOnline,
   isSkillsCliAvailable,
   resolveProjectRoot,
@@ -299,6 +300,41 @@ describe("bundled paths", () => {
 
   it("AGENTS_DIR is a string ending with agents", () => {
     expect(AGENTS_DIR).toMatch(/agents$/);
+  });
+});
+
+// ── isNewerVersion ───────────────────────────────────────────────────────────
+
+describe("isNewerVersion", () => {
+  it("returns true when candidate is a higher patch", () => {
+    expect(isNewerVersion("0.5.3", "0.5.2")).toBe(true);
+  });
+
+  it("returns true when candidate is a higher minor", () => {
+    expect(isNewerVersion("0.6.0", "0.5.9")).toBe(true);
+  });
+
+  it("returns true when candidate is a higher major", () => {
+    expect(isNewerVersion("1.0.0", "0.9.9")).toBe(true);
+  });
+
+  it("returns false when versions are equal", () => {
+    expect(isNewerVersion("0.5.3", "0.5.3")).toBe(false);
+  });
+
+  it("returns false when candidate is older — the bug fix", () => {
+    // Before the fix init.ts used `latest !== version`, which prompted a
+    // "downgrade" when running a local prerelease newer than npm's latest.
+    expect(isNewerVersion("0.5.2", "0.5.3")).toBe(false);
+  });
+
+  it("treats a prerelease as older than the matching release", () => {
+    expect(isNewerVersion("0.5.3-alpha.1", "0.5.3")).toBe(false);
+    expect(isNewerVersion("0.5.3", "0.5.3-alpha.1")).toBe(true);
+  });
+
+  it("still allows upgrades from a prerelease to a newer release", () => {
+    expect(isNewerVersion("0.5.4", "0.5.4-beta.0")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- `argent init` compared versions with `latest !== version`, so testing a locally-built prerelease (e.g. `0.5.3`) against the current npm `latest` (e.g. `0.5.2`) triggered an "update" prompt that would silently downgrade the CLI.
- Switch to `semver.gt` via the `semver` package, and only prompt when the remote version is strictly greater than the installed one.
- Adds `semver` / `@types/semver` as dependencies and covers the new `isNewerVersion` helper with unit tests.

## Test plan
- [x] `npx vitest run` in `packages/mcp` — 223 tests pass
- [ ] Manually run `argent init` against a locally installed prerelease — confirm no update prompt appears
- [ ] Run `argent init` with an older installed version — confirm the update prompt still works