### PR TITLE
fix: preserve old Zed config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2035,6 +2035,12 @@
       "version": "8.0.2",
       "license": "BSD-2-Clause"
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "dev": true,
@@ -3670,6 +3676,7 @@
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client",
         "@clack/prompts": "^1.1.0",
+        "jsonc-parser": "^3.3.1",
         "picocolors": "^1.1.1",
         "semver": "^7.7.4",
         "smol-toml": "^1.6.1",

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@argent/tools-client": "file:../argent-tools-client",
     "@clack/prompts": "^1.1.0",
+    "jsonc-parser": "^3.3.1",
     "picocolors": "^1.1.1",
     "semver": "^7.7.4",
     "smol-toml": "^1.6.1",

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -10,12 +10,14 @@ import {
 } from "./constants.js";
 import {
   readJson,
+  readJsonc,
   writeJson,
   dirExists,
   readToml,
   writeToml,
   readYaml,
   writeYaml,
+  editJsoncFile,
 } from "./utils.js";
 import { isMap } from "yaml";
 
@@ -385,26 +387,29 @@ const zedAdapter: McpConfigAdapter = {
     return path.join(homedir(), ".config", "zed", "settings.json");
   },
 
+  // Zed's settings.json is JSONC (line + block comments, trailing commas).
+  // The previous JSON.parse → mutate → JSON.stringify path silently stripped
+  // every comment in the user's hand-edited file. All four entry points now
+  // go through editJsoncFile, which applies path-targeted text edits via
+  // jsonc-parser so comments and formatting outside the touched key survive.
   write(configPath: string, entry: McpServerEntry): void {
-    const config = readJson(configPath);
-    const servers = (config.context_servers ?? {}) as Record<string, unknown>;
-    servers[MCP_SERVER_KEY] = {
+    editJsoncFile(configPath, ["context_servers", MCP_SERVER_KEY], {
       source: "custom",
       command: entry.command,
       args: entry.args,
       env: entry.env,
-    };
-    config.context_servers = servers;
-    writeJson(configPath, config);
+    });
   },
 
   remove(configPath: string): boolean {
     if (!fs.existsSync(configPath)) return false;
-    const config = readJson(configPath);
+    // JSONC-tolerant read: a user-authored settings.json may contain comments
+    // that JSON.parse would reject (silently swallowed by readJson, leaving
+    // this branch thinking nothing needed removing).
+    const config = readJsonc(configPath);
     const servers = config.context_servers as Record<string, unknown> | undefined;
     if (!servers?.[MCP_SERVER_KEY]) return false;
-    delete servers[MCP_SERVER_KEY];
-    writeJsonOrRemove(configPath, config);
+    editJsoncFile(configPath, ["context_servers", MCP_SERVER_KEY], undefined);
     return true;
   },
 
@@ -417,13 +422,7 @@ const zedAdapter: McpConfigAdapter = {
       scope === "global"
         ? path.join(homedir(), ".config", "zed", "settings.json")
         : path.join(root, ".zed", "settings.json");
-    const config = readJson(settingsPath);
-    const agent = (config.agent ?? {}) as Record<string, unknown>;
-    const perms = (agent.tool_permissions ?? {}) as Record<string, unknown>;
-    perms.default = "allow";
-    agent.tool_permissions = perms;
-    config.agent = agent;
-    writeJson(settingsPath, config);
+    editJsoncFile(settingsPath, ["agent", "tool_permissions", "default"], "allow");
   },
 
   removeAllowlist(root: string, scope: "local" | "global"): void {
@@ -432,13 +431,12 @@ const zedAdapter: McpConfigAdapter = {
         ? path.join(homedir(), ".config", "zed", "settings.json")
         : path.join(root, ".zed", "settings.json");
     if (!fs.existsSync(settingsPath)) return;
-    const config = readJson(settingsPath);
+    const config = readJsonc(settingsPath);
     const perms = (config.agent as Record<string, unknown>)?.tool_permissions as
       | Record<string, unknown>
       | undefined;
     if (!perms || perms.default !== "allow") return;
-    perms.default = "confirm";
-    writeJsonOrRemove(settingsPath, config);
+    editJsoncFile(settingsPath, ["agent", "tool_permissions", "default"], "confirm");
   },
 };
 

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -7,6 +7,12 @@ import semver from "semver";
 import { PACKAGE_NAME, NPM_REGISTRY } from "./constants.js";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 import { Document, parseDocument } from "yaml";
+import {
+  applyEdits as applyJsoncEdits,
+  modify as modifyJsonc,
+  parse as parseJsonc,
+  type JSONPath,
+} from "jsonc-parser";
 
 // ── Package root resolution ───────────────────────────────────────────────────
 // At runtime this module ships in two shapes:
