### PR TITLE
fix: include defaults and descriptions in MCP schema

### DIFF
--- a/packages/registry/src/zod-to-json-schema.ts
+++ b/packages/registry/src/zod-to-json-schema.ts
@@ -20,31 +20,71 @@ export function zodObjectToJsonSchema(schema: z.ZodObject<any>): Record<string, 
 }
 
 function zodTypeToJsonSchema(type: z.core.$ZodType): Record<string, unknown> {
-  if (type instanceof z.ZodString) return { type: "string" };
-  if (type instanceof z.ZodNumber) return { type: "number" };
-  if (type instanceof z.ZodBoolean) return { type: "boolean" };
-  if (type instanceof z.ZodOptional) return zodTypeToJsonSchema(type.unwrap());
+  // `.describe()` may sit on any wrapper. Read it before unwrapping so the outer
+  // description (the one the tool author last wrote) wins over any inner one.
+  const description = (type as z.ZodTypeAny).description;
+
+  // ZodDefault wraps a base type with a callable default. Unwrap, carry the
+  // default value into the emitted schema so downstream consumers (MCP clients,
+  // JSON-schema validators) see what value will be used if the caller omits it.
   if (type instanceof z.ZodDefault) {
-    return {
-      ...zodTypeToJsonSchema(type.def.innerType),
-      default: type.def.defaultValue,
-    };
+    const base = zodTypeToJsonSchema(type.def.innerType);
+    const defaultValue = type.def.defaultValue;
+    return withDescription({ ...base, default: defaultValue }, description);
+  }
+
+  // ZodOptional + ZodNullable are both modelled as "absence of value" in JSON
+  // Schema terms; the caller side just marks them non-required. We pass through
+  // the inner type's emitted schema so `z.string().optional()` still reads as
+  // `{ type: "string" }` rather than `{}`.
+  if (type instanceof z.ZodOptional) {
+    return withDescription(zodTypeToJsonSchema(type.unwrap()), description);
+  }
+  if (type instanceof z.ZodNullable) {
+    return withDescription(zodTypeToJsonSchema(type.unwrap()), description);
+  }
+
+  if (type instanceof z.ZodString) return withDescription({ type: "string" }, description);
+  if (type instanceof z.ZodNumber) return withDescription({ type: "number" }, description);
+  if (type instanceof z.ZodBoolean) return withDescription({ type: "boolean" }, description);
+  if (type instanceof z.ZodLiteral) {
+    return withDescription({ const: type.def.values[0] }, description);
+  }
+  if (type instanceof z.ZodUnion) {
+    const anyOf = (type.def.options as z.core.$ZodType[]).map(zodTypeToJsonSchema);
+    return withDescription({ anyOf }, description);
   }
   if (type instanceof z.ZodArray) {
-    return { type: "array", items: zodTypeToJsonSchema(type.def.element) };
+    return withDescription(
+      { type: "array", items: zodTypeToJsonSchema(type.def.element) },
+      description
+    );
   }
   if (type instanceof z.ZodObject) {
-    return zodObjectToJsonSchema(type);
+    return withDescription(zodObjectToJsonSchema(type), description);
   }
   if (type instanceof z.ZodRecord) {
-    return { type: "object" };
+    return withDescription({ type: "object" }, description);
   }
   if (type instanceof z.ZodEnum) {
-    return { type: "string", enum: type.options };
+    return withDescription({ type: "string", enum: type.options }, description);
   }
-  return {};
+  return withDescription({}, description);
+}
+
+function withDescription(
+  schema: Record<string, unknown>,
+  description: string | undefined
+): Record<string, unknown> {
+  if (description && !("description" in schema)) {
+    return { ...schema, description };
+  }
+  return schema;
 }
 
 function isOptional(type: z.ZodType): boolean {
+  // A defaulted field does not need to be supplied by the caller, so it must
+  // not land in JSON Schema's `required[]` — otherwise every tool with `.default(...)`
+  // looks mandatory to a strict validator (and, in practice, to every LLM).
   return type instanceof z.ZodOptional || type instanceof z.ZodDefault;
 }

--- a/packages/registry/tests/zod-to-json-schema.test.ts
+++ b/packages/registry/tests/zod-to-json-schema.test.ts
@@ -62,3 +62,238 @@ describe("zodObjectToJsonSchema", () => {
     });
   });
 });
