### PR TITLE
fix(blueprints): reject undefined device.id before spawning helper

### DIFF
--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -176,8 +176,16 @@ function spawnDaemon(udid: string, socketPath: string): Promise<ChildProcess> {
       }
     });
 
+    // Defense-in-depth: udid is validated at the factory entry, but a missing
+    // value here would crash the whole tool-server. The handler runs inside
+    // an async event listener, so a `udid.slice(0, 8)` against `undefined`
+    // throws synchronously and propagates to the process-wide
+    // `uncaughtException` handler — which the tool-server treats as fatal
+    // and exits on. Tag with "?" if udid is ever empty rather than blowing
+    // up the process.
+    const udidTag = typeof udid === "string" && udid.length > 0 ? udid.slice(0, 8) : "?";
     proc.stderr?.on("data", (data: string) => {
-      process.stderr.write(`[ax-service ${udid.slice(0, 8)}] ${data}`);
+      process.stderr.write(`[ax-service ${udidTag}] ${data}`);
     });
 
     proc.on("exit", (code) => {
@@ -218,6 +226,19 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
     if (device.platform !== "ios") {
       throw new Error(
         `${AX_SERVICE_NAMESPACE} is iOS-only. The target '${device.id}' classifies as Android — describe falls back to uiautomator on Android, which does not need this service.`
+      );
+    }
+    // device.id must be a non-empty string. A tool that resolves the device
+    // from a missing `udid` argument can land here with `device.id ===
+    // undefined`. Without this guard, `getSocketPath(undefined).slice` would
+    // crash synchronously in the awaited factory (caught by the registry as
+    // a service error), and `udid.slice(0, 8)` inside the spawned process'
+    // stderr handler would crash inside an async event listener — which the
+    // tool-server treats as fatal via `uncaughtException`.
+    if (typeof device.id !== "string" || device.id.length === 0) {
+      throw new Error(
+        `${AX_SERVICE_NAMESPACE}.factory requires a non-empty device.id; got ${JSON.stringify(device.id)}. ` +
+          `This usually means a tool invocation reached the ax-service blueprint without a 'udid' argument.`
       );
     }
 

--- a/packages/tool-server/src/blueprints/simulator-server.ts
+++ b/packages/tool-server/src/blueprints/simulator-server.ts
@@ -115,8 +115,16 @@ function spawnSimulatorServerProcess(
       }
     });
 
+    // Defense-in-depth: udid is validated at the factory entry, but a missing
+    // value here would crash the whole tool-server. The handler runs inside
+    // an async event listener, so a `udid.slice(0, 8)` against `undefined`
+    // throws synchronously and propagates to the process-wide
+    // `uncaughtException` handler — which the tool-server treats as fatal
+    // and exits on. Tag with "?" if udid is ever empty rather than blowing
+    // up the process.
+    const udidTag = typeof udid === "string" && udid.length > 0 ? udid.slice(0, 8) : "?";
     proc.stderr?.on("data", (data: Buffer) => {
-      process.stderr.write(`[sim ${udid.slice(0, 8)}] ${data}`);
+      process.stderr.write(`[sim ${udidTag}] ${data}`);
     });
 
     proc.on("exit", () => {
@@ -150,6 +158,20 @@ export const simulatorServerBlueprint: ServiceBlueprint<SimulatorServerApi, Devi
       );
     }
     const { device } = opts;
+    // device.id must be a non-empty string. A tool that resolves the device
+    // from a missing `udid` argument can land here with `device.id ===
+    // undefined` (TypeScript's compile-time check is bypassed when the inner
+    // tool is invoked through a wrapper like flow-add-step that doesn't
+    // re-validate the inner schema). Without this guard, we end up spawning
+    // `simulator-server <platform> --id undefined` — the spawned binary
+    // exits, writes to stderr, and the stderr handler then dereferences
+    // `undefined.slice` which fires inside an event listener and is fatal.
+    if (typeof device.id !== "string" || device.id.length === 0) {
+      throw new Error(
+        `${SIMULATOR_SERVER_NAMESPACE}.factory requires a non-empty device.id; got ${JSON.stringify(device.id)}. ` +
+          `This usually means a tool invocation reached the simulator-server blueprint without a 'udid' argument.`
+      );
+    }
     // iOS accessibility automation flag — no-op equivalent on Android so skip
     // the xcrun call entirely there. Android also needs an `adb` preflight
     // because the simulator-server binary shells out to adb internally; without