@@ -184,6 +190,116 @@ export function readJson(filePath: string): Record<string, unknown> {
 export function writeJson(filePath: string, data: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
+}
+
+// ── JSONC helpers ────────────────────────────────────────────────────────────
+// Comment-preserving edits for editor settings files that are JSONC (Zed).
+// Unlike the JSON.parse → mutate → JSON.stringify path used elsewhere, these
+// helpers operate on the source string via jsonc-parser's modify(), so user
+// comments, trailing commas, blank lines, and key ordering all survive.
+
+// jsonc-parser's modify() needs a formatting hint for newly-inserted keys.
+// Zed's bundled defaults use 2-space indentation; matching that keeps writes
+// visually consistent for the common case.
+const JSONC_FORMATTING = { tabSize: 2, insertSpaces: true } as const;
+
+function setJsoncIn(text: string, jsonPath: JSONPath, value: unknown): string {
+  const edits = modifyJsonc(text, jsonPath, value, { formattingOptions: JSONC_FORMATTING });
+  return applyJsoncEdits(text, edits);
+}
+
+function readJsoncFileRaw(filePath: string): { text: string; hadBom: boolean } {
+  if (!fs.existsSync(filePath)) return { text: "{}", hadBom: false };
+  let text = fs.readFileSync(filePath, "utf8");
+  const hadBom = text.charCodeAt(0) === 0xfeff;
+  if (hadBom) text = text.slice(1);
+  if (text.trim() === "") text = "{}";
+  return { text, hadBom };
+}
+
+function getAtJsoncPath(value: unknown, jsonPath: JSONPath): unknown {
+  let cur: unknown = value;
+  for (const key of jsonPath) {
+    if (!cur || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string | number, unknown>)[key as string | number];
+  }
+  return cur;
+}
+
+function isEmptyPlainObject(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value as object).length === 0
+  );
+}
+
+function rmEmptyDir(dirPath: string): void {
+  try {
+    if (!fs.existsSync(dirPath)) return;
+    if (!fs.statSync(dirPath).isDirectory()) return;
+    if (fs.readdirSync(dirPath).length > 0) return;
+    fs.rmdirSync(dirPath);
+  } catch {
+    // non-fatal
+  }
+}
+
+/**
+ * Read a JSON-with-Comments file (line + block comments + trailing commas).
+ * Used by callers that need to inspect Zed's settings.json without the
+ * `JSON.parse` failure on user-authored comments. For mutations go through
+ * {@link editJsoncFile} instead — it preserves comments on write.
+ */
+export function readJsonc(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) return {};
+  let raw = fs.readFileSync(filePath, "utf8");
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+  if (raw.trim() === "") return {};
+  const parsed = parseJsonc(raw, [], { allowTrailingComma: true }) as
+    | Record<string, unknown>
+    | undefined;
+  return parsed ?? {};
+}
+
+/**
+ * Apply a single path-targeted edit to a JSONC config file in place.
+ * Comments, trailing commas, blank lines, and key ordering outside the
+ * edited path are preserved (jsonc-parser's modify() operates on the source
+ * text rather than a parsed object).
+ *
+ * Pass `undefined` as `value` to delete the key. Empty ancestor objects are
+ * pruned, and if the document collapses to `{}` the file (and an empty
+ * parent directory) is removed — mirroring the JSON `writeJsonOrRemove`
+ * semantics used elsewhere.
+ *
+ * Use this for editor settings files that are JSONC (Zed). For pure JSON
+ * configs go through {@link writeJson} instead — JSONC.modify is overhead
+ * when there are no comments to preserve.
+ */
+export function editJsoncFile(filePath: string, jsonPath: JSONPath, value: unknown): void {
+  const { text: initial, hadBom } = readJsoncFileRaw(filePath);
+  let text = setJsoncIn(initial, jsonPath, value);
+
+  if (value === undefined) {
+    for (let i = jsonPath.length - 1; i > 0; i--) {
+      const parentPath = jsonPath.slice(0, i);
+      const parsed = parseJsonc(text, [], { allowTrailingComma: true });
+      if (!isEmptyPlainObject(getAtJsoncPath(parsed, parentPath))) break;
+      text = setJsoncIn(text, parentPath, undefined);
+    }
+  }
+
+  const parsed = parseJsonc(text, [], { allowTrailingComma: true });
+  if (isEmptyPlainObject(parsed)) {
+    fs.rmSync(filePath, { force: true });
+    rmEmptyDir(path.dirname(filePath));
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, (hadBom ? "﻿" : "") + text);
 }
 
 // ── Directory helpers ─────────────────────────────────────────────────────────

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { parse as parseYaml } from "yaml";
+import { parse as parseJsonc } from "jsonc-parser";
 import {
   ALL_ADAPTERS,
   getMcpEntry,
@@ -53,6 +54,15 @@ function setupTmpDir(): string {
 
 function readJsonFile(filePath: string): Record<string, unknown> {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+// JSONC-tolerant variant for tests that read back files the Zed adapter
+// wrote — those preserve user comments and trailing commas, so strict
+// JSON.parse rejects them.
+function readJsoncFile(filePath: string): Record<string, unknown> {
+  return parseJsonc(fs.readFileSync(filePath, "utf8"), [], {
+    allowTrailingComma: true,
+  }) as Record<string, unknown>;
 }
 
 function readYamlFile(filePath: string): Record<string, unknown> {
@@ -287,6 +297,76 @@ describe("Zed adapter", () => {
 
   it("globalPath returns ~/.config/zed/settings.json", () => {
     expect(adapter.globalPath()).toBe(path.join(os.homedir(), ".config", "zed", "settings.json"));
+  });
+
+  // Zed's settings.json is JSONC. The plain JSON.parse → mutate → JSON.stringify
+  // round-trip used elsewhere strips every // and /* */ comment, plus trailing
+  // commas. The Zed adapter goes through editJsoncFile so user-authored
+  // formatting outside the touched key survives byte-for-byte.
+  it("preserves user comments and trailing commas across write/remove", () => {
+    const configPath = path.join(tmpDir, ".zed", "settings.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const original = `{
+  // Theme
+  "theme": "One Dark",
+  /* fonts */
+  "buffer_font_size": 14,
+}
+`;
+    fs.writeFileSync(configPath, original);
+
+    adapter.write(configPath, getMcpEntry());
+    let after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain("// Theme");
+    expect(after).toContain("/* fonts */");
+    expect(after).toContain('"buffer_font_size": 14');
+    // The trailing comma after the last user key must still be present.
+    expect(after).toMatch(/14,\s*\n/);
+    // And the argent entry actually got written.
+    expect(readJsoncFile(configPath).context_servers).toHaveProperty("argent");
+
+    expect(adapter.remove(configPath)).toBe(true);
+    after = fs.readFileSync(configPath, "utf8");
+    // Comments stay after we leave again.
+    expect(after).toContain("// Theme");
+    expect(after).toContain("/* fonts */");
+    // context_servers wrapper was empty after removing argent and got pruned.
+    expect(readJsoncFile(configPath)).not.toHaveProperty("context_servers");
+  });
+
+  it("removes the file when only the argent key was present", () => {
+    const configPath = path.join(tmpDir, ".zed", "settings.json");
+    adapter.write(configPath, getMcpEntry());
+    // No user keys, just our entry — remove() should clean up the file.
+    expect(adapter.remove(configPath)).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it("addAllowlist/removeAllowlist round-trip preserves comments", () => {
+    const configPath = path.join(tmpDir, ".zed", "settings.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `{
+  // user note
+  "theme": "Solarized"
+}
+`
+    );
+
+    adapter.addAllowlist(tmpDir, "local");
+    let after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain("// user note");
+    expect((readJsoncFile(configPath).agent as Record<string, unknown>).tool_permissions).toEqual({
+      default: "allow",
+    });
+
+    adapter.removeAllowlist(tmpDir, "local");
+    after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain("// user note");
+    expect((readJsoncFile(configPath).agent as Record<string, unknown>).tool_permissions).toEqual({
+      default: "confirm",
+    });
   });
 });
 

--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -35,6 +35,14 @@ const ALIASES = {
   "@argent/cli": CLI_ENTRY,
 };
 
+// esbuild on platform:"node" defaults mainFields to ["main","module"], which
+// picks UMD entries that use runtime `require("./impl/...")`. Those requires
+// can't be statically resolved during bundling and fail at runtime because
+// the impl/ folder isn't shipped next to the bundle. Prefer "module" so we
+// pick ESM entries with static imports that get fully inlined. Affects e.g.
+// jsonc-parser, which ships both UMD (main) and ESM (module).
+const MAIN_FIELDS = ["module", "main"];
+
 // Banner injected into ESM bundles so any inlined CJS dependencies that call
 // `require()` work without a real CJS context.
 const ESM_REQUIRE_BANNER = {
@@ -72,6 +80,7 @@ esbuild.buildSync({
   format: "cjs",
   outfile: OUT_FILE,
   alias: ALIASES,
+  mainFields: MAIN_FIELDS,
 });
 
 console.log(`✓ Bundled tools server → ${path.relative(process.cwd(), OUT_FILE)}`);
@@ -89,6 +98,7 @@ esbuild.buildSync({
   alias: ALIASES,
   banner: ESM_REQUIRE_BANNER,
   external: ["node:*"],
+  mainFields: MAIN_FIELDS,
 });
 
 console.log(`✓ Bundled installer → ${path.relative(process.cwd(), INSTALLER_OUT_FILE)}`);
@@ -105,6 +115,7 @@ esbuild.buildSync({
   alias: ALIASES,
   banner: ESM_REQUIRE_BANNER,
   external: ["node:*"],
+  mainFields: MAIN_FIELDS,
 });
 
 console.log(`✓ Bundled MCP server → ${path.relative(process.cwd(), MCP_OUT_FILE)}`);
@@ -120,6 +131,7 @@ esbuild.buildSync({
   alias: ALIASES,
   banner: ESM_REQUIRE_BANNER,
   external: ["node:*"],
+  mainFields: MAIN_FIELDS,
 });
 
 console.log(`✓ Bundled CLI commands → ${path.relative(process.cwd(), CLI_OUT_FILE)}`);


### PR DESCRIPTION
Closes #165.

`argent init` was wiping users' `~/.config/zed/settings.json` - Zed's settings format is JSONC, so `readJson` used `JSON.parse` and silently fell back to `{}` on any parse failure, after which the Zed adapter would overwrite the file with an argent-only stub.
