### PR TITLE
feat: Add CLI capability to argent 

### DIFF
--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -3,12 +3,16 @@
  * argent CLI — globally-installed entry point.
  *
  * Usage:
- *   argent mcp          Start the MCP stdio server (used by editors)
- *   argent init         Set up argent in a workspace (MCP + skills + rules)
- *   argent install      Alias for init
- *   argent update       Check for updates, refresh configuration
- *   argent uninstall    Remove argent from a workspace
- *   argent remove       Alias for uninstall
+ *   argent mcp                    Start the MCP stdio server (used by editors)
+ *   argent init                   Set up argent in a workspace (MCP + skills + rules)
+ *   argent install                Alias for init
+ *   argent update                 Check for updates, refresh configuration
+ *   argent uninstall              Remove argent from a workspace
+ *   argent remove                 Alias for uninstall
+ *   argent tools                  List tools exposed by the tool-server
+ *   argent tools describe <name>  Show one tool's flags
+ *   argent run <tool> [flags]     Invoke a tool by name
+ *   argent server status|stop|logs   Manage the shared tool-server
  */
 
 import { PACKAGE_NAME } from "./cli/constants.js";
@@ -42,6 +46,9 @@ Commands:
   update      Check for updates and refresh configuration
   uninstall   Remove argent configuration from the workspace
   remove      Alias for uninstall
