### PR TITLE
chore: bump package versions to 0.6.0-next.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3631,7 +3631,7 @@
     },
     "packages/argent": {
       "name": "@swmansion/argent",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3660,7 +3660,7 @@
     },
     "packages/argent-cli": {
       "name": "@argent/cli",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client"
       },
@@ -3672,7 +3672,7 @@
     },
     "packages/argent-installer": {
       "name": "@argent/installer",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client",
         "@clack/prompts": "^1.1.0",
@@ -3691,7 +3691,7 @@
     },
     "packages/argent-mcp": {
       "name": "@argent/mcp",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client",
         "@modelcontextprotocol/sdk": "^1.20.0"
@@ -3704,7 +3704,7 @@
     },
     "packages/argent-tools-client": {
       "name": "@argent/tools-client",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.5.0",
@@ -3743,7 +3743,7 @@
     },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.5.0"
@@ -3751,7 +3751,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "dependencies": {
         "zod": "^3.23.0"
       },
@@ -4111,14 +4111,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.6.0-next.0",
+      "version": "0.6.0-next.1",
       "dependencies": {
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
         "@argent/registry": "file:../registry",

--- a/packages/argent-cli/package.json
+++ b/packages/argent-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/cli",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "description": "Shell CLI commands for argent: tools, run, server",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/installer",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "description": "Workspace setup logic for argent: init, update, uninstall",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-mcp/package.json
+++ b/packages/argent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/mcp",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "description": "MCP stdio protocol adapter — talks to the argent tool-server and forwards calls",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-tools-client/package.json
+++ b/packages/argent-tools-client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tools-client",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "description": "Spawn-and-talk client for the argent tool-server (used by MCP and CLI)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "description": "MCP server for iOS Simulator control",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/native-devtools-ios/package.json
+++ b/packages/native-devtools-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-ios",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "type": "module",
   "description": "Claude Code skills for iOS simulator interaction via argent",
   "scripts": {

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.6.0-next.0",
+  "version": "0.6.0-next.1",
   "description": "Framework-agnostic tool registry for iOS simulator control",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps all 9 published packages from `0.6.0-next.0` → `0.6.0-next.1` in preparation for the next prerelease publish (the `0.6.0-next.0` train was blocked by the build-config and update-checker fixes in #172 and #173).
- Affected: `@swmansion/argent`, `@argent/cli`, `@argent/installer`, `@argent/mcp`, `@argent/tools-client`, `@argent/native-devtools-ios`, `@argent/registry`, `@argent/skills`, `@argent/tool-server`. `packages/ui` (`0.0.1`) is on a separate version track and left as-is, matching #171.
- Lockfile updated via `npm install` — only the 9 workspace `version` entries changed.

## Test plan
- [ ] CI green
- [ ] Run `Publish prerelease to npm (next)` workflow against this commit (after #172 and #173 land) and confirm publish succeeds