### PR TITLE
fix(skills): prefix bare skill references with 'argent-'

### DIFF
--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -48,7 +48,7 @@ Before starting to interact with the app, read the `argent-simulator-interact` s
 - Interaction tools (`gesture-tap`, `gesture-swipe`, `gesture-pinch`, `gesture-rotate`, `gesture-custom`, `launch-app`, etc.) return a screenshot automatically.
   Call `screenshot` separately only for a baseline before any action or after a delay.
 - Always open apps with `launch-app` or `open-url` — never tap home screen icons.
-- Always use `run-sequence` when performing multiple sequential simulator actions where you don't need to observe the screen between steps. More in `simulator-interact` skill.
+- Always use `run-sequence` when performing multiple sequential simulator actions where you don't need to observe the screen between steps. More in `argent-simulator-interact` skill.
 - When the session ends or the user says they are done: call `stop-all-simulator-servers`.
   If the user started Metro separately, ask whether to call `stop-metro` (specify the port if not 8081).
 - If tools provided by mcp-server are not sufficient and action can be done using `xcrun` or other commands, use the command. Examples: changing simulator options, performing simulator action such as lock, shake, etc.

--- a/packages/skills/skills/argent-react-native-optimization/SKILL.md
+++ b/packages/skills/skills/argent-react-native-optimization/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: argent-react-native-optimization
-description: Optimizes a React Native app by profiling first to find real bottlenecks, then sweeping for mechanical issues. Entry-point for all performance work. Use when the app feels slow, user asks to optimize, fix re-renders, reduce jank, or improve startup. Delegates to react-native-profiler for measurement.
+description: Optimizes a React Native app by profiling first to find real bottlenecks, then sweeping for mechanical issues. Entry-point for all performance work. Use when the app feels slow, user asks to optimize, fix re-renders, reduce jank, or improve startup. Delegates to argent-react-native-profiler for measurement.
 ---
 
 ## Rules
 
 - Do not apply shotgun optimizations. Measure first, define what "good enough" looks like (target metric + threshold), fix the top offender, re-measure honestly.
 - **Quick scan** — `react-profiler-renders` for a live render count table. Identifies hot components instantly.
-- **Deep measure** — load `react-native-profiler` skill. `react-profiler-start` → interact → `react-profiler-stop` → `react-profiler-analyze`.
+- **Deep measure** — load `argent-react-native-profiler` skill. `react-profiler-start` → interact → `react-profiler-stop` → `react-profiler-analyze`.
 - **Inspect** — `react-profiler-component-source` per finding. `react-profiler-fiber-tree` to trace component ancestry and render cost.
 - **Verify correctness** - before fixing, recollect information from steps above and make a logical conclusion whether the approach is worth undertaking.
 - **Fix** — apply one fix. Validate with `debugger-evaluate` before committing.
 - **Re-measure** — report whether the target metric improved, regressed, or stayed flat. Check for regressions in other areas. If no net benefit or unacceptable tradeoffs, revert.
 - **Profile for discovery, not only verification.** Use the profiler to find issues static analysis missed, not only to confirm fixes.
-- **One fix per cycle for architectural changes.** Mechanical batch fixes (inline styles, index keys) can be grouped — re-profile once after the batch. When the measurement involves simulator interaction, record it as a flow (`create-flow` skill) before the first run so all subsequent cycles replay identical steps.
+- **One fix per cycle for architectural changes.** Mechanical batch fixes (inline styles, index keys) can be grouped — re-profile once after the batch. When the measurement involves simulator interaction, record it as a flow (`argent-create-flow` skill) before the first run so all subsequent cycles replay identical steps.
 - **React Compiler**: if `react-profiler-analyze` reports `reactCompilerEnabled: true`, do NOT propose `useCallback`/`useMemo`/`React.memo` unless you confirmed compiler bail-out via `react-profiler-fiber-tree` (absent `useMemoCache`).
 - **Sub-agents**: Phases 1–2 dispatch sub-agents — one per file for lint results, one per checklist item for semantic. Sub-agents CANNOT touch the simulator - all profiling and E2E verification must happen in the main agent.
 
