### PR TITLE
feat: clean up `describe` output

### DIFF
--- a/packages/tool-server/src/tools/describe/compress.ts
+++ b/packages/tool-server/src/tools/describe/compress.ts
@@ -72,9 +72,26 @@ function framesEqual(a: DescribeFrame, b: DescribeFrame): boolean {
 // Targeting info (label / identifier) on the wrapper is forwarded to the
 // surviving child if the child has none, so e.g. `id/launcher → unnamed View`
 // becomes a single `View id=launcher` instead of vanishing the id entirely.
+//
+// Refuse to collapse only when both layers carry differing *labels* or
+// *values*: an `AXGroup label="Calendar widget" → AXButton label="Open"`
+// stack at the same bounds describes two semantically distinct entities and
+// folding it to just the button would silently lose the widget context.
+// Identifier conflicts between layers are common platform-internal noise —
+// the launcher chain `id/content → id/launcher → id/drag_layer` carries a
+// distinct resource-id at every level even though no agent would target the
+// outer two. We tolerate that by keeping the child's identifier and dropping
+// the wrapper's; the merge function below preserves the wrapper's id only
+// when the child has none.
 function shouldCollapseSingleChildWrapper(node: DescribeNode, only: DescribeNode): boolean {
   if (!STRUCTURAL_ROLES.has(node.role)) return false;
   if (!framesEqual(node.frame, only.frame)) return false;
+  if (node.label !== undefined && only.label !== undefined && node.label !== only.label) {
+    return false;
+  }
+  if (node.value !== undefined && only.value !== undefined && node.value !== only.value) {
+    return false;
+  }
   return true;
 }
 

--- a/packages/tool-server/src/tools/describe/compress.ts
+++ b/packages/tool-server/src/tools/describe/compress.ts
@@ -1,0 +1,171 @@
+import type { DescribeNode, DescribeFrame } from "./contract";
+
+// Roles we treat as pure layout containers — they only matter when they carry
+// a label, identifier, or value. The AX service emits AXGroup as the fallback
+// for anything without a recognised trait, and uiautomator surfaces the raw
+// Android layout class names; both classes commonly appear five-deep around
+// the actually-meaningful leaves.
+const STRUCTURAL_ROLES = new Set<string>([
+  // iOS AX fallback
+  "AXGroup",
+  // Android view-hierarchy containers (uiautomator passes these through
+  // verbatim from `class` when deriveUiAutomatorRole has no semantic mapping)
+  "View",
+  "ViewGroup",
+  "FrameLayout",
+  "LinearLayout",
+  "RelativeLayout",
+  "AbsoluteLayout",
+  "TableLayout",
+  "TableRow",
+  "GridLayout",
+  "ConstraintLayout",
+  "MotionLayout",
+  "CoordinatorLayout",
+  "AppBarLayout",
+  "CardView",
+  "ViewPager",
+  "ViewPager2",
+  "ComposeView",
+  "AndroidComposeView",
+]);
+
+// 4 decimals = 0.0001 of the screen ≈ 0.1px on a 1080-wide display, well under
+// any tap target. Three would land in the same pixel as the next element on
+// dense layouts; five+ keeps floating-point noise (the `.0796...199005` tails
+// the AX service emits) without buying any usable precision.
+const FRAME_PRECISION = 1e4;
+
+function roundFrameComponent(value: number): number {
+  return Math.round(value * FRAME_PRECISION) / FRAME_PRECISION;
+}
+
+function roundFrame(frame: DescribeFrame): DescribeFrame {
+  return {
+    x: roundFrameComponent(frame.x),
+    y: roundFrameComponent(frame.y),
+    width: roundFrameComponent(frame.width),
+    height: roundFrameComponent(frame.height),
+  };
+}
+
+function isNoiseWrapper(node: DescribeNode): boolean {
+  if (!STRUCTURAL_ROLES.has(node.role)) return false;
+  if (node.label) return false;
+  if (node.identifier) return false;
+  if (node.value) return false;
+  return true;
+}
+
+function framesEqual(a: DescribeFrame, b: DescribeFrame): boolean {
+  return (
+    roundFrameComponent(a.x) === roundFrameComponent(b.x) &&
+    roundFrameComponent(a.y) === roundFrameComponent(b.y) &&
+    roundFrameComponent(a.width) === roundFrameComponent(b.width) &&
+    roundFrameComponent(a.height) === roundFrameComponent(b.height)
+  );
+}
+
+// Pure layout containers that exist only to hold one same-bounds child add no
+// spatial information — `Screen → drag_layer → launcher → workspace → ...`
+// is six levels of hand-walking just to reach the date widget. Collapse them.
+// Targeting info (label / identifier) on the wrapper is forwarded to the
+// surviving child if the child has none, so e.g. `id/launcher → unnamed View`
+// becomes a single `View id=launcher` instead of vanishing the id entirely.
+function shouldCollapseSingleChildWrapper(node: DescribeNode, only: DescribeNode): boolean {
+  if (!STRUCTURAL_ROLES.has(node.role)) return false;
+  if (!framesEqual(node.frame, only.frame)) return false;
+  return true;
+}
+
+function mergeIdentityFromCollapsedWrapper(
+  wrapper: DescribeNode,
+  child: DescribeNode
+): DescribeNode {
+  return {
+    ...child,
+    ...(child.label === undefined && wrapper.label !== undefined ? { label: wrapper.label } : {}),
+    ...(child.identifier === undefined && wrapper.identifier !== undefined
+      ? { identifier: wrapper.identifier }
+      : {}),
+    ...(child.value === undefined && wrapper.value !== undefined ? { value: wrapper.value } : {}),
+  };
+}
+
+// Stable structural fingerprint used to deduplicate sibling subtrees. The AX
+// service emits widget contents twice on iOS home screens (the Map widget /
+// "MONDAY, 04 MAY" / "No events today" trio repeats verbatim); a pure
+// (role, frame, label) check would also fold non-duplicate siblings, so we
+// hash the full subtree including descendants.
+function fingerprintNode(node: DescribeNode): string {
+  return JSON.stringify({
+    role: node.role,
+    frame: node.frame,
+    label: node.label ?? null,
+    identifier: node.identifier ?? null,
+    value: node.value ?? null,
+    children: node.children.map(fingerprintNode),
+  });
+}
+
+function dedupSiblings(nodes: DescribeNode[]): DescribeNode[] {
+  if (nodes.length < 2) return nodes;
+  const seen = new Set<string>();
+  const out: DescribeNode[] = [];
+  for (const n of nodes) {
+    const key = fingerprintNode(n);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(n);
+  }
+  return out;
+}
+
+// Bottom-up rewrite. Each call returns the list of nodes that should appear
+// in the parent's `children`: usually one node, zero if the subtree dropped
+// to nothing, or many when a noise wrapper is promoted. The synthetic root
+// is preserved by `compressDescribeTree` regardless of whether it itself
+// looks like a wrapper — a tree without a root violates the contract.
+function rewriteSubtree(node: DescribeNode): DescribeNode[] {
+  const compressedChildren = dedupSiblings(node.children.flatMap(rewriteSubtree));
+
+  if (isNoiseWrapper(node)) {
+    return compressedChildren;
+  }
+
+  if (
+    compressedChildren.length === 1 &&
+    shouldCollapseSingleChildWrapper(node, compressedChildren[0]!)
+  ) {
+    return [mergeIdentityFromCollapsedWrapper(node, compressedChildren[0]!)];
+  }
+
+  return [
+    {
+      role: node.role,
+      frame: roundFrame(node.frame),
+      children: compressedChildren,
+      ...(node.label !== undefined ? { label: node.label } : {}),
+      ...(node.identifier !== undefined ? { identifier: node.identifier } : {}),
+      ...(node.value !== undefined ? { value: node.value } : {}),
+    },
+  ];
+}
+
+/**
+ * Compress a describe tree by collapsing pure-layout wrappers into their
+ * children, deduplicating identical sibling subtrees, and rounding normalized
+ * frame components to 4 decimals. Idempotent: a second pass returns an equal
+ * tree.
+ */
+export function compressDescribeTree(root: DescribeNode): DescribeNode {
+  const rewrittenChildren = dedupSiblings(root.children.flatMap(rewriteSubtree));
+  return {
+    role: root.role,
+    frame: roundFrame(root.frame),
+    children: rewrittenChildren,
+    ...(root.label !== undefined ? { label: root.label } : {}),
+    ...(root.identifier !== undefined ? { identifier: root.identifier } : {}),
+    ...(root.value !== undefined ? { value: root.value } : {}),
+  };
+}

--- a/packages/tool-server/src/tools/describe/platforms/android.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android.ts
@@ -1,5 +1,6 @@
 import type { ToolDependency } from "@argent/registry";
 import type { DescribeResult } from "../contract";
+import { compressDescribeTree } from "../compress";
 import { adbExecOutBinary } from "../../../utils/adb";
 import { getAndroidScreenSize } from "../../../utils/android-screen";
 import { parseUiAutomatorDump } from "../../../utils/uiautomator-parser";
@@ -32,6 +33,6 @@ export async function describeAndroid(udid: string, _bundleId?: string): Promise
         `Unlock the device or take a screenshot as a fallback.`
     );
   }