--- a/packages/tool-server/test/blueprints/ax-service.test.ts
+++ b/packages/tool-server/test/blueprints/ax-service.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import type { DeviceInfo } from "@argent/registry";
+import { axServiceBlueprint } from "../../src/blueprints/ax-service";
+
+/**
+ * Same crash class as `simulator-server`: a missing `udid` reaching the
+ * factory caused `getSocketPath(undefined).slice` to throw synchronously
+ * inside an awaited factory (rejected as a service error), and the stderr
+ * handler's `udid.slice(0, 8)` would crash inside an async event listener
+ * — which propagates to the process-wide `uncaughtException` handler and
+ * kills the entire tool-server.
+ *
+ * The factory must reject the bad input synchronously with a descriptive
+ * Error, *after* the existing apple-only check so an Android caller still
+ * gets the clearer "iOS-only" diagnostic.
+ */
+describe("ax-service blueprint — input validation", () => {
+  it("rejects when options.device is missing", async () => {
+    await expect(axServiceBlueprint.factory({}, "ignored")).rejects.toThrow(
+      /requires a resolved DeviceInfo via options\.device/
+    );
+  });
+
+  it("rejects an Android device with the iOS-only diagnostic before id-shape check", async () => {
+    const device: DeviceInfo = { id: "emulator-5554", platform: "android", kind: "emulator" };
+    await expect(axServiceBlueprint.factory({}, "ignored", { device })).rejects.toThrow(/iOS-only/);
+  });
+
+  it("rejects when device.id is undefined", async () => {
+    const device = { id: undefined, platform: "ios", kind: "simulator" } as unknown as DeviceInfo;
+    await expect(axServiceBlueprint.factory({}, "ignored", { device })).rejects.toThrow(
+      /requires a non-empty device\.id/
+    );
+  });
+
+  it("rejects when device.id is an empty string", async () => {
+    const device: DeviceInfo = { id: "", platform: "ios", kind: "simulator" };
+    await expect(axServiceBlueprint.factory({}, "ignored", { device })).rejects.toThrow(
+      /requires a non-empty device\.id/
+    );
+  });
+
+  it("rejects when device.id is a non-string value", async () => {
+    const device = { id: 42, platform: "ios", kind: "simulator" } as unknown as DeviceInfo;
+    await expect(axServiceBlueprint.factory({}, "ignored", { device })).rejects.toThrow(
+      /requires a non-empty device\.id/
+    );
+  });
+});

