### PR TITLE
fix: opencode detect alternative filenames

### DIFF
--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -721,46 +721,36 @@ const openCodeAdapter: McpConfigAdapter = {
   },
 
   write(configPath: string, entry: McpServerEntry): void {
-    const config = readJson(configPath);
-    const servers = (config.mcp ?? {}) as Record<string, unknown>;
-    servers[MCP_SERVER_KEY] = {
+    editJsoncFile(configPath, ["mcp", MCP_SERVER_KEY], {
       type: "local",
       command: [entry.command, ...entry.args],
       enabled: true,
       environment: entry.env,
-    };
-    config.mcp = servers;
-    writeJson(configPath, config);
+    });
   },
 
   remove(configPath: string): boolean {
     if (!fs.existsSync(configPath)) return false;
-    const config = readJson(configPath);
+    const config = readJsonc(configPath);
     const servers = config.mcp as Record<string, unknown> | undefined;
     if (!servers?.[MCP_SERVER_KEY]) return false;
-    delete servers[MCP_SERVER_KEY];
-    writeJsonOrRemove(configPath, config);
+    editJsoncFile(configPath, ["mcp", MCP_SERVER_KEY], undefined);
     return true;
   },
 
   addAllowlist(root: string, scope: "local" | "global"): void {
     const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
     if (!configPath) return;
-    const config = readJson(configPath);
-    const tools = (config.tools ?? {}) as Record<string, unknown>;
-    tools[OPENCODE_ALLOWLIST_PATTERN] = true;
-    config.tools = tools;
-    writeJson(configPath, config);
+    editJsoncFile(configPath, ["tools", OPENCODE_ALLOWLIST_PATTERN], true);
   },
 
   removeAllowlist(root: string, scope: "local" | "global"): void {
     const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
     if (!configPath || !fs.existsSync(configPath)) return;
-    const config = readJson(configPath);
+    const config = readJsonc(configPath);
     const tools = config.tools as Record<string, unknown> | undefined;
     if (!tools || !(OPENCODE_ALLOWLIST_PATTERN in tools)) return;
-    delete tools[OPENCODE_ALLOWLIST_PATTERN];
-    writeJsonOrRemove(configPath, config);
+    editJsoncFile(configPath, ["tools", OPENCODE_ALLOWLIST_PATTERN], undefined);
   },
 };
 

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -681,11 +681,8 @@ const hermesAdapter: McpConfigAdapter = {
 
 const OPENCODE_BINARY = "opencode";
 const OPENCODE_ALLOWLIST_PATTERN = "argent*";
-// Filename candidates opencode's own loader recognizes, in the order it picks
-// a write target. Global mirrors upstream's `globalConfigFile()` (.jsonc wins
-// over .json, with config.json kept last as the legacy/migrated fallback).
-// Project picks .jsonc first because opencode deep-merges it on top of
-// opencode.json at read time, so writes there survive the merge.
+
+// Same filename prioritization order that's used by opencode CLI
 const OPENCODE_PROJECT_FILES = ["opencode.jsonc", "opencode.json"] as const;
 const OPENCODE_GLOBAL_FILES = ["opencode.jsonc", "opencode.json", "config.json"] as const;
 

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -681,6 +681,11 @@ const hermesAdapter: McpConfigAdapter = {
 
 const OPENCODE_BINARY = "opencode";
 const OPENCODE_ALLOWLIST_PATTERN = "argent*";
+// Filename candidates opencode's own loader recognizes. Precedence matches
+// upstream: project walks accept .jsonc first; global merges config.json
+// (legacy/migrated) before opencode.json/.jsonc.
+const OPENCODE_PROJECT_FILES = ["opencode.jsonc", "opencode.json"] as const;
+const OPENCODE_GLOBAL_FILES = ["config.json", "opencode.json", "opencode.jsonc"] as const;
 
 function hasOpenCodeBinary(): boolean {
   try {
@@ -692,6 +697,14 @@ function hasOpenCodeBinary(): boolean {
   }
 }
 
+function pickOpencodeConfig(dir: string, candidates: readonly string[]): string {
+  for (const name of candidates) {
+    const candidate = path.join(dir, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return path.join(dir, "opencode.json");
+}
+
 const openCodeAdapter: McpConfigAdapter = {
   name: "opencode",
 
@@ -700,11 +713,11 @@ const openCodeAdapter: McpConfigAdapter = {
   },
 
   projectPath(root: string): string | null {
-    return path.join(root, "opencode.json");
+    return pickOpencodeConfig(root, OPENCODE_PROJECT_FILES);
   },
 
   globalPath(): string | null {
-    return path.join(homedir(), ".config", "opencode", "opencode.json");
+    return pickOpencodeConfig(path.join(homedir(), ".config", "opencode"), OPENCODE_GLOBAL_FILES);
   },
 
   write(configPath: string, entry: McpServerEntry): void {

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -681,11 +681,13 @@ const hermesAdapter: McpConfigAdapter = {
 
 const OPENCODE_BINARY = "opencode";
 const OPENCODE_ALLOWLIST_PATTERN = "argent*";
-// Filename candidates opencode's own loader recognizes. Precedence matches
-// upstream: project walks accept .jsonc first; global merges config.json
-// (legacy/migrated) before opencode.json/.jsonc.
+// Filename candidates opencode's own loader recognizes, in the order it picks
+// a write target. Global mirrors upstream's `globalConfigFile()` (.jsonc wins
+// over .json, with config.json kept last as the legacy/migrated fallback).
+// Project picks .jsonc first because opencode deep-merges it on top of
+// opencode.json at read time, so writes there survive the merge.
 const OPENCODE_PROJECT_FILES = ["opencode.jsonc", "opencode.json"] as const;
-const OPENCODE_GLOBAL_FILES = ["config.json", "opencode.json", "opencode.jsonc"] as const;
+const OPENCODE_GLOBAL_FILES = ["opencode.jsonc", "opencode.json", "config.json"] as const;
 
 function hasOpenCodeBinary(): boolean {
   try {

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -113,6 +113,7 @@ const PROJECT_ROOT_MARKERS = [
   ".zed",
   ".opencode",
   "opencode.json",
+  "opencode.jsonc",
   "skills-lock.json",
 ];
 

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -910,13 +910,34 @@ describe("opencode adapter", () => {
     expect(adapter.projectPath(tmpDir)).toBe(path.join(tmpDir, "opencode.json"));
   });
 
-  it("globalPath prefers existing config.json over default opencode.json", () => {
+  it("globalPath returns legacy config.json when it is the only candidate", () => {
     homedirOverride = path.join(tmpDir, "home");
     const opencodeDir = path.join(homedirOverride, ".config", "opencode");
     fs.mkdirSync(opencodeDir, { recursive: true });
     const configJsonPath = path.join(opencodeDir, "config.json");
     fs.writeFileSync(configJsonPath, "{}");
     expect(adapter.globalPath()).toBe(configJsonPath);
+  });
+
+  // Mirrors opencode's own globalConfigFile() precedence so the file argent
+  // writes is the same one opencode treats as authoritative.
+  it("globalPath prefers opencode.jsonc over opencode.json over config.json", () => {
+    homedirOverride = path.join(tmpDir, "home");
+    const opencodeDir = path.join(homedirOverride, ".config", "opencode");
+    fs.mkdirSync(opencodeDir, { recursive: true });
+    fs.writeFileSync(path.join(opencodeDir, "config.json"), "{}");
+    fs.writeFileSync(path.join(opencodeDir, "opencode.json"), "{}");
+    fs.writeFileSync(path.join(opencodeDir, "opencode.jsonc"), "{}");
+    expect(adapter.globalPath()).toBe(path.join(opencodeDir, "opencode.jsonc"));
+  });
+
+  it("globalPath prefers opencode.json over config.json when .jsonc is absent", () => {
+    homedirOverride = path.join(tmpDir, "home");
+    const opencodeDir = path.join(homedirOverride, ".config", "opencode");
+    fs.mkdirSync(opencodeDir, { recursive: true });
+    fs.writeFileSync(path.join(opencodeDir, "config.json"), "{}");
+    fs.writeFileSync(path.join(opencodeDir, "opencode.json"), "{}");
+    expect(adapter.globalPath()).toBe(path.join(opencodeDir, "opencode.json"));
   });
 
   it("globalPath falls back to opencode.json when no candidate exists", () => {

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -900,6 +900,32 @@ describe("opencode adapter", () => {
     );
   });
 
+  it("projectPath prefers existing opencode.jsonc over default opencode.json", () => {
+    const jsoncPath = path.join(tmpDir, "opencode.jsonc");
+    fs.writeFileSync(jsoncPath, "{}");
+    expect(adapter.projectPath(tmpDir)).toBe(jsoncPath);
+  });
+
+  it("projectPath falls back to opencode.json when no candidate exists", () => {
+    expect(adapter.projectPath(tmpDir)).toBe(path.join(tmpDir, "opencode.json"));
+  });
+
+  it("globalPath prefers existing config.json over default opencode.json", () => {
+    homedirOverride = path.join(tmpDir, "home");
+    const opencodeDir = path.join(homedirOverride, ".config", "opencode");
+    fs.mkdirSync(opencodeDir, { recursive: true });
+    const configJsonPath = path.join(opencodeDir, "config.json");
+    fs.writeFileSync(configJsonPath, "{}");
+    expect(adapter.globalPath()).toBe(configJsonPath);
+  });
+
+  it("globalPath falls back to opencode.json when no candidate exists", () => {
+    homedirOverride = path.join(tmpDir, "home");
+    expect(adapter.globalPath()).toBe(
+      path.join(homedirOverride, ".config", "opencode", "opencode.json")
+    );
+  });
+
   it("addAllowlist sets 'argent*' wildcard in tools (local)", () => {
     const configPath = path.join(tmpDir, "opencode.json");
     adapter.write(configPath, getMcpEntry());

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -980,6 +980,32 @@ describe("opencode adapter", () => {
     expect(tools.write).toBe("ask");
     expect(tools["argent*"]).toBe(true);
   });
+
+  // opencode supports both opencode.json (strict JSON) and opencode.jsonc
+  // (with comments + trailing commas). Going through editJsoncFile means
+  // user-authored comments survive write/remove the same way they do for Zed.
+  it("preserves user comments when writing into opencode.jsonc", () => {
+    const configPath = path.join(tmpDir, "opencode.jsonc");
+    const original = `{
+  // top-of-file comment
+  "theme": "opencode-dark",
+  /* trailing block comment */
+}
+`;
+    fs.writeFileSync(configPath, original);
+
+    adapter.write(configPath, getMcpEntry());
+
+    const after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain("// top-of-file comment");
+    expect(after).toContain("/* trailing block comment */");
+    expect(after).toContain('"theme": "opencode-dark"');
+
+    const parsed = readJsoncFile(configPath);
+    const servers = parsed.mcp as Record<string, unknown>;
+    expect(servers).toHaveProperty("argent");
+    expect((servers.argent as Record<string, unknown>).type).toBe("local");
+  });
 });
 
 // ── Claude permissions ────────────────────────────────────────────────────────

--- a/packages/argent-installer/test/utils.test.ts
+++ b/packages/argent-installer/test/utils.test.ts
@@ -185,6 +185,15 @@ describe("resolveProjectRoot", () => {
 
     expect(resolveProjectRoot(nestedDir)).toBe(nestedDir);
   });
+
+  it("recognizes opencode.jsonc as a project root marker", () => {
+    const projectRoot = path.join(tmpDir, "project");
+    const nestedDir = path.join(projectRoot, "src");
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, "opencode.jsonc"), "{}");
+
+    expect(resolveProjectRoot(nestedDir)).toBe(projectRoot);
+  });
 });
 
 // ── detectPackageManager ──────────────────────────────────────────────────────


### PR DESCRIPTION
OpenCode supports:
- project-scope: `opencode.jsonc` and `opencode.json`; 
- global-scope: `config.json` (legacy/migrated), `opencode.json`, and `opencode.jsonc`

This PR adds support for these alternative filenames.
This PR also adds `jsonc` support.

<img width="502" height="377" alt="image" src="https://github.com/user-attachments/assets/a0f1d437-93ce-4677-bc6f-b8d0c8427b57" />
