### PR TITLE
fix: redbox on `debugger-evaluate`

### DIFF
--- a/packages/tool-server/src/utils/debugger/scripts/disable-logbox.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/disable-logbox.ts
@@ -1,11 +1,17 @@
 /**
  * IIFE that scans the Metro module registry for the LogBox module
  * and calls `ignoreAllLogs(true)` to suppress the yellow/red overlay,
- * monkey-patches `LogBoxData.addException` to drop uncaught exceptions
- * (the redbox path used by `TurboModuleRegistry.getEnforcing(...)` and
- * other top-level module-load throws — `ignoreAllLogs` only flips an
+ * wraps `LogBoxData.addException` so it short-circuits while LogBox is
+ * disabled (the redbox path used by `TurboModuleRegistry.getEnforcing(...)`
+ * and other top-level module-load throws — `ignoreAllLogs` only flips an
  * observer flag and does not block `addException`), then clears any
  * already-queued LogBox entries.
+ *
+ * The wrapper consults `LBData.isDisabled()` on each call so a later
+ * `LB.ignoreAllLogs(false)` restores fatal-redbox visibility — important
+ * for devs who disconnect the debugger and keep developing. When
+ * `isDisabled` is unavailable, the wrapper defaults to no-op (matching
+ * the prior behavior on RN versions without that API).
  *
  * Uses `__r.getModules()` (available in DEV) to iterate only
  * already-initialized modules, avoiding forced evaluation of unloaded
@@ -70,8 +76,14 @@ export const DISABLE_LOGBOX_SCRIPT = `(function() {
     LB.ignoreAllLogs(true);
   }
   if (LBData) {
-    if (typeof LBData.addException === 'function') {
-      LBData.addException = function() {};
+    if (typeof LBData.addException === 'function' && !LBData.__argentAddExceptionWrapped) {
+      var origAddException = LBData.addException;
+      LBData.addException = function() {
+        var disabled = typeof LBData.isDisabled === 'function' ? LBData.isDisabled() : true;
+        if (disabled) return;
+        return origAddException.apply(LBData, arguments);
+      };
+      LBData.__argentAddExceptionWrapped = true;
     }
     LBData.clear();
   }

--- a/packages/tool-server/src/utils/debugger/scripts/disable-logbox.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/disable-logbox.ts
@@ -1,13 +1,16 @@
 /**
  * IIFE that scans the Metro module registry for the LogBox module
  * and calls `ignoreAllLogs(true)` to suppress the yellow/red overlay,
- * then clears any already-queued LogBox entries (e.g. SegmentFetcher).
+ * monkey-patches `LogBoxData.addException` to drop uncaught exceptions
+ * (the redbox path used by `TurboModuleRegistry.getEnforcing(...)` and
+ * other top-level module-load throws — `ignoreAllLogs` only flips an
+ * observer flag and does not block `addException`), then clears any
+ * already-queued LogBox entries.
  *
  * Uses `__r.getModules()` (available in DEV) to iterate only
  * already-initialized modules, avoiding forced evaluation of unloaded
  * modules. This prevents Metro's `guardedLoadModule` from reporting
- * errors to LogBox when a module's top-level code throws (e.g.
- * `TurboModuleRegistry.getEnforcing('SegmentFetcher')` in Expo builds).
+ * errors to LogBox when a module's top-level code throws.
  *
  * Falls back to the ErrorUtils-suppression approach when `getModules`
  * is unavailable: temporarily nulls `global.ErrorUtils` so that any
@@ -67,6 +70,9 @@ export const DISABLE_LOGBOX_SCRIPT = `(function() {
     LB.ignoreAllLogs(true);
   }
   if (LBData) {
+    if (typeof LBData.addException === 'function') {
+      LBData.addException = function() {};
+    }
     LBData.clear();
   }
 })()`;

--- a/packages/tool-server/src/utils/debugger/scripts/disable-logbox.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/disable-logbox.ts
@@ -1,29 +1,12 @@
 /**
- * IIFE that scans the Metro module registry for the LogBox module
- * and calls `ignoreAllLogs(true)` to suppress the yellow/red overlay,
- * wraps `LogBoxData.addException` so it short-circuits while LogBox is
- * disabled (the redbox path used by `TurboModuleRegistry.getEnforcing(...)`
- * and other top-level module-load throws — `ignoreAllLogs` only flips an
- * observer flag and does not block `addException`), then clears any
- * already-queued LogBox entries.
+ * Suppress LogBox while the debugger is connected:
+ *  - ignoreAllLogs(true): hide warnings.
+ *  - wrap addException: ignoreAllLogs alone doesn't block fatal redboxes;
+ *    wrapping (rather than replacing) lets ignoreAllLogs(false) re-enable them.
+ *  - clear(): empty already-queued entries.
  *
- * The wrapper consults `LBData.isDisabled()` on each call so a later
- * `LB.ignoreAllLogs(false)` restores fatal-redbox visibility — important
- * for devs who disconnect the debugger and keep developing. When
- * `isDisabled` is unavailable, the wrapper defaults to no-op (matching
- * the prior behavior on RN versions without that API).
- *
- * Uses `__r.getModules()` (available in DEV) to iterate only
- * already-initialized modules, avoiding forced evaluation of unloaded
- * modules. This prevents Metro's `guardedLoadModule` from reporting
- * errors to LogBox when a module's top-level code throws.
- *
- * Falls back to the ErrorUtils-suppression approach when `getModules`
- * is unavailable: temporarily nulls `global.ErrorUtils` so that any
- * errors thrown during `__r(i)` scanning are caught by our try-catch
- * instead of being routed to LogBox via `ErrorUtils.reportFatalError`.
- *
- * Safe to call at any time — exits early when __r is unavailable.
+ * Walks only already-initialized modules (__r.getModules) so we don't
+ * force-load modules that throw on init.
  */
 export const DISABLE_LOGBOX_SCRIPT = `(function() {
   if (typeof __r !== 'function') return;

--- a/packages/tool-server/test/disable-logbox.test.ts
+++ b/packages/tool-server/test/disable-logbox.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import vm from "node:vm";
+import { DISABLE_LOGBOX_SCRIPT } from "../src/utils/debugger/scripts/disable-logbox";
+
+/**
+ * The script runs inside the React Native JS runtime via CDP `Runtime.evaluate`.
+ * We exercise it in a Node `vm` sandbox with a hand-rolled Metro module registry
+ * (`__r`) so we can assert the actual fix for issue #160: `LogBoxData.addException`
+ * is monkey-patched so future redbox exceptions (e.g. from
+ * `TurboModuleRegistry.getEnforcing('SegmentFetcher')`) are dropped.
+ */
+
+interface MockModuleMeta {
+  isInitialized: boolean;
+  factory: () => unknown;
+  exports?: unknown;
+}
+
+function makeRequire(modules: Map<number, MockModuleMeta>) {
+  function __r(id: number) {
+    const meta = modules.get(id);
+    if (!meta) throw new Error(`unknown module ${id}`);
+    if (!meta.isInitialized) {
+      meta.isInitialized = true;
+      meta.exports = meta.factory();
+    }
+    return meta.exports;
+  }
+  __r.getModules = () =>
+    Array.from(modules.entries()).map(
+      ([id, meta]) => [id, meta] as [number, MockModuleMeta]
+    );
+  return __r;
+}
+
+function makeLogBoxData() {
+  const calls = { addException: 0, addLog: 0, clear: 0 };
+  const data = {
+    _isDisabled: false,
+    addLog() {
+      calls.addLog++;
+    },
+    addException() {
+      calls.addException++;
+    },
+    clear() {
+      calls.clear++;
+    },
+    isMessageIgnored() {
+      return false;
+    },
+    setDisabled(v: boolean) {
+      data._isDisabled = v;
+    },
+  };
+  return { data, calls };
+}
+
+function makeLogBox(lbData: ReturnType<typeof makeLogBoxData>["data"]) {
+  return {
+    ignoreAllLogs(value?: boolean) {
+      lbData.setDisabled(value !== false);
+    },
+  };
+}
+
+describe("DISABLE_LOGBOX_SCRIPT", () => {
+  it("patches addException so future redbox exceptions are dropped (the #160 fix)", () => {
+    const { data: lbData, calls } = makeLogBoxData();
+    const lb = makeLogBox(lbData);
+
+    const modules = new Map<number, MockModuleMeta>([
+      [1, {
+        isInitialized: true,
+        factory: () => ({ default: lb }),
+        exports: { default: lb },
+      }],
+      [2, {
+        isInitialized: true,
+        factory: () => lbData,
+        exports: lbData,
+      }],
+    ]);
+
+    const sandbox = vm.createContext({ __r: makeRequire(modules), global: {} });
+    vm.runInContext(DISABLE_LOGBOX_SCRIPT, sandbox);
+
+    expect(lbData._isDisabled).toBe(true);
+    expect(calls.clear).toBe(1);
+
+    lbData.addException();
+    expect(calls.addException).toBe(0);
+  });
+
+  it("exits cleanly when __r is unavailable", () => {
+    const sandbox = vm.createContext({ global: {} });
+    expect(() => vm.runInContext(DISABLE_LOGBOX_SCRIPT, sandbox)).not.toThrow();
+  });
+
+  it("falls back to the ErrorUtils-suppressing scan when getModules is missing", () => {
+    const { data: lbData, calls } = makeLogBoxData();
+
+    function __r(id: number) {
+      if (id === 0) return { default: makeLogBox(lbData) };
+      if (id === 1) return lbData;
+      throw new Error("missing");
+    }
+    const globalShim: { ErrorUtils: unknown } = { ErrorUtils: { sentinel: 1 } };
+    const sandbox = vm.createContext({ __r, global: globalShim });
+    vm.runInContext(DISABLE_LOGBOX_SCRIPT, sandbox);
+
+    expect(lbData._isDisabled).toBe(true);
+    expect(calls.clear).toBe(1);
+    lbData.addException();
+    expect(calls.addException).toBe(0);
+    expect(globalShim.ErrorUtils).toEqual({ sentinel: 1 });
+  });
+});

--- a/packages/tool-server/test/disable-logbox.test.ts
+++ b/packages/tool-server/test/disable-logbox.test.ts
@@ -27,9 +27,7 @@ function makeRequire(modules: Map<number, MockModuleMeta>) {
     return meta.exports;
   }
   __r.getModules = () =>
-    Array.from(modules.entries()).map(
-      ([id, meta]) => [id, meta] as [number, MockModuleMeta]
-    );
+    Array.from(modules.entries()).map(([id, meta]) => [id, meta] as [number, MockModuleMeta]);
   return __r;
 }
 
@@ -70,16 +68,22 @@ describe("DISABLE_LOGBOX_SCRIPT", () => {
     const lb = makeLogBox(lbData);
 
     const modules = new Map<number, MockModuleMeta>([
-      [1, {
-        isInitialized: true,
-        factory: () => ({ default: lb }),
-        exports: { default: lb },
-      }],
-      [2, {
-        isInitialized: true,
-        factory: () => lbData,
-        exports: lbData,
-      }],
+      [
+        1,
+        {
+          isInitialized: true,
+          factory: () => ({ default: lb }),
+          exports: { default: lb },
+        },
+      ],
+      [
+        2,
+        {
+          isInitialized: true,
+          factory: () => lbData,
+          exports: lbData,
+        },
+      ],
     ]);
 
     const sandbox = vm.createContext({ __r: makeRequire(modules), global: {} });

--- a/packages/tool-server/test/disable-logbox.test.ts
+++ b/packages/tool-server/test/disable-logbox.test.ts
@@ -47,6 +47,9 @@ function makeLogBoxData() {
     isMessageIgnored() {
       return false;
     },
+    isDisabled() {
+      return data._isDisabled;
+    },
     setDisabled(v: boolean) {
       data._isDisabled = v;
     },
@@ -96,6 +99,57 @@ describe("DISABLE_LOGBOX_SCRIPT", () => {
     expect(calls.addException).toBe(0);
   });
 
+  it("re-enables addException when LogBox is later un-disabled (e.g. ignoreAllLogs(false))", () => {
+    // Regression guard: an earlier revision replaced addException with a hard
+    // no-op, which left fatal redboxes silently swallowed even after a dev
+    // disconnected the debugger and called ignoreAllLogs(false). The wrapper
+    // must consult isDisabled() per call so the original behavior returns.
+    const { data: lbData, calls } = makeLogBoxData();
+    const lb = makeLogBox(lbData);
+
+    const modules = new Map<number, MockModuleMeta>([
+      [1, { isInitialized: true, factory: () => ({ default: lb }), exports: { default: lb } }],
+      [2, { isInitialized: true, factory: () => lbData, exports: lbData }],
+    ]);
+    const sandbox = vm.createContext({ __r: makeRequire(modules), global: {} });
+    vm.runInContext(DISABLE_LOGBOX_SCRIPT, sandbox);
+
+    // Disabled: addException no-ops.
+    expect(lbData._isDisabled).toBe(true);
+    lbData.addException();
+    expect(calls.addException).toBe(0);
+
+    // Re-enable: addException now calls through to the original.
+    lb.ignoreAllLogs(false);
+    expect(lbData._isDisabled).toBe(false);
+    lbData.addException();
+    expect(calls.addException).toBe(1);
+
+    // Disable again: addException no-ops again.
+    lb.ignoreAllLogs(true);
+    lbData.addException();
+    expect(calls.addException).toBe(1);
+  });
+
+  it("does not double-wrap addException if the script is run twice", () => {
+    const { data: lbData, calls } = makeLogBoxData();
+    const lb = makeLogBox(lbData);
+    const modules = new Map<number, MockModuleMeta>([
+      [1, { isInitialized: true, factory: () => ({ default: lb }), exports: { default: lb } }],
+      [2, { isInitialized: true, factory: () => lbData, exports: lbData }],
+    ]);
+    const sandbox = vm.createContext({ __r: makeRequire(modules), global: {} });
+    vm.runInContext(DISABLE_LOGBOX_SCRIPT, sandbox);
+    const wrappedOnce = lbData.addException;
+    vm.runInContext(DISABLE_LOGBOX_SCRIPT, sandbox);
+    expect(lbData.addException).toBe(wrappedOnce);
+
+    // Behavior still correct: re-enable still falls through to the original.
+    lb.ignoreAllLogs(false);
+    lbData.addException();
+    expect(calls.addException).toBe(1);
+  });
+
   it("exits cleanly when __r is unavailable", () => {
     const sandbox = vm.createContext({ global: {} });
     expect(() => vm.runInContext(DISABLE_LOGBOX_SCRIPT, sandbox)).not.toThrow();
@@ -103,9 +157,10 @@ describe("DISABLE_LOGBOX_SCRIPT", () => {
 
   it("falls back to the ErrorUtils-suppressing scan when getModules is missing", () => {
     const { data: lbData, calls } = makeLogBoxData();
+    const lb = makeLogBox(lbData);
 
     function __r(id: number) {
-      if (id === 0) return { default: makeLogBox(lbData) };
+      if (id === 0) return { default: lb };
       if (id === 1) return lbData;
       throw new Error("missing");
     }
@@ -118,5 +173,10 @@ describe("DISABLE_LOGBOX_SCRIPT", () => {
     lbData.addException();
     expect(calls.addException).toBe(0);
     expect(globalShim.ErrorUtils).toEqual({ sentinel: 1 });
+
+    // Same re-enable behavior on the fallback path.
+    lb.ignoreAllLogs(false);
+    lbData.addException();
+    expect(calls.addException).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #160

On some setups `debugger-evaluate` tool call triggered a redbox.

This PR fixes that issue.

- We wrap `LBData.addException` to short-circuit while `LBData.isDisabled()` is true.
- `LB.ignoreAllLogs(false)` then re-enables fatals naturally — no uninstall needed.

## Details

`LogBox.ignoreAllLogs(true)` only flips an observer flag — it doesn't prevent `LogBoxData.addException` from enqueueing fatal logs or the inspector from auto-opening for them. Wrapping `addException` (rather than replacing it with a no-op) means uncaught top-level throws like `TurboModuleRegistry.getEnforcing('SegmentFetcher')` (common in Expo `expo run:ios` builds where the native module isn't linked) no longer surface as a redbox while LogBox is disabled — and re-enabling LogBox restores them.

A handful of lines in `disable-logbox.ts`; the rest of the diff is a new test file (no tests existed for this script before).

## Test plan

- [x] `npm test` in `packages/tool-server` — all pass, including 5 new vitest cases covering the wrapper, the re-enable path, the no-double-wrap guard, the no-`__r` early-exit, and the ErrorUtils-fallback path
- [x] `npm run build` clean
- [x] **End-to-end repro on iOS simulator** (iPhone 16 Pro, RN 0.81.5, Expo 54 dev-client): an async uncaught throw via `debugger-evaluate` reproduced the issue's exact redbox under the unpatched script; under the patched script the redbox was suppressed, and after `LB.ignoreAllLogs(false)` a subsequent throw surfaced again as expected.