--- a/packages/tool-server/test/blueprints/simulator-server.test.ts
+++ b/packages/tool-server/test/blueprints/simulator-server.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import type { DeviceInfo } from "@argent/registry";
+import { simulatorServerBlueprint } from "../../src/blueprints/simulator-server";
+
+/**
+ * Regression for the bug where a missing `udid` reached the simulator-server
+ * blueprint factory, the child was spawned with `--id undefined`, and the
+ * stderr handler later threw `TypeError: Cannot read properties of undefined
+ * (reading 'slice')` — that error fired inside an async event listener and
+ * propagated to the process-wide `uncaughtException` handler, killing the
+ * entire tool-server.
+ *
+ * Reachable in the wild via tool wrappers that don't re-validate the inner
+ * tool's schema (e.g. `flow-add-step` with stringified `args` that omit
+ * `udid`). The factory must reject the bad input synchronously with a
+ * descriptive Error rather than spawning the child at all.
+ */
+describe("simulator-server blueprint — input validation", () => {
+  it("rejects when options.device is missing", async () => {
+    await expect(simulatorServerBlueprint.factory({}, "ignored")).rejects.toThrow(
+      /requires a resolved DeviceInfo via options\.device/
+    );
+  });
+
+  it("rejects when device.id is undefined", async () => {
+    const device = { id: undefined, platform: "ios", kind: "simulator" } as unknown as DeviceInfo;
+    await expect(simulatorServerBlueprint.factory({}, "ignored", { device })).rejects.toThrow(
+      /requires a non-empty device\.id/
+    );
+  });
+
+  it("rejects when device.id is an empty string", async () => {
+    const device: DeviceInfo = { id: "", platform: "ios", kind: "simulator" };
+    await expect(simulatorServerBlueprint.factory({}, "ignored", { device })).rejects.toThrow(
+      /requires a non-empty device\.id/
+    );
+  });
+
+  it("rejects when device.id is a non-string value", async () => {
+    const device = { id: 42, platform: "ios", kind: "simulator" } as unknown as DeviceInfo;
+    await expect(simulatorServerBlueprint.factory({}, "ignored", { device })).rejects.toThrow(
+      /requires a non-empty device\.id/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The `simulator-server` and `ax-service` blueprints both forward their spawned helper's stderr through:

```ts
proc.stderr?.on("data", (data) => {
  process.stderr.write(`[... ${udid.slice(0, 8)}] ${data}`);
});
```

When a tool wrapper that doesn't re-validate the inner tool's schema (e.g. `flow-add-step` invoked with stringified `args` that omit `udid`) reached either factory with `device.id === undefined`, the helper was spawned with `--id undefined`. The spawned binary exited with output on stderr, and `udid.slice(0, 8)` then threw a `TypeError: Cannot read properties of undefined (reading 'slice')` **inside an async event listener** — which propagates to the tool-server's `uncaughtException` handler and is treated as fatal. The whole server crashed.

This was 100% reproducible against a freshly-booted tool-server:

```bash
curl -X POST .../tools/flow-start-recording -d '{"name":"x","project_root":"...","executionPrerequisite":"none"}'
curl -X POST .../tools/flow-add-step       -d '{"command":"gesture-tap","args":"{\"x\":0.5,\"y\":0.5}"}'
# every subsequent tool call fails with "Couldn't connect to server"
```

## Fix

Two-part defense, applied symmetrically to both blueprints:

1. **Validate `device.id` at the factory entry.** Throw a descriptive error before spawning if `device.id` is missing, empty, or non-string. The failure now surfaces as a normal service error (the registry marks the service as ERROR, the dependent tool returns a 5xx with a clear message), instead of a process-wide crash.

2. **Defense-in-depth in the stderr handler.** Pre-compute a `udidTag` constant that falls back to `"?"` if `udid` is ever empty. With the factory guard in place this branch can't trigger today, but it ensures any future code path that reaches the handler with a bad `udid` can't reintroduce the same crash class.

## Test plan

- [x] `vitest run` — full tool-server suite: 581/581 pass (4 new in `simulator-server.test.ts`, 5 new in `ax-service.test.ts`).
- [x] `npx tsc --build` clean.
- [x] `prettier --check` clean.
- [x] E2E reproduction:
  - Pre-fix on `feat/android-emulator-support` HEAD: `flow-add-step → gesture-tap` (no `udid`) crashes the tool-server (subsequent requests fail with `Connection refused`); log shows `[tool-server] Uncaught exception: TypeError: Cannot read properties of undefined (reading 'slice')`.
  - Post-fix: same call returns a clean `500` with `SimulatorServer.factory requires a non-empty device.id; got undefined. This usually means a tool invocation reached the simulator-server blueprint without a 'udid' argument.` Server stays alive across 4 repeated triggers; `grep -c "Uncaught exception"` in the log = `0`.
  - Sanity: `list-devices`, `gesture-tap` with a valid `udid`, and `run-sequence` continue to work normally.

## Notes

- Targets `feat/android-emulator-support` as base. The crash only manifests on that branch — the new `DeviceInfo`-keyed factory signature is what makes `device.id === undefined` reachable. On `origin/main`, the same `udid.slice(0, 8)` line is present but unreachable with `undefined` (the older `services: (params) => ({ k: \`SimulatorServer:${params.udid}\` })` template-literalizes `undefined` to the string `"undefined"`, so `slice` doesn't throw).
- The fix only changes blueprint behaviour for inputs that previously crashed the process. No existing well-formed callsite is affected.