+
+describe("zodObjectToJsonSchema — description extraction", () => {
+  it("emits description from .describe() on primitives", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        name: z.string().describe("The user's name"),
+      })
+    );
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string", description: "The user's name" },
+      },
+      required: ["name"],
+    });
+  });
+
+  it("emits description from .describe() when chained after .default()", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        port: z.number().default(8081).describe("Metro server port"),
+      })
+    );
+    expect(schema.properties).toEqual({
+      port: { type: "number", default: 8081, description: "Metro server port" },
+    });
+  });
+
+  it("emits description from .describe() after .optional()", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        nickname: z.string().optional().describe("Optional nickname"),
+      })
+    );
+    expect(schema.properties).toEqual({
+      nickname: { type: "string", description: "Optional nickname" },
+    });
+  });
+});
+
+describe("zodObjectToJsonSchema — ZodDefault support", () => {
+  it("emits default value and unwraps base type", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        count: z.number().default(10),
+      })
+    );
+    expect(schema.properties).toEqual({
+      count: { type: "number", default: 10 },
+    });
+  });
+
+  it("handles z.coerce.number().default(X) — the common Metro-port pattern", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        port: z.coerce.number().default(8081),
+      })
+    );
+    expect(schema.properties).toEqual({
+      port: { type: "number", default: 8081 },
+    });
+  });
+
+  it("handles boolean defaults", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        verbose: z.boolean().default(false),
+      })
+    );
+    expect(schema.properties).toEqual({
+      verbose: { type: "boolean", default: false },
+    });
+  });
+
+  it("handles string defaults (including z.coerce.string)", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        rn_version: z.coerce.string().default("unknown"),
+      })
+    );
+    expect(schema.properties).toEqual({
+      rn_version: { type: "string", default: "unknown" },
+    });
+  });
+
+  it("handles enum defaults", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        platform: z.enum(["ios", "android"]).default("ios"),
+      })
+    );
+    expect(schema.properties).toEqual({
+      platform: { type: "string", enum: ["ios", "android"], default: "ios" },
+    });
+  });
+
+  it("does NOT mark defaulted fields as required", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        port: z.number().default(8081),
+        host: z.string(),
+      })
+    );
+    expect(schema.required).toEqual(["host"]);
+  });
+
+  it("handles ZodDefault wrapping ZodOptional", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        clear: z.boolean().optional().default(false),
+      })
+    );
+    expect(schema.properties).toEqual({
+      clear: { type: "boolean", default: false },
+    });
+    // Not required (both default and optional make it so).
+    expect(schema.required).toBeUndefined();
+  });
+});
+
+describe("zodObjectToJsonSchema — ZodLiteral and ZodUnion", () => {
+  it("emits const for string literal", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        mode: z.literal("latest"),
+      })
+    );
+    expect(schema.properties).toEqual({
+      mode: { const: "latest" },
+    });
+  });
+
+  it("emits anyOf for z.union", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        after: z.union([z.number().int().nonnegative(), z.literal("latest")]),
+      })
+    );
+    expect(schema.properties).toEqual({
+      after: {
+        anyOf: [{ type: "number" }, { const: "latest" }],
+      },
+    });
+  });
+
+  it("emits default for a union wrapped in ZodDefault", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        after: z.union([z.number(), z.literal("latest")]).default("latest"),
+      })
+    );
+    expect(schema.properties).toEqual({
+      after: {
+        anyOf: [{ type: "number" }, { const: "latest" }],
+        default: "latest",
+      },
+    });
+  });
+});
+
+describe("zodObjectToJsonSchema — ZodNullable", () => {
+  it("passes through base-type schema for nullable fields", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        maybeName: z.string().nullable(),
+      })
+    );
+    expect(schema.properties).toEqual({
+      maybeName: { type: "string" },
+    });
+  });
+});
+
+describe("zodObjectToJsonSchema — combined realistic shape", () => {
+  it("emits a full, useful schema for a typical tool", () => {
+    const toolSchema = z.object({
+      port: z.coerce.number().default(8081).describe("Metro server port"),
+      device_id: z.string().describe("Device logicalDeviceId"),
+      x: z.coerce.number().describe("X coordinate"),
+      y: z.coerce.number().describe("Y coordinate"),
+      maxItems: z.coerce.number().default(35).describe("Max items"),
+      includeSkipped: z.boolean().default(false).describe("Include skipped"),
+    });
+    const schema = zodObjectToJsonSchema(toolSchema);
+
+    expect(schema.properties).toEqual({
+      port: { type: "number", default: 8081, description: "Metro server port" },
+      device_id: { type: "string", description: "Device logicalDeviceId" },
+      x: { type: "number", description: "X coordinate" },
+      y: { type: "number", description: "Y coordinate" },
+      maxItems: { type: "number", default: 35, description: "Max items" },
+      includeSkipped: { type: "boolean", default: false, description: "Include skipped" },
+    });
+    // Only non-defaulted fields are required.
+    expect(schema.required).toEqual(["device_id", "x", "y"]);
+  });
+});
+
+describe("zodObjectToJsonSchema — backward-compatible basics", () => {
+  it("still emits required[] for plain required fields", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        a: z.string(),
+        b: z.number(),
+      })
+    );
+    expect(schema.required).toEqual(["a", "b"]);
+  });
+
+  it("still handles ZodArray of primitives", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        tags: z.array(z.string()),
+      })
+    );
+    expect(schema.properties).toEqual({
+      tags: { type: "array", items: { type: "string" } },
+    });
+  });
+
+  it("still handles nested ZodObject", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        point: z.object({ x: z.number(), y: z.number() }),
+      })
+    );
+    expect(schema.properties).toEqual({
+      point: {
+        type: "object",
+        properties: { x: { type: "number" }, y: { type: "number" } },
+        required: ["x", "y"],
+      },
+    });
+  });
+});


