### PR TITLE
fix(tool-server): use semver for update-checker comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,6 +4124,7 @@
         "@argent/registry": "file:../registry",
         "@clack/prompts": "^1.1.0",
         "express": "^4.19.2",
+        "semver": "^7.7.4",
         "source-map-js": "^1.2.1",
         "tree-sitter": "^0.21.1",
         "tree-sitter-typescript": "^0.23.2",
@@ -4134,6 +4135,7 @@
       "devDependencies": {
         "@types/express": "^4.17.21",
         "@types/node": "^22.0.0",
+        "@types/semver": "^7.7.1",
         "@types/supertest": "^7.2.0",
         "@types/ws": "^8.5.10",
         "supertest": "^7.2.2",

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -16,6 +16,7 @@
     "@argent/native-devtools-ios": "file:../native-devtools-ios",
     "@clack/prompts": "^1.1.0",
     "express": "^4.19.2",
+    "semver": "^7.7.4",
     "source-map-js": "^1.2.1",
     "tree-sitter": "^0.21.1",
     "tree-sitter-typescript": "^0.23.2",
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^22.0.0",
+    "@types/semver": "^7.7.1",
     "@types/supertest": "^7.2.0",
     "@types/ws": "^8.5.10",
     "supertest": "^7.2.2",

--- a/packages/tool-server/src/utils/update-checker.ts
+++ b/packages/tool-server/src/utils/update-checker.ts
@@ -1,4 +1,5 @@
 import https from "node:https";
+import semver from "semver";
 import { version as currentVersion } from "../../package.json";
 
 const PACKAGE_NAME = "@swmansion/argent";
@@ -38,27 +39,13 @@ export function suppressUpdateNote(durationMs: number): void {
   suppressUntil = Date.now() + durationMs;
 }
 
-/**
- * Parses a semver string "major.minor.patch" into numeric components.
- * Returns null for non-semver strings (pre-release tags, etc.).
- */
-function parseSemver(v: string): [number, number, number] | null {
-  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(v);
-  if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-/**
- * Returns true if `latest` is strictly greater than `current` by semver ordering.
- * Returns false for non-semver strings (pre-release, local dev versions).
- */
 function isNewerVersion(latest: string, current: string): boolean {
-  const l = parseSemver(latest);
-  const c = parseSemver(current);
-  if (!l || !c) return false;
-  if (l[0] !== c[0]) return l[0] > c[0];
-  if (l[1] !== c[1]) return l[1] > c[1];
-  return l[2] > c[2];
+  if (!semver.valid(latest) || !semver.valid(current)) return false;
+  // Never push prereleases — only notify when a stable version is newer.
+  // This still flags correctly when `current` is a prerelease (e.g. 0.6.0-next.0
+  // → 0.6.0) because semver.gt treats stable as greater than its prereleases.
+  if (semver.prerelease(latest)) return false;
+  return semver.gt(latest, current);
 }
 
 /**


### PR DESCRIPTION
## Summary
- The homegrown `parseSemver` in `packages/tool-server/src/utils/update-checker.ts` only matched plain `MAJOR.MINOR.PATCH` and returned `null` for prerelease strings. After [#171](https://github.com/software-mansion/argent/pull/171) bumped the local version to `0.6.0-next.0`, `isNewerVersion` started returning `false` for **any** value of `latest`, because the *current* side failed to parse. Two consequences:
  - Users on the `next` dist-tag are never notified of new releases (silent feature degradation, not a crash).
  - The `detects an available update on startup` unit test broke because its asserted state now reads `{ updateAvailable: false, latestVersion: "99.0.0" }` instead of `{ true, "99.0.0" }` — see [run 25161184594](https://github.com/software-mansion/argent/actions/runs/25161184594/job/73755770427).
- Replaces the regex parser with the `semver` package (already pinned at `^7.7.4` and present in the lockfile via `@argent/installer`). Adds it as a dep of `@argent/tool-server` along with `@types/semver`.
- Keeps the existing UX rule: don't notify when upstream `latest` is itself a prerelease — npm's `latest` dist-tag should be stable, and we shouldn't push betas to stable users. `semver.gt` correctly treats a stable version as greater than its own prereleases, so a user on `0.6.0-next.0` will be notified when `0.6.0` ships.

## Behavior matrix
| current | npm `latest` | before (broken) | after |
|---|---|---|---|
| `0.6.0-next.0` | `99.0.0` | not flagged | **flagged** |
| `0.6.0-next.0` | `0.6.0` | not flagged | **flagged** |
| `0.6.0` | `99.0.0` | flagged | flagged |
| `0.6.0` | `1.0.0-beta.1` | not flagged | not flagged |
| anything | invalid string | not flagged | not flagged |

## Test plan
- [x] `npm test -w @argent/tool-server -- test/update-checker.test.ts` — all 10 tests pass (was 9/10).
- [x] `npm test -w @argent/tool-server` — full suite 444/444 passes.
- [x] `npx tsc --build` clean from the repo root.
- [ ] CI green on this branch.