+  tools       List tools exposed by the tool-server
+  run         Invoke a tool by name (use \`argent run <tool> --help\` for flags)
+  server      Manage the shared tool-server (status / stop / logs)
 
 Options:
   --help, -h     Show this help message
@@ -65,6 +72,12 @@ async function main(): Promise<void> {
     case "uninstall":
     case "remove":
       return (await import("./cli/uninstall.js")).uninstall(rest);
+    case "tools":
+      return (await import("./cli/tools.js")).tools(rest);
+    case "run":
+      return (await import("./cli/run.js")).run(rest);
+    case "server":
+      return (await import("./cli/server.js")).server(rest);
     case "--version":
     case "-v":
       console.log(getInstalledVersion() ?? "unknown");

--- a/packages/mcp/src/cli/flag-parser.ts
+++ b/packages/mcp/src/cli/flag-parser.ts
@@ -1,0 +1,265 @@
+// Convert a tool's JSON Schema (the input shape produced by zodObjectToJsonSchema
+// in @argent/registry) plus argv into the JSON args object the tool-server expects.
+//
+// Supported flag forms:
+//   --name value          (string / number / integer / boolean-with-value)
+//   --name=value
+//   --name                (boolean: true)
+//   --no-name             (boolean: false)
+//   --name a --name b     (array of scalars)
+//   --name-json '<json>'  (arbitrary nested object/array — escape hatch)
+//   --args '<json>'       (whole-payload escape hatch; merges with parsed flags)
+//   --args -              (read whole-payload JSON from stdin)
+//
+// Scalar field types come from JSON Schema: string, number, integer, boolean, enum.
+// Array fields: items.type must be a scalar to get a repeatable flag.
+// Object fields and arrays of objects fall through to --field-json.
+
+export interface JsonSchema {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema;
+  enum?: unknown[];
+  description?: string;
+}
+
+export interface FlagParseResult {
+  args: Record<string, unknown>;
+  positional: string[];
+  helpRequested: boolean;
+  rawArgs: string | null; // value passed to --args, if any (for stdin handling)
+}
+
+export interface FlagParseError {
+  message: string;
+}
+
+export class FlagParseException extends Error {}
+
+function isScalarType(type: string | undefined): boolean {
+  return type === "string" || type === "number" || type === "integer" || type === "boolean";
+}
+
+function coerceScalar(raw: string, type: string | undefined, field: string): unknown {
+  if (type === "number") {
+    const n = Number(raw);
+    if (Number.isNaN(n)) throw new FlagParseException(`--${field} expected a number, got "${raw}"`);
+    return n;
+  }
+  if (type === "integer") {
+    const n = Number(raw);
+    if (!Number.isInteger(n))
+      throw new FlagParseException(`--${field} expected an integer, got "${raw}"`);
+    return n;
+  }
+  if (type === "boolean") {
+    if (raw === "true" || raw === "1") return true;
+    if (raw === "false" || raw === "0") return false;
+    throw new FlagParseException(`--${field} expected true/false, got "${raw}"`);
+  }
+  // string or unknown: pass through
+  return raw;
+}
+
+function parseJsonOrThrow(raw: string, label: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new FlagParseException(
+      `${label} could not be parsed as JSON: ${err instanceof Error ? err.message : err}`
+    );
+  }
+}
+
+/**
+ * Parses argv against the given schema. Throws FlagParseException on bad input.
+ * Returned `args` contains parsed fields; the caller is responsible for merging
+ * `--args` JSON (if given) and validating required fields server-side.
+ */
+export function parseFlags(argv: string[], schema: JsonSchema | undefined): FlagParseResult {
+  const properties = schema?.properties ?? {};
+  const args: Record<string, unknown> = {};
+  const positional: string[] = [];
+  let helpRequested = false;
+  let rawArgs: string | null = null;
+
+  // Track which fields have already received a scalar value. A second value for
+  // an array field appends; a second value for a scalar field overwrites
+  // (with a warning would be nice but we keep it silent to avoid stderr noise).
+  const seenArrayFields = new Set<string>();
+
+  function takeNext(i: number, flag: string): { value: string; nextIndex: number } {
+    if (i + 1 >= argv.length) {
+      throw new FlagParseException(`--${flag} requires a value`);
+    }
+    return { value: argv[i + 1]!, nextIndex: i + 1 };
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i]!;
+
+    if (tok === "--help" || tok === "-h") {
+      helpRequested = true;
+      continue;
+    }
+
+    if (tok === "--") {
+      // Treat the rest as positional.
+      for (let j = i + 1; j < argv.length; j++) positional.push(argv[j]!);
+      break;
+    }
+
+    if (!tok.startsWith("--")) {
+      positional.push(tok);
+      continue;
+    }
+
+    // Strip leading "--" and split "--name=value" into name + inline value.
+    const eq = tok.indexOf("=");
+    let flag: string;
+    let inlineValue: string | undefined;
+    if (eq >= 0) {
+      flag = tok.slice(2, eq);
+      inlineValue = tok.slice(eq + 1);
+    } else {
+      flag = tok.slice(2);
+    }
+
+    // ── Whole-payload escape hatch ──
+    if (flag === "args") {
+      const { value, nextIndex } =
+        inlineValue !== undefined ? { value: inlineValue, nextIndex: i } : takeNext(i, "args");
+      rawArgs = value;
+      i = nextIndex;
+      continue;
+    }
+
+    // ── Per-field JSON escape hatch: --foo-json '<json>' ──
+    if (flag.endsWith("-json")) {
+      const fieldName = flag.slice(0, -"-json".length);
+      const { value, nextIndex } =
+        inlineValue !== undefined ? { value: inlineValue, nextIndex: i } : takeNext(i, flag);
+      args[fieldName] = parseJsonOrThrow(value, `--${flag}`);
+      i = nextIndex;
+      continue;
+    }
+
+    // ── --no-foo: explicit false for boolean flags ──
+    if (flag.startsWith("no-")) {
+      const fieldName = flag.slice(3);
+      const propSchema = properties[fieldName];
+      if (propSchema?.type === "boolean") {
+        if (inlineValue !== undefined) {
+          throw new FlagParseException(`--no-${fieldName} does not take a value`);
+        }
+        args[fieldName] = false;
+        continue;
+      }
+      // Not a known boolean field; fall through to be treated as a normal flag
+      // (so users can still pass an unknown --no-foo if the tool wants it).
+    }
+
+    const propSchema = properties[flag];
+
+    // ── Boolean: bare flag means true; allow --foo=true|false explicitly ──
+    if (propSchema?.type === "boolean") {
+      if (inlineValue !== undefined) {
+        args[flag] = coerceScalar(inlineValue, "boolean", flag);
+      } else {
+        // Bare boolean flag: true. Don't consume next argv to avoid surprising
+        // behavior when a positional follows.
+        args[flag] = true;
+      }
+      continue;
+    }
+
+    // ── Array: repeatable. items.type must be scalar; otherwise tell the user
+    //    to use --field-json. ──
+    if (propSchema?.type === "array") {
+      const itemType = propSchema.items?.type;
+      if (!isScalarType(itemType)) {
+        throw new FlagParseException(
+          `--${flag} is an array of objects; pass it as --${flag}-json '<json>' or --args '<json>'`
+        );
+      }
+      const { value, nextIndex } =
+        inlineValue !== undefined ? { value: inlineValue, nextIndex: i } : takeNext(i, flag);
+      const coerced = coerceScalar(value, itemType, flag);
+      if (!seenArrayFields.has(flag)) {
+        args[flag] = [coerced];
+        seenArrayFields.add(flag);
+      } else {
+        (args[flag] as unknown[]).push(coerced);
+      }
+      if (inlineValue === undefined) i = nextIndex;
+      continue;
+    }
+
+    // ── Object field: must use --field-json ──
+    if (propSchema?.type === "object") {
+      throw new FlagParseException(
+        `--${flag} is an object; pass it as --${flag}-json '<json>' or --args '<json>'`
+      );
+    }
+
+    // ── Scalar (string / number / integer / enum) or unknown field. We still
+    //    accept unknown flags so tools can evolve their schemas without
+    //    breaking the CLI; tool-server will return a 400 if invalid. ──
+    const { value, nextIndex } =
+      inlineValue !== undefined ? { value: inlineValue, nextIndex: i } : takeNext(i, flag);
+    args[flag] = coerceScalar(value, propSchema?.type, flag);
+    if (inlineValue === undefined) i = nextIndex;
+  }
+
+  return { args, positional, helpRequested, rawArgs };
+}
+
+/**
+ * Render a tool's schema as a human-readable usage block: one line per field
+ * showing flag, type, required flag, and (if present) enum values. Used by
+ * both `tools describe` and the auto-help fallback in `run --help`.
+ */
+export function formatSchemaUsage(schema: JsonSchema | undefined): string {
+  if (!schema || !schema.properties) return "  (no parameters)";
+  const required = new Set(schema.required ?? []);
+  const lines: string[] = [];
+  const entries = Object.entries(schema.properties);
+  if (entries.length === 0) return "  (no parameters)";
+
+  // Determine column width for flag names so types align.
+  let maxFlagLen = 0;
+  for (const [name, prop] of entries) {
+    const display = renderFlagName(name, prop);
+    if (display.length > maxFlagLen) maxFlagLen = display.length;
+  }
+
+  for (const [name, prop] of entries) {
+    const flag = renderFlagName(name, prop).padEnd(maxFlagLen, " ");
+    const typeLabel = renderType(prop);
+    const req = required.has(name) ? " (required)" : "";
+    const desc = prop.description ? `  ${prop.description}` : "";
+    lines.push(`  ${flag}  ${typeLabel}${req}${desc}`);
+  }
+  return lines.join("\n");
+}
+
+function renderFlagName(name: string, prop: JsonSchema): string {
+  if (prop.type === "object" || (prop.type === "array" && !isScalarType(prop.items?.type))) {
+    return `--${name}-json <json>`;
+  }
+  if (prop.type === "boolean") return `--${name}`;
+  return `--${name} <value>`;
+}
+
+function renderType(prop: JsonSchema): string {
+  if (prop.enum && Array.isArray(prop.enum)) {
+    return `enum: ${prop.enum.map((v) => JSON.stringify(v)).join(" | ")}`;
+  }
+  if (prop.type === "array") {
+    const item = prop.items?.type ?? "any";
+    const suffix = isScalarType(prop.items?.type) ? " (repeatable)" : "";
+    return `array<${item}>${suffix}`;
+  }
+  return prop.type ?? "any";
+}

--- a/packages/mcp/src/cli/run.ts
+++ b/packages/mcp/src/cli/run.ts
@@ -1,0 +1,205 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fetchTool, callTool, type ToolMeta } from "./tools-client.js";
+import {
+  parseFlags,
+  formatSchemaUsage,
+  FlagParseException,
+  type JsonSchema,
+} from "./flag-parser.js";
+
+interface RunOptions {
+  json: boolean;
+  outPath: string | null;
+  argvForFlags: string[];
+}
+
+function splitOptions(argv: string[]): RunOptions {
+  // Pull out CLI-only options (--json, --out) before passing the rest to the
+  // schema-driven flag parser. We do this here so they don't get mistaken for
+  // tool fields when a tool happens to have a "json" or "out" property.
+  let json = false;
+  let outPath: string | null = null;
+  const rest: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i]!;
+    if (tok === "--json") {
+      json = true;
+      continue;
+    }
+    if (tok === "--out") {
+      const v = argv[i + 1];
+      if (!v) throw new FlagParseException("--out requires a path");
+      outPath = v;
+      i += 1;
+      continue;
+    }
+    if (tok.startsWith("--out=")) {
+      outPath = tok.slice("--out=".length);
+      continue;
+    }
+    rest.push(tok);
+  }
+
+  return { json, outPath, argvForFlags: rest };
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+function printToolHelp(meta: ToolMeta): void {
+  const description = meta.description?.trim() ?? "";
+  console.log(`argent run ${meta.name} [flags]`);
+  if (description) console.log(`\n${description}\n`);
+  console.log("Flags:");
+  console.log(formatSchemaUsage(meta.inputSchema as JsonSchema));
+  console.log("\nGlobal flags:");
+  console.log("  --args <json>          Pass the entire payload as JSON (overrides flags)");
+  console.log("  --args -               Read the entire payload as JSON from stdin");
+  console.log("  --<field>-json <json>  Pass a single field as JSON (objects/nested arrays)");
+  console.log("  --json                 Print the raw JSON result");
+  console.log("  --out <path>           For image results, save to <path> instead of fetching URL");
+  console.log("  --help, -h             Show this help");
+}
+
+async function fetchImageToFile(
+  result: { url?: string; path?: string },
+  outPath: string
+): Promise<void> {
+  const url = result.url;
+  if (!url) {
+    throw new Error("Tool result did not include a `url`; cannot save image");
+  }
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to download image: ${res.status} ${res.statusText}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  fs.mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true });
+  fs.writeFileSync(outPath, buf);
+}
+
+function renderResult(result: unknown, outputHint: string | undefined, json: boolean): string {
+  if (json) return JSON.stringify(result, null, 2);
+
+  if (
+    outputHint === "image" &&
+    result &&
+    typeof result === "object" &&
+    "path" in result &&
+    typeof (result as { path: unknown }).path === "string"
+  ) {
+    const r = result as { path: string; url?: string };
+    return `Saved screenshot: ${r.path}`;
+  }
+
+  if (typeof result === "string") return result;
+  return JSON.stringify(result, null, 2);
+}
+
+export async function run(argv: string[]): Promise<void> {
+  const [toolName, ...rest] = argv;
+
+  if (!toolName || toolName === "--help" || toolName === "-h") {
+    console.log(`Usage: argent run <tool> [flags]
+
+Invoke a tool exposed by the argent tool-server. Run \`argent tools\` to list
+available tools, or \`argent tools describe <name>\` to see one tool's flags.
+
+Examples:
+  argent run list-simulators
+  argent run gesture-tap --udid <UDID> --x 0.5 --y 0.5
+  argent run screenshot --udid <UDID> --out ./screen.png
+  argent run run-sequence --udid <UDID> --steps-json '[{"tool":"button","args":{"button":"home"}}]'
+  argent run gesture-tap --args '{"udid":"<UDID>","x":0.5,"y":0.5}'
+`);
+    return;
+  }
+
+  const { json, outPath, argvForFlags } = splitOptions(rest);
+
+  const meta = await fetchTool(toolName);
+  if (!meta) {
+    console.error(`Tool "${toolName}" not found. Run \`argent tools\` to list available tools.`);
+    process.exit(1);
+  }
+
+  let parsed;
+  try {
+    parsed = parseFlags(argvForFlags, meta.inputSchema as JsonSchema);
+  } catch (err) {
+    if (err instanceof FlagParseException) {
+      console.error(`Error: ${err.message}\n`);
+      printToolHelp(meta);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  if (parsed.helpRequested) {
+    printToolHelp(meta);
+    return;
+  }
+
+  // Build the final args payload. Precedence: --args JSON, then per-flag values
+  // merged on top so users can mix `--args '{...}' --x 0.5` to override one
+  // field. (Last write wins; flags override --args.)
+  let payload: Record<string, unknown> = {};
+  if (parsed.rawArgs !== null) {
+    let rawJson = parsed.rawArgs;
+    if (rawJson === "-") {
+      rawJson = await readStdin();
+    }
+    try {
+      const parsedRaw = JSON.parse(rawJson);
+      if (parsedRaw === null || typeof parsedRaw !== "object" || Array.isArray(parsedRaw)) {
+        console.error("--args must be a JSON object");
+        process.exit(2);
+      }
+      payload = parsedRaw as Record<string, unknown>;
+    } catch (err) {
+      console.error(`--args is not valid JSON: ${err instanceof Error ? err.message : err}`);
+      process.exit(2);
+    }
+  }
+  for (const [k, v] of Object.entries(parsed.args)) {
+    payload[k] = v;
+  }
+
+  let result: unknown;
+  let note: string | undefined;
+  try {
+    const resp = await callTool(toolName, payload);
+    result = resp.data;
+    note = resp.note;
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  // Image side-effect: save before rendering so --out works in non-JSON mode
+  // and --json mode still prints the structured result.
+  if (outPath && meta.outputHint === "image" && result && typeof result === "object") {
+    try {
+      await fetchImageToFile(result as { url?: string; path?: string }, outPath);
+    } catch (err) {
+      console.error(`Failed to save image: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  }
+
+  if (note) console.error(note);
+  console.log(renderResult(result, meta.outputHint, json));
+
+  if (outPath && meta.outputHint === "image" && !json) {
+    console.log(`Wrote: ${outPath}`);
+  }
+}

--- a/packages/mcp/src/cli/server.ts
+++ b/packages/mcp/src/cli/server.ts
@@ -1,0 +1,128 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { homedir } from "node:os";
+import { spawn } from "node:child_process";
+import { killToolServer } from "../launcher.js";
+
+const STATE_DIR = path.join(homedir(), ".argent");
+const STATE_FILE = path.join(STATE_DIR, "tool-server.json");
+const LOG_FILE = path.join(STATE_DIR, "tool-server.log");
+
+interface ToolsServerState {
+  port: number;
+  pid: number;
+  startedAt: string;
+  bundlePath: string;
+}
+
+function readState(): ToolsServerState | null {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf8")) as ToolsServerState;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isHealthy(port: number, timeoutMs = 2000): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/tools`, { signal: controller.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function statusCmd(json: boolean): Promise<void> {
+  const state = readState();
+  if (!state) {
+    if (json) {
+      console.log(JSON.stringify({ running: false }, null, 2));
+    } else {
+      console.log("tool-server: not running (no state file)");
+    }
+    return;
+  }
+  const alive = isProcessAlive(state.pid);
+  const healthy = alive ? await isHealthy(state.port) : false;
+  if (json) {
+    console.log(JSON.stringify({ running: alive && healthy, ...state, alive, healthy }, null, 2));
+    return;
+  }
+  console.log(`tool-server:`);
+  console.log(`  url:        http://127.0.0.1:${state.port}`);
+  console.log(`  pid:        ${state.pid}`);
+  console.log(`  startedAt:  ${state.startedAt}`);
+  console.log(`  process:    ${alive ? "alive" : "dead"}`);
+  console.log(`  health:     ${healthy ? "ok" : "unreachable"}`);
+  if (!alive || !healthy) {
+    console.log(`\nState file is stale; next \`argent\` invocation will respawn the server.`);
+  }
+}
+
+async function stopCmd(): Promise<void> {
+  const state = readState();
+  if (!state) {
+    console.log("tool-server: not running");
+    return;
+  }
+  await killToolServer();
+  console.log(`tool-server stopped (pid ${state.pid}).`);
+}
+
+function logsCmd(follow: boolean): void {
+  if (!fs.existsSync(LOG_FILE)) {
+    console.log(`No log file at ${LOG_FILE}`);
+    return;
+  }
+  if (!follow) {
+    process.stdout.write(fs.readFileSync(LOG_FILE, "utf8"));
+    return;
+  }
+  // -f: tail -f equivalent. Spawning `tail` keeps this small and behaves the
+  // same as the user's terminal expects (Ctrl-C to exit).
+  const child = spawn("tail", ["-f", LOG_FILE], { stdio: "inherit" });
+  child.on("exit", (code) => process.exit(code ?? 0));
+}
+
+export async function server(argv: string[]): Promise<void> {
+  const sub = argv[0];
+  const json = argv.includes("--json");
+  const follow = argv.includes("-f") || argv.includes("--follow");
+
+  if (!sub || sub === "--help" || sub === "-h") {
+    console.log(`Usage:
+  argent server status [--json]   Show tool-server pid, port, and health
+  argent server stop              Terminate the running tool-server
+  argent server logs [-f]         Print (or follow) the tool-server log
+`);
+    return;
+  }
+
+  switch (sub) {
+    case "status":
+      await statusCmd(json);
+      return;
+    case "stop":
+      await stopCmd();
+      return;
+    case "logs":
+      logsCmd(follow);
+      return;
+    default:
+      console.error(`Unknown subcommand: server ${sub}`);
+      process.exit(1);
+  }
+}

--- a/packages/mcp/src/cli/tools-client.ts
+++ b/packages/mcp/src/cli/tools-client.ts
@@ -1,0 +1,56 @@
+import { ensureToolsServer } from "../launcher.js";
+
+export interface ToolMeta {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  outputHint?: string;
+  alwaysLoad?: boolean;
+  searchHint?: string;
+}
+
+export interface ToolInvocationResult {
+  data: unknown;
+  note?: string;
+}
+
+let cachedBaseUrl: string | null = null;
+
+async function baseUrl(): Promise<string> {
+  if (process.env.ARGENT_TOOLS_URL) return process.env.ARGENT_TOOLS_URL;
+  if (cachedBaseUrl) return cachedBaseUrl;
+  cachedBaseUrl = await ensureToolsServer();
+  return cachedBaseUrl;
+}
+
+export async function fetchTools(): Promise<ToolMeta[]> {
+  const url = await baseUrl();
+  const res = await fetch(`${url}/tools`);
+  if (!res.ok) throw new Error(`GET /tools failed: ${res.status} ${res.statusText}`);
+  const json = (await res.json()) as { tools: ToolMeta[] };
+  return json.tools;
+}
+
+export async function fetchTool(name: string): Promise<ToolMeta | null> {
+  const tools = await fetchTools();
+  return tools.find((t) => t.name === name) ?? null;
+}
+
+export async function callTool(name: string, args: unknown): Promise<ToolInvocationResult> {
+  const url = await baseUrl();
+  const res = await fetch(`${url}/tools/${encodeURIComponent(name)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args ?? {}),
+  });
+  const json = (await res.json().catch(() => ({}))) as {
+    data?: unknown;
+    error?: string;
+    message?: string;
+    note?: string;
+  };
+  if (!res.ok) {
+    throw new Error(json.error ?? json.message ?? `${res.status} ${res.statusText}`);
+  }
+  return { data: json.data, note: json.note };
+}

--- a/packages/mcp/src/cli/tools.ts
+++ b/packages/mcp/src/cli/tools.ts
@@ -1,0 +1,82 @@
+import { fetchTool, fetchTools } from "./tools-client.js";
+import { formatSchemaUsage, type JsonSchema } from "./flag-parser.js";
+
+function summarize(description: string | undefined, max = 80): string {
+  if (!description) return "";
+  const firstLine = description.split("\n", 1)[0]!.trim();
+  if (firstLine.length <= max) return firstLine;
+  return firstLine.slice(0, max - 1).trimEnd() + "…";
+}
+
+async function listTools(json: boolean): Promise<void> {
+  const tools = await fetchTools();
+  if (json) {
+    console.log(JSON.stringify(tools, null, 2));
+    return;
+  }
+
+  if (tools.length === 0) {
+    console.log("(no tools registered)");
+    return;
+  }
+
+  const sorted = [...tools].sort((a, b) => a.name.localeCompare(b.name));
+  const maxName = sorted.reduce((m, t) => Math.max(m, t.name.length), 0);
+  for (const t of sorted) {
+    const summary = summarize(t.description);
+    console.log(`  ${t.name.padEnd(maxName, " ")}  ${summary}`);
+  }
+  console.log(`\n${sorted.length} tools. Run \`argent tools describe <name>\` for details.`);
+}
+
+async function describeTool(name: string, json: boolean): Promise<void> {
+  const meta = await fetchTool(name);
+  if (!meta) {
+    console.error(`Tool "${name}" not found. Run \`argent tools\` to list available tools.`);
+    process.exit(1);
+  }
+  if (json) {
+    console.log(JSON.stringify(meta, null, 2));
+    return;
+  }
+  console.log(`Tool: ${meta.name}\n`);
+  if (meta.description) console.log(`${meta.description.trim()}\n`);
+  console.log("Flags:");
+  console.log(formatSchemaUsage(meta.inputSchema as JsonSchema));
+  if (meta.outputHint) console.log(`\nOutput hint: ${meta.outputHint}`);
+}
+
+export async function tools(argv: string[]): Promise<void> {
+  const json = argv.includes("--json");
+  const positional = argv.filter((a) => !a.startsWith("--"));
+  const sub = positional[0];
+
+  if (!sub) {
+    await listTools(json);
+    return;
+  }
+
+  if (sub === "describe") {
+    const name = positional[1];
+    if (!name) {
+      console.error("Usage: argent tools describe <tool-name>");
+      process.exit(1);
+    }
+    await describeTool(name, json);
+    return;
+  }
+
+  if (sub === "--help" || sub === "-h") {
+    console.log(`Usage:
+  argent tools                       List available tools
+  argent tools describe <name>       Show one tool's flags and description
+
+Options:
+  --json                             Print machine-readable JSON
+`);
+    return;
+  }
+
+  console.error(`Unknown subcommand: tools ${sub}`);
+  process.exit(1);
+}


### PR DESCRIPTION
This PR adds a thin cli layer to argent by introducing 3 new commands: 

1) `server` allows for checking the tools-server status 
2) `tools` allows for tools discovery 
3) `run` allows for running tools straight from the shell 

This is a baseline functionality needed for testing hypothesis that CLI with skills is more efficient then mcp and allow should allow easier integration with potential cloud infrastructure 