### PR TITLE
fix installer update version detection under npx

### DIFF
--- a/packages/argent-installer/src/index.ts
+++ b/packages/argent-installer/src/index.ts
@@ -2,4 +2,4 @@ export { init } from "./init.js";
 export { update } from "./update.js";
 export { uninstall } from "./uninstall.js";
 export { PACKAGE_NAME, MCP_BINARY_NAME, MCP_SERVER_KEY } from "./constants.js";
-export { getInstalledVersion } from "./utils.js";
+export { getInstalledVersion, getGloballyInstalledVersion } from "./utils.js";

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -3,7 +3,7 @@ import pc from "picocolors";
 import { execFileSync } from "node:child_process";
 import { detectAdapters, getMcpEntry, copyRulesAndAgents } from "./mcp-configs.js";
 import {
-  getInstalledVersion,
+  getGloballyInstalledVersion,
   getLatestVersion,
   isGloballyInstalled,
   isNewerVersion,
@@ -23,14 +23,15 @@ export async function update(args: string[]): Promise<void> {
 
   p.intro(pc.bgCyan(pc.black(" argent update ")));
 
-  // When invoked via `npx @swmansion/argent update`, getInstalledVersion()
-  // reads the npx-cached package.json — which is always the latest, so a
-  // straight version compare would falsely report "already on the latest"
-  // even after the user uninstalled the global package. Detect that we're
-  // running transiently and treat the missing global install as a fresh-
-  // install path instead.
+  // When invoked via `npx @swmansion/argent update`, the running package is
+  // the npx cache and will always be at the latest published version. Reading the
+  // version from PACKAGE_ROOT would falsely report "already on the latest"
+  // both when no global install exists AND when the global install is
+  // outdated. getGloballyInstalledVersion() resolves the *real* global
+  // binary's package.json, so the compare reflects what the user has
+  // installed rather than what npx just downloaded.
   const globallyInstalled = isGloballyInstalled();
-  const installed = globallyInstalled ? getInstalledVersion() : null;
+  const installed = globallyInstalled ? getGloballyInstalledVersion() : null;
 
   if (globallyInstalled && !installed) {
     p.log.error("Could not determine installed version.");

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -334,6 +334,37 @@ export function getInstalledVersion(): string | null {
   }
 }
 
+/**
+ * Read the version of the globally-installed argent package — distinct from
+ * {@link getInstalledVersion}, which reads the package.json this code is
+ * currently executing from. When invoked via `npx @swmansion/argent`, the
+ * npx cache is always at the latest published version, so reading
+ * PACKAGE_ROOT/package.json masks an outdated global install and lets the
+ * update check report "already on the latest" incorrectly. This helper
+ * resolves the global binary via `which -a` / `where`, follows symlinks to
+ * the actual entrypoint, and walks up to the owning package.json instead.
+ *
+ * Returns null when argent is not permanently installed on PATH, or when
+ * the global package layout cannot be resolved (e.g., Windows wrapper
+ * scripts that aren't symlinks). Callers should treat null as "could not
+ * determine" — preferable to silently using the running package's version,
+ * which is the bug this guards against.
+ */
+export function getGloballyInstalledVersion(): string | null {
+  const binaryPath = getGlobalBinaryPath();
+  if (!binaryPath) return null;
+  try {
+    const realPath = fs.realpathSync(binaryPath);
+    const pkgRoot = resolvePackageRoot(path.dirname(realPath));
+    const pkg = JSON.parse(fs.readFileSync(path.join(pkgRoot, "package.json"), "utf8")) as {
+      version?: string;
+    };
+    return pkg.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
 const PROBE_TIMEOUT_MS = 3_000;
 
 export function getLatestVersion(): string {
@@ -368,26 +399,37 @@ export function isTempRunnerPath(binaryPath: string): boolean {
 }
 
 /**
- * True iff argent is permanently installed on the user's PATH (not just being
- * executed transiently from an npx / dlx / bunx cache). On Windows `where`
+ * Resolve the path of the globally-installed argent binary, ignoring
+ * temp-runner caches (npx / pnpm dlx / bunx / yarn dlx). On Windows `where`
  * returns every match, on Unix `which -a` does — we inspect each line so a
- * concurrent npx invocation does not mask a real global install.
+ * concurrent npx invocation does not mask a real global install. Returns
+ * null when argent is not permanently installed on PATH.
  */
-export function isGloballyInstalled(): boolean {
+function getGlobalBinaryPath(): string | null {
   try {
     const cmd = process.platform === "win32" ? "where" : "which -a";
     const output = execSync(`${cmd} ${MCP_BINARY_NAME}`, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
-    return output
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .some((line) => !isTempRunnerPath(line));
+    return (
+      output
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .find((line) => !isTempRunnerPath(line)) ?? null
+    );
   } catch {
-    return false;
+    return null;
   }
+}
+
+/**
+ * True iff argent is permanently installed on the user's PATH (not just being
+ * executed transiently from an npx / dlx / bunx cache).
+ */
+export function isGloballyInstalled(): boolean {
+  return getGlobalBinaryPath() !== null;
 }
 
 export function isSkillsCliAvailable(): boolean {

--- a/packages/argent-installer/test/update.test.ts
+++ b/packages/argent-installer/test/update.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   getInstalledVersion,
+  getGloballyInstalledVersion,
   detectPackageManager,
   globalInstallCommand,
   formatShellCommand,
@@ -13,6 +17,15 @@ describe("update — version comparison logic", () => {
     const version = getInstalledVersion();
     // In the test environment this reads the package.json from the dist/..
     // directory which may not exist; either way the function should not throw.
+    expect(version === null || /^\d+\.\d+\.\d+/.test(version)).toBe(true);
+  });
+
+  it("getGloballyInstalledVersion returns a semver-like string or null", () => {
+    // Test envs may or may not have a global argent install; either result
+    // is acceptable as long as the call doesn't throw and the shape is
+    // valid. The point of this helper is to NOT confuse the running
+    // (possibly npx-cached) version with the persisted global one.
+    const version = getGloballyInstalledVersion();
     expect(version === null || /^\d+\.\d+\.\d+/.test(version)).toBe(true);
   });
 });
@@ -91,3 +104,96 @@ describe("update — registry safety", () => {
     }
   });
 });
+
+// These exercise getGloballyInstalledVersion against a real on-disk install
+// layout (binary symlinked into a node_modules/<pkg>/ directory tree) rather
+// than mocking. That way we actually validate the bug fix end-to-end:
+//   which/where -> realpath -> walk up to package.json -> read version.
+// Skipped on Windows because creating fs symlinks there needs admin rights
+// (or developer mode), which isn't reliable in CI.
+describe.skipIf(process.platform === "win32")(
+  "update — getGloballyInstalledVersion against a staged install",
+  () => {
+    let tmpDir: string;
+    let originalPath: string | undefined;
+
+    // Narrow PATH to system dirs so `which` itself stays reachable while
+    // hiding any real argent install on the dev machine. /usr/bin and /bin
+    // do not contain argent on any standard Unix layout (npm/pnpm/yarn/brew
+    // all install elsewhere), so a real binary cannot leak into the result.
+    const SYSTEM_PATH = `/usr/bin${path.delimiter}/bin`;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-installer-test-"));
+      originalPath = process.env.PATH;
+    });
+
+    afterEach(() => {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    // Mimics the layout npm/pnpm/yarn produce for a global install — a bin
+    // entry that is a symlink into <prefix>/lib/node_modules/<pkg>/dist/.
+    // Returns the dir to put on PATH. The package name is irrelevant: the
+    // helper resolves the symlink and walks up to the first package.json,
+    // which is what matters for the bug we're guarding against.
+    function stageInstall(root: string, version: string): string {
+      const pkgRoot = path.join(root, "lib", "node_modules", "fake-argent");
+      const distDir = path.join(pkgRoot, "dist");
+      const binDir = path.join(root, "bin");
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pkgRoot, "package.json"),
+        JSON.stringify({ name: "fake-argent", version, bin: { argent: "dist/cli.js" } })
+      );
+      const cliPath = path.join(distDir, "cli.js");
+      fs.writeFileSync(cliPath, "#!/usr/bin/env node\n");
+      fs.chmodSync(cliPath, 0o755);
+      fs.symlinkSync(cliPath, path.join(binDir, "argent"));
+      return binDir;
+    }
+
+    it("reads the version from the actual global package.json, not PACKAGE_ROOT", () => {
+      // This is the headline regression: even when invoked from npx (where
+      // PACKAGE_ROOT is the latest published version), the function must
+      // report the version of the binary that's actually on PATH.
+      const binDir = stageInstall(tmpDir, "9.9.9");
+      process.env.PATH = `${binDir}${path.delimiter}${SYSTEM_PATH}`;
+
+      expect(getGloballyInstalledVersion()).toBe("9.9.9");
+    });
+
+    it("skips an npx-style transient install ahead of the permanent one on PATH", () => {
+      // Simulates: npx caches latest argent, user has an older global
+      // install. Without the temp-runner filter `which -a` returns the
+      // cache first and we'd report "latest" — masking the outdated global.
+      const transientBin = stageInstall(path.join(tmpDir, "cache", "_npx", "abc123"), "0.0.1");
+      const persistentBin = stageInstall(path.join(tmpDir, "persistent"), "9.9.9");
+      // Transient first so a naive "first match" would pick it.
+      process.env.PATH = [transientBin, persistentBin, SYSTEM_PATH].join(path.delimiter);
+
+      expect(getGloballyInstalledVersion()).toBe("9.9.9");
+    });
+
+    it("returns null when no permanent install is on PATH", () => {
+      const emptyBinDir = path.join(tmpDir, "empty-bin");
+      fs.mkdirSync(emptyBinDir);
+      process.env.PATH = `${emptyBinDir}${path.delimiter}${SYSTEM_PATH}`;
+
+      expect(getGloballyInstalledVersion()).toBeNull();
+    });
+
+    it("returns null when only a transient runner has argent on PATH", () => {
+      // No permanent install — only an npx-style cache. This is the
+      // "running via npx with no global ever installed" case; the function
+      // must NOT fall back to reporting the transient version.
+      const transientBin = stageInstall(path.join(tmpDir, "cache", "_npx", "xyz"), "1.2.3");
+      process.env.PATH = `${transientBin}${path.delimiter}${SYSTEM_PATH}`;
+
+      expect(getGloballyInstalledVersion()).toBeNull();
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- fix `argent update` version detection when invoked via `npx @swmansion/argent`, so it compares against the actually installed global binary instead of the transient npx-cached package
- add `getGloballyInstalledVersion()` that resolves the real global binary path (`which -a` / `where`), follows symlinks, and reads the owning `package.json`
- add regression tests covering staged global-install layouts and npx-style transient paths to prevent false "already on latest" results