### PR TITLE
fix: build workspace deps before packing/publishing argent

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -53,6 +53,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npx tsc --build
+
       - run: npm run build -w @swmansion/argent
 
       - run: test -x packages/argent/bin/simulator-server

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npx tsc --build
+
       - run: npm run build -w @swmansion/argent
 
       - run: test -x packages/argent/bin/simulator-server

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:tool-server": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "download:simulator-server": "bash scripts/download-simulator-server.sh",
     "download:native-binaries": "bash scripts/download-native-binaries.sh",
-    "pack": "npm run download:simulator-server && npm run download:native-binaries && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
+    "pack": "npm run download:simulator-server && npm run download:native-binaries && npm run build && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
     "pack:mcp": "npm run pack",
     "dev": "node scripts/dev.cjs",
     "format": "prettier --write ."


### PR DESCRIPTION
## Summary
- The `publish` and `publish-next` workflows ran `npm run build -w @swmansion/argent` directly, but after the recent CLI/MCP/main split, `@swmansion/argent` imports types from `@argent/cli`, `@argent/mcp`, `@argent/installer`, `@argent/tools-client`. Those packages expose types from their own `dist/index.d.ts`, which doesn't exist until they're built — so argent's `tsc` failed with `TS2307: Cannot find module '@argent/...'` (e.g. [run 25161244218](https://github.com/software-mansion/argent/actions/runs/25161244218)).
- Added `npx tsc --build` before the per-workspace argent build in both publish workflows so the sibling packages produce their `dist/` first. This mirrors what `unit-tests.yml` already does, which is why the regression didn't surface on PRs.
- Applied the same fix to the root `pack` script (`npm run pack`) since it had the same latent bug for local packing.

## Test plan
- [x] Reproduced the failure locally by wiping every `dist/` and `tsconfig.tsbuildinfo`, then running `npm run build -w @swmansion/argent` — same four `TS2307` errors as CI.
- [x] Verified `npx tsc --build && npm run build -w @swmansion/argent` succeeds from a clean state.
- [ ] Re-run the `Publish prerelease to npm (next)` workflow against this branch (or after merge) to confirm green.