### PR TITLE
feat: add Get Started tip to end of argent init flow

### DIFF
--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -567,8 +567,14 @@ export async function init(args: string[]): Promise<void> {
   p.note(summaryLines.join("\n"), "Summary");
 
   p.note(
-    `Ask your assistant ${pc.cyan(`"What can Argent do?"`)} — it will walk\nyou through all capabilities available.`,
-    "Get Started"
+    [
+      `${pc.bold("Ready to start?")} Ask your assistant:`,
+      "",
+      `   ${pc.bold(pc.cyan(`"What can Argent do?"`))}`,
+      "",
+      pc.dim("It will walk you through all capabilities available."),
+    ].join("\n"),
+    pc.bold(pc.cyan("Get Started"))
   );
 
   p.outro(pc.green("Argent is ready!"));

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -568,16 +568,16 @@ export async function init(args: string[]): Promise<void> {
 
   p.note(
     [
-      `${pc.bold("Ready to start?")} Ask your assistant:`,
+      pc.bold(pc.green("Argent is ready!")),
+      "",
+      `${pc.bold("Get started")} by asking your assistant:`,
       "",
       `   ${pc.bold(pc.cyan(`"What can Argent do?"`))}`,
       "",
       pc.dim("It will walk you through all capabilities available."),
     ].join("\n"),
-    pc.bold(pc.cyan("Get Started"))
+    pc.bgGreen(pc.black(" Get Started "))
   );
-
-  p.outro(pc.green("Argent is ready!"));
 }
 
 export function printBanner(): void {

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -578,7 +578,7 @@ export async function init(args: string[]): Promise<void> {
     ].join("\n"),
     pc.bgGreen(pc.black(" Get Started "))
   );
-  p.outro("");
+  p.outro("Done.");
 }
 
 export function printBanner(): void {

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -566,17 +566,19 @@ export async function init(args: string[]): Promise<void> {
 
   p.note(summaryLines.join("\n"), "Summary");
 
-  p.outro(
+  p.note(
     [
-      pc.bgGreen(pc.black(" Argent is ready! ")),
+      pc.bold(pc.green("Argent is ready!")),
       "",
       `${pc.bold("Get started")} by asking your assistant:`,
       "",
       `   ${pc.bold(pc.cyan(`"What can Argent do?"`))}`,
       "",
       pc.dim("It will walk you through all capabilities available."),
-    ].join("\n")
+    ].join("\n"),
+    pc.bgGreen(pc.black(" Get Started "))
   );
+  p.outro("");
 }
 
 export function printBanner(): void {

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -565,6 +565,12 @@ export async function init(args: string[]): Promise<void> {
   ];
 
   p.note(summaryLines.join("\n"), "Summary");
+
+  p.note(
+    `Ask your assistant ${pc.cyan(`"What can Argent do?"`)} — it will walk\nyou through all capabilities available.`,
+    "Get Started"
+  );
+
   p.outro(pc.green("Argent is ready!"));
 }
 

--- a/packages/mcp/src/cli/init.ts
+++ b/packages/mcp/src/cli/init.ts
@@ -566,17 +566,16 @@ export async function init(args: string[]): Promise<void> {
 
   p.note(summaryLines.join("\n"), "Summary");
 
-  p.note(
+  p.outro(
     [
-      pc.bold(pc.green("Argent is ready!")),
+      pc.bgGreen(pc.black(" Argent is ready! ")),
       "",
       `${pc.bold("Get started")} by asking your assistant:`,
       "",
       `   ${pc.bold(pc.cyan(`"What can Argent do?"`))}`,
       "",
       pc.dim("It will walk you through all capabilities available."),
-    ].join("\n"),
-    pc.bgGreen(pc.black(" Get Started "))
+    ].join("\n")
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds a final "Get Started" note to `argent init` pointing users to ask their assistant _"What can Argent do?"_ — the same tip already present in the README.
- Motivated by user feedback ("I opened the docs, installed it. Now what am I supposed to do?"): the init flow previously ended with a summary and "Argent is ready!" but did not hint at how to actually start using it.

## Test plan
- [x] `npx tsc --noEmit` passes in `packages/mcp`
- [x] `npx vitest run test/cli/init.test.ts` passes
- [ ] Manually run `argent init` and confirm the new "Get Started" note renders correctly before the outro