### PR TITLE
feat: improve iOS profiler startup, shutdown, and exit recovery

### DIFF
--- a/packages/tool-server/src/blueprints/ios-profiler-session.ts
+++ b/packages/tool-server/src/blueprints/ios-profiler-session.ts
@@ -1,5 +1,7 @@
 import { TypedEventEmitter, type ServiceBlueprint, type ServiceEvents } from "@argent/registry";
+import type { ChildProcess } from "child_process";
 import type { CpuSample, UiHang, MemoryLeak, CpuHotspot } from "../utils/ios-profiler/types";
+import { waitForChildExit } from "../utils/ios-profiler/lifecycle";
 
 export const IOS_PROFILER_SESSION_NAMESPACE = "IosProfilerSession";
 
@@ -14,13 +16,24 @@ export interface IosProfilerSessionApi {
   deviceId: string;
   appProcess: string | null;
   xctracePid: number | null;
+  xctraceProcess: ChildProcess | null;
   traceFile: string | null;
   exportedFiles: Record<string, string | null> | null;
   profilingActive: boolean;
   wallClockStartMs: number | null;
   parsedData: IosProfilerParsedData | null;
   recordingTimeout: NodeJS.Timeout | null;
+  recordingTimedOut: boolean;
+  recordingExitedUnexpectedly: boolean;
+  lastExitInfo: { code: number | null; signal: string | null } | null;
 }
+
+// Discard semantics on dispose: registry teardown only fires from process
+// shutdown, where any in-flight xctrace recording is being abandoned. Skip the
+// SIGINT finalise grace (that is the explicit `ios-profiler-stop` contract)
+// and SIGKILL straight away so shutdown is not held up. The partial .trace on
+// disk is left in place.
+const DISPOSE_REAP_MS = 1_000;
 
 export const iosInstrumentsSessionBlueprint: ServiceBlueprint<IosProfilerSessionApi, string> = {
   namespace: IOS_PROFILER_SESSION_NAMESPACE,
@@ -34,12 +47,16 @@ export const iosInstrumentsSessionBlueprint: ServiceBlueprint<IosProfilerSession
       deviceId: _payload,
       appProcess: null,
       xctracePid: null,
+      xctraceProcess: null,
       traceFile: null,
       exportedFiles: null,
       profilingActive: false,
       wallClockStartMs: null,
       parsedData: null,
       recordingTimeout: null,
+      recordingTimedOut: false,
+      recordingExitedUnexpectedly: false,
+      lastExitInfo: null,
     };
 
     const events = new TypedEventEmitter<ServiceEvents>();
@@ -51,13 +68,17 @@ export const iosInstrumentsSessionBlueprint: ServiceBlueprint<IosProfilerSession
           clearTimeout(state.recordingTimeout);
           state.recordingTimeout = null;
         }
-        if (state.profilingActive && state.xctracePid) {
+        const child = state.xctraceProcess;
+        if (state.profilingActive && child) {
           try {
-            process.kill(state.xctracePid, "SIGINT");
+            child.kill("SIGKILL");
           } catch {
-            // process may already be dead
+            // already dead
           }
+          await waitForChildExit(child, DISPOSE_REAP_MS);
           state.profilingActive = false;
+          state.xctracePid = null;
+          state.xctraceProcess = null;
         }
       },
       events,

