### PR TITLE
fix: detect missing global install in argent update

### DIFF
--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -2,7 +2,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { execSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import {
   detectAdapters,
   ALL_ADAPTERS,
@@ -16,6 +16,7 @@ import {
   AGENTS_DIR,
   getInstalledVersion,
   getLatestVersion,
+  isGloballyInstalled,
   isNewerVersion,
   isOnline,
   isSkillsCliAvailable,
@@ -26,31 +27,7 @@ import {
   type ShellCommand,
 } from "./utils.js";
 import { refreshArgentSkills, formatSkillRefreshSummary } from "./skills.js";
-import { PACKAGE_NAME, MCP_BINARY_NAME } from "./constants.js";
-
-// Path segments used by temp package runners (npx, pnpm dlx, bunx, yarn dlx).
-// When invoked via one of these, the runner prepends its cache .bin/ dir to PATH,
-// so `which argent` succeeds even though argent is not permanently installed globally.
-const TEMP_RUNNER_MARKERS = [
-  "_npx",
-  "/dlx-",
-  "\\dlx-",
-  "bun/install/cache",
-  ".bun\\install\\cache",
-];
-
-function isGloballyInstalled(): boolean {
-  try {
-    const cmd = process.platform === "win32" ? "where" : "which";
-    const binaryPath = execSync(`${cmd} ${MCP_BINARY_NAME}`, {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    return !TEMP_RUNNER_MARKERS.some((marker) => binaryPath.includes(marker));
-  } catch {
-    return false;
-  }
-}
+import { PACKAGE_NAME } from "./constants.js";
 
 function runShellCommand(cmd: ShellCommand): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -5,6 +5,7 @@ import { detectAdapters, getMcpEntry, copyRulesAndAgents } from "./mcp-configs.j
 import {
   getInstalledVersion,
   getLatestVersion,
+  isGloballyInstalled,
   isNewerVersion,
   detectPackageManager,
   globalInstallCommand,
@@ -22,8 +23,16 @@ export async function update(args: string[]): Promise<void> {
 
   p.intro(pc.bgCyan(pc.black(" argent update ")));
 
-  const installed = getInstalledVersion();
-  if (!installed) {
+  // When invoked via `npx @swmansion/argent update`, getInstalledVersion()
+  // reads the npx-cached package.json — which is always the latest, so a
+  // straight version compare would falsely report "already on the latest"
+  // even after the user uninstalled the global package. Detect that we're
+  // running transiently and treat the missing global install as a fresh-
+  // install path instead.
+  const globallyInstalled = isGloballyInstalled();
+  const installed = globallyInstalled ? getInstalledVersion() : null;
+
+  if (globallyInstalled && !installed) {
     p.log.error("Could not determine installed version.");
     process.exit(1);
   }
@@ -42,11 +51,19 @@ export async function update(args: string[]): Promise<void> {
 
   spinner.stop("Version check complete.");
 
-  p.log.info(`Installed: ${pc.cyan(`v${installed}`)}`);
+  if (installed) {
+    p.log.info(`Installed: ${pc.cyan(`v${installed}`)}`);
+  } else {
+    p.log.warn(`${PACKAGE_NAME} is not installed globally.`);
+  }
   p.log.info(`Latest:    ${pc.cyan(`v${latest}`)}`);
 
-  if (isNewerVersion(latest, installed)) {
-    p.log.warn(`Update available: ${pc.yellow(`v${installed}`)} -> ${pc.green(`v${latest}`)}`);
+  const needsInstall = !installed || isNewerVersion(latest, installed);
+
+  if (needsInstall) {
+    if (installed) {
+      p.log.warn(`Update available: ${pc.yellow(`v${installed}`)} -> ${pc.green(`v${latest}`)}`);
+    }
 
     const pm = detectPackageManager();
     const cmd = globalInstallCommand(pm, `${PACKAGE_NAME}@${latest}`);
@@ -56,12 +73,14 @@ export async function update(args: string[]): Promise<void> {
       p.log.message(pc.dim("  Press y for yes, n for no, enter to confirm."));
 
       const proceed = await p.confirm({
-        message: `Update to v${latest}?`,
+        message: installed
+          ? `Update to v${latest}?`
+          : `Install ${PACKAGE_NAME}@${latest} globally?`,
         initialValue: true,
       });
 
       if (p.isCancel(proceed) || !proceed) {
-        p.cancel("Update cancelled.");
+        p.cancel(installed ? "Update cancelled." : "Install cancelled.");
         process.exit(0);
       }
     }
@@ -76,7 +95,7 @@ export async function update(args: string[]): Promise<void> {
         env: { ...process.env, ARGENT_SKIP_POSTINSTALL: "1" },
       });
     } catch (err) {
-      p.log.error(`Update failed: ${err}`);
+      p.log.error(`${installed ? "Update" : "Install"} failed: ${err}`);
       process.exit(1);
     }
   } else {

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -4,7 +4,7 @@ import * as dns from "node:dns";
 import * as os from "node:os";
 import { execSync } from "node:child_process";
 import semver from "semver";
-import { PACKAGE_NAME, NPM_REGISTRY } from "./constants.js";
+import { PACKAGE_NAME, NPM_REGISTRY, MCP_BINARY_NAME } from "./constants.js";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 import { Document, parseDocument } from "yaml";
 import {
@@ -350,6 +350,44 @@ export function getLatestVersion(): string {
 export function isNewerVersion(candidate: string, current: string): boolean {
   if (!semver.valid(candidate) || !semver.valid(current)) return false;
   return semver.gt(candidate, current);
+}
+
+// Path segments used by temp package runners (npx, pnpm dlx, bunx, yarn dlx).
+// When invoked via one of these, the runner prepends its cache .bin/ dir to PATH,
+// so `which argent` succeeds even though argent is not permanently installed globally.
+const TEMP_RUNNER_MARKERS = [
+  "_npx",
+  "/dlx-",
+  "\\dlx-",
+  "bun/install/cache",
+  ".bun\\install\\cache",
+];
+
+export function isTempRunnerPath(binaryPath: string): boolean {
+  return TEMP_RUNNER_MARKERS.some((marker) => binaryPath.includes(marker));
+}
+
+/**
+ * True iff argent is permanently installed on the user's PATH (not just being
+ * executed transiently from an npx / dlx / bunx cache). On Windows `where`
+ * returns every match, on Unix `which -a` does — we inspect each line so a
+ * concurrent npx invocation does not mask a real global install.
+ */
+export function isGloballyInstalled(): boolean {
+  try {
+    const cmd = process.platform === "win32" ? "where" : "which -a";
+    const output = execSync(`${cmd} ${MCP_BINARY_NAME}`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .some((line) => !isTempRunnerPath(line));
+  } catch {
+    return false;
+  }
 }
 
 export function isSkillsCliAvailable(): boolean {

--- a/packages/argent-installer/test/update.test.ts
+++ b/packages/argent-installer/test/update.test.ts
@@ -4,6 +4,7 @@ import {
   detectPackageManager,
   globalInstallCommand,
   formatShellCommand,
+  isTempRunnerPath,
 } from "../src/utils.js";
 import { PACKAGE_NAME, NPM_REGISTRY } from "../src/constants.js";
 
@@ -51,6 +52,33 @@ describe("update — constants are correct", () => {
 
   it("NPM_REGISTRY is the npm registry", () => {
     expect(NPM_REGISTRY).toContain("registry.npmjs.org");
+  });
+});
+
+describe("update — temp runner detection", () => {
+  // npx-cached argent shares the latest version, so without this filter the
+  // version compare would falsely match latest after the user uninstalled the
+  // global package via `npx @swmansion/argent uninstall`.
+  it("flags npx cache paths as transient", () => {
+    expect(isTempRunnerPath("/Users/me/.npm/_npx/abc123/node_modules/.bin/argent")).toBe(true);
+  });
+
+  it("flags pnpm dlx cache paths as transient", () => {
+    expect(isTempRunnerPath("/Users/me/.pnpm-store/dlx-1234/node_modules/.bin/argent")).toBe(true);
+  });
+
+  it("flags bun install cache paths as transient", () => {
+    expect(isTempRunnerPath("/Users/me/.bun/install/cache/argent")).toBe(true);
+  });
+
+  it("flags Windows dlx cache paths as transient", () => {
+    expect(isTempRunnerPath("C:\\Users\\me\\AppData\\Local\\dlx-abc\\argent.cmd")).toBe(true);
+  });
+
+  it("treats real global install paths as permanent", () => {
+    expect(isTempRunnerPath("/usr/local/bin/argent")).toBe(false);
+    expect(isTempRunnerPath("/opt/homebrew/bin/argent")).toBe(false);
+    expect(isTempRunnerPath("C:\\Users\\me\\AppData\\Roaming\\npm\\argent.cmd")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

`npx @swmansion/argent update` falsely reported *"Already on the latest version"* after the user had removed the package via `npx @swmansion/argent uninstall`.

`getInstalledVersion()` reads `package.json` from `PACKAGE_ROOT`, which under `npx` is the npx-cached copy of argent — always the registry's latest. The version compare then matches and short-circuits, hiding the fact that there is no global install at all.

- Share `isGloballyInstalled()` between `init` and `update` via `utils.ts`; `update.ts` now routes through a fresh-install prompt (`Install @swmansion/argent@<latest> globally?`) when no permanent argent binary is on PATH.
- Fix a Windows-only bug in the temp-runner check while the helper was being moved: `where argent` returns multiple lines, and the previous logic flagged the entire output as transient if *any* line contained an npx marker. Now each line from `where` / `which -a` is inspected independently, so a real global install is not masked by a concurrent npx invocation.
- Add `isTempRunnerPath()` plus 5 unit tests covering npx, pnpm dlx, bunx, Windows dlx, and real global paths.

## Test plan

- [x] `npm run build` (argent-installer) — passes
- [x] `npm test` (argent-installer) — 231 passing (5 new)
- [x] `npx prettier --write` on touched files — no diffs
- [ ] Manual: `npm install -g @swmansion/argent` → `npx @swmansion/argent uninstall` → `npx @swmansion/argent update` should now offer to install the latest version instead of reporting "already on the latest"
- [ ] Manual: `argent update` while globally installed and on latest still reports "already on the latest version"
- [ ] Manual: `argent update` while globally installed and on an older version still prompts to update