### PR TITLE
fix(stop-all-simulator-servers): include AXService daemons in cleanup

### DIFF
--- a/packages/tool-server/src/tools/simulator/stop-all-simulator-servers.ts
+++ b/packages/tool-server/src/tools/simulator/stop-all-simulator-servers.ts
@@ -2,8 +2,13 @@ import { ServiceState } from "@argent/registry";
 import type { Registry, ToolDefinition } from "@argent/registry";
 import { SIMULATOR_SERVER_NAMESPACE } from "../../blueprints/simulator-server";
 import { NATIVE_DEVTOOLS_NAMESPACE } from "../../blueprints/native-devtools";
+import { AX_SERVICE_NAMESPACE } from "../../blueprints/ax-service";
 
-const PREFIXES = [`${SIMULATOR_SERVER_NAMESPACE}:`, `${NATIVE_DEVTOOLS_NAMESPACE}:`];
+const PREFIXES = [
+  `${SIMULATOR_SERVER_NAMESPACE}:`,
+  `${NATIVE_DEVTOOLS_NAMESPACE}:`,
+  `${AX_SERVICE_NAMESPACE}:`,
+];
 
 export function createStopAllSimulatorServersTool(
   registry: Registry

--- a/packages/tool-server/test/stop-tools.test.ts
+++ b/packages/tool-server/test/stop-tools.test.ts
@@ -98,6 +98,23 @@ describe("stop-all-simulator-servers", () => {
     expect(result).toEqual({ stopped: ["SimulatorServer:BBB"] });
     expect(registry.disposeService).toHaveBeenCalledOnce();
   });
+
+  it("disposes AXService daemons too — describe spawns one per simulator", async () => {
+    const services = new Map([
+      ["SimulatorServer:AAA", { state: ServiceState.RUNNING, dependents: [] }],
+      ["NativeDevtools:AAA", { state: ServiceState.RUNNING, dependents: [] }],
+      ["AXService:AAA", { state: ServiceState.RUNNING, dependents: [] }],
+    ]);
+    const registry = createMockRegistry(services);
+    const tool = createStopAllSimulatorServersTool(registry);
+
+    const result = await tool.execute!({}, undefined);
+
+    expect(new Set(result.stopped)).toEqual(
+      new Set(["SimulatorServer:AAA", "NativeDevtools:AAA", "AXService:AAA"])
+    );
+    expect(registry.disposeService).toHaveBeenCalledWith("AXService:AAA");
+  });
 });
 
 describe("stop-metro", () => {


### PR DESCRIPTION
`stop-all-simulator-servers` was meant to free every per-simulator service the tool-server spawned, but its `PREFIXES` allowlist only matched `SimulatorServer:` and `NativeDevtools:`. The AX daemon `AXService:<udid>` was silently skipped.

## Reproduction (on `main`)

```bash
$ curl -s -X POST :51051/tools/boot-simulator -d '{"udid":"<UDID>"}'
$ curl -s -X POST :51051/tools/describe -d '{"udid":"<UDID>"}'

# describe spawns ax-service:
$ ls /tmp/ax-*.sock                     # /tmp/ax-<UDID-prefix>.sock
$ ps aux | grep ax-service              # PID running

$ curl -s -X POST :51051/tools/stop-all-simulator-servers -d '{}'
{"data":{"stopped":["NativeDevtools:<UDID>"]}}     # AXService missing

$ ls /tmp/ax-*.sock                     # socket file still present
$ ps aux | grep ax-service              # daemon still running
```

## Fix

Add `AX_SERVICE_NAMESPACE` to the `PREFIXES` allowlist so the same sweep that handles the other two iOS-only services takes the AX daemon down too. Existing test file gets one new case asserting all three URNs are returned.