--- a/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { spawn, execSync } from "child_process";
+import { spawn, execSync, type ChildProcess } from "child_process";
 import * as path from "path";
 import type { ToolDefinition } from "@argent/registry";
 import {
@@ -7,8 +7,20 @@ import {
   type IosProfilerSessionApi,
 } from "../../../blueprints/ios-profiler-session";
 import { getDebugDir } from "../../../utils/react-profiler/debug/dump";
+import { listenForDarwinNotification, type NotifyHandle } from "../../../utils/ios-profiler/notify";
+import { waitForXctraceReady } from "../../../utils/ios-profiler/startup";
 
 const DEFAULT_TEMPLATE_PATH = path.resolve(__dirname, "Argent.tracetemplate");
+const STARTUP_TIMEOUT_MS = 10_000;
+const DETECT_RUNNING_APP_TIMEOUT_MS = 10_000;
+const NOTIFY_REGISTER_TIMEOUT_MS = 2_000;
+const RECORDING_CAP_MS = 10 * 60 * 1000;
+const MAX_START_ATTEMPTS = 2;
+const RETRY_DELAY_MS = 1_200;
+// Verbatim stderr prefix emitted by xctrace's own process resolver when the
+// `--attach <name>` lookup misses. Stable upstream signal — see
+// IOS_PROFILER_DETECTION_ANALYSIS.md for the cold-launch race this guards.
+const COLD_START_SIGNATURE = "Cannot find process matching name:";
 
 const zodSchema = z.object({
   device_id: z.string().describe("iOS Simulator or device UDID"),
@@ -32,10 +44,19 @@ interface AppInfo {
 }
 
 function detectRunningApp(udid: string): string {
-  // 1. Get running UIKitApplication processes
-  const launchctlOutput = execSync(`xcrun simctl spawn ${udid} launchctl list`, {
-    encoding: "utf-8",
-  });
+  let launchctlOutput: string;
+  try {
+    launchctlOutput = execSync(`xcrun simctl spawn ${udid} launchctl list`, {
+      encoding: "utf-8",
+      timeout: DETECT_RUNNING_APP_TIMEOUT_MS,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to enumerate running processes on simulator ${udid} within ${DETECT_RUNNING_APP_TIMEOUT_MS} ms. ` +
+        `Verify the simulator is booted and responsive, then retry. Underlying error: ${msg}`
+    );
+  }
 
   const runningBundleIds = new Set<string>();
   for (const line of launchctlOutput.split("\n")) {
@@ -51,14 +72,22 @@ function detectRunningApp(udid: string): string {
     );
   }
 
-  // 2. Get installed app metadata
-  const listAppsOutput = execSync(`xcrun simctl listapps ${udid} | plutil -convert json -o - -`, {
-    encoding: "utf-8",
-  });
+  let listAppsOutput: string;
+  try {
+    listAppsOutput = execSync(`xcrun simctl listapps ${udid} | plutil -convert json -o - -`, {
+      encoding: "utf-8",
+      timeout: DETECT_RUNNING_APP_TIMEOUT_MS,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to list installed apps on simulator ${udid} within ${DETECT_RUNNING_APP_TIMEOUT_MS} ms. ` +
+        `Verify the simulator is booted and responsive, then retry. Underlying error: ${msg}`
+    );
+  }
 
   const installedApps: Record<string, AppInfo> = JSON.parse(listAppsOutput);
 
-  // 3. Cross-reference: running user apps
   const runningUserApps: AppInfo[] = [];
   for (const [, appInfo] of Object.entries(installedApps)) {
     if (appInfo.ApplicationType === "User" && runningBundleIds.has(appInfo.CFBundleIdentifier)) {
@@ -85,6 +114,65 @@ function detectRunningApp(udid: string): string {
   }
 
   return runningUserApps[0].CFBundleExecutable;
+}
+
+/**
+ * Subscribe-before-spawn for the locale-robust ready signal. Darwin
+ * notifications are not queued, so the listener must be registered before
+ * xctrace can fire `--notify-tracing-started`. Returns null if notifyutil
+ * fails to register in time — the caller falls back to the stdout substring
+ * match that `waitForXctraceReady` always listens for.
+ */
+async function registerStartupNotify(name: string): Promise<NotifyHandle | null> {
+  let handle: NotifyHandle;
+  try {
+    handle = listenForDarwinNotification(name);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[ios-profiler] failed to spawn notifyutil (${msg}); falling back to stdout substring match.\n`
+    );
+    return null;
+  }
+
+  const ready = await Promise.race([
+    handle.ready.then(() => true as const),
+    new Promise<false>((r) => setTimeout(() => r(false), NOTIFY_REGISTER_TIMEOUT_MS)),
+  ]);
+  if (ready) return handle;
+
+  handle.cancel();
+  process.stderr.write(
+    `[ios-profiler] notifyutil did not register within ${NOTIFY_REGISTER_TIMEOUT_MS} ms; ` +
+      `falling back to stdout substring match.\n`
+  );
+  return null;
+}
+
+function resetStartState(api: IosProfilerSessionApi): void {
+  api.xctracePid = null;
+  api.xctraceProcess = null;
+  api.traceFile = null;
+  api.appProcess = null;
+}
+
+export function handleXctraceExit(
+  api: IosProfilerSessionApi,
+  code: number | null,
+  signal: string | null
+): void {
+  if (!api.profilingActive) return;
+  if (api.recordingTimeout) {
+    clearTimeout(api.recordingTimeout);
+    api.recordingTimeout = null;
+  }
+  api.xctracePid = null;
+  api.xctraceProcess = null;
+  api.profilingActive = false;
+  if (!api.recordingTimedOut) {
+    api.recordingExitedUnexpectedly = true;
+  }
+  api.lastExitInfo = { code, signal };
 }
 
 export const iosInstrumentsStartTool: ToolDefinition<
@@ -119,11 +207,18 @@ Fails if no app is running on the simulator or xctrace cannot attach to the proc
       .slice(0, 15);
     const outputFile = path.join(debugDir, `ios-profiler-${timestamp}.trace`);
 
-    api.appProcess = appProcess;
-    api.traceFile = outputFile;
+    api.recordingTimedOut = false;
+    api.recordingExitedUnexpectedly = false;
+    api.lastExitInfo = null;
 
-    return new Promise((resolve, reject) => {
-      const xctraceProcess = spawn("xctrace", [
+    const attemptStart = async (): Promise<{ child: ChildProcess; pid: number }> => {
+      api.appProcess = appProcess;
+      api.traceFile = outputFile;
+
+      const notifyName = `com.argent.ios-profiler.started.${process.pid}.${Date.now()}`;
+      const notify = await registerStartupNotify(notifyName);
+
+      const xctraceArgs = [
         "record",
         "--template",
         templatePath,
@@ -133,58 +228,92 @@ Fails if no app is running on the simulator or xctrace cannot attach to the proc
         appProcess,
         "--output",
         outputFile,
-      ]);
+        "--no-prompt",
+      ];
+      if (notify) {
+        xctraceArgs.push("--notify-tracing-started", notifyName);
+      }
 
+      const xctraceProcess = spawn("xctrace", xctraceArgs, {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
       api.xctracePid = xctraceProcess.pid ?? null;
+      api.xctraceProcess = xctraceProcess;
 
-      xctraceProcess.stdout.on("data", (data: Buffer) => {
-        const output = data.toString();
+      try {
+        await waitForXctraceReady(xctraceProcess, { notify, timeoutMs: STARTUP_TIMEOUT_MS });
+      } catch (err) {
+        resetStartState(api);
+        throw err;
+      }
 
-        if (output.includes("Ctrl-C to stop") || output.includes("Starting recording")) {
-          api.profilingActive = true;
-          api.wallClockStartMs = Date.now();
-          if (api.xctracePid) {
-            api.recordingTimeout = setTimeout(
-              () => {
-                xctraceProcess.kill("SIGINT");
-                api.profilingActive = false;
-                api.xctracePid = null;
-                api.recordingTimeout = null;
-              },
-              10 * 60 * 1000
-            );
-            resolve({
-              status: "recording",
-              pid: api.xctracePid,
-              traceFile: outputFile,
-            });
-          }
+      if (!xctraceProcess.pid) {
+        // pid is set synchronously after spawn — guard so we never resolve
+        // with `pid: 0` if Node ever changes that contract.
+        try {
+          xctraceProcess.kill("SIGKILL");
+        } catch {
+          // already dead
         }
-      });
+        resetStartState(api);
+        throw new Error("xctrace process has no pid; cannot resolve start.");
+      }
 
-      xctraceProcess.stderr.on("data", (data: Buffer) => {
-        const errorOutput = data.toString();
-        if (
-          errorOutput.includes("Target failed to run") ||
-          errorOutput.includes("failed with errors")
-        ) {
-          api.xctracePid = null;
-          if (api.recordingTimeout) {
-            clearTimeout(api.recordingTimeout);
-            api.recordingTimeout = null;
-          }
-          reject(new Error(`Failed to attach to iOS process: ${errorOutput}`));
-        }
-      });
+      return { child: xctraceProcess, pid: xctraceProcess.pid };
+    };
 
-      xctraceProcess.on("error", (err: Error) => {
-        api.xctracePid = null;
-        if (api.recordingTimeout) {
-          clearTimeout(api.recordingTimeout);
-          api.recordingTimeout = null;
+    // Bounded retry scoped to this single call: xctrace's process resolver can
+    // miss a freshly cold-launched app even after launchd has registered it.
+    // Same shape as fetchWithReconnect in packages/argent-mcp/src/mcp-server.ts.
+    const startMs = Date.now();
+    const startWithRetry = async (): Promise<{ child: ChildProcess; pid: number }> => {
+      for (let attempt = 1; attempt <= MAX_START_ATTEMPTS; attempt++) {
+        try {
+          return await attemptStart();
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          const isColdStart = msg.includes(COLD_START_SIGNATURE);
+          if (!isColdStart) throw err;
+          if (attempt >= MAX_START_ATTEMPTS) break;
+          process.stderr.write(
+            `[ios-profiler] xctrace could not find "${appProcess}" on attempt ${attempt}/${MAX_START_ATTEMPTS}; ` +
+              `waiting ${RETRY_DELAY_MS} ms for cold-start to settle, then retrying.\n`
+          );
+          await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
         }
-        reject(new Error(`Failed to start xctrace: ${err.message}`));
-      });
-    });
+      }
+      const totalMs = Date.now() - startMs;
+      throw new Error(
+        `xctrace could not find process "${appProcess}" after ${MAX_START_ATTEMPTS} attempts within ${totalMs} ms. ` +
+          `The app appears to be cold-launching — its bundle is registered with launchd, but xctrace's process resolver hasn't seen it yet. ` +
+          `Wait 1–2 seconds for the app to finish launching and retry. ` +
+          `If the wrong app is being detected, pass app_process explicitly with the CFBundleExecutable.`
+      );
+    };
+
+    const { child: xctraceProcess, pid: xctracePid } = await startWithRetry();
+
+    api.profilingActive = true;
+    api.wallClockStartMs = Date.now();
+    api.recordingTimeout = setTimeout(() => {
+      try {
+        xctraceProcess.kill("SIGINT");
+      } catch {
+        // already dead
+      }
+      api.profilingActive = false;
+      api.xctracePid = null;
+      api.xctraceProcess = null;
+      api.recordingTimeout = null;
+      api.recordingTimedOut = true;
+    }, RECORDING_CAP_MS);
+
+    xctraceProcess.on("exit", (code, signal) => handleXctraceExit(api, code, signal));
+
+    return {
+      status: "recording",
+      pid: xctracePid,
+      traceFile: outputFile,
+    };
   },
 };

--- a/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-start.ts
@@ -17,9 +17,8 @@ const NOTIFY_REGISTER_TIMEOUT_MS = 2_000;
 const RECORDING_CAP_MS = 10 * 60 * 1000;
 const MAX_START_ATTEMPTS = 2;
 const RETRY_DELAY_MS = 1_200;
-// Verbatim stderr prefix emitted by xctrace's own process resolver when the
-// `--attach <name>` lookup misses. Stable upstream signal — see
-// IOS_PROFILER_DETECTION_ANALYSIS.md for the cold-launch race this guards.
+// stderr prefix emitted by xctrace's own process resolver when the
+// `--attach <name>` lookup misses.
 const COLD_START_SIGNATURE = "Cannot find process matching name:";
 
 const zodSchema = z.object({

--- a/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-stop.ts
+++ b/packages/tool-server/src/tools/profiler/ios-profiler/ios-profiler-stop.ts
@@ -6,19 +6,24 @@ import {
 } from "../../../blueprints/ios-profiler-session";
 import { exportIosTraceData } from "../../../utils/ios-profiler/export";
 import type { ExportDiagnostics } from "../../../utils/ios-profiler/export";
+import { shutdownChild } from "../../../utils/ios-profiler/lifecycle";
+
+const STOP_GRACE_MS = 30_000;
+const STOP_TERM_MS = 5_000;
+const STOP_KILL_MS = 5_000;
 
 const zodSchema = z.object({
   device_id: z.string().describe("iOS Simulator or device UDID"),
 });
 
-export const iosInstrumentsStopTool: ToolDefinition<
-  z.infer<typeof zodSchema>,
-  {
-    traceFile: string;
-    exportedFiles: Record<string, string | null>;
-    exportDiagnostics: ExportDiagnostics;
-  }
-> = {
+interface StopResult {
+  traceFile: string;
+  exportedFiles: Record<string, string | null>;
+  exportDiagnostics: ExportDiagnostics;
+  warning?: string;
+}
+
+export const iosInstrumentsStopTool: ToolDefinition<z.infer<typeof zodSchema>, StopResult> = {
   id: "ios-profiler-stop",
   description: `Stop iOS Instruments profiling and export trace data to XML files.
 Sends SIGINT to the running xctrace process, waits for it to finish packaging the trace,
@@ -33,7 +38,33 @@ Fails if no active ios-profiler-start session exists for the given device_id.`,
   async execute(services) {
     const api = services.session as IosProfilerSessionApi;
 
-    if (!api.profilingActive || !api.xctracePid || !api.traceFile) {
+    // Recover a recording where xctrace is already gone but the trace bundle
+    // is on disk: either the in-process 10-min cap fired, or xctrace exited
+    // unexpectedly (attached app died, simulator daemon hiccup, etc).
+    if ((api.recordingTimedOut || api.recordingExitedUnexpectedly) && api.traceFile) {
+      const traceFile = api.traceFile;
+      const wasTimeout = api.recordingTimedOut;
+      const exitInfo = api.lastExitInfo;
+      api.recordingTimedOut = false;
+      api.recordingExitedUnexpectedly = false;
+      api.lastExitInfo = null;
+
+      const { files: exportedFiles, diagnostics } = exportIosTraceData(traceFile);
+      api.exportedFiles = exportedFiles;
+
+      const warning = wasTimeout
+        ? "Recording timed out at 10 min cap; exported the partial trace. " +
+          "Call ios-profiler-start again for a fresh recording."
+        : `xctrace exited before stop was called (code=${exitInfo?.code ?? "?"}, ` +
+          `signal=${exitInfo?.signal ?? "?"}); exported the partial trace. ` +
+          "Common causes: attached app terminated, simulator daemon restart. " +
+          "Call ios-profiler-start again for a fresh recording.";
+      process.stderr.write(`[ios-profiler] ${warning}\n`);
+
+      return { traceFile, exportedFiles, exportDiagnostics: diagnostics, warning };
+    }
+
+    if (!api.profilingActive || !api.xctraceProcess || !api.traceFile) {
       throw new Error("No active iOS profiling session found. Call ios-profiler-start first.");
     }
 
@@ -42,31 +73,35 @@ Fails if no active ios-profiler-start session exists for the given device_id.`,
       api.recordingTimeout = null;
     }
 
-    const pidToKill = api.xctracePid;
-    process.kill(pidToKill, "SIGINT");
-
-    // Wait for xctrace process to finish packaging
-    await new Promise<void>((resolve) => {
-      const checkInterval = setInterval(() => {
-        try {
-          process.kill(pidToKill, 0);
-        } catch {
-          clearInterval(checkInterval);
-          resolve();
-        }
-      }, 1000);
+    const result = await shutdownChild(api.xctraceProcess, {
+      graceMs: STOP_GRACE_MS,
+      termMs: STOP_TERM_MS,
+      killMs: STOP_KILL_MS,
     });
+
+    let warning: string | undefined;
+    if (!result.clean) {
+      warning =
+        `xctrace did not respond to SIGINT${result.signalUsed === "SIGKILL" ? "/SIGTERM" : ""}; ` +
+        `${result.signalUsed} was used. Trace bundle may be incomplete.`;
+      process.stderr.write(`[ios-profiler] ${warning}\n`);
+    }
 
     api.profilingActive = false;
     api.xctracePid = null;
+    api.xctraceProcess = null;
+    api.recordingExitedUnexpectedly = false;
+    api.lastExitInfo = null;
 
     const { files: exportedFiles, diagnostics } = exportIosTraceData(api.traceFile);
     api.exportedFiles = exportedFiles;
 
-    return {
+    const stopResult: StopResult = {
       traceFile: api.traceFile,
       exportedFiles,
       exportDiagnostics: diagnostics,
     };
+    if (warning) stopResult.warning = warning;
+    return stopResult;
   },
 };

--- a/packages/tool-server/src/utils/ios-profiler/IOS_PROFILER_REFERENCE.md
+++ b/packages/tool-server/src/utils/ios-profiler/IOS_PROFILER_REFERENCE.md
@@ -1,0 +1,237 @@
+# iOS Profiler — Reference
+
+A concise overview of how Argent's iOS profiling works: what native machinery is invoked, what gets captured, how the data is processed, and what comes back to the agent.
+
+For the deeper "why" of each pipeline decision, see `PIPELINE_DESIGN.md`. For day-to-day workflow, see the `argent-ios-profiler` skill.
+
+---
+
+## 1. TL;DR
+
+Argent profiles iOS by driving Apple's own profiling stack (`xctrace`/Instruments) from a Node tool server, then post-processing the trace into an LLM-friendly markdown report.
+
+```
+launch-app → ios-profiler-start → (user/agent interacts) → ios-profiler-stop → ios-profiler-analyze → profiler-stack-query (drill-down) / profiler-combined-report (with React)
+```
+
+Three concerns are captured: **CPU hotspots**, **UI hangs**, and **memory leaks**. Each is summarised, classified RED/YELLOW, and accompanied by app call chains for actionability.
+
+---
+
+## 2. Native foundations
+
+| Layer | What it is | How Argent uses it |
+| --- | --- | --- |
+| **Instruments / `xctrace`** | Apple's tracing framework. `xctrace` is the headless CLI used by the Instruments app under the hood. | Every iOS profiling action is just an `xctrace record` / `xctrace export` invocation spawned by Argent. |
+| **`.tracetemplate`** | A binary plist describing which Instruments to attach and how to configure them. | Argent ships `Argent.tracetemplate`, passed via `xctrace record --template`. |
+| **`xcrun simctl`** | Simulator control. `simctl spawn ... launchctl list` enumerates running processes; `simctl listapps` enumerates installed bundles. | Used by `ios-profiler-start` to auto-detect the foreground user app (`CFBundleExecutable`) so the user does not have to specify it. |
+| **Trace bundle (`.trace`)** | The package `xctrace record` produces. Internally a SQLite-backed structure with per-instrument tables. | `xctrace export --xpath ...` extracts individual tables to XML for parsing. |
+
+`xctrace` runs via `child_process.spawn`. The PID is held in the per-device session blueprint (`IosProfilerSession`); SIGINT terminates recording cleanly so the trace bundle finalises.
+
+---
+
+## 3. What is recorded (bundled template)
+
+`Argent.tracetemplate` enables the following Instruments. Identifiers are taken from the binary plist (`com.apple.xray.instrument-type.*` / `com.apple.dt-perfteam.*`):
+
+| Instrument identifier | Common name | Used by Argent's pipeline? |
+| --- | --- | --- |
+| `com.apple.xray.instrument-type.coresampler2` | **Time Profiler** (kernel-driven sampling profiler) | **Yes** — exported as the `time-profile` table → CPU hotspots. |
+| `com.apple.dt-perfteam.hangs` | **Hangs** (main-thread responsiveness detector) | **Yes** — exported as the `potential-hangs` table → UI hangs. |
+| `com.apple.xray.instrument-type.homeleaks` | **Leaks** (periodic leak scan) | **Yes** — exported via the `Leaks` track → memory leaks. |
+| `com.apple.xray.instrument-type.oa` | **Allocations** (object lifetime + alloc tree) | Recorded but currently not consumed. |
+| `com.apple.xray.instrument-type.poi` | **Points of Interest** (`os_signpost`) | Recorded but not consumed. |
+| `com.apple.xray.instrument-type.device-thermal-state` | **Thermal State** | Recorded but not consumed. |
+
+> The hangs Instrument is the same engine that powers Xcode's "hang reports" — Apple's term for any stretch of time the main thread fails to service the run loop.
+
+---
+
+## 4. The three tools (capture flow)
+
+All three are wired through `ios-profiler-session` (per-device service, keyed by UDID).
+
+### `ios-profiler-start`
+
+1. **Detect the target app** — runs `xcrun simctl spawn <udid> launchctl list`, parses `UIKitApplication:<bundleId>` lines, cross-references with `simctl listapps` to keep only `User` apps. Fails fast if zero or more than one app match.
+2. **Resolve the template** — defaults to bundled `Argent.tracetemplate`, override via `template_path`.
+3. **Spawn `xctrace record`**:
+   ```
+   xctrace record \
+     --template <Argent.tracetemplate> \
+     --device <udid> \
+     --attach <CFBundleExecutable> \
+     --output <tmpdir>/argent-profiler-cwd/ios-profiler-<ts>.trace
+   ```
+4. **Start gating** — only resolves the tool call once `xctrace` prints `Starting recording` / `Ctrl-C to stop` on stdout. At that point Argent records `Date.now()` (`wallClockStartMs`) — the anchor used later for cross-tool time alignment.
+5. **Safety timeout** — auto-SIGINTs after 10 minutes if `stop` is never called.
+
+### `ios-profiler-stop`
+
+1. `process.kill(xctracePid, "SIGINT")` and poll `process.kill(pid, 0)` until the child exits (xctrace needs a moment to finalise the trace bundle).
+2. Run **schema-aware export**:
+   - First call `xctrace export --toc` to discover what schemas the trace actually contains.
+   - Pick the first match from `["time-profile", "cpu-profile", "time-sample"]` for CPU.
+   - Fall back to brute-forcing each candidate if TOC parsing fails.
+   - For Leaks, append `--hal` on `xctrace` ≥ 15 (required by newer xctrace versions for the leaks export); retry without the flag on failure for backward compatibility.
+3. Three XMLs land next to the `.trace` bundle:
+   - `<base>_raw_cpu.xml`     — `time-profile` table
+   - `<base>_raw_hangs.xml`   — `potential-hangs` table
+   - `<base>_raw_leaks.xml`   — `Leaks` track detail
+4. Returns `{ traceFile, exportedFiles, exportDiagnostics }`. `exportDiagnostics` carries the discovered schema list and any per-stream errors so the agent can debug missing data.
+
+### `ios-profiler-analyze`
+
+Runs the post-processing pipeline, caches the parsed data on the session (so `profiler-stack-query` can reuse it), and renders the markdown report. Returns `{ report, reportFile, bottlenecksTotal }`. The full report is also written to `<base>-report.md` so the agent can re-read it later without re-analysing.
+
+---
+
+## 5. Pipeline (XML → bottlenecks)
+
+```
+parseCpuFile  ─┐
+parseHangsFile ┼─► correlateHangsWithCpu ──► uiHangs + hangSampleTimestamps
+parseLeaksFile ┘                                                │
+                                                                ▼
+                                  aggregateCpuHotspots(hangSampleTimestamps)
+                                  aggregateLeaks
+                                                ──► bottlenecks: CpuHotspot[] | UiHang[] | MemoryLeak[]
+```
+
+### Stage 0 — XML parser (`pipeline/xml-parser.ts`)
+
+`xctrace` exports rely on an **id/ref deduplication scheme**: each `<frame>`, `<binary>`, `<backtrace>`, `<thread>`, `<weight>`, `<hang-type>`, etc. is defined once with `id="N"` and referenced afterwards by `<… ref="N"/>`. The parser maintains a `Map` per element type and resolves refs as it goes — without this most rows would be empty.
+
+DOM parsing is impractical (multi-MB files, deep nesting), so the parser pulls only what it needs with targeted regex (`<row[\s>](.*?)</row>`). System frames are flagged here using `SYSTEM_LIBRARY_PATH_PREFIXES` (`/usr/lib/`, `/System/Library/`, `/Library/Developer/CoreSimulator/`) so later stages can cheaply filter them out.
+
+Output shapes:
+
+```ts
+CpuSample = { timestampNs, threadFmt, weightNs, stack: StackFrame[] }   // leaf-first
+RawHang   = { startNs, durationNs, hangType, threadFmt }
+RawLeak   = { objectType, sizeBytes, responsibleFrame, responsibleLibrary, count }
+```
+
+### Stage 1 — Correlate (`pipeline/01-correlate.ts`)
+
+- **Hang ↔ CPU correlation.** For each hang, filter CPU samples whose `timestampNs` ∈ `[startNs, startNs + durationNs]`. Within that window, count the **dominant function** of every sample and the **app call chain** (system + hex frames stripped). Top 5 functions and top 3 chains attach to the hang. Their timestamps are also returned in `hangSampleTimestamps` so Stage 2 can flag overlapping CPU hotspots.
+- **Leak aggregation.** Group raw leaks by `objectType`, summing `sizeBytes * count`. Sorted by total size descending. (Leaks have no timestamps, so they cannot be correlated with CPU samples — they are reported independently and always RED.)
+- Hang severity is classified from the type string: contains `severe` or equals `hang` ⇒ RED; `microhang` ⇒ YELLOW.
+
+### Stage 2 — Aggregate CPU (`pipeline/02-aggregate.ts`)
+
+- **Dominant function detection** (per stack, leaf-first, 3-tier preference):
+  1. First non-system, non-hex, non-RN-framework frame (`RN_FRAMEWORK_SIGNATURES` = `RCT`, `Yoga`, `Hermes`, `JSI`, `React`, `facebook::`, `hermes::`, `jsi::`, `HermesRuntime`). This favours user code and third-party SDKs (FullStory, Sentry, Firebase…).
+  2. First non-system, non-hex frame (allowing RN internals).
+  3. First named frame, else `stack[0]`.
+- **Thread normalisation** — fragments like `"main thread"`, `"Main Thread"`, `"com.apple.main-thread"` collapse to `"Main Thread"`; Hermes/JS variants → `"JS/Hermes"`; `"AppName 0x1e4715 (…)"` → `"AppName"`. Without this, hotspots fragment across name variants.
+- **Group key** = `dominantFunction + "|||" + normalizedThread`. For each group, accumulate sample count, total weight (ns), timestamps, and per-call-chain frequency.
+- **Filter** below `MIN_WEIGHT_PERCENTAGE = 3%` of total trace weight (cuts noise from xctrace's high sample rate).
+- **Severity** — > 15 % wall time ⇒ RED; 3 – 15 % ⇒ YELLOW.
+- **`duringHang` flag** — true when any timestamp in the group hits a `hangSampleTimestamps` entry.
+- **Burst windows** — sort timestamps, split clusters separated by > 500 ms gaps. Each burst is `{ startMs, endMs, sampleCount }`. Helps tell "200 ms once at startup" from "5 ms every 50 ms".
+
+---
+
+## 6. What the report contains
+
+`renderIosProfilerReport` produces a markdown document with these sections:
+
+1. **Header** — trace filename, platform, timestamp, any export warnings.
+2. **Summary table** — counts and severity rollup per category (CPU Hotspots / UI Hangs / Memory Leaks).
+3. **CPU Hotspots** — table of dominant function, thread, weight (ms / %), sample count, `duringHang` flag, severity. Per hotspot: top 3 call chains and either burst windows or active range.
+4. **UI Hangs** — table of type / start (`MM:SS.mmm`) / duration / severity. Per hang: top app call chains during the hang window with sample counts (or top suspected functions if chain extraction was empty).
+5. **Memory Leaks** — table of object type, count, total size, responsible frame, library.
+6. **Suggested Improvements** — a one-liner per finding with a templated remediation hint.
+7. **Next Steps** — concrete `profiler-stack-query` invocations the agent can chain into.
+
+The inline report is capped (top 5 hotspots, top 3 hangs); the full report is always written to `<trace>-report.md` for re-read.
+
+---
+
+## 7. Drill-down: `profiler-stack-query`
+
+Reads the cached `parsedData` on the session — no XML re-parse. Modes:
+
+| Mode | Inputs | What you get |
+| --- | --- | --- |
+| `hang_stacks` | `hang_index` | The hang's suspected functions, app call chains during the hang, plus all unique stacks across CPU samples whose dominant function matches a suspect. |
+| `function_callers` | `function_name` | Frames immediately above (callers) and below (callees) the named frame across all samples, ranked by frequency. Effectively a poor-man's call graph for a hot native function. |
+| `thread_breakdown` | optional `thread` filter | Per-thread weight (ms/%) and sample count. With a filter, also lists hotspots on that thread. |
+| `leak_stacks` | optional `object_type` filter | Filtered, sorted memory leak table. |
+
+Top-N is configurable (default 15).
+
+---
+
+## 8. Reload past sessions: `profiler-load`
+
+Lists prior `.trace` directories under the debug dir (`<os.tmpdir()>/argent-profiler-cwd/`, e.g. `/var/folders/.../T/argent-profiler-cwd/` on macOS) and re-parses them on demand:
+
+- `mode=list` — enumerate sessions on disk.
+- `mode=load_instruments session_id=<ts> device_id=<UDID>` — re-runs the parsing pipeline on the stored XMLs and re-hydrates the session so query tools work again.
+- (Also supports `mode=load_react` for Hermes profiler sessions; same idea, different files.)
+
+This is what makes before/after comparisons possible without keeping the original capture session alive.
+
+---
+
+## 9. Cross-tool correlation: `profiler-combined-report`
+
+When both `react-profiler-analyze` and `ios-profiler-analyze` ran on the same session, this tool aligns them on a shared **wall-clock anchor**:
+
+- React Profiler stamps `Date.now()` at start and uses `performance.now()` ms internally.
+- iOS Instruments uses trace-relative ns starting at 0; the wall-clock anchor is `wallClockStartMs` recorded by `ios-profiler-start`.
+- Helpers in `utils/profiler-shared/time-align.ts` convert in either direction.
+
+For each iOS hang the tool maps `[hangStart, hangEnd]` → wall-clock and looks for React commits whose `[timestamp, timestamp + totalRenderMs]` overlap (200 ms tolerance for jitter). The output report includes:
+
+- **Hang ↔ Commit correlations** — top overlapping commit per hang with its root-cause component, top components, JS CPU hotspots, and native CPU "suspects".
+- **Hangs without React commit match** — likely pure native work.
+- **Memory leaks** — heuristically flagged when `objectType` or `responsibleFrame` matches a recently-mounted React component name.
+
+---
+
+## 10. Severity rules at a glance
+
+| Category | Condition | Severity |
+| --- | --- | --- |
+| CPU hotspot | wall-time > 15 % | RED |
+| CPU hotspot | wall-time 3 – 15 % | YELLOW |
+| CPU hotspot | wall-time < 3 % | filtered out |
+| UI hang | type contains `severe` or equals `hang` | RED |
+| UI hang | `microhang` | YELLOW |
+| Memory leak | any | RED |
+
+> Note: `argent-ios-profiler/SKILL.md` currently documents the YELLOW band as 5–15 %. The implementation uses 3–15 % (`MIN_WEIGHT_PERCENTAGE = 3` in `02-aggregate.ts`). The code is the source of truth.
+
+---
+
+## 11. Caveats worth keeping in mind
+
+- **Simulator ≠ device.** Simulator CPU times reflect the host Mac. For absolute numbers, profile a real device.
+- **`xctrace` overhead.** Hermes runtime internals (`JSLexer`, `JSONEmitter`, etc.) dominating the JS thread usually means profiler overhead, not app work.
+- **Run-to-run variance.** Treat changes < ~15 % across a single run as noise.
+- **Live data variance.** Different API responses change rendering work — record a flow (`argent-create-flow`) for stable before/after comparisons.
+- **xctrace requirement.** Needs Xcode CLT installed (`xcrun xctrace version`). Some commands (`--hal` for leaks) gate on `xctrace ≥ 15`.
+
+---
+
+## 12. Source map
+
+| Concern | File |
+| --- | --- |
+| Tool definitions | `tools/profiler/ios-profiler/{start,stop,analyze}.ts` |
+| Drill-down query | `tools/profiler/query/profiler-stack-query.ts` |
+| Reload past sessions | `tools/profiler/query/profiler-load.ts` |
+| Cross-tool correlation | `tools/profiler/combined/profiler-combined-report.ts` |
+| Per-device session state | `blueprints/ios-profiler-session.ts` |
+| Bundled template | `utils/ios-profiler/Argent.tracetemplate` |
+| Schema-aware XML export | `utils/ios-profiler/export.ts` |
+| Pipeline (parser + 2 stages) | `utils/ios-profiler/pipeline/{xml-parser,01-correlate,02-aggregate,index}.ts` |
+| Markdown rendering | `utils/ios-profiler/render.ts` |
+| RN/system filter signatures | `utils/ios-profiler/config.ts` |
+| Cross-tool time alignment | `utils/profiler-shared/time-align.ts` |
+| Design rationale | `utils/ios-profiler/PIPELINE_DESIGN.md` |
+| User-facing workflow | `packages/argent/skills/argent-ios-profiler/SKILL.md` |

--- a/packages/tool-server/src/utils/ios-profiler/IOS_PROFILER_REFERENCE.md
+++ b/packages/tool-server/src/utils/ios-profiler/IOS_PROFILER_REFERENCE.md
@@ -20,12 +20,12 @@ Three concerns are captured: **CPU hotspots**, **UI hangs**, and **memory leaks*
 
 ## 2. Native foundations
 
-| Layer | What it is | How Argent uses it |
-| --- | --- | --- |
-| **Instruments / `xctrace`** | Apple's tracing framework. `xctrace` is the headless CLI used by the Instruments app under the hood. | Every iOS profiling action is just an `xctrace record` / `xctrace export` invocation spawned by Argent. |
-| **`.tracetemplate`** | A binary plist describing which Instruments to attach and how to configure them. | Argent ships `Argent.tracetemplate`, passed via `xctrace record --template`. |
-| **`xcrun simctl`** | Simulator control. `simctl spawn ... launchctl list` enumerates running processes; `simctl listapps` enumerates installed bundles. | Used by `ios-profiler-start` to auto-detect the foreground user app (`CFBundleExecutable`) so the user does not have to specify it. |
-| **Trace bundle (`.trace`)** | The package `xctrace record` produces. Internally a SQLite-backed structure with per-instrument tables. | `xctrace export --xpath ...` extracts individual tables to XML for parsing. |
+| Layer                       | What it is                                                                                                                         | How Argent uses it                                                                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Instruments / `xctrace`** | Apple's tracing framework. `xctrace` is the headless CLI used by the Instruments app under the hood.                               | Every iOS profiling action is just an `xctrace record` / `xctrace export` invocation spawned by Argent.                             |
+| **`.tracetemplate`**        | A binary plist describing which Instruments to attach and how to configure them.                                                   | Argent ships `Argent.tracetemplate`, passed via `xctrace record --template`.                                                        |
+| **`xcrun simctl`**          | Simulator control. `simctl spawn ... launchctl list` enumerates running processes; `simctl listapps` enumerates installed bundles. | Used by `ios-profiler-start` to auto-detect the foreground user app (`CFBundleExecutable`) so the user does not have to specify it. |
+| **Trace bundle (`.trace`)** | The package `xctrace record` produces. Internally a SQLite-backed structure with per-instrument tables.                            | `xctrace export --xpath ...` extracts individual tables to XML for parsing.                                                         |
 
 `xctrace` runs via `child_process.spawn`. The PID is held in the per-device session blueprint (`IosProfilerSession`); SIGINT terminates recording cleanly so the trace bundle finalises.
 
@@ -35,14 +35,14 @@ Three concerns are captured: **CPU hotspots**, **UI hangs**, and **memory leaks*
 
 `Argent.tracetemplate` enables the following Instruments. Identifiers are taken from the binary plist (`com.apple.xray.instrument-type.*` / `com.apple.dt-perfteam.*`):
 
-| Instrument identifier | Common name | Used by Argent's pipeline? |
-| --- | --- | --- |
-| `com.apple.xray.instrument-type.coresampler2` | **Time Profiler** (kernel-driven sampling profiler) | **Yes** — exported as the `time-profile` table → CPU hotspots. |
-| `com.apple.dt-perfteam.hangs` | **Hangs** (main-thread responsiveness detector) | **Yes** — exported as the `potential-hangs` table → UI hangs. |
-| `com.apple.xray.instrument-type.homeleaks` | **Leaks** (periodic leak scan) | **Yes** — exported via the `Leaks` track → memory leaks. |
-| `com.apple.xray.instrument-type.oa` | **Allocations** (object lifetime + alloc tree) | Recorded but currently not consumed. |
-| `com.apple.xray.instrument-type.poi` | **Points of Interest** (`os_signpost`) | Recorded but not consumed. |
-| `com.apple.xray.instrument-type.device-thermal-state` | **Thermal State** | Recorded but not consumed. |
+| Instrument identifier                                 | Common name                                         | Used by Argent's pipeline?                                     |
+| ----------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| `com.apple.xray.instrument-type.coresampler2`         | **Time Profiler** (kernel-driven sampling profiler) | **Yes** — exported as the `time-profile` table → CPU hotspots. |
+| `com.apple.dt-perfteam.hangs`                         | **Hangs** (main-thread responsiveness detector)     | **Yes** — exported as the `potential-hangs` table → UI hangs.  |
+| `com.apple.xray.instrument-type.homeleaks`            | **Leaks** (periodic leak scan)                      | **Yes** — exported via the `Leaks` track → memory leaks.       |
+| `com.apple.xray.instrument-type.oa`                   | **Allocations** (object lifetime + alloc tree)      | Recorded but currently not consumed.                           |
+| `com.apple.xray.instrument-type.poi`                  | **Points of Interest** (`os_signpost`)              | Recorded but not consumed.                                     |
+| `com.apple.xray.instrument-type.device-thermal-state` | **Thermal State**                                   | Recorded but not consumed.                                     |
 
 > The hangs Instrument is the same engine that powers Xcode's "hang reports" — Apple's term for any stretch of time the main thread fails to service the run loop.
 
@@ -76,9 +76,9 @@ All three are wired through `ios-profiler-session` (per-device service, keyed by
    - Fall back to brute-forcing each candidate if TOC parsing fails.
    - For Leaks, append `--hal` on `xctrace` ≥ 15 (required by newer xctrace versions for the leaks export); retry without the flag on failure for backward compatibility.
 3. Three XMLs land next to the `.trace` bundle:
-   - `<base>_raw_cpu.xml`     — `time-profile` table
-   - `<base>_raw_hangs.xml`   — `potential-hangs` table
-   - `<base>_raw_leaks.xml`   — `Leaks` track detail
+   - `<base>_raw_cpu.xml` — `time-profile` table
+   - `<base>_raw_hangs.xml` — `potential-hangs` table
+   - `<base>_raw_leaks.xml` — `Leaks` track detail
 4. Returns `{ traceFile, exportedFiles, exportDiagnostics }`. `exportDiagnostics` carries the discovered schema list and any per-stream errors so the agent can debug missing data.
 
 ### `ios-profiler-analyze`
@@ -154,12 +154,12 @@ The inline report is capped (top 5 hotspots, top 3 hangs); the full report is al
 
 Reads the cached `parsedData` on the session — no XML re-parse. Modes:
 
-| Mode | Inputs | What you get |
-| --- | --- | --- |
-| `hang_stacks` | `hang_index` | The hang's suspected functions, app call chains during the hang, plus all unique stacks across CPU samples whose dominant function matches a suspect. |
-| `function_callers` | `function_name` | Frames immediately above (callers) and below (callees) the named frame across all samples, ranked by frequency. Effectively a poor-man's call graph for a hot native function. |
-| `thread_breakdown` | optional `thread` filter | Per-thread weight (ms/%) and sample count. With a filter, also lists hotspots on that thread. |
-| `leak_stacks` | optional `object_type` filter | Filtered, sorted memory leak table. |
+| Mode               | Inputs                        | What you get                                                                                                                                                                   |
+| ------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `hang_stacks`      | `hang_index`                  | The hang's suspected functions, app call chains during the hang, plus all unique stacks across CPU samples whose dominant function matches a suspect.                          |
+| `function_callers` | `function_name`               | Frames immediately above (callers) and below (callees) the named frame across all samples, ranked by frequency. Effectively a poor-man's call graph for a hot native function. |
+| `thread_breakdown` | optional `thread` filter      | Per-thread weight (ms/%) and sample count. With a filter, also lists hotspots on that thread.                                                                                  |
+| `leak_stacks`      | optional `object_type` filter | Filtered, sorted memory leak table.                                                                                                                                            |
 
 Top-N is configurable (default 15).
 
@@ -195,14 +195,14 @@ For each iOS hang the tool maps `[hangStart, hangEnd]` → wall-clock and looks 
 
 ## 10. Severity rules at a glance
 
-| Category | Condition | Severity |
-| --- | --- | --- |
-| CPU hotspot | wall-time > 15 % | RED |
-| CPU hotspot | wall-time 3 – 15 % | YELLOW |
-| CPU hotspot | wall-time < 3 % | filtered out |
-| UI hang | type contains `severe` or equals `hang` | RED |
-| UI hang | `microhang` | YELLOW |
-| Memory leak | any | RED |
+| Category    | Condition                               | Severity     |
+| ----------- | --------------------------------------- | ------------ |
+| CPU hotspot | wall-time > 15 %                        | RED          |
+| CPU hotspot | wall-time 3 – 15 %                      | YELLOW       |
+| CPU hotspot | wall-time < 3 %                         | filtered out |
+| UI hang     | type contains `severe` or equals `hang` | RED          |
+| UI hang     | `microhang`                             | YELLOW       |
+| Memory leak | any                                     | RED          |
 
 > Note: `argent-ios-profiler/SKILL.md` currently documents the YELLOW band as 5–15 %. The implementation uses 3–15 % (`MIN_WEIGHT_PERCENTAGE = 3` in `02-aggregate.ts`). The code is the source of truth.
 
@@ -220,18 +220,18 @@ For each iOS hang the tool maps `[hangStart, hangEnd]` → wall-clock and looks 
 
 ## 12. Source map
 
-| Concern | File |
-| --- | --- |
-| Tool definitions | `tools/profiler/ios-profiler/{start,stop,analyze}.ts` |
-| Drill-down query | `tools/profiler/query/profiler-stack-query.ts` |
-| Reload past sessions | `tools/profiler/query/profiler-load.ts` |
-| Cross-tool correlation | `tools/profiler/combined/profiler-combined-report.ts` |
-| Per-device session state | `blueprints/ios-profiler-session.ts` |
-| Bundled template | `utils/ios-profiler/Argent.tracetemplate` |
-| Schema-aware XML export | `utils/ios-profiler/export.ts` |
+| Concern                      | File                                                                          |
+| ---------------------------- | ----------------------------------------------------------------------------- |
+| Tool definitions             | `tools/profiler/ios-profiler/{start,stop,analyze}.ts`                         |
+| Drill-down query             | `tools/profiler/query/profiler-stack-query.ts`                                |
+| Reload past sessions         | `tools/profiler/query/profiler-load.ts`                                       |
+| Cross-tool correlation       | `tools/profiler/combined/profiler-combined-report.ts`                         |
+| Per-device session state     | `blueprints/ios-profiler-session.ts`                                          |
+| Bundled template             | `utils/ios-profiler/Argent.tracetemplate`                                     |
+| Schema-aware XML export      | `utils/ios-profiler/export.ts`                                                |
 | Pipeline (parser + 2 stages) | `utils/ios-profiler/pipeline/{xml-parser,01-correlate,02-aggregate,index}.ts` |
-| Markdown rendering | `utils/ios-profiler/render.ts` |
-| RN/system filter signatures | `utils/ios-profiler/config.ts` |
-| Cross-tool time alignment | `utils/profiler-shared/time-align.ts` |
-| Design rationale | `utils/ios-profiler/PIPELINE_DESIGN.md` |
-| User-facing workflow | `packages/argent/skills/argent-ios-profiler/SKILL.md` |
+| Markdown rendering           | `utils/ios-profiler/render.ts`                                                |
+| RN/system filter signatures  | `utils/ios-profiler/config.ts`                                                |
+| Cross-tool time alignment    | `utils/profiler-shared/time-align.ts`                                         |
+| Design rationale             | `utils/ios-profiler/PIPELINE_DESIGN.md`                                       |
+| User-facing workflow         | `packages/argent/skills/argent-ios-profiler/SKILL.md`                         |

--- a/packages/tool-server/src/utils/ios-profiler/export.ts
+++ b/packages/tool-server/src/utils/ios-profiler/export.ts
@@ -1,5 +1,5 @@
-import { execSync } from "child_process";
 import * as path from "path";
+import { execSyncWithTimeout } from "./run-with-timeout";
 
 /**
  * Known xctrace schema names that contain CPU time-profile data.
@@ -31,9 +31,9 @@ export interface ExportDiagnostics {
 
 function getXctraceVersion(): number {
   try {
-    const output = execSync("xctrace version 2>&1 || true", {
+    const output = execSyncWithTimeout("xctrace version 2>&1 || true", {
       encoding: "utf-8",
-    });
+    }) as string;
     const match = output.match(/(\d+)\./);
     return match ? parseInt(match[1]!, 10) : 0;
   } catch {
@@ -47,10 +47,10 @@ function getXctraceVersion(): number {
  */
 function discoverTraceSchemas(traceFile: string): string[] {
   try {
-    const toc = execSync(`xctrace export --input "${traceFile}" --toc`, {
+    const toc = execSyncWithTimeout(`xctrace export --input "${traceFile}" --toc`, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
-    });
+    }) as string;
     const schemas: string[] = [];
     const schemaRe = /schema="([^"]+)"/g;
     let m;
@@ -100,9 +100,12 @@ function tryCpuExportFallback(
   for (const candidate of CPU_SCHEMA_CANDIDATES) {
     const xpath = `/trace-toc/run[@number="1"]/data/table[@schema="${candidate}"]`;
     try {
-      execSync(`xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${xpath}'`, {
-        stdio: "pipe",
-      });
+      execSyncWithTimeout(
+        `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${xpath}'`,
+        {
+          stdio: "pipe",
+        }
+      );
       diagnostics.cpuSchemaUsed = candidate;
       return true;
     } catch {
@@ -137,7 +140,7 @@ export function exportIosTraceData(traceFile: string): {
 
       if (resolvedXpath) {
         try {
-          execSync(
+          execSyncWithTimeout(
             `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${resolvedXpath}'`,
             { stdio: "pipe" }
           );
@@ -163,7 +166,7 @@ export function exportIosTraceData(traceFile: string): {
       const xcVersion = getXctraceVersion();
       const halFlag = xcVersion >= 15 ? " --hal" : "";
       try {
-        execSync(
+        execSyncWithTimeout(
           `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${config.xpath}'${halFlag}`,
           { stdio: "pipe" }
         );
@@ -171,7 +174,7 @@ export function exportIosTraceData(traceFile: string): {
       } catch {
         if (halFlag) {
           try {
-            execSync(
+            execSyncWithTimeout(
               `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${config.xpath}'`,
               { stdio: "pipe" }
             );
@@ -190,7 +193,7 @@ export function exportIosTraceData(traceFile: string): {
 
     // Default export (hangs, etc.)
     try {
-      execSync(
+      execSyncWithTimeout(
         `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${config.xpath}'`,
         { stdio: "pipe" }
       );

--- a/packages/tool-server/src/utils/ios-profiler/lifecycle.ts
+++ b/packages/tool-server/src/utils/ios-profiler/lifecycle.ts
@@ -1,0 +1,79 @@
+import type { ChildProcess } from "child_process";
+
+export interface ShutdownTimings {
+  /** SIGINT → exit window. */
+  graceMs: number;
+  /** SIGTERM → exit window if SIGINT was ignored. */
+  termMs: number;
+  /** SIGKILL → exit window if SIGTERM was ignored. */
+  killMs: number;
+}
+
+export interface ShutdownResult {
+  /** True if SIGINT alone was enough to bring the child down. */
+  clean: boolean;
+  /** The signal that ultimately produced the exit (or was last attempted). */
+  signalUsed: "SIGINT" | "SIGTERM" | "SIGKILL";
+}
+
+/**
+ * Resolves true if the child has already exited or exits within `ms`.
+ * Resolves false on timeout. Driven by the `'exit'` event (delivered straight
+ * from `waitpid()`), not by polling — no PID-reuse hazard.
+ */
+export function waitForChildExit(child: ChildProcess, ms: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    const onExit = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      child.removeListener("exit", onExit);
+      resolve(false);
+    }, ms);
+    child.once("exit", onExit);
+  });
+}
+
+/**
+ * Bring the child down via the SIGINT → SIGTERM → SIGKILL ladder. Each
+ * `child.kill(...)` is sent through the handle, so a kernel-reused PID can
+ * never be the recipient. Returns whether SIGINT alone was sufficient.
+ */
+export async function shutdownChild(
+  child: ChildProcess,
+  t: ShutdownTimings
+): Promise<ShutdownResult> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { clean: true, signalUsed: "SIGINT" };
+  }
+
+  try {
+    child.kill("SIGINT");
+  } catch {
+    // already dead
+  }
+  if (await waitForChildExit(child, t.graceMs)) {
+    return { clean: true, signalUsed: "SIGINT" };
+  }
+
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // already dead
+  }
+  if (await waitForChildExit(child, t.termMs)) {
+    return { clean: false, signalUsed: "SIGTERM" };
+  }
+
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // already dead
+  }
+  await waitForChildExit(child, t.killMs);
+  return { clean: false, signalUsed: "SIGKILL" };
+}

--- a/packages/tool-server/src/utils/ios-profiler/notify.ts
+++ b/packages/tool-server/src/utils/ios-profiler/notify.ts
@@ -1,0 +1,80 @@
+import { spawn } from "child_process";
+
+const NOTIFYUTIL_PATH = "/usr/bin/notifyutil";
+const REGISTRATION_DELAY_MS = 300;
+
+export interface NotifyHandle {
+  /** Resolves once notifyutil has had time to register its listener with notifyd. */
+  ready: Promise<void>;
+  /** Resolves when the notification fires (notifyutil exits with code 0). */
+  fired: Promise<void>;
+  /** Kill the notifyutil child if no longer needed. */
+  cancel: () => void;
+}
+
+/**
+ * Subscribe to a Darwin notification via `/usr/bin/notifyutil -1 <name>`.
+ *
+ * Darwin notifications are not queued: a fast-starting `xctrace record` can
+ * post the notification before a late-spawned listener registers, and the
+ * resolve trigger is missed. Callers MUST await `ready` before spawning the
+ * notifying process so the listener is live first.
+ *
+ * `notifyutil -v` only writes to stdout when the notification fires, so we
+ * cannot detect the registration boundary by reading bytes. We use a fixed
+ * delay matching the timing proven in `ios-profiler-repro/05-notify-tracing-started.sh`.
+ * If `notifyutil` fails to spawn at all, `ready` rejects so callers can fall back.
+ */
+export function listenForDarwinNotification(name: string): NotifyHandle {
+  const proc = spawn(NOTIFYUTIL_PATH, ["-v", "-1", name]);
+
+  let firedResolve: () => void = () => {};
+  let fired = false;
+
+  const fired$ = new Promise<void>((r) => {
+    firedResolve = r;
+  });
+
+  let readyResolve: () => void = () => {};
+  let readyReject: (e: Error) => void = () => {};
+  let readySettled = false;
+  const ready = new Promise<void>((res, rej) => {
+    readyResolve = () => {
+      if (readySettled) return;
+      readySettled = true;
+      res();
+    };
+    readyReject = (e) => {
+      if (readySettled) return;
+      readySettled = true;
+      rej(e);
+    };
+  });
+
+  const registrationTimer = setTimeout(readyResolve, REGISTRATION_DELAY_MS);
+
+  proc.on("exit", (code) => {
+    if (!fired && code === 0) {
+      fired = true;
+      firedResolve();
+    }
+    // Non-zero exit: never fire. Caller falls back to stdout substring match.
+  });
+  proc.on("error", (err) => {
+    clearTimeout(registrationTimer);
+    readyReject(err);
+  });
+
+  return {
+    ready,
+    fired: fired$,
+    cancel: () => {
+      clearTimeout(registrationTimer);
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // already dead
+      }
+    },
+  };
+}

--- a/packages/tool-server/src/utils/ios-profiler/run-with-timeout.ts
+++ b/packages/tool-server/src/utils/ios-profiler/run-with-timeout.ts
@@ -1,0 +1,18 @@
+import { execSync as nodeExecSync, type ExecSyncOptions } from "child_process";
+
+export const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
+
+/**
+ * Wrapper around execSync that always supplies a timeout. A misbehaving
+ * `xctrace export`, `xctrace version`, or shelled-out helper would otherwise
+ * block the Node event loop indefinitely.
+ */
+export function execSyncWithTimeout(
+  command: string,
+  options: ExecSyncOptions & { timeout?: number } = {}
+): Buffer | string {
+  return nodeExecSync(command, {
+    timeout: DEFAULT_EXEC_TIMEOUT_MS,
+    ...options,
+  });
+}

--- a/packages/tool-server/src/utils/ios-profiler/startup.ts
+++ b/packages/tool-server/src/utils/ios-profiler/startup.ts
@@ -1,0 +1,93 @@
+import type { ChildProcess } from "child_process";
+import type { NotifyHandle } from "./notify";
+
+export interface WaitForXctraceReadyOptions {
+  notify: NotifyHandle | null;
+  timeoutMs: number;
+}
+
+export interface WaitForXctraceReadyResult {
+  /** stderr accumulated during startup; empty once we reach ready. */
+  stderrBuffer: string;
+}
+
+/**
+ * Wait for `xctrace record` to reach the recording state. Resolves on either
+ * the Darwin notification (preferred) or the localised stdout substring
+ * fallback. Rejects on early child exit, spawn error, or startup timeout —
+ * and on timeout sends SIGKILL so the child cannot leak.
+ *
+ * Listeners installed here stay attached for the lifetime of the child: late
+ * events (notably the async `'error'` Node emits if a `kill()` syscall fails)
+ * would crash the process if there were no `'error'` listener at all. They
+ * become no-ops after settle because (a) `settle()` short-circuits and (b)
+ * `resolve()` / `reject()` on an already-settled promise is a no-op. The
+ * caller is free to attach its own post-ready listeners alongside.
+ */
+export function waitForXctraceReady(
+  child: ChildProcess,
+  { notify, timeoutMs }: WaitForXctraceReadyOptions
+): Promise<WaitForXctraceReadyResult> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let stderrBuffer = "";
+
+    const settle = (run: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(startupTimer);
+      if (notify) notify.cancel();
+      run();
+    };
+
+    child.stdout?.on("data", (data: Buffer) => {
+      const text = data.toString();
+      if (text.includes("Ctrl-C to stop") || text.includes("Starting recording")) {
+        settle(() => resolve({ stderrBuffer }));
+      }
+    });
+
+    child.stderr?.on("data", (data: Buffer) => {
+      stderrBuffer += data.toString();
+    });
+
+    child.on("exit", (code, signal) => {
+      settle(() =>
+        reject(
+          new Error(
+            `xctrace record exited before recording started (code=${code}, signal=${signal}). ` +
+              `stderr: ${stderrBuffer.trim() || "<empty>"}`
+          )
+        )
+      );
+    });
+
+    child.on("error", (err: Error) => {
+      settle(() => reject(new Error(`Failed to start xctrace: ${err.message}`)));
+    });
+
+    const startupTimer = setTimeout(() => {
+      settle(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // already dead
+        }
+        reject(
+          new Error(
+            `xctrace record did not start within ${timeoutMs} ms. ` +
+              `Last stderr: ${stderrBuffer.trim() || "<empty>"}`
+          )
+        );
+      });
+    }, timeoutMs);
+
+    if (notify) {
+      notify.fired
+        .then(() => settle(() => resolve({ stderrBuffer })))
+        .catch(() => {
+          // notify failures fall through to stdout substring match
+        });
+    }
+  });
+}

--- a/packages/tool-server/test/ios-instruments/cold-start-retry.test.ts
+++ b/packages/tool-server/test/ios-instruments/cold-start-retry.test.ts
@@ -62,15 +62,14 @@ describe("ios-profiler-start cold-start retry", () => {
       waitForXctraceReady: waitForReady,
     }));
 
-    const { iosInstrumentsStartTool: startTool } = await import(
-      "../../src/tools/profiler/ios-profiler/ios-profiler-start"
-    );
+    const { iosInstrumentsStartTool: startTool } =
+      await import("../../src/tools/profiler/ios-profiler/ios-profiler-start");
 
     const api = await buildSession();
-    const promise = startTool.execute(
-      { session: api } as never,
-      { device_id: "DEVICE-UDID", app_process: "MyApp" }
-    );
+    const promise = startTool.execute({ session: api } as never, {
+      device_id: "DEVICE-UDID",
+      app_process: "MyApp",
+    });
 
     // Drain the retry sleep (1.2s) so the second attempt can run.
     await vi.advanceTimersByTimeAsync(1_200);
@@ -104,15 +103,13 @@ describe("ios-profiler-start cold-start retry", () => {
       waitForXctraceReady: waitForReady,
     }));
 
-    const { iosInstrumentsStartTool: startTool } = await import(
-      "../../src/tools/profiler/ios-profiler/ios-profiler-start"
-    );
+    const { iosInstrumentsStartTool: startTool } =
+      await import("../../src/tools/profiler/ios-profiler/ios-profiler-start");
 
     const api = await buildSession();
-    const promise = startTool.execute(
-      { session: api } as never,
-      { device_id: "DEVICE-UDID", app_process: "MyApp" }
-    ).catch((e) => e);
+    const promise = startTool
+      .execute({ session: api } as never, { device_id: "DEVICE-UDID", app_process: "MyApp" })
+      .catch((e) => e);
 
     await vi.advanceTimersByTimeAsync(1_200);
 
@@ -152,16 +149,15 @@ describe("ios-profiler-start cold-start retry", () => {
       waitForXctraceReady: waitForReady,
     }));
 
-    const { iosInstrumentsStartTool: startTool } = await import(
-      "../../src/tools/profiler/ios-profiler/ios-profiler-start"
-    );
+    const { iosInstrumentsStartTool: startTool } =
+      await import("../../src/tools/profiler/ios-profiler/ios-profiler-start");
 
     const api = await buildSession();
     await expect(
-      startTool.execute(
-        { session: api } as never,
-        { device_id: "DEVICE-UDID", app_process: "MyApp" }
-      )
+      startTool.execute({ session: api } as never, {
+        device_id: "DEVICE-UDID",
+        app_process: "MyApp",
+      })
     ).rejects.toThrow("device not found");
 
     expect(waitForReady).toHaveBeenCalledTimes(1);

--- a/packages/tool-server/test/ios-instruments/cold-start-retry.test.ts
+++ b/packages/tool-server/test/ios-instruments/cold-start-retry.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import {
+  iosInstrumentsSessionBlueprint,
+  type IosProfilerSessionApi,
+} from "../../src/blueprints/ios-profiler-session";
+
+// xctrace's verbatim cold-launch race signature, asserted on as a stable
+// upstream contract by the retry detector in ios-profiler-start.
+const COLD_START_ERROR =
+  "xctrace record exited before recording started (code=19, signal=null). " +
+  "stderr: Cannot find process matching name: MyApp";
+
+class StartFakeChild extends EventEmitter {
+  pid = 9999;
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  kill = vi.fn();
+}
+
+async function buildSession(): Promise<IosProfilerSessionApi> {
+  const instance = await iosInstrumentsSessionBlueprint.factory({}, "DEVICE-UDID");
+  return instance.api;
+}
+
+describe("ios-profiler-start cold-start retry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("child_process");
+    vi.doUnmock("../../src/utils/react-profiler/debug/dump");
+    vi.doUnmock("../../src/utils/ios-profiler/notify");
+    vi.doUnmock("../../src/utils/ios-profiler/startup");
+  });
+
+  it("retries once when xctrace fails with the cold-start signature, then resolves", async () => {
+    const spawnFn = vi.fn(() => new StartFakeChild());
+    const waitForReady = vi
+      .fn()
+      .mockRejectedValueOnce(new Error(COLD_START_ERROR))
+      .mockResolvedValueOnce({ stderrBuffer: "" });
+
+    vi.doMock("child_process", () => ({
+      spawn: spawnFn,
+      execSync: vi.fn(() => ""),
+    }));
+    vi.doMock("../../src/utils/react-profiler/debug/dump", () => ({
+      getDebugDir: vi.fn(async () => "/tmp/argent-profiler-cwd"),
+    }));
+    vi.doMock("../../src/utils/ios-profiler/notify", () => ({
+      listenForDarwinNotification: vi.fn(() => {
+        throw new Error("notifyutil unavailable in tests");
+      }),
+    }));
+    vi.doMock("../../src/utils/ios-profiler/startup", () => ({
+      waitForXctraceReady: waitForReady,
+    }));
+
+    const { iosInstrumentsStartTool: startTool } = await import(
+      "../../src/tools/profiler/ios-profiler/ios-profiler-start"
+    );
+
+    const api = await buildSession();
+    const promise = startTool.execute(
+      { session: api } as never,
+      { device_id: "DEVICE-UDID", app_process: "MyApp" }
+    );
+
+    // Drain the retry sleep (1.2s) so the second attempt can run.
+    await vi.advanceTimersByTimeAsync(1_200);
+
+    const result = await promise;
+    expect(result.status).toBe("recording");
+    expect(result.pid).toBe(9999);
+    expect(waitForReady).toHaveBeenCalledTimes(2);
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+    expect(api.profilingActive).toBe(true);
+    expect(api.appProcess).toBe("MyApp");
+  });
+
+  it("throws a classified cold-start error after exhausting attempts", async () => {
+    const spawnFn = vi.fn(() => new StartFakeChild());
+    const waitForReady = vi.fn().mockRejectedValue(new Error(COLD_START_ERROR));
+
+    vi.doMock("child_process", () => ({
+      spawn: spawnFn,
+      execSync: vi.fn(() => ""),
+    }));
+    vi.doMock("../../src/utils/react-profiler/debug/dump", () => ({
+      getDebugDir: vi.fn(async () => "/tmp/argent-profiler-cwd"),
+    }));
+    vi.doMock("../../src/utils/ios-profiler/notify", () => ({
+      listenForDarwinNotification: vi.fn(() => {
+        throw new Error("notifyutil unavailable in tests");
+      }),
+    }));
+    vi.doMock("../../src/utils/ios-profiler/startup", () => ({
+      waitForXctraceReady: waitForReady,
+    }));
+
+    const { iosInstrumentsStartTool: startTool } = await import(
+      "../../src/tools/profiler/ios-profiler/ios-profiler-start"
+    );
+
+    const api = await buildSession();
+    const promise = startTool.execute(
+      { session: api } as never,
+      { device_id: "DEVICE-UDID", app_process: "MyApp" }
+    ).catch((e) => e);
+
+    await vi.advanceTimersByTimeAsync(1_200);
+
+    const err = (await promise) as Error;
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain('xctrace could not find process "MyApp" after 2 attempts');
+    expect(err.message).toContain("cold-launching");
+    expect(err.message).toContain("pass app_process explicitly");
+    expect(waitForReady).toHaveBeenCalledTimes(2);
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+    expect(api.profilingActive).toBe(false);
+    expect(api.xctracePid).toBeNull();
+    expect(api.xctraceProcess).toBeNull();
+  });
+
+  it("does not retry when xctrace fails with an unrelated error", async () => {
+    const spawnFn = vi.fn(() => new StartFakeChild());
+    const otherError = new Error(
+      "xctrace record exited before recording started (code=1, signal=null). " +
+        "stderr: Recording failed: device not found"
+    );
+    const waitForReady = vi.fn().mockRejectedValue(otherError);
+
+    vi.doMock("child_process", () => ({
+      spawn: spawnFn,
+      execSync: vi.fn(() => ""),
+    }));
+    vi.doMock("../../src/utils/react-profiler/debug/dump", () => ({
+      getDebugDir: vi.fn(async () => "/tmp/argent-profiler-cwd"),
+    }));
+    vi.doMock("../../src/utils/ios-profiler/notify", () => ({
+      listenForDarwinNotification: vi.fn(() => {
+        throw new Error("notifyutil unavailable in tests");
+      }),
+    }));
+    vi.doMock("../../src/utils/ios-profiler/startup", () => ({
+      waitForXctraceReady: waitForReady,
+    }));
+
+    const { iosInstrumentsStartTool: startTool } = await import(
+      "../../src/tools/profiler/ios-profiler/ios-profiler-start"
+    );
+
+    const api = await buildSession();
+    await expect(
+      startTool.execute(
+        { session: api } as never,
+        { device_id: "DEVICE-UDID", app_process: "MyApp" }
+      )
+    ).rejects.toThrow("device not found");
+
+    expect(waitForReady).toHaveBeenCalledTimes(1);
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(api.profilingActive).toBe(false);
+  });
+});

--- a/packages/tool-server/test/ios-instruments/dispose.test.ts
+++ b/packages/tool-server/test/ios-instruments/dispose.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+import {
+  iosInstrumentsSessionBlueprint,
+  type IosProfilerSessionApi,
+} from "../../src/blueprints/ios-profiler-session";
+
+// Minimal ChildProcess fake — same shape as the lifecycle tests.
+class FakeChild extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  respondsTo: Set<NodeJS.Signals> = new Set();
+  respondAfterMs = 0;
+  signalLog: NodeJS.Signals[] = [];
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.signalLog.push(signal);
+    if (this.respondsTo.has(signal) && this.exitCode === null && this.signalCode === null) {
+      setTimeout(() => this.exitWith(signal), this.respondAfterMs);
+    }
+    return true;
+  }
+
+  exitWith(signal: NodeJS.Signals | null): void {
+    this.signalCode = signal;
+    this.exitCode = signal ? null : 0;
+    this.emit("exit", this.exitCode, this.signalCode);
+  }
+}
+
+const asChild = (c: FakeChild): ChildProcess => c as unknown as ChildProcess;
+
+async function buildSession(): Promise<{
+  api: IosProfilerSessionApi;
+  dispose: () => Promise<void>;
+}> {
+  const instance = await iosInstrumentsSessionBlueprint.factory({}, "DEVICE-UDID");
+  return { api: instance.api, dispose: instance.dispose };
+}
+
+describe("iosInstrumentsSessionBlueprint dispose", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("is a no-op when no recording is active", async () => {
+    const { dispose } = await buildSession();
+    await expect(dispose()).resolves.toBeUndefined();
+  });
+
+  it("clears the 10-min recording timer even with no live xctrace", async () => {
+    const { api, dispose } = await buildSession();
+    const onFire = vi.fn();
+    api.recordingTimeout = setTimeout(onFire, 60_000);
+    await dispose();
+    expect(api.recordingTimeout).toBeNull();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it("SIGKILLs xctrace immediately rather than running the SIGINT grace ladder", async () => {
+    const { api, dispose } = await buildSession();
+    const child = new FakeChild();
+    child.respondsTo = new Set<NodeJS.Signals>(["SIGKILL"]);
+    child.respondAfterMs = 1;
+    api.profilingActive = true;
+    api.xctracePid = 1234;
+    api.xctraceProcess = asChild(child);
+
+    const promise = dispose();
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+
+    expect(child.signalLog).toEqual(["SIGKILL"]);
+    expect(api.profilingActive).toBe(false);
+    expect(api.xctracePid).toBeNull();
+    expect(api.xctraceProcess).toBeNull();
+  });
+
+  it("returns within the reap window even if SIGKILL never reaps the handle", async () => {
+    const { api, dispose } = await buildSession();
+    const child = new FakeChild();
+    // respondsTo is empty — the fake never emits 'exit'. Real OS kernels reap
+    // SIGKILL targets near-instantly; this scenario asserts dispose still
+    // unblocks if for any reason 'exit' never fires.
+    api.profilingActive = true;
+    api.xctracePid = 1234;
+    api.xctraceProcess = asChild(child);
+
+    const promise = dispose();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await promise;
+
+    expect(child.signalLog).toEqual(["SIGKILL"]);
+    expect(api.profilingActive).toBe(false);
+    expect(api.xctracePid).toBeNull();
+    expect(api.xctraceProcess).toBeNull();
+  });
+
+  it("survives kill() throwing on an already-dead handle", async () => {
+    const { api, dispose } = await buildSession();
+    const child = new FakeChild();
+    child.kill = vi.fn(() => {
+      throw new Error("ESRCH");
+    });
+    child.exitCode = 0;
+    api.profilingActive = true;
+    api.xctracePid = 1234;
+    api.xctraceProcess = asChild(child);
+
+    await expect(dispose()).resolves.toBeUndefined();
+    expect(api.profilingActive).toBe(false);
+  });
+});

--- a/packages/tool-server/test/ios-instruments/lifecycle.test.ts
+++ b/packages/tool-server/test/ios-instruments/lifecycle.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+import { waitForChildExit, shutdownChild } from "../../src/utils/ios-profiler/lifecycle";
+
+// A minimal fake of ChildProcess that supports the surface lifecycle.ts uses:
+// `exitCode`, `signalCode`, `kill(signal)`, and the `'exit'` event.
+class FakeChild extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  /** Signals that, when received, cause the fake to "exit" after `respondAfterMs`. */
+  respondsTo: Set<NodeJS.Signals> = new Set();
+  /** Latency between receiving a respected signal and emitting `'exit'`. */
+  respondAfterMs = 0;
+  /** Recorded log of every signal sent through `kill()`. */
+  signalLog: NodeJS.Signals[] = [];
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.signalLog.push(signal);
+    if (this.respondsTo.has(signal) && this.exitCode === null && this.signalCode === null) {
+      setTimeout(() => this.exitWith(signal), this.respondAfterMs);
+    }
+    return true;
+  }
+
+  exitWith(signal: NodeJS.Signals | null): void {
+    this.signalCode = signal;
+    this.exitCode = signal ? null : 0;
+    this.emit("exit", this.exitCode, this.signalCode);
+  }
+
+  exitClean(): void {
+    this.exitCode = 0;
+    this.signalCode = null;
+    this.emit("exit", 0, null);
+  }
+}
+
+const asChild = (c: FakeChild): ChildProcess => c as unknown as ChildProcess;
+
+describe("waitForChildExit", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("resolves true synchronously when child has already exited", async () => {
+    const child = new FakeChild();
+    child.exitClean();
+    await expect(waitForChildExit(asChild(child), 1000)).resolves.toBe(true);
+  });
+
+  it("resolves true synchronously when child was killed by signal", async () => {
+    const child = new FakeChild();
+    child.exitWith("SIGKILL");
+    await expect(waitForChildExit(asChild(child), 1000)).resolves.toBe(true);
+  });
+
+  it("resolves true when child exits before the deadline", async () => {
+    const child = new FakeChild();
+    const promise = waitForChildExit(asChild(child), 1000);
+    setTimeout(() => child.exitClean(), 200);
+    await vi.advanceTimersByTimeAsync(200);
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("resolves false when the deadline expires first", async () => {
+    const child = new FakeChild();
+    const promise = waitForChildExit(asChild(child), 500);
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("clears the deadline timer once the child exits", async () => {
+    const child = new FakeChild();
+    const promise = waitForChildExit(asChild(child), 5000);
+    setTimeout(() => child.exitClean(), 100);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(await promise).toBe(true);
+    // No pending timers after early exit (deadline was cleared).
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("shutdownChild", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const TIMINGS = { graceMs: 30_000, termMs: 5_000, killMs: 5_000 };
+
+  it("returns clean=SIGINT immediately when child is already dead", async () => {
+    const child = new FakeChild();
+    child.exitClean();
+    const result = await shutdownChild(asChild(child), TIMINGS);
+    expect(result).toEqual({ clean: true, signalUsed: "SIGINT" });
+    expect(child.signalLog).toEqual([]);
+  });
+
+  it("returns clean=SIGINT when SIGINT is sufficient", async () => {
+    const child = new FakeChild();
+    child.respondsTo = new Set<NodeJS.Signals>(["SIGINT"]);
+    child.respondAfterMs = 100;
+    const promise = shutdownChild(asChild(child), TIMINGS);
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(promise).resolves.toEqual({ clean: true, signalUsed: "SIGINT" });
+    expect(child.signalLog).toEqual(["SIGINT"]);
+  });
+
+  it("escalates to SIGTERM when SIGINT is ignored", async () => {
+    const child = new FakeChild();
+    child.respondsTo = new Set<NodeJS.Signals>(["SIGTERM"]);
+    child.respondAfterMs = 50;
+    const promise = shutdownChild(asChild(child), TIMINGS);
+    // SIGINT window expires (30s), then SIGTERM is sent and lands.
+    await vi.advanceTimersByTimeAsync(TIMINGS.graceMs);
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(promise).resolves.toEqual({ clean: false, signalUsed: "SIGTERM" });
+    expect(child.signalLog).toEqual(["SIGINT", "SIGTERM"]);
+  });
+
+  it("escalates to SIGKILL when SIGINT and SIGTERM are ignored", async () => {
+    const child = new FakeChild();
+    child.respondsTo = new Set<NodeJS.Signals>(["SIGKILL"]);
+    child.respondAfterMs = 1;
+    const promise = shutdownChild(asChild(child), TIMINGS);
+    await vi.advanceTimersByTimeAsync(TIMINGS.graceMs);
+    await vi.advanceTimersByTimeAsync(TIMINGS.termMs);
+    await vi.advanceTimersByTimeAsync(child.respondAfterMs);
+    await expect(promise).resolves.toEqual({ clean: false, signalUsed: "SIGKILL" });
+    expect(child.signalLog).toEqual(["SIGINT", "SIGTERM", "SIGKILL"]);
+  });
+
+  it("returns SIGKILL even if the child never responds at all", async () => {
+    const child = new FakeChild();
+    // respondsTo is empty → child ignores every signal
+    const promise = shutdownChild(asChild(child), TIMINGS);
+    await vi.advanceTimersByTimeAsync(TIMINGS.graceMs);
+    await vi.advanceTimersByTimeAsync(TIMINGS.termMs);
+    await vi.advanceTimersByTimeAsync(TIMINGS.killMs);
+    await expect(promise).resolves.toEqual({ clean: false, signalUsed: "SIGKILL" });
+    expect(child.signalLog).toEqual(["SIGINT", "SIGTERM", "SIGKILL"]);
+  });
+
+  it("survives kill() throwing (already-dead races)", async () => {
+    const child = new FakeChild();
+    child.kill = vi.fn(() => {
+      throw new Error("ESRCH");
+    });
+    const promise = shutdownChild(asChild(child), TIMINGS);
+    // No signal landed; deadline expires through every stage.
+    await vi.advanceTimersByTimeAsync(TIMINGS.graceMs);
+    await vi.advanceTimersByTimeAsync(TIMINGS.termMs);
+    await vi.advanceTimersByTimeAsync(TIMINGS.killMs);
+    await expect(promise).resolves.toEqual({ clean: false, signalUsed: "SIGKILL" });
+  });
+});

--- a/packages/tool-server/test/ios-instruments/stop-recovery.test.ts
+++ b/packages/tool-server/test/ios-instruments/stop-recovery.test.ts
@@ -111,10 +111,9 @@ describe("ios-profiler-stop recovery branch", () => {
     api.recordingExitedUnexpectedly = true;
     api.lastExitInfo = { code: 0, signal: null };
 
-    const result = await iosInstrumentsStopTool.execute(
-      { session: api } as never,
-      { device_id: "DEVICE-UDID" }
-    );
+    const result = await iosInstrumentsStopTool.execute({ session: api } as never, {
+      device_id: "DEVICE-UDID",
+    });
 
     expect(mockedExport).toHaveBeenCalledWith(FAKE_TRACE);
     expect(result.traceFile).toBe(FAKE_TRACE);
@@ -131,10 +130,9 @@ describe("ios-profiler-stop recovery branch", () => {
     api.recordingExitedUnexpectedly = true;
     api.lastExitInfo = { code: 137, signal: "SIGKILL" };
 
-    const result = await iosInstrumentsStopTool.execute(
-      { session: api } as never,
-      { device_id: "DEVICE-UDID" }
-    );
+    const result = await iosInstrumentsStopTool.execute({ session: api } as never, {
+      device_id: "DEVICE-UDID",
+    });
 
     expect(result.warning).toContain("code=137");
     expect(result.warning).toContain("signal=SIGKILL");
@@ -146,10 +144,9 @@ describe("ios-profiler-stop recovery branch", () => {
     api.recordingTimedOut = true;
     api.recordingExitedUnexpectedly = false;
 
-    const result = await iosInstrumentsStopTool.execute(
-      { session: api } as never,
-      { device_id: "DEVICE-UDID" }
-    );
+    const result = await iosInstrumentsStopTool.execute({ session: api } as never, {
+      device_id: "DEVICE-UDID",
+    });
 
     expect(result.warning).toContain("Recording timed out at 10 min cap");
     expect(result.warning).not.toContain("xctrace exited before stop");
@@ -192,10 +189,9 @@ describe("ios-profiler-stop recovery branch", () => {
     api.xctraceProcess = asChild(child);
     api.traceFile = FAKE_TRACE;
 
-    const promise = iosInstrumentsStopTool.execute(
-      { session: api } as never,
-      { device_id: "DEVICE-UDID" }
-    );
+    const promise = iosInstrumentsStopTool.execute({ session: api } as never, {
+      device_id: "DEVICE-UDID",
+    });
     await vi.advanceTimersByTimeAsync(10);
     const result = await promise;
 
@@ -250,9 +246,8 @@ describe("ios-profiler-start fresh-start reset", () => {
       waitForXctraceReady: vi.fn(async () => ({ stderrBuffer: "" })),
     }));
 
-    const { iosInstrumentsStartTool: startTool } = await import(
-      "../../src/tools/profiler/ios-profiler/ios-profiler-start"
-    );
+    const { iosInstrumentsStartTool: startTool } =
+      await import("../../src/tools/profiler/ios-profiler/ios-profiler-start");
 
     const api = await buildSession();
     // Pre-populate stale state from a prior aborted run.
@@ -260,10 +255,10 @@ describe("ios-profiler-start fresh-start reset", () => {
     api.lastExitInfo = { code: 1, signal: null };
     api.recordingTimedOut = true;
 
-    const result = await startTool.execute(
-      { session: api } as never,
-      { device_id: "DEVICE-UDID", app_process: "MyApp" }
-    );
+    const result = await startTool.execute({ session: api } as never, {
+      device_id: "DEVICE-UDID",
+      app_process: "MyApp",
+    });
 
     expect(result.status).toBe("recording");
     expect(api.recordingExitedUnexpectedly).toBe(false);

--- a/packages/tool-server/test/ios-instruments/stop-recovery.test.ts
+++ b/packages/tool-server/test/ios-instruments/stop-recovery.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+import {
+  iosInstrumentsSessionBlueprint,
+  type IosProfilerSessionApi,
+} from "../../src/blueprints/ios-profiler-session";
+
+// Mock the trace exporter so tests don't shell out to xctrace or touch disk.
+vi.mock("../../src/utils/ios-profiler/export", () => ({
+  exportIosTraceData: vi.fn(),
+}));
+
+import { exportIosTraceData } from "../../src/utils/ios-profiler/export";
+import { iosInstrumentsStopTool } from "../../src/tools/profiler/ios-profiler/ios-profiler-stop";
+import { handleXctraceExit } from "../../src/tools/profiler/ios-profiler/ios-profiler-start";
+
+const mockedExport = vi.mocked(exportIosTraceData);
+
+class FakeChild extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  respondsTo: Set<NodeJS.Signals> = new Set();
+  respondAfterMs = 0;
+  signalLog: NodeJS.Signals[] = [];
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.signalLog.push(signal);
+    if (this.respondsTo.has(signal) && this.exitCode === null && this.signalCode === null) {
+      setTimeout(() => this.exitWith(signal), this.respondAfterMs);
+    }
+    return true;
+  }
+
+  exitWith(signal: NodeJS.Signals | null): void {
+    this.signalCode = signal;
+    this.exitCode = signal ? null : 0;
+    this.emit("exit", this.exitCode, this.signalCode);
+  }
+}
+
+const asChild = (c: FakeChild): ChildProcess => c as unknown as ChildProcess;
+
+async function buildSession(): Promise<IosProfilerSessionApi> {
+  const instance = await iosInstrumentsSessionBlueprint.factory({}, "DEVICE-UDID");
+  return instance.api;
+}
+
+const FAKE_TRACE = "/tmp/argent-profiler-cwd/ios-profiler-20260101-000000.trace";
+const FAKE_EXPORT_RESULT = {
+  files: { cpu: "/tmp/cpu.xml", hangs: "/tmp/hangs.xml", leaks: "/tmp/leaks.xml" },
+  diagnostics: { tocSchemas: ["time-profile"], cpuSchemaUsed: "time-profile", errors: {} },
+};
+
+describe("handleXctraceExit", () => {
+  it("sets recordingExitedUnexpectedly and lastExitInfo on a non-timeout exit", async () => {
+    const api = await buildSession();
+    const child = new FakeChild();
+    api.profilingActive = true;
+    api.xctracePid = 1234;
+    api.xctraceProcess = asChild(child);
+    api.traceFile = FAKE_TRACE;
+
+    handleXctraceExit(api, 0, null);
+
+    expect(api.profilingActive).toBe(false);
+    expect(api.xctracePid).toBeNull();
+    expect(api.xctraceProcess).toBeNull();
+    expect(api.recordingExitedUnexpectedly).toBe(true);
+    expect(api.recordingTimedOut).toBe(false);
+    expect(api.lastExitInfo).toEqual({ code: 0, signal: null });
+    expect(api.traceFile).toBe(FAKE_TRACE);
+  });
+
+  it("does not flip recordingExitedUnexpectedly when the timeout path already fired", async () => {
+    const api = await buildSession();
+    api.profilingActive = true;
+    api.recordingTimedOut = true;
+
+    handleXctraceExit(api, null, "SIGINT");
+
+    expect(api.recordingExitedUnexpectedly).toBe(false);
+    expect(api.recordingTimedOut).toBe(true);
+    expect(api.lastExitInfo).toEqual({ code: null, signal: "SIGINT" });
+  });
+
+  it("is a no-op when profilingActive is already false", async () => {
+    const api = await buildSession();
+    api.profilingActive = false;
+
+    handleXctraceExit(api, 0, null);
+
+    expect(api.recordingExitedUnexpectedly).toBe(false);
+    expect(api.lastExitInfo).toBeNull();
+  });
+});
+
+describe("ios-profiler-stop recovery branch", () => {
+  beforeEach(() => {
+    mockedExport.mockReset();
+    mockedExport.mockReturnValue(FAKE_EXPORT_RESULT);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("exports the trace when recordingExitedUnexpectedly is set", async () => {
+    const api = await buildSession();
+    api.traceFile = FAKE_TRACE;
+    api.recordingExitedUnexpectedly = true;
+    api.lastExitInfo = { code: 0, signal: null };
+
+    const result = await iosInstrumentsStopTool.execute(
+      { session: api } as never,
+      { device_id: "DEVICE-UDID" }
+    );
+
+    expect(mockedExport).toHaveBeenCalledWith(FAKE_TRACE);
+    expect(result.traceFile).toBe(FAKE_TRACE);
+    expect(result.exportedFiles).toEqual(FAKE_EXPORT_RESULT.files);
+    expect(result.exportDiagnostics).toEqual(FAKE_EXPORT_RESULT.diagnostics);
+    expect(result.warning).toBeDefined();
+    expect(api.recordingExitedUnexpectedly).toBe(false);
+    expect(api.lastExitInfo).toBeNull();
+  });
+
+  it("warning string includes code= and signal= from lastExitInfo", async () => {
+    const api = await buildSession();
+    api.traceFile = FAKE_TRACE;
+    api.recordingExitedUnexpectedly = true;
+    api.lastExitInfo = { code: 137, signal: "SIGKILL" };
+
+    const result = await iosInstrumentsStopTool.execute(
+      { session: api } as never,
+      { device_id: "DEVICE-UDID" }
+    );
+
+    expect(result.warning).toContain("code=137");
+    expect(result.warning).toContain("signal=SIGKILL");
+  });
+
+  it("preserves the original 10-min timeout warning (regression)", async () => {
+    const api = await buildSession();
+    api.traceFile = FAKE_TRACE;
+    api.recordingTimedOut = true;
+    api.recordingExitedUnexpectedly = false;
+
+    const result = await iosInstrumentsStopTool.execute(
+      { session: api } as never,
+      { device_id: "DEVICE-UDID" }
+    );
+
+    expect(result.warning).toContain("Recording timed out at 10 min cap");
+    expect(result.warning).not.toContain("xctrace exited before stop");
+    expect(api.recordingTimedOut).toBe(false);
+  });
+
+  it("falls through to the unrecoverable error when no recovery flag is set", async () => {
+    const api = await buildSession();
+    api.traceFile = FAKE_TRACE; // a stale traceFile alone must not trigger recovery
+
+    await expect(
+      iosInstrumentsStopTool.execute({ session: api } as never, { device_id: "DEVICE-UDID" })
+    ).rejects.toThrow("No active iOS profiling session found");
+    expect(mockedExport).not.toHaveBeenCalled();
+  });
+
+  it("throws unrecoverable when start was never called", async () => {
+    const api = await buildSession();
+
+    await expect(
+      iosInstrumentsStopTool.execute({ session: api } as never, { device_id: "DEVICE-UDID" })
+    ).rejects.toThrow("No active iOS profiling session found. Call ios-profiler-start first.");
+    expect(mockedExport).not.toHaveBeenCalled();
+  });
+
+  it("clears recordingExitedUnexpectedly and lastExitInfo on a clean happy-path stop", async () => {
+    vi.useFakeTimers();
+    const api = await buildSession();
+    const child = new FakeChild();
+    child.respondsTo = new Set<NodeJS.Signals>(["SIGINT"]);
+    child.respondAfterMs = 10;
+    // Simulate the production wiring: the start tool registers handleXctraceExit
+    // as the 'exit' listener. When SIGINT lands during shutdownChild, the handler
+    // fires and dirties recordingExitedUnexpectedly/lastExitInfo before stop
+    // resumes. The happy-path reset must scrub both.
+    child.on("exit", (code, signal) => handleXctraceExit(api, code, signal));
+
+    api.profilingActive = true;
+    api.xctracePid = 4321;
+    api.xctraceProcess = asChild(child);
+    api.traceFile = FAKE_TRACE;
+
+    const promise = iosInstrumentsStopTool.execute(
+      { session: api } as never,
+      { device_id: "DEVICE-UDID" }
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    const result = await promise;
+
+    expect(result.warning).toBeUndefined();
+    expect(result.traceFile).toBe(FAKE_TRACE);
+    expect(api.profilingActive).toBe(false);
+    expect(api.xctraceProcess).toBeNull();
+    expect(api.recordingExitedUnexpectedly).toBe(false);
+    expect(api.lastExitInfo).toBeNull();
+  });
+});
+
+describe("ios-profiler-start fresh-start reset", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("child_process");
+    vi.doUnmock("../../src/utils/react-profiler/debug/dump");
+    vi.doUnmock("../../src/utils/ios-profiler/notify");
+    vi.doUnmock("../../src/utils/ios-profiler/startup");
+  });
+
+  it("resets stale recordingExitedUnexpectedly and lastExitInfo before establishing a new session", async () => {
+    class StartFakeChild extends EventEmitter {
+      pid = 9999;
+      stdout = new EventEmitter();
+      stderr = new EventEmitter();
+      exitCode: number | null = null;
+      signalCode: NodeJS.Signals | null = null;
+      kill = vi.fn();
+    }
+
+    const fakeChild = new StartFakeChild();
+
+    vi.doMock("child_process", () => ({
+      spawn: vi.fn(() => fakeChild),
+      execSync: vi.fn(() => ""), // detectRunningApp is bypassed via app_process
+    }));
+    vi.doMock("../../src/utils/react-profiler/debug/dump", () => ({
+      getDebugDir: vi.fn(async () => "/tmp/argent-profiler-cwd"),
+    }));
+    vi.doMock("../../src/utils/ios-profiler/notify", () => ({
+      listenForDarwinNotification: vi.fn(() => {
+        throw new Error("notifyutil unavailable in tests");
+      }),
+    }));
+    vi.doMock("../../src/utils/ios-profiler/startup", () => ({
+      waitForXctraceReady: vi.fn(async () => ({ stderrBuffer: "" })),
+    }));
+
+    const { iosInstrumentsStartTool: startTool } = await import(
+      "../../src/tools/profiler/ios-profiler/ios-profiler-start"
+    );
+
+    const api = await buildSession();
+    // Pre-populate stale state from a prior aborted run.
+    api.recordingExitedUnexpectedly = true;
+    api.lastExitInfo = { code: 1, signal: null };
+    api.recordingTimedOut = true;
+
+    const result = await startTool.execute(
+      { session: api } as never,
+      { device_id: "DEVICE-UDID", app_process: "MyApp" }
+    );
+
+    expect(result.status).toBe("recording");
+    expect(api.recordingExitedUnexpectedly).toBe(false);
+    expect(api.lastExitInfo).toBeNull();
+    expect(api.recordingTimedOut).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Refactor of the iOS profiler (`xctrace`-driven) session to make start, stop, and unexpected-exit handling proper, without the iOS hanging infinitely.

### Startup (`ios-profiler-start`)
- **Locale ready signal**: subscribe-before-spawn to a Darwin notification (`com.argent.ios-profiler.started.<pid>.<ts>`) via `notifyutil`, passed through `xctrace --notify-tracing-started`. Falls back to the existing stdout substring match (`Starting recording` / `Ctrl-C to stop`) if `notifyutil` fails to spawn or register within 2 s.
- **Startup timeout**: new 10 s cap on reaching the ready state — on timeout, `SIGKILL` the child so it cannot leak. 
- **Bounded `simctl` calls**: `detectRunningApp` now applies a 10 s timeout to both `xcrun simctl spawn ... launchctl list` and `xcrun simctl listapps`, with explicit error messages telling the user to verify the simulator is booted.
- **Cold-start retry**: if xctrace's process resolver fails with `"Cannot find process matching name:"` (launchd has registered the bundle but xctrace's resolver hasn't caught up), the tool retries once after a 1.2 s backoff — up to 2 attempts total. On exhausted retries throws a classified error naming the cold-launch race and pointing at `app_process` as the override. Non-cold-start failures propagate immediately without retry.
- **Exit listener installed**: every `xctrace record` child gets a long-lived `'exit'` handler (`handleXctraceExit`) that marks the session as `recordingExitedUnexpectedly` and stores `lastExitInfo`.

### Shutdown (`ios-profiler-stop`)
- **SIGINT → SIGTERM → SIGKILL ladder** via `utils/ios-profiler/lifecycle.ts::shutdownChild` (30 s grace, 5 s term, 5 s kill).
- **Returns a `warning`** when the ladder had to escalate past SIGINT, so callers know the trace bundle may be incomplete.

### Exit recovery
- **New `recordingTimedOut` / `recordingExitedUnexpectedly` flags** on the session API. If `ios-profiler-stop` is called after either fired, the tool now exports whatever `.trace` bundle is on disk and returns it with a descriptive `warning` instead of throwing "no active session".
- Covers the in-process 10-min recording cap, attached-app crashes, and simulator daemon hiccups.

### Dispose semantics
- Registry teardown (process shutdown) skips SIGINT and goes straight to `SIGKILL` with a 1 s reap window. The explicit `ios-profiler-stop` contract is the only path that takes the slow finalise grace.

### Other
- `utils/ios-profiler/run-with-timeout.ts`: `execSyncWithTimeout` wrapper with a 60 s default — guards every shelled-out `xctrace export` / `xctrace version`.
- New reference doc `utils/ios-profiler/IOS_PROFILER_REFERENCE.md` covering the native foundations, capture flow, and pipeline.

## Tests
New unit tests under `packages/tool-server/test/ios-instruments/`