### PR TITLE
feat(tool-server): prefix stdout/stderr lines with ISO timestamp

### DIFF
--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -8,6 +8,12 @@ import { startUpdateChecker } from "./utils/update-checker";
 const PROCESS_TIMEOUT_MS = 5_000;
 
 export function start(): void {
+  for (const stream of [process.stdout, process.stderr] as const) {
+    const orig = stream.write.bind(stream);
+    stream.write = ((chunk: string | Uint8Array, ...rest: unknown[]) =>
+      orig(`[${new Date().toISOString()}] ${chunk}`, ...(rest as []))) as typeof stream.write;
+  }
+
   // ── Global error handlers ─────────────────────────────────────────
   // The tool server should exit on uncaught errors (state may be corrupted),
   // but attempt graceful cleanup first so child processes are not orphaned.

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -7,12 +7,30 @@ import { startUpdateChecker } from "./utils/update-checker";
 
 const PROCESS_TIMEOUT_MS = 5_000;
 
-export function start(): void {
+/**
+ * Prepends an ISO timestamp to every line written to stdout/stderr.
+ *
+ * We replace `stream.write` rather than wrapping `console.*` because the MCP
+ * transport and other internal paths bypass `console` and call `process.stdout`
+ * / `process.stderr` directly.
+ *
+ * The override is safe: we call the original bound `write` with the modified
+ * chunk and forward all remaining arguments unchanged.
+ *
+ * Set WRAP_STDIO_DISABLED=1 in the environment to opt out (diagnosis mainly)
+ */
+function initializeStdioTimestampWrapper(): void {
+  if (process.env.WRAP_STDIO_DISABLED) return;
+
   for (const stream of [process.stdout, process.stderr] as const) {
     const orig = stream.write.bind(stream);
     stream.write = ((chunk: string | Uint8Array, ...rest: unknown[]) =>
       orig(`[${new Date().toISOString()}] ${chunk}`, ...(rest as []))) as typeof stream.write;
   }
+}
+
+export function start(): void {
+  initializeStdioTimestampWrapper();
 
   // ── Global error handlers ─────────────────────────────────────────
   // The tool server should exit on uncaught errors (state may be corrupted),


### PR DESCRIPTION
Adds timestamp to every `tool-server.log` line.

`mcp-calls.log` already has timestamps, so no changes.

The tz is UTC+0 because that's what we already use for the `mcp-calls.log`

Works:

<img width="1074" height="599" alt="image" src="https://github.com/user-attachments/assets/db7094f3-8957-4f37-8643-9b2e7c449a1e" />