@@ -43,15 +43,15 @@ See [references/semantic-checklist.md](references/semantic-checklist.md) for ful
 
 ### Phase 3: Visual profiling
 
-1. Load `react-native-profiler` skill, start dual profiling
+1. Load `argent-react-native-profiler` skill, start dual profiling
 2. Exercise key user flows (navigate screens the user specified, or all major flows)
 3. Analyze with `react-profiler-analyze` + `ios-profiler-analyze` + `profiler-combined-report`
 4. Cross-reference profiling results with Phase 1–2 findings
-5. Fix highest-impact issues. Re-profile after architectural changes; batch mechanical fixes. If a recorded flow breaks after a fix (e.g., UI layout changed), follow `create-flow` skill to repair the flow rather than silently discarding it.
+5. Fix highest-impact issues. Re-profile after architectural changes; batch mechanical fixes. If a recorded flow breaks after a fix (e.g., UI layout changed), follow `argent-create-flow` skill to repair the flow rather than silently discarding it.
 
 ### Phase 4: Verify no regressions
 
-Navigate every screen and UI flow within scope, confirm each renders without errors. If no scope was specified, verify the entire app — cover all reachable screens via `simulator-interact`. Use `debugger-log-registry` to check for runtime errors and take screenshots to check for red/yellow error screens. Check for regressions introduced by fixes (e.g., fewer re-renders but higher CPU, or new jank in a different screen). Main agent only.
+Navigate every screen and UI flow within scope, confirm each renders without errors. If no scope was specified, verify the entire app — cover all reachable screens via `argent-simulator-interact`. Use `debugger-log-registry` to check for runtime errors and take screenshots to check for red/yellow error screens. Check for regressions introduced by fixes (e.g., fewer re-renders but higher CPU, or new jank in a different screen). Main agent only.
 
 ## App-wide optimization
 

--- a/packages/tool-server/src/tools/debugger/debugger-component-tree.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-component-tree.ts
@@ -521,7 +521,7 @@ full-screen transparent wrappers, and implementation-detail components are prune
 Each visible component is listed with its name, text content, and normalized
 tap coordinates in [0,1] space (fractions of the screen, not pixels—same space as tap/swipe/gesture and simulator-server touch).
 
-This is the preferred element discovery tool for React Native apps. More information in react-native-app-workflow skill.
+This is the preferred element discovery tool for React Native apps. More information in argent-react-native-app-workflow skill.
 
 Workflow:
   1. Call this tool to get the component tree.

--- a/packages/tool-server/src/tools/gesture-tap/index.ts
+++ b/packages/tool-server/src/tools/gesture-tap/index.ts
@@ -23,7 +23,7 @@ export const gestureTapTool: ToolDefinition<Params, GestureTapResult> = {
 Sends a Down event followed by an Up event at the same point.
 Use when you need to tap a button, link, or any tappable element on the simulator screen.
 Returns { tapped: true, timestampMs }. Fails if the simulator server is not running for the given UDID.
-Before tapping, determine the correct coordinates by using discovery tools: describe, native-describe-screen, debugger-component-tree. More information in \`simulator-interact\` skill`,
+Before tapping, determine the correct coordinates by using discovery tools: describe, native-describe-screen, debugger-component-tree. More information in \`argent-simulator-interact\` skill`,
   alwaysLoad: true,
   searchHint: "tap press button element simulator touch down up",
   zodSchema,


### PR DESCRIPTION
All skills are currently exposed as `argent-***`. In the markdown though, we refer to them as just `***`. This may confuse the agent when it tries reading `skills/***` instead of `skills/argent-***`.

This PR changes all skill references in docs to the correct `argent-***` form. 

## Why?
There's no downside to this fix. Keeping it as-is potentially introduces some confusion especially if when the user is running a weaker model or if we encounter namespace conflicts.