-  const tree = parseUiAutomatorDump(raw, size.width, size.height);
+  const tree = compressDescribeTree(parseUiAutomatorDump(raw, size.width, size.height));
   return { tree, source: "uiautomator" };
 }

--- a/packages/tool-server/src/tools/describe/platforms/ios.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios.ts
@@ -2,6 +2,7 @@ import type { DeviceInfo, Registry, ToolDependency } from "@argent/registry";
 import { axServiceRef, type AXServiceApi } from "../../../blueprints/ax-service";
 import { nativeDevtoolsRef, type NativeDevtoolsApi } from "../../../blueprints/native-devtools";
 import type { DescribeResult } from "../contract";
+import { compressDescribeTree } from "../compress";
 import { adaptAXDescribeToDescribeResult } from "./ios-ax-adapter";
 import { adaptNativeDescribeToDescribeResult } from "./ios-native-adapter";
 import { parseNativeDescribeScreenResult } from "../../native-devtools/native-describe-contract";
@@ -27,7 +28,7 @@ export async function describeIos(
   const axRef = axServiceRef(device);
   const axApi = await registry.resolveService<AXServiceApi>(axRef.urn, axRef.options);
   const response = await axApi.describe();
-  const tree = adaptAXDescribeToDescribeResult(response);
+  const tree = compressDescribeTree(adaptAXDescribeToDescribeResult(response));
 
   if (tree.children.length > 0) {
     return { tree, source: "ax-service" };
@@ -54,7 +55,7 @@ export async function describeIos(
     }
 
     const parsed = parseNativeDescribeScreenResult(rawResult);
-    const nativeTree = adaptNativeDescribeToDescribeResult(parsed);
+    const nativeTree = compressDescribeTree(adaptNativeDescribeToDescribeResult(parsed));
     return { tree: nativeTree, source: "native-devtools" };
   } catch {
     // Native devtools unavailable or no connected app — return the empty AX result

--- a/packages/tool-server/test/describe-compress.test.ts
+++ b/packages/tool-server/test/describe-compress.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from "vitest";
+import { compressDescribeTree } from "../src/tools/describe/compress";
+import type { DescribeNode } from "../src/tools/describe/contract";
+
+function leaf(role: string, label?: string, identifier?: string): DescribeNode {
+  return {
+    role,
+    frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+    children: [],
+    ...(label !== undefined ? { label } : {}),
+    ...(identifier !== undefined ? { identifier } : {}),
+  };
+}
+
+function wrap(
+  role: string,
+  children: DescribeNode[],
+  extras: Partial<DescribeNode> = {}
+): DescribeNode {
+  return {
+    role,
+    frame: { x: 0, y: 0, width: 1, height: 1 },
+    children,
+    ...extras,
+  };
+}
+
+describe("compressDescribeTree — wrapper promotion", () => {
+  it("collapses a chain of empty structural wrappers around a leaf", () => {
+    // Mirrors the Android pixel-launcher dump: 5+ FrameLayout/LinearLayout
+    // wrappers with no content-desc, no resource-id, full-screen bounds.
+    const input = wrap("FrameLayout", [
+      wrap("LinearLayout", [
+        wrap("FrameLayout", [
+          wrap("FrameLayout", [
+            wrap("FrameLayout", [leaf("Button", "Submit", "com.example:id/submit")]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const out = compressDescribeTree(input);
+
+    expect(out.role).toBe("FrameLayout"); // root preserved
+    expect(out.children).toHaveLength(1);
+    expect(out.children[0]?.role).toBe("Button");
+    expect(out.children[0]?.label).toBe("Submit");
+    expect(out.children[0]?.identifier).toBe("com.example:id/submit");
+  });
+
+  it("preserves structural wrappers that carry an identifier", () => {
+    // resource-ids like `id/scrim_view` may not be human-targeted, but they're
+    // the only stable handle uiautomator gives for some screens — keep them.
+    const input = wrap("FrameLayout", [
+      wrap("ScrollView", [leaf("StaticText", "Mon, May 4")], {
+        identifier: "com.example:id/workspace",
+      }),
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children).toHaveLength(1);
+    expect(out.children[0]?.identifier).toBe("com.example:id/workspace");
+    expect(out.children[0]?.children[0]?.role).toBe("StaticText");
+  });
+
+  it("preserves structural wrappers that carry a label", () => {
+    const input = wrap("FrameLayout", [
+      wrap("AXGroup", [leaf("AXStaticText", "Subtitle")], { label: "Calendar" }),
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children[0]?.label).toBe("Calendar");
+    expect(out.children[0]?.role).toBe("AXGroup");
+  });
+
+  it("preserves wrappers whose role is semantic (ScrollView, WebView, …)", () => {
+    // ScrollView matters even without a label: agents look at the role to
+    // decide whether to scroll. Same for WebView / Button / etc.
+    const input = wrap("FrameLayout", [
+      wrap("ScrollView", [leaf("StaticText", "Row 1"), leaf("StaticText", "Row 2")]),
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children).toHaveLength(1);
+    expect(out.children[0]?.role).toBe("ScrollView");
+    expect(out.children[0]?.children).toHaveLength(2);
+  });
+
+  it("drops empty noise leaves entirely", () => {
+    const input = wrap("FrameLayout", [
+      leaf("FrameLayout"),
+      leaf("View"),
+      leaf("Button", "Keep me"),
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children).toHaveLength(1);
+    expect(out.children[0]?.label).toBe("Keep me");
+  });
+
+  it("promotes multiple children of a noise wrapper up one level", () => {
+    const input = wrap("FrameLayout", [
+      wrap("LinearLayout", [
+        leaf("Button", "Phone"),
+        leaf("Button", "Messages"),
+        leaf("Button", "Camera"),
+      ]),
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children.map((c) => c.label)).toEqual(["Phone", "Messages", "Camera"]);
+  });
+
+  it("preserves the root node even when it would otherwise be a noise wrapper", () => {
+    // Without this guard the tree contract (single root) would be violated
+    // whenever the synthetic Screen / AXGroup root gets flattened.
+    const input: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [leaf("Button", "OK")],
+    };
+    const out = compressDescribeTree(input);
+    expect(out.role).toBe("Screen");
+    expect(out.children).toHaveLength(1);
+  });
+});
+
+describe("compressDescribeTree — same-frame single-child wrapper collapse", () => {
+  it("drops a structural wrapper whose only child has the same frame", () => {
+    // Reproduces the launcher chain: Screen → FrameLayout(id=content) →
+    // FrameLayout(id=launcher) → FrameLayout(id=drag_layer). All three
+    // FrameLayouts are full-screen single-child containers.
+    const input = wrap("Screen", [
+      wrap(
+        "FrameLayout",
+        [
+          wrap(
+            "FrameLayout",
+            [wrap("FrameLayout", [leaf("Button", "Submit")], { identifier: "id/drag_layer" })],
+            { identifier: "id/launcher" }
+          ),
+        ],
+        { identifier: "id/content" }
+      ),
+    ]);
+    const out = compressDescribeTree(input);
+    // FrameLayout id=drag_layer has 1 child (Button) — Button frame is 0.1/0.2/0.3/0.4 vs
+    // wrapper 0/0/1/1, so drag_layer is kept (different frame). The two
+    // outer FrameLayouts (content, launcher) are full-screen single-child
+    // wrappers around drag_layer (same frame), so they collapse with their
+    // identifiers folded into drag_layer (which already has its own).
+    expect(out.role).toBe("Screen");
+    expect(out.children).toHaveLength(1);
+    expect(out.children[0]?.role).toBe("FrameLayout");
+    expect(out.children[0]?.identifier).toBe("id/drag_layer");
+  });
+
+  it("forwards a wrapper's identifier to a child that has none", () => {
+    // Realistic shape: a `Button label='Submit'` (no resource-id of its own)
+    // wrapped in a same-bounds FrameLayout that owns the resource-id. After
+    // collapse the Button keeps its label and inherits id=action_button so
+    // the targetable handle survives.
+    const child: DescribeNode = {
+      role: "Button",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [],
+      label: "Submit",
+    };
+    const input = wrap("Screen", [
+      wrap("FrameLayout", [child], { identifier: "id/action_button" }),
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children[0]?.role).toBe("Button");
+    expect(out.children[0]?.label).toBe("Submit");
+    expect(out.children[0]?.identifier).toBe("id/action_button");
+  });
+
+  it("does not collapse a multi-child wrapper even if all bounds align", () => {
+    // hotseat-style grouping: spatial siblings under one ID. Collapsing it
+    // would lose a meaningful container handle.
+    const input = wrap("Screen", [
+      wrap(
+        "ViewGroup",
+        [leaf("StaticText", "Phone"), leaf("StaticText", "Messages"), leaf("StaticText", "Camera")],
+        { identifier: "id/hotseat" }
+      ),
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children[0]?.identifier).toBe("id/hotseat");
+    expect(out.children[0]?.children).toHaveLength(3);
+  });
+
+  it("does not collapse when frames differ", () => {
+    const child: DescribeNode = {
+      role: "Button",
+      frame: { x: 0.4, y: 0.45, width: 0.2, height: 0.05 },
+      children: [],
+      label: "OK",
+    };
+    const wrapper = wrap("FrameLayout", [child], { identifier: "id/footer" });
+    const input = wrap("Screen", [wrapper]);
+    const out = compressDescribeTree(input);
+    // wrapper frame {0,0,1,1} != child frame {0.4,...} → wrapper kept
+    expect(out.children[0]?.identifier).toBe("id/footer");
+    expect(out.children[0]?.children[0]?.label).toBe("OK");
+  });
+});
+
+describe("compressDescribeTree — sibling deduplication", () => {
+  it("drops adjacent and non-adjacent identical siblings", () => {
+    // Reproduces the iOS home-screen widget repeat: AX service emits the Map /
+    // calendar header / "No events today" trio twice. With three other items
+    // mixed in, adjacent-only dedup would miss it.
+    const child = (label: string): DescribeNode => ({
+      role: "AXStaticText",
+      frame: { x: 0.1, y: 0.1, width: 0.5, height: 0.05 },
+      children: [],
+      label,
+    });
+    const input = wrap("AXGroup", [
+      child("Map"),
+      child("MONDAY, 04 MAY"),
+      child("No events today"),
+      child("Map"), // duplicate
+      child("MONDAY, 04 MAY"), // duplicate
+      child("No events today"), // duplicate
+      child("Calendar"),
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children.map((c) => c.label)).toEqual([
+      "Map",
+      "MONDAY, 04 MAY",
+      "No events today",
+      "Calendar",
+    ]);
+  });
+
+  it("treats subtree shape as part of the dedup key", () => {
+    // Same role+frame+label, but different children — must not collapse.
+    const a: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0.1, y: 0.1, width: 0.5, height: 0.5 },
+      children: [
+        {
+          role: "AXButton",
+          frame: { x: 0.2, y: 0.2, width: 0.1, height: 0.1 },
+          children: [],
+          label: "A",
+        },
+      ],
+      label: "Group",
+    };
+    const b: DescribeNode = {
+      ...a,
+      children: [
+        {
+          role: "AXButton",
+          frame: { x: 0.2, y: 0.2, width: 0.1, height: 0.1 },
+          children: [],
+          label: "B",
+        },
+      ],
+    };
+    const out = compressDescribeTree(wrap("AXGroup", [a, b], { label: "root" }));
+    expect(out.children).toHaveLength(2);
+  });
+
+  it("does not dedup elements that differ only in identifier", () => {
+    // resource-ids are how agents target Android views — never collapse two
+    // siblings whose only distinguishing field is identifier.
+    const input = wrap(
+      "AXGroup",
+      [
+        {
+          role: "Image",
+          frame: { x: 0.1, y: 0.1, width: 0.1, height: 0.1 },
+          children: [],
+          label: "Icon",
+          identifier: "id/a",
+        },
+        {
+          role: "Image",
+          frame: { x: 0.1, y: 0.1, width: 0.1, height: 0.1 },
+          children: [],
+          label: "Icon",
+          identifier: "id/b",
+        },
+      ],
+      { label: "root" }
+    );
+    const out = compressDescribeTree(input);
+    expect(out.children).toHaveLength(2);
+    expect(out.children.map((c) => c.identifier)).toEqual(["id/a", "id/b"]);
+  });
+});
+
+describe("compressDescribeTree — frame rounding", () => {
+  it("rounds normalized components to 4 decimals", () => {
+    // 0.07960199005 → 0.0796 keeps the tap point inside the same pixel on a
+    // 1080-wide screen (Δ ≈ 0.0000019 ≈ 0.002 px) while halving the byte count.
+    const input: DescribeNode = {
+      role: "Button",
+      frame: { x: 0.07960199005, y: 0.180778032037, width: 0.39303482587, height: 0.05823942 },
+      children: [],
+      label: "x",
+    };
+    const out = compressDescribeTree(wrap("AXGroup", [input], { label: "root" }));
+    expect(out.children[0]?.frame).toEqual({
+      x: 0.0796,
+      y: 0.1808,
+      width: 0.393,
+      height: 0.0582,
+    });
+  });
+
+  it("rounds the root frame too", () => {
+    const input: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0.0001234, y: 0.0001234, width: 0.9999876, height: 0.9999876 },
+      children: [],
+    };
+    const out = compressDescribeTree(input);
+    expect(out.frame).toEqual({ x: 0.0001, y: 0.0001, width: 1, height: 1 });
+  });
+});
+
+describe("compressDescribeTree — idempotence", () => {
+  it("is idempotent: compressing twice equals compressing once", () => {
+    const input = wrap("FrameLayout", [
+      wrap("LinearLayout", [leaf("Button", "Submit", "id/submit"), leaf("FrameLayout")]),
+      leaf("StaticText", "Hello"),
+    ]);
+    const once = compressDescribeTree(input);
+    const twice = compressDescribeTree(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("preserves explicit value field", () => {
+    const input = wrap("AXGroup", [
+      {
+        role: "AXAdjustable",
+        frame: { x: 0.1, y: 0.1, width: 0.1, height: 0.1 },
+        children: [],
+        label: "Volume",
+        value: "50%",
+      },
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children[0]?.value).toBe("50%");
+  });
+});
+
+describe("compressDescribeTree — does not strip undefined optional fields", () => {
+  it("emits children-only nodes without label/identifier/value keys", () => {
+    // A node with no semantic info but a semantic role (e.g. ScrollView) should
+    // serialise without `label: undefined` / `identifier: undefined` / `value:
+    // undefined` keys, otherwise the JSON gets noisier than before compression.
+    const input = wrap("AXGroup", [wrap("ScrollView", [leaf("StaticText", "x")])]);
+    const out = compressDescribeTree(input);
+    const sv = out.children[0]!;
+    expect(sv.role).toBe("ScrollView");
+    expect("label" in sv).toBe(false);
+    expect("identifier" in sv).toBe(false);
+    expect("value" in sv).toBe(false);
+  });
+});

--- a/packages/tool-server/test/describe-compress.test.ts
+++ b/packages/tool-server/test/describe-compress.test.ts
@@ -199,6 +199,72 @@ describe("compressDescribeTree — same-frame single-child wrapper collapse", ()
     expect(out.children[0]?.identifier).toBe("id/footer");
     expect(out.children[0]?.children[0]?.label).toBe("OK");
   });
+
+  it("refuses to collapse when wrapper and child carry conflicting labels", () => {
+    // Two real semantic layers stacked at the same bounds. Folding into the
+    // child would silently drop "Calendar widget" — keep both layers visible.
+    const child: DescribeNode = {
+      role: "AXButton",
+      frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      children: [],
+      label: "Open",
+    };
+    const wrapper: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      children: [child],
+      label: "Calendar widget",
+    };
+    const out = compressDescribeTree(wrap("Screen", [wrapper]));
+    expect(out.children[0]?.role).toBe("AXGroup");
+    expect(out.children[0]?.label).toBe("Calendar widget");
+    expect(out.children[0]?.children[0]?.label).toBe("Open");
+  });
+
+  it("collapses when wrapper and child have differing identifiers, keeping the child's", () => {
+    // resource-id stacks like `id/content → id/launcher → id/drag_layer` are
+    // platform-internal noise — collapse them aggressively so agents reach
+    // the actionable child without crawling five layers. The child's id wins
+    // since it's the closest to the actual rendered element.
+    const child: DescribeNode = {
+      role: "Button",
+      frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      children: [],
+      identifier: "id/inner",
+      label: "Submit",
+    };
+    const wrapper: DescribeNode = {
+      role: "FrameLayout",
+      frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      children: [child],
+      identifier: "id/outer",
+    };
+    const out = compressDescribeTree(wrap("Screen", [wrapper]));
+    expect(out.children).toHaveLength(1);
+    expect(out.children[0]?.role).toBe("Button");
+    expect(out.children[0]?.identifier).toBe("id/inner");
+    expect(out.children[0]?.label).toBe("Submit");
+  });
+
+  it("still collapses when the wrapper's label matches the child's exactly", () => {
+    // No information lost — fold the redundant layer.
+    const child: DescribeNode = {
+      role: "Button",
+      frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      children: [],
+      label: "Submit",
+    };
+    const wrapper: DescribeNode = {
+      role: "FrameLayout",
+      frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      children: [child],
+      label: "Submit",
+    };
+    const out = compressDescribeTree(wrap("Screen", [wrapper]));
+    expect(out.children).toHaveLength(1);
+    expect(out.children[0]?.role).toBe("Button");
+    expect(out.children[0]?.label).toBe("Submit");
+  });
 });
 
 describe("compressDescribeTree — sibling deduplication", () => {
@@ -357,5 +423,61 @@ describe("compressDescribeTree — does not strip undefined optional fields", ()
     expect("label" in sv).toBe(false);
     expect("identifier" in sv).toBe(false);
     expect("value" in sv).toBe(false);
+  });
+});
+
+describe("compressDescribeTree — input safety & no-op shapes", () => {
+  it("does not mutate the input tree", () => {
+    const input: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        wrap("FrameLayout", [
+          wrap("LinearLayout", [
+            {
+              role: "Button",
+              frame: { x: 0.07960199005, y: 0.180778032037, width: 0.3, height: 0.05 },
+              children: [],
+              label: "Submit",
+              identifier: "id/submit",
+            },
+          ]),
+        ]),
+      ],
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    compressDescribeTree(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("handles a root with empty children", () => {
+    const input: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [],
+    };
+    const out = compressDescribeTree(input);
+    expect(out.role).toBe("Screen");
+    expect(out.children).toEqual([]);
+  });
+
+  it("returns an equivalent tree when no node is compressible", () => {
+    const input = wrap("Screen", [
+      {
+        role: "Button",
+        frame: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 },
+        children: [],
+        label: "Yes",
+      },
+      {
+        role: "Button",
+        frame: { x: 0.4, y: 0.1, width: 0.2, height: 0.05 },
+        children: [],
+        label: "No",
+      },
+    ]);
+    const out = compressDescribeTree(input);
+    expect(out.children).toHaveLength(2);
+    expect(out.children.map((c) => c.label)).toEqual(["Yes", "No"]);
   });
 });

--- a/packages/tool-server/test/describe-tool.test.ts
+++ b/packages/tool-server/test/describe-tool.test.ts
@@ -317,6 +317,54 @@ describe("describe tool", () => {
     );
   });
 
+  it("falls back to native-devtools when AX returns only labelless trait-less elements", async () => {
+    // describeIos passes the AX response through compressDescribeTree before
+    // checking children.length. Trait-less + labelless elements adapt to
+    // `AXGroup` (the ios-native-adapter fallback) with no label / value /
+    // identifier — pure noise wrappers that compression drops, leaving an
+    // empty tree. The tool then enters the native-devtools fallback path,
+    // matching the behavior we want for screens that AX can describe only
+    // structurally.
+    const axApi = makeAXServiceApi({
+      alertVisible: false,
+      screenFrame: { width: 440, height: 956 },
+      elements: [
+        {
+          frame: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 },
+          traits: [],
+        },
+        {
+          frame: { x: 0.4, y: 0.1, width: 0.2, height: 0.05 },
+          traits: [],
+        },
+      ],
+    });
+
+    const nativeApi = makeNativeDevtoolsApi({
+      connectedBundleIds: ["com.example.app"],
+      describeScreenResult: {
+        screenFrame: { x: 0, y: 0, width: 440, height: 956 },
+        elements: [
+          {
+            frame: { x: 10, y: 100, width: 420, height: 40 },
+            tapPoint: { x: 220, y: 120 },
+            normalizedFrame: { x: 0.023, y: 0.105, width: 0.955, height: 0.042 },
+            normalizedTapPoint: { x: 0.5, y: 0.126 },
+            traits: ["staticText"],
+            label: "Real label from native devtools",
+          },
+        ],
+      },
+    });
+
+    const registry = makeMockRegistry({ axService: axApi, nativeDevtools: nativeApi });
+    const tool = createDescribeTool(registry);
+
+    const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
+    expect(result.source).toBe("native-devtools");
+    expect(result.tree.children[0]?.label).toBe("Real label from native devtools");
+  });
+
   it("returns empty AX result when native queryViewHierarchy returns an error", async () => {
     const axApi = makeAXServiceApi({
       alertVisible: false,


### PR DESCRIPTION
Stacked on #148 — review after that lands.

# STILL WORK IN PROGRESS

## Why

Real captures from the iPhone 16 Pro home screen and a Pixel emulator launcher:

| Platform | Before | After | Δ pretty | Δ minified |
| --- | --- | --- | --- | --- |
| Android (uiautomator) | 32 nodes, depth 14, 17.9 KB pretty | 23 nodes, depth 6, 8.0 KB pretty | **−56 %** | −37 % |
| iOS (AX-service) | 18 nodes, depth 1, 4.2 KB pretty | 15 nodes, depth 1, 3.0 KB pretty | **−28 %** | −34 % |

The Android tree had 5+ FrameLayout / LinearLayout wrappers with no `content-desc` / `resource-id` chained around every actually-meaningful leaf, and a launcher-chain (`Screen → id/content → id/launcher → id/drag_layer`) of single-child same-bounds containers. The iOS tree had every widget element repeated verbatim (Map, "MONDAY, 04 MAY", "No events today" each appeared twice).

## What

A shared post-processor `compressDescribeTree` runs after both platform adapters (AX + native-devtools fallback on iOS, uiautomator on Android). It applies four rules, all idempotent:

1. **Drop pure-noise structural wrappers.** `View` / `ViewGroup` / `FrameLayout` / `LinearLayout` / `RelativeLayout` / `AXGroup` / etc. with no `label`, `identifier`, or `value` are removed and their children promoted up.
2. **Collapse same-frame single-child structural wrappers.** Forward `label` / `identifier` / `value` to the surviving child if it has none. Refuses the collapse when wrapper and child carry **differing labels or values** (e.g. `AXGroup label="Calendar widget" → AXButton label="Open"` is preserved as two layers — both labels are real). Identifier conflicts collapse with the child winning, since the chains they appear in (`id/content → id/launcher → id/drag_layer`) are platform-internal noise.
3. **Deduplicate structurally-identical sibling subtrees.** Hash on `(role, frame, label, identifier, value, recursive children)` — kills the iOS widget-repeat noise without folding distinct items that happen to share a frame.
4. **Round normalized frame components to 4 decimals.** ≈ 0.1 px on a 1080-wide screen, well under any tap-target tolerance. Replaces the AX service's `0.07960199005`-style float-noise tails.

The synthetic root is always preserved (single-root contract). Semantic roles (`Button`, `TextField`, `StaticText`, `Image`, `Switch`, `CheckBox`, `RadioButton`, `ScrollView`, `WebView`, `AXButton`, `AXTextField`, `AXStaticText`, `AXLink`, `AXImage`, `AXHeading`, `AXTabBar`, `AXAdjustable`) are never dropped — agents can still reason about what to do with each element.

### Behavior change worth flagging

iOS describe previously returned `source: "ax-service"` whenever AX returned any elements. Now an AX response containing only labelless trait-less elements (which adapt to bare `AXGroup` leaves) compresses to an empty tree and triggers the existing native-devtools fallback. That's almost always a strict improvement (the fallback gives a richer, app-scoped tree) but it is a real behavioral expansion. Pinned with a regression test in `describe-tool.test.ts`.

## Test plan

- [x] Unit: 24 new tests in `describe-compress.test.ts` covering wrapper promotion, same-frame collapse, conflict refusal, sibling dedup, frame rounding, idempotence, no-op shapes, and input-mutation safety.
- [x] Unit: 1 new test in `describe-tool.test.ts` pinning the AX-empty-after-compression → native fallback path.
- [x] Full tool-server suite: 627 pass (was 620, +7 new). Registry suite: 57 pass.
- [x] `npx prettier --check .` clean for changed files.
- [x] Real-world before/after measured on captured iOS + Android dumps (numbers above).
- [ ] Visual regression: I have not run this against a live RN app yet — would be good for a reviewer to spot-check that targeting elements via `describe` still works in their usual flow.

## Stack

Branch is one commit + one post-review-fix commit on top of `feat/android-emulator-support` (PR #148). No diverging history; once #148 lands, GitHub will auto-retarget this PR to `main`.