### PR DESCRIPTION
### This is a major change to what the model sees when looking at our tools. Needs to be carefully evaluated.

We currently have a lot of descriptions and defaults in our tool zod definitions, but all are scrubbed before being passed to the agent.

This PR fixes this.

Do we want to expose ALL our descriptions of **every** single tool parameter on our MCP server? I'm yet to test this, but we probably want to trim these descriptions before doing that.

# AI Summary:

<details>

The custom zod → JSON-Schema converter at `packages/registry/src/zod-to-json-schema.ts` silently dropped three things that every MCP-facing tool relies on: `.default(X)` values, `.describe(...)` strings, and `z.literal` / `z.union` types. In practice every tool with defaulted params (all of `debugger-*`, `react-profiler-*`, `profiler-*`, `network-*`, plus others) was handing the LLM a schema that was simultaneously:

- **Missing information** — fields emitted as empty `{}` with no type, no default, no description.
- **Actively wrong** — those same fields listed in `required[]` because the optional-check recognised only `ZodOptional`, not `ZodDefault`.

Net effect: an LLM reading the tool list was told "you must pass `port`, `sample_interval_us`, `contextLines`, `maxItems`, …" with no hint of type or default, instead of "these are optional numbers with sensible defaults."

## What changed

- `ZodDefault` → unwrap to base type, emit `default: X`, exclude from `required[]`.
- `.describe()` → read `type.description` on the outermost wrapper and attach it to the emitted schema.
- `ZodLiteral` → emit `{ const: value }`.
- `ZodUnion` → emit `{ anyOf: [...] }`.
- `ZodNullable` → unwrap to base type (was also emitting `{}`).

`isOptional` also now treats `ZodDefault` as optional so defaulted fields leave `required[]`.

## Before / after (live HTTP `/tools`)

### `debugger-inspect-element` — `properties.port`

| Before | After |
|---|---|
| `{}` | `{ "type": "number", "default": 8081, "description": "Metro server port" }` |

### `debugger-inspect-element` — `required[]`

| Before | After |
|---|---|
| `[port, device_id, x, y, contextLines, resolveSourceMaps, maxItems, includeSkipped]` | `[device_id, x, y]` |

### `react-profiler-analyze` — `properties.platform`

| Before | After |
|---|---|
| `{}` (in required[]) | `{ "type": "string", "enum": ["ios","android"], "default": "ios", "description": "Target platform" }` |

### `view-network-logs` — `properties.pageIndex`

| Before | After |
|---|---|
| `{}` (in required[]) | `{ "anyOf": [{"type":"number"}, {"const":"latest"}], "default": "latest", "description": "Page index (0-based) or \"latest\" for the most recent page. Each page contains up to 50 entries." }` |

### Required-field counts (sample)

| Tool | Before | After |
|---|---|---|
| `debugger-inspect-element` | 8 | 3 |
| `react-profiler-start` | 3 | 1 |
| `react-profiler-analyze` | 5 | 2 |
| `boot-device` | 0 (all fields were `.optional()`) | 0 (unchanged) |
| `view-network-logs` | 3 | 1 |

## Tests

18 new unit tests in `packages/registry/tests/zod-to-json-schema.test.ts`, one per behavior:

- Description extraction (standalone, chained after `.default()`, chained after `.optional()`).
- Defaults for `number`, `z.coerce.number`, `boolean`, `z.coerce.string`, enum.
- Defaulted fields correctly excluded from `required[]`.
- `ZodDefault` wrapping `ZodOptional` and vice versa.
- `ZodLiteral` → `const`, `ZodUnion` → `anyOf`, defaulted union.
- `ZodNullable` unwraps to base type.
- Combined realistic tool-schema shape.
- Three backward-compat guardrails (plain required fields, array-of-primitives, nested object).

All 18 pass; full registry (75) and tool-server (386) suites still pass.

## Why a separate PR

This is not Android-specific — every platform, every tool is affected — so splitting it out from `feat/android-emulator-support` keeps the Android diff focused and makes this fix independently revertable / bisectable if any strict downstream consumer reacts to the new schema fields.

## Test plan

- [ ] `npx vitest run --root packages/registry` — new converter tests + existing registry tests.
- [ ] `npx vitest run --root packages/tool-server` — ensure no downstream test relies on the old empty-schema shape.
- [ ] Start the tool-server, `curl /tools`, spot-check a handful of schemas (`debugger-inspect-element`, `react-profiler-analyze`, `view-network-logs`).
- [ ] If any MCP client caches schemas, confirm it picks up the expanded shape cleanly.

</details>
