### PR TITLE
feat(describe): render tree as text to cut token cost

### DIFF
--- a/packages/tool-server/src/tools/describe/contract.ts
+++ b/packages/tool-server/src/tools/describe/contract.ts
@@ -51,8 +51,22 @@ export const describeNodeSchema: z.ZodType<DescribeNode> = z.lazy(() =>
     .passthrough()
 );
 
-export interface DescribeResult {
+// Internal shape produced by the per-platform adapters. The `tree` is consumed
+// by the formatter in `format-tree.ts` and then dropped before the tool replies
+// — callers see `DescribeResult` below, which surfaces only the rendered text.
+export interface DescribeTreeData {
   tree: DescribeNode;
+  source: "ax-service" | "native-devtools" | "uiautomator";
+  should_restart?: boolean;
+}
+
+// Public describe-tool response. The full JSON `tree` (the previous payload's
+// biggest cost — ~6× the byte size of the formatted rendering on a typical iOS
+// screen) is no longer surfaced; `description` is a text rendering produced by
+// `format-tree.ts` that preserves every label, role, and frame the agent needs
+// for taps.
+export interface DescribeResult {
+  description: string;
   // "ax-service" / "native-devtools" come from iOS; "uiautomator" is the
   // Android branch's underlying provider. Agents that branch on `source`
   // (e.g. to decide whether to also call `native-find-views` for a richer

--- a/packages/tool-server/src/tools/describe/contract.ts
+++ b/packages/tool-server/src/tools/describe/contract.ts
@@ -51,12 +51,19 @@ export const describeNodeSchema: z.ZodType<DescribeNode> = z.lazy(() =>
     .passthrough()
 );
 
+// Where the tree came from. "ax-service" / "native-devtools" come from iOS;
+// "uiautomator" is the Android branch's underlying provider. Agents that
+// branch on `source` (e.g. to decide whether to also call `native-find-views`
+// for a richer tree) need to distinguish the Android case from an iOS
+// native-devtools fallback — which the previous shared label hid.
+export type DescribeSource = "ax-service" | "native-devtools" | "uiautomator";
+
 // Internal shape produced by the per-platform adapters. The `tree` is consumed
 // by the formatter in `format-tree.ts` and then dropped before the tool replies
 // — callers see `DescribeResult` below, which surfaces only the rendered text.
 export interface DescribeTreeData {
   tree: DescribeNode;
-  source: "ax-service" | "native-devtools" | "uiautomator";
+  source: DescribeSource;
   should_restart?: boolean;
 }
 
@@ -67,12 +74,7 @@ export interface DescribeTreeData {
 // for taps.
 export interface DescribeResult {
   description: string;
-  // "ax-service" / "native-devtools" come from iOS; "uiautomator" is the
-  // Android branch's underlying provider. Agents that branch on `source`
-  // (e.g. to decide whether to also call `native-find-views` for a richer
-  // tree) need to distinguish the Android case from an iOS native-devtools
-  // fallback — which the previous shared label hid.
-  source: "ax-service" | "native-devtools" | "uiautomator";
+  source: DescribeSource;
   should_restart?: boolean;
 }
 

--- a/packages/tool-server/src/tools/describe/format-tree.ts
+++ b/packages/tool-server/src/tools/describe/format-tree.ts
@@ -62,13 +62,13 @@ function formatFlags(n: DescribeNode): string {
 function hasContent(n: DescribeNode): boolean {
   return Boolean(
     n.label ||
-      n.value ||
-      n.identifier ||
-      n.clickable ||
-      n.longClickable ||
-      n.scrollable ||
-      n.checkable ||
-      (typeof n.scrollHidden === "number" && n.scrollHidden > 0)
+    n.value ||
+    n.identifier ||
+    n.clickable ||
+    n.longClickable ||
+    n.scrollable ||
+    n.checkable ||
+    (typeof n.scrollHidden === "number" && n.scrollHidden > 0)
   );
 }
 

--- a/packages/tool-server/src/tools/describe/format-tree.ts
+++ b/packages/tool-server/src/tools/describe/format-tree.ts
@@ -8,12 +8,13 @@ import type { DescribeFrame, DescribeNode } from "./contract";
 // already in the tree, never drops or merges nodes.
 //
 // Two rendering modes are picked automatically:
-//   - "flat" trees (AXGroup root with no grandchildren — what ax-service returns
-//     on iOS): bucket by y into screen zones, then split the bottom zone into
-//     keyboard rows by rounded y. This produces the same shape as the hand-
-//     formatted iOS output an agent gets used to seeing.
-//   - "nested" trees (uiautomator on Android, or native-devtools fallback that
-//     produces hierarchy): indented DFS, one labeled / interactive node per line.
+//   - "flat" trees (root → leaves, no grandchildren — what ax-service emits):
+//     sort nodes in reading order, then split into groups wherever a gap
+//     between consecutive nodes is large relative to the typical node size.
+//     The same algorithm runs whether the layout is dense / sparse, portrait
+//     / landscape, or contains horizontal strips, vertical strips, or both.
+//   - "nested" trees (uiautomator on Android, or native-devtools fallback):
+//     indented DFS so the parent / child structure is visible directly.
 // The chosen mode is reported at the top so a consumer that wants to re-parse
 // the formatted text can branch on it.
 
@@ -61,13 +62,13 @@ function formatFlags(n: DescribeNode): string {
 function hasContent(n: DescribeNode): boolean {
   return Boolean(
     n.label ||
-    n.value ||
-    n.identifier ||
-    n.clickable ||
-    n.longClickable ||
-    n.scrollable ||
-    n.checkable ||
-    (typeof n.scrollHidden === "number" && n.scrollHidden > 0)
+      n.value ||
+      n.identifier ||
+      n.clickable ||
+      n.longClickable ||
+      n.scrollable ||
+      n.checkable ||
+      (typeof n.scrollHidden === "number" && n.scrollHidden > 0)
   );
 }
 
@@ -82,113 +83,111 @@ function formatLine(n: DescribeNode, indent: number): string {
 }
 
 function isFlatTree(root: DescribeNode): boolean {
-  // A flat tree is one with only root → leaves. This is what the iOS
-  // ax-service adapter emits today; treating it as flat lets us use the
-  // zone-based layout, which is far more legible than a 50-item indented list.
+  // Root → leaves with no grandchildren. This is what the iOS ax-service
+  // adapter emits; the flat renderer relies on the assumption that every
+  // child is a positioned leaf.
   if (root.children.length === 0) return true;
   return root.children.every((c) => c.children.length === 0);
 }
 
-// ---- flat (iOS-style) renderer ----
+// ---- flat renderer ----
 
-// Zone boundaries are tuned for portrait phones with the standard iOS keyboard
-// surface (~y >= 0.66). On iPad / landscape, the formatter still renders — but
-// the section headers become "Body" / "Bottom" without further keyboard
-// splitting since the row-detection heuristic only fires for tight y clusters.
-const ZONE_TOP_MAX = 0.15;
-const ZONE_BODY_MAX = 0.5;
-// 0.66 ceiling so the iOS predictive bar (AXTabBar elements at y≈0.62) and any
-// other content sitting between the composer and the keyboard land in the action
-// zone rather than the catch-all "Other" section.
-const ZONE_ACTION_MAX = 0.66;
-const ZONE_KEYBOARD_MIN = 0.66;
+// Absolute gap (in normalized [0,1] coordinates) that separates two clusters.
+// A pair of nodes whose extents on an axis are farther apart than this counts
+// as a section break. 0.06 — 6% of screen — is large enough to not split
+// keyboard rows or list items that sit close together, and small enough to
+// split distinct UI regions like sidebar/content or status bar/body. Applied
+// to both axes equally so the algorithm has no horizontal/vertical bias.
+const CLUSTER_GAP_THRESHOLD = 0.06;
 
-type Zone = "top" | "body" | "action" | "keyboard" | "other";
+/**
+ * Split nodes along an axis wherever the empty band between consecutive
+ * nodes exceeds CLUSTER_GAP_THRESHOLD. Nodes whose extents overlap on the
+ * axis (negative gap) always stay together. Returns [nodes] unchanged when
+ * no gap is large enough to split.
+ */
+function partitionByAxisGap(nodes: DescribeNode[], axis: "x" | "y"): DescribeNode[][] {
+  if (nodes.length < 2) return [nodes];
+  const sizeKey = axis === "x" ? "width" : "height";
+  const items = nodes
+    .map((n) => ({
+      start: n.frame[axis],
+      end: n.frame[axis] + n.frame[sizeKey],
+      node: n,
+    }))
+    .sort((a, b) => a.start - b.start);
 
-function zoneOf(n: DescribeNode): Zone {
-  const y = n.frame.y;
-  if (y < ZONE_TOP_MAX) return "top";
-  if (y < ZONE_BODY_MAX) return "body";
-  if (y < ZONE_ACTION_MAX) return "action";
-  if (y >= ZONE_KEYBOARD_MIN) return "keyboard";
-  return "other";
+  const runs: DescribeNode[][] = [];
+  let current: DescribeNode[] = [items[0]!.node];
+  let runEnd = items[0]!.end;
+  for (let i = 1; i < items.length; i++) {
+    const gap = items[i]!.start - runEnd;
+    if (gap > CLUSTER_GAP_THRESHOLD) {
+      runs.push(current);
+      current = [];
+    }
+    current.push(items[i]!.node);
+    runEnd = Math.max(runEnd, items[i]!.end);
+  }
+  if (current.length > 0) runs.push(current);
+  return runs;
 }
 
-const ZONE_TITLES: Record<Zone, string> = {
-  top: "Top bar",
-  body: "Body / content",
-  action: "Composer / predictive / action bar",
-  keyboard: "Bottom / keyboard",
-  other: "Other",
-};
+/**
+ * Cluster nodes by recursively splitting on whichever axis produces a real
+ * separation. At each level we try both x and y, pick the one that breaks
+ * the input into more partitions, and recurse into each piece. Recursion
+ * stops once neither axis produces a split, so a single tight group (a
+ * keyboard, a toolbar, a column) survives as one cluster regardless of
+ * orientation.
+ */
+function clusterNodes(nodes: DescribeNode[]): DescribeNode[][] {
+  if (nodes.length <= 1) return nodes.length === 0 ? [] : [nodes];
 
-function classifyKeyboardRow(items: DescribeNode[]): string {
-  const labels = items.map((i) => i.label ?? "");
-  if (labels.some((l) => l === "Dictate" || l === "Next keyboard")) return "globe / dictate";
-  if (labels.some((l) => l === "return")) return "numbers / emoji / space / return";
-  if (labels.some((l) => l === "shift")) return "shift + letters + delete";
-  const onlyLetters = labels.filter((l) => l.length > 0).every((l) => l.length <= 2);
-  if (onlyLetters && labels.some((l) => l.length === 1)) return "letters";
-  return "row";
+  const byY = partitionByAxisGap(nodes, "y");
+  const byX = partitionByAxisGap(nodes, "x");
+
+  if (byY.length <= 1 && byX.length <= 1) return [nodes];
+
+  const partitions = byY.length >= byX.length ? byY : byX;
+  return partitions.flatMap(clusterNodes);
+}
+
+function readingOrder(nodes: DescribeNode[]): DescribeNode[] {
+  return [...nodes].sort((a, b) => a.frame.y - b.frame.y || a.frame.x - b.frame.x);
+}
+
+/** Sort clusters themselves in reading order using their top-left corner. */
+function clusterOrigin(c: DescribeNode[]): { y: number; x: number } {
+  let y = Infinity;
+  let x = Infinity;
+  for (const n of c) {
+    if (n.frame.y < y) y = n.frame.y;
+    if (n.frame.x < x) x = n.frame.x;
+  }
+  return { y, x };
 }
 
 function renderFlat(root: DescribeNode): string[] {
-  const lines: string[] = [];
   const interesting = root.children.filter(hasContent);
+  if (interesting.length === 0) return [];
 
-  const byZone = new Map<Zone, DescribeNode[]>();
-  for (const n of interesting) {
-    const z = zoneOf(n);
-    if (!byZone.has(z)) byZone.set(z, []);
-    byZone.get(z)!.push(n);
+  const clusters = clusterNodes(interesting).sort((a, b) => {
+    const oa = clusterOrigin(a);
+    const ob = clusterOrigin(b);
+    return oa.y - ob.y || oa.x - ob.x;
+  });
+
+  const lines: string[] = [];
+  for (let i = 0; i < clusters.length; i++) {
+    if (clusters.length > 1) lines.push(`— Group ${i + 1} —`);
+    for (const n of readingOrder(clusters[i]!)) lines.push(formatLine(n, 1));
+    if (i < clusters.length - 1) lines.push("");
   }
-
-  const orderedZones: Zone[] = ["top", "body", "action"];
-  for (const z of orderedZones) {
-    const items = byZone.get(z);
-    if (!items?.length) continue;
-    items.sort((a, b) => a.frame.y - b.frame.y || a.frame.x - b.frame.x);
-    lines.push(`— ${ZONE_TITLES[z]} —`);
-    for (const n of items) lines.push(formatLine(n, 1));
-    lines.push("");
-  }
-
-  // Keyboard zone: subdivide by row using rounded y. iOS QWERTY rows are
-  // ~0.062 tall and exactly aligned, so rounding to two decimals collapses
-  // each row to a single bucket. Any other "bottom" cluster (e.g. iPad
-  // toolbar) falls into one row bucket and renders as a single section.
-  const keyboard = byZone.get("keyboard");
-  if (keyboard?.length) {
-    const rows = new Map<number, DescribeNode[]>();
-    for (const n of keyboard) {
-      const key = Math.round(n.frame.y * 100);
-      if (!rows.has(key)) rows.set(key, []);
-      rows.get(key)!.push(n);
-    }
-    const orderedKeys = [...rows.keys()].sort((a, b) => a - b);
-    let idx = 1;
-    for (const k of orderedKeys) {
-      const row = rows.get(k)!.sort((a, b) => a.frame.x - b.frame.x);
-      const cat = classifyKeyboardRow(row);
-      lines.push(`— Bottom row ${idx}: ${cat} —`);
-      for (const n of row) lines.push(formatLine(n, 1));
-      lines.push("");
-      idx++;
-    }
-  }
-
-  const other = byZone.get("other");
-  if (other?.length) {
-    other.sort((a, b) => a.frame.y - b.frame.y || a.frame.x - b.frame.x);
-    lines.push("— Other —");
-    for (const n of other) lines.push(formatLine(n, 1));
-    lines.push("");
-  }
-
   return lines;
 }
 
-// ---- nested (Android-style) renderer ----
+// ---- nested renderer ----
 
 function renderNested(root: DescribeNode): string[] {
   const lines: string[] = [];

--- a/packages/tool-server/src/tools/describe/format-tree.ts
+++ b/packages/tool-server/src/tools/describe/format-tree.ts
@@ -9,10 +9,10 @@ import type { DescribeFrame, DescribeNode } from "./contract";
 //
 // Two rendering modes are picked automatically:
 //   - "flat" trees (root → leaves, no grandchildren — what ax-service emits):
-//     sort nodes in reading order, then split into groups wherever a gap
-//     between consecutive nodes is large relative to the typical node size.
-//     The same algorithm runs whether the layout is dense / sparse, portrait
-//     / landscape, or contains horizontal strips, vertical strips, or both.
+//     emit one line per labeled / interactive node, sorted in reading order
+//     (top-to-bottom, then left-to-right). Spatial relationships are already
+//     fully described by each line's frame, so no grouping or section
+//     headers are added.
 //   - "nested" trees (uiautomator on Android, or native-devtools fallback):
 //     indented DFS so the parent / child structure is visible directly.
 // The chosen mode is reported at the top so a consumer that wants to re-parse
@@ -92,99 +92,12 @@ function isFlatTree(root: DescribeNode): boolean {
 
 // ---- flat renderer ----
 
-// Absolute gap (in normalized [0,1] coordinates) that separates two clusters.
-// A pair of nodes whose extents on an axis are farther apart than this counts
-// as a section break. 0.06 — 6% of screen — is large enough to not split
-// keyboard rows or list items that sit close together, and small enough to
-// split distinct UI regions like sidebar/content or status bar/body. Applied
-// to both axes equally so the algorithm has no horizontal/vertical bias.
-const CLUSTER_GAP_THRESHOLD = 0.06;
-
-/**
- * Split nodes along an axis wherever the empty band between consecutive
- * nodes exceeds CLUSTER_GAP_THRESHOLD. Nodes whose extents overlap on the
- * axis (negative gap) always stay together. Returns [nodes] unchanged when
- * no gap is large enough to split.
- */
-function partitionByAxisGap(nodes: DescribeNode[], axis: "x" | "y"): DescribeNode[][] {
-  if (nodes.length < 2) return [nodes];
-  const sizeKey = axis === "x" ? "width" : "height";
-  const items = nodes
-    .map((n) => ({
-      start: n.frame[axis],
-      end: n.frame[axis] + n.frame[sizeKey],
-      node: n,
-    }))
-    .sort((a, b) => a.start - b.start);
-
-  const runs: DescribeNode[][] = [];
-  let current: DescribeNode[] = [items[0]!.node];
-  let runEnd = items[0]!.end;
-  for (let i = 1; i < items.length; i++) {
-    const gap = items[i]!.start - runEnd;
-    if (gap > CLUSTER_GAP_THRESHOLD) {
-      runs.push(current);
-      current = [];
-    }
-    current.push(items[i]!.node);
-    runEnd = Math.max(runEnd, items[i]!.end);
-  }
-  if (current.length > 0) runs.push(current);
-  return runs;
-}
-
-/**
- * Cluster nodes by recursively splitting on whichever axis produces a real
- * separation. At each level we try both x and y, pick the one that breaks
- * the input into more partitions, and recurse into each piece. Recursion
- * stops once neither axis produces a split, so a single tight group (a
- * keyboard, a toolbar, a column) survives as one cluster regardless of
- * orientation.
- */
-function clusterNodes(nodes: DescribeNode[]): DescribeNode[][] {
-  if (nodes.length <= 1) return nodes.length === 0 ? [] : [nodes];
-
-  const byY = partitionByAxisGap(nodes, "y");
-  const byX = partitionByAxisGap(nodes, "x");
-
-  if (byY.length <= 1 && byX.length <= 1) return [nodes];
-
-  const partitions = byY.length >= byX.length ? byY : byX;
-  return partitions.flatMap(clusterNodes);
-}
-
-function readingOrder(nodes: DescribeNode[]): DescribeNode[] {
-  return [...nodes].sort((a, b) => a.frame.y - b.frame.y || a.frame.x - b.frame.x);
-}
-
-/** Sort clusters themselves in reading order using their top-left corner. */
-function clusterOrigin(c: DescribeNode[]): { y: number; x: number } {
-  let y = Infinity;
-  let x = Infinity;
-  for (const n of c) {
-    if (n.frame.y < y) y = n.frame.y;
-    if (n.frame.x < x) x = n.frame.x;
-  }
-  return { y, x };
-}
-
 function renderFlat(root: DescribeNode): string[] {
-  const interesting = root.children.filter(hasContent);
-  if (interesting.length === 0) return [];
-
-  const clusters = clusterNodes(interesting).sort((a, b) => {
-    const oa = clusterOrigin(a);
-    const ob = clusterOrigin(b);
-    return oa.y - ob.y || oa.x - ob.x;
-  });
-
-  const lines: string[] = [];
-  for (let i = 0; i < clusters.length; i++) {
-    if (clusters.length > 1) lines.push(`— Group ${i + 1} —`);
-    for (const n of readingOrder(clusters[i]!)) lines.push(formatLine(n, 1));
-    if (i < clusters.length - 1) lines.push("");
-  }
-  return lines;
+  return root.children
+    .filter(hasContent)
+    .slice()
+    .sort((a, b) => a.frame.y - b.frame.y || a.frame.x - b.frame.x)
+    .map((n) => formatLine(n, 1));
 }
 
 // ---- nested renderer ----

--- a/packages/tool-server/src/tools/describe/format-tree.ts
+++ b/packages/tool-server/src/tools/describe/format-tree.ts
@@ -1,0 +1,232 @@
+import type { DescribeFrame, DescribeNode } from "./contract";
+
+// Token-efficient view of a pruned DescribeNode tree. The previous shape sent
+// the full JSON tree to the agent, which on a typical iOS screen ran ~6× the
+// byte cost of this rendering once nested object braces, keys, and indentation
+// were counted. Runs after the per-platform adapters (and the Android v2
+// trimmer in uiautomator-parser) finish — this layer only re-presents what's
+// already in the tree, never drops or merges nodes.
+//
+// Two rendering modes are picked automatically:
+//   - "flat" trees (AXGroup root with no grandchildren — what ax-service returns
+//     on iOS): bucket by y into screen zones, then split the bottom zone into
+//     keyboard rows by rounded y. This produces the same shape as the hand-
+//     formatted iOS output an agent gets used to seeing.
+//   - "nested" trees (uiautomator on Android, or native-devtools fallback that
+//     produces hierarchy): indented DFS, one labeled / interactive node per line.
+// The chosen mode is reported at the top so a consumer that wants to re-parse
+// the formatted text can branch on it.
+
+function clampFinite(n: number): number {
+  return Number.isFinite(n) ? n : 0;
+}
+
+function fmtFrame(f: DescribeFrame): string {
+  return `(${clampFinite(f.x).toFixed(3)}, ${clampFinite(f.y).toFixed(3)}, ${clampFinite(
+    f.width
+  ).toFixed(3)}, ${clampFinite(f.height).toFixed(3)})`;
+}
+
+function escapeForLine(s: string): string {
+  // Embedded newlines / tabs in labels break the per-line alignment that callers
+  // grep against. Backslash-escape rather than strip so the original character is
+  // recoverable when an agent passes the line back through a parser.
+  return s.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
+}
+
+function formatLabel(label: string | undefined): string {
+  if (!label) return "";
+  return `"${escapeForLine(label)}"`;
+}
+
+function formatAttr(name: string, value: string | undefined): string {
+  if (!value) return "";
+  return ` ${name}="${escapeForLine(value)}"`;
+}
+
+function formatFlags(n: DescribeNode): string {
+  const flags: string[] = [];
+  if (n.clickable) flags.push("clickable");
+  if (n.longClickable) flags.push("long-clickable");
+  if (n.scrollable) flags.push("scrollable");
+  if (n.checkable) flags.push(n.checked ? "checked" : "checkable");
+  if (n.disabled) flags.push("disabled");
+  if (n.password) flags.push("password");
+  if (typeof n.scrollHidden === "number" && n.scrollHidden > 0) {
+    flags.push(`scrollHidden=${n.scrollHidden}`);
+  }
+  return flags.length === 0 ? "" : ` [${flags.join(",")}]`;
+}
+
+function hasContent(n: DescribeNode): boolean {
+  return Boolean(
+    n.label ||
+    n.value ||
+    n.identifier ||
+    n.clickable ||
+    n.longClickable ||
+    n.scrollable ||
+    n.checkable ||
+    (typeof n.scrollHidden === "number" && n.scrollHidden > 0)
+  );
+}
+
+function formatLine(n: DescribeNode, indent: number): string {
+  const pad = "  ".repeat(indent);
+  const role = n.role.padEnd(12);
+  const labelPart = formatLabel(n.label);
+  const valuePart = formatAttr("value", n.value);
+  const idPart = formatAttr("id", n.identifier);
+  const flagPart = formatFlags(n);
+  return `${pad}${role} ${labelPart}${valuePart}${idPart}${flagPart}  ${fmtFrame(n.frame)}`;
+}
+
+function isFlatTree(root: DescribeNode): boolean {
+  // A flat tree is one with only root → leaves. This is what the iOS
+  // ax-service adapter emits today; treating it as flat lets us use the
+  // zone-based layout, which is far more legible than a 50-item indented list.
+  if (root.children.length === 0) return true;
+  return root.children.every((c) => c.children.length === 0);
+}
+
+// ---- flat (iOS-style) renderer ----
+
+// Zone boundaries are tuned for portrait phones with the standard iOS keyboard
+// surface (~y >= 0.66). On iPad / landscape, the formatter still renders — but
+// the section headers become "Body" / "Bottom" without further keyboard
+// splitting since the row-detection heuristic only fires for tight y clusters.
+const ZONE_TOP_MAX = 0.15;
+const ZONE_BODY_MAX = 0.5;
+// 0.66 ceiling so the iOS predictive bar (AXTabBar elements at y≈0.62) and any
+// other content sitting between the composer and the keyboard land in the action
+// zone rather than the catch-all "Other" section.
+const ZONE_ACTION_MAX = 0.66;
+const ZONE_KEYBOARD_MIN = 0.66;
+
+type Zone = "top" | "body" | "action" | "keyboard" | "other";
+
+function zoneOf(n: DescribeNode): Zone {
+  const y = n.frame.y;
+  if (y < ZONE_TOP_MAX) return "top";
+  if (y < ZONE_BODY_MAX) return "body";
+  if (y < ZONE_ACTION_MAX) return "action";
+  if (y >= ZONE_KEYBOARD_MIN) return "keyboard";
+  return "other";
+}
+
+const ZONE_TITLES: Record<Zone, string> = {
+  top: "Top bar",
+  body: "Body / content",
+  action: "Composer / predictive / action bar",
+  keyboard: "Bottom / keyboard",
+  other: "Other",
+};
+
+function classifyKeyboardRow(items: DescribeNode[]): string {
+  const labels = items.map((i) => i.label ?? "");
+  if (labels.some((l) => l === "Dictate" || l === "Next keyboard")) return "globe / dictate";
+  if (labels.some((l) => l === "return")) return "numbers / emoji / space / return";
+  if (labels.some((l) => l === "shift")) return "shift + letters + delete";
+  const onlyLetters = labels.filter((l) => l.length > 0).every((l) => l.length <= 2);
+  if (onlyLetters && labels.some((l) => l.length === 1)) return "letters";
+  return "row";
+}
+
+function renderFlat(root: DescribeNode): string[] {
+  const lines: string[] = [];
+  const interesting = root.children.filter(hasContent);
+
+  const byZone = new Map<Zone, DescribeNode[]>();
+  for (const n of interesting) {
+    const z = zoneOf(n);
+    if (!byZone.has(z)) byZone.set(z, []);
+    byZone.get(z)!.push(n);
+  }
+
+  const orderedZones: Zone[] = ["top", "body", "action"];
+  for (const z of orderedZones) {
+    const items = byZone.get(z);
+    if (!items?.length) continue;
+    items.sort((a, b) => a.frame.y - b.frame.y || a.frame.x - b.frame.x);
+    lines.push(`— ${ZONE_TITLES[z]} —`);
+    for (const n of items) lines.push(formatLine(n, 1));
+    lines.push("");
+  }
+
+  // Keyboard zone: subdivide by row using rounded y. iOS QWERTY rows are
+  // ~0.062 tall and exactly aligned, so rounding to two decimals collapses
+  // each row to a single bucket. Any other "bottom" cluster (e.g. iPad
+  // toolbar) falls into one row bucket and renders as a single section.
+  const keyboard = byZone.get("keyboard");
+  if (keyboard?.length) {
+    const rows = new Map<number, DescribeNode[]>();
+    for (const n of keyboard) {
+      const key = Math.round(n.frame.y * 100);
+      if (!rows.has(key)) rows.set(key, []);
+      rows.get(key)!.push(n);
+    }
+    const orderedKeys = [...rows.keys()].sort((a, b) => a - b);
+    let idx = 1;
+    for (const k of orderedKeys) {
+      const row = rows.get(k)!.sort((a, b) => a.frame.x - b.frame.x);
+      const cat = classifyKeyboardRow(row);
+      lines.push(`— Bottom row ${idx}: ${cat} —`);
+      for (const n of row) lines.push(formatLine(n, 1));
+      lines.push("");
+      idx++;
+    }
+  }
+
+  const other = byZone.get("other");
+  if (other?.length) {
+    other.sort((a, b) => a.frame.y - b.frame.y || a.frame.x - b.frame.x);
+    lines.push("— Other —");
+    for (const n of other) lines.push(formatLine(n, 1));
+    lines.push("");
+  }
+
+  return lines;
+}
+
+// ---- nested (Android-style) renderer ----
+
+function renderNested(root: DescribeNode): string[] {
+  const lines: string[] = [];
+  // Iterative DFS so very deep Compose / RN trees don't risk a stack overflow.
+  type Frame = { node: DescribeNode; depth: number };
+  const stack: Frame[] = [{ node: root, depth: 0 }];
+  while (stack.length > 0) {
+    const { node, depth } = stack.pop()!;
+    if (depth === 0 || hasContent(node) || node.children.length > 0) {
+      lines.push(formatLine(node, depth));
+    }
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      stack.push({ node: node.children[i]!, depth: depth + 1 });
+    }
+  }
+  return lines;
+}
+
+export interface FormatDescribeOptions {
+  source?: string;
+}
+
+export function formatDescribeTree(root: DescribeNode, opts: FormatDescribeOptions = {}): string {
+  const mode: "flat" | "nested" = isFlatTree(root) ? "flat" : "nested";
+  const header: string[] = [];
+  if (opts.source) header.push(`Source: ${opts.source}`);
+  header.push(`Mode: ${mode}`);
+  header.push(
+    "Coordinates are normalized [0,1] fractions of the screen (x, y, width, height), " +
+      "not pixels — pass them straight to gesture-tap / gesture-swipe / gesture-pinch, " +
+      "which expect this same space. " +
+      "To tap an element, use its centre: tap_x = frame.x + frame.width / 2, " +
+      "tap_y = frame.y + frame.height / 2."
+  );
+  header.push("");
+  header.push(`ROOT  ${root.role} ${fmtFrame(root.frame)}`);
+  header.push("");
+
+  const body = mode === "flat" ? renderFlat(root) : renderNested(root);
+  return [...header, ...body].join("\n").replace(/\n+$/, "\n");
+}

--- a/packages/tool-server/src/tools/describe/format-tree.ts
+++ b/packages/tool-server/src/tools/describe/format-tree.ts
@@ -1,4 +1,4 @@
-import type { DescribeFrame, DescribeNode } from "./contract";
+import type { DescribeFrame, DescribeNode, DescribeSource } from "./contract";
 
 // Token-efficient view of a pruned DescribeNode tree. The previous shape sent
 // the full JSON tree to the agent, which on a typical iOS screen ran ~6× the
@@ -7,16 +7,38 @@ import type { DescribeFrame, DescribeNode } from "./contract";
 // trimmer in uiautomator-parser) finish — this layer only re-presents what's
 // already in the tree, never drops or merges nodes.
 //
-// Two rendering modes are picked automatically:
-//   - "flat" trees (root → leaves, no grandchildren — what ax-service emits):
-//     emit one line per labeled / interactive node, sorted in reading order
-//     (top-to-bottom, then left-to-right). Spatial relationships are already
-//     fully described by each line's frame, so no grouping or section
-//     headers are added.
-//   - "nested" trees (uiautomator on Android, or native-devtools fallback):
-//     indented DFS so the parent / child structure is visible directly.
-// The chosen mode is reported at the top so a consumer that wants to re-parse
-// the formatted text can branch on it.
+// Mode is decided by the originating `source`, not the tree silhouette:
+//   - "ax-service" and "native-devtools" (the iOS providers) emit a flat list
+//     of leaves under a synthetic root; the flat renderer sorts those in
+//     reading order (top-to-bottom, then left-to-right).
+//   - "uiautomator" (Android) emits a real parent/child tree; the nested
+//     renderer is an iterative DFS that preserves depth via indentation.
+// Picking by source (rather than checking `every child has no grandchildren`)
+// keeps behaviour stable for callers that diff two close-in-time describes —
+// a single accidental grandchild used to flip an ax-service response into
+// nested mode discontinuously.
+//
+// What gets emitted: any node with a "content" role (AXButton, AXImage,
+// AXStaticText, …) is printed even when its label is empty, so an icon-only
+// button or an undecorated image still surfaces as `AXImage  (frame)`. Pure
+// container roles (AXGroup, RCTView, …) only print when they carry their own
+// label / value / identifier / interactivity flag, OR (in nested mode) when
+// they have descendants worth showing.
+
+const CONTENT_ROLES = new Set([
+  // iOS AX traits surfaced by mapNativeTraitsToDescribeRole. AXGroup is
+  // deliberately excluded: it's the catch-all wrapper, so requiring it to
+  // carry its own label/value before we emit a line keeps decorative
+  // groupings out of the output.
+  "AXButton",
+  "AXStaticText",
+  "AXImage",
+  "AXLink",
+  "AXTextField",
+  "AXHeading",
+  "AXTabBar",
+  "AXAdjustable",
+]);
 
 function clampFinite(n: number): number {
   return Number.isFinite(n) ? n : 0;
@@ -72,44 +94,60 @@ function hasContent(n: DescribeNode): boolean {
   );
 }
 
+// A node is worth its own line when EITHER it carries its own metadata
+// (`hasContent`) OR its role tells us it's a thing the user can act on. The
+// role check is what keeps unlabeled `AXImage`s and icon-only `AXButton`s on
+// screen — without it, anything missing `accessibilityLabel` on iOS would
+// silently vanish from describe (the bug the user originally flagged).
+function shouldEmit(n: DescribeNode): boolean {
+  return hasContent(n) || CONTENT_ROLES.has(n.role);
+}
+
 function formatLine(n: DescribeNode, indent: number): string {
   const pad = "  ".repeat(indent);
-  const role = n.role.padEnd(12);
+  // Drop value when it's the same string as label — iOS reports placeholder
+  // text under both fields for text inputs, which doubled the byte cost for
+  // zero added signal.
+  const dedupedValue = n.value && n.value !== n.label ? n.value : undefined;
   const labelPart = formatLabel(n.label);
-  const valuePart = formatAttr("value", n.value);
+  const valuePart = formatAttr("value", dedupedValue);
   const idPart = formatAttr("id", n.identifier);
   const flagPart = formatFlags(n);
-  return `${pad}${role} ${labelPart}${valuePart}${idPart}${flagPart}  ${fmtFrame(n.frame)}`;
+  // Single space between role and the rest — we deliberately don't pad the
+  // role to a fixed column. Padding to 12 chars worked for iOS AX roles (all
+  // ≤12 chars) but broke alignment the moment Android passed through raw
+  // class names like `androidx.compose.ui.platform.ComposeView` (41 chars).
+  const annotations = `${labelPart}${valuePart}${idPart}${flagPart}`.trim();
+  const annotated = annotations ? ` ${annotations}` : "";
+  return `${pad}${n.role}${annotated}  ${fmtFrame(n.frame)}`;
 }
 
-function isFlatTree(root: DescribeNode): boolean {
-  // Root → leaves with no grandchildren. This is what the iOS ax-service
-  // adapter emits; the flat renderer relies on the assumption that every
-  // child is a positioned leaf.
-  if (root.children.length === 0) return true;
-  return root.children.every((c) => c.children.length === 0);
-}
-
-// ---- flat renderer ----
+// ---- flat renderer (ax-service, native-devtools) ----
 
 function renderFlat(root: DescribeNode): string[] {
   return root.children
-    .filter(hasContent)
+    .filter(shouldEmit)
     .slice()
     .sort((a, b) => a.frame.y - b.frame.y || a.frame.x - b.frame.x)
     .map((n) => formatLine(n, 1));
 }
 
-// ---- nested renderer ----
+// ---- nested renderer (uiautomator) ----
 
 function renderNested(root: DescribeNode): string[] {
   const lines: string[] = [];
   // Iterative DFS so very deep Compose / RN trees don't risk a stack overflow.
+  // Start at the root's children (depth 1) — the root itself is already
+  // printed by the header's ROOT line, so emitting it again here just
+  // duplicates the same role/frame for every nested-mode response.
   type Frame = { node: DescribeNode; depth: number };
-  const stack: Frame[] = [{ node: root, depth: 0 }];
+  const stack: Frame[] = [];
+  for (let i = root.children.length - 1; i >= 0; i--) {
+    stack.push({ node: root.children[i]!, depth: 1 });
+  }
   while (stack.length > 0) {
     const { node, depth } = stack.pop()!;
-    if (depth === 0 || hasContent(node) || node.children.length > 0) {
+    if (shouldEmit(node) || node.children.length > 0) {
       lines.push(formatLine(node, depth));
     }
     for (let i = node.children.length - 1; i >= 0; i--) {
@@ -120,13 +158,13 @@ function renderNested(root: DescribeNode): string[] {
 }
 
 export interface FormatDescribeOptions {
-  source?: string;
+  source: DescribeSource;
 }
 
-export function formatDescribeTree(root: DescribeNode, opts: FormatDescribeOptions = {}): string {
-  const mode: "flat" | "nested" = isFlatTree(root) ? "flat" : "nested";
+export function formatDescribeTree(root: DescribeNode, opts: FormatDescribeOptions): string {
+  const mode: "flat" | "nested" = opts.source === "uiautomator" ? "nested" : "flat";
   const header: string[] = [];
-  if (opts.source) header.push(`Source: ${opts.source}`);
+  header.push(`Source: ${opts.source}`);
   header.push(`Mode: ${mode}`);
   header.push(
     "Coordinates are normalized [0,1] fractions of the screen (x, y, width, height), " +

--- a/packages/tool-server/src/tools/describe/index.ts
+++ b/packages/tool-server/src/tools/describe/index.ts
@@ -1,9 +1,24 @@
 import { z } from "zod";
 import type { Registry, ToolCapability, ToolDefinition } from "@argent/registry";
-import type { DescribeResult } from "./contract";
+import type { DescribeResult, DescribeTreeData } from "./contract";
 import { dispatchByPlatform } from "../../utils/cross-platform-tool";
 import { describeAndroid, androidRequires } from "./platforms/android";
 import { iosRequires, describeIos } from "./platforms/ios";
+import { formatDescribeTree } from "./format-tree";
+
+// In-between layer between the per-platform adapters (which still own all
+// pruning — the Android v2 trimmer in uiautomator-parser stays untouched) and
+// the public DescribeResult. The internal `tree` is converted to a token-
+// efficient text rendering here and then dropped, so the caller (LLM) never
+// pays for the JSON tree.
+function withDescription(data: DescribeTreeData): DescribeResult {
+  const out: DescribeResult = {
+    description: formatDescribeTree(data.tree, { source: data.source }),
+    source: data.source,
+  };
+  if (data.should_restart) out.should_restart = data.should_restart;
+  return out;
+}
 
 const zodSchema = z.object({
   udid: z
@@ -66,11 +81,13 @@ For React Native apps, debugger-component-tree returns React component names wit
       capability,
       ios: {
         requires: iosRequires,
-        handler: (_services, params, device) => describeIos(registry, device, params),
+        handler: async (_services, params, device) =>
+          withDescription(await describeIos(registry, device, params)),
       },
       android: {
         requires: androidRequires,
-        handler: (_services, params) => describeAndroid(params.udid, params.bundleId),
+        handler: async (_services, params) =>
+          withDescription(await describeAndroid(params.udid, params.bundleId)),
       },
     }),
   };

--- a/packages/tool-server/src/tools/describe/index.ts
+++ b/packages/tool-server/src/tools/describe/index.ts
@@ -57,11 +57,14 @@ system dialogs, permission prompts, and any foreground app content. On Android, 
 When a system dialog is visible, describe returns the dialog's interactive elements (buttons, text)
 with tap coordinates. When no dialog is present, it returns the foreground app's accessible elements.
 
-Returns a JSON tree of UI elements with roles, labels, values, and frame coordinates in normalized
-[0,1] space (fractions of the screen, not pixels) — the same coordinate space as tap/swipe/gesture
-and simulator-server touch input.
+Returns \`{ description, source }\` where \`description\` is a text rendering of the UI tree — one
+line per element with its role, label/value/id, interactivity flags, and frame. Frame coordinates
+are normalized [0,1] fractions of the screen width/height (not pixels) — the same space as
+gesture-tap / gesture-swipe / gesture-pinch.
 
-Use frame.x + frame.width/2 as the tap X coordinate, frame.y + frame.height/2 as tap Y.
+To tap an element use the centre of its frame: \`tap_x = frame.x + frame.width / 2\`,
+\`tap_y = frame.y + frame.height / 2\`. The same formula appears in the response header so it
+can be applied to a line in isolation.
 
 For app-scoped inspection with full UIKit properties (accessibilityIdentifier, viewClassName),
 use native-describe-screen with an explicit bundleId instead (iOS only).

--- a/packages/tool-server/src/tools/describe/platforms/android/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/index.ts
@@ -1,12 +1,12 @@
 import type { ToolDependency } from "@argent/registry";
-import type { DescribeResult } from "../../contract";
+import type { DescribeTreeData } from "../../contract";
 import { adbExecOutBinary } from "../../../../utils/adb";
 import { getAndroidScreenSize } from "../../../../utils/android-screen";
 import { parseUiAutomatorDump } from "./uiautomator-parser";
 
 export const androidRequires: ToolDependency[] = ["adb"];
 
-export async function describeAndroid(udid: string, _bundleId?: string): Promise<DescribeResult> {
+export async function describeAndroid(udid: string, _bundleId?: string): Promise<DescribeTreeData> {
   // Per-call dump path so concurrent describes on the same serial don't race
   // on /sdcard/window_dump.xml (one call's cat would read the other's dump
   // mid-write). `uiautomator` rejects unwritable paths, so we target

--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -3,7 +3,7 @@ import { axServiceRef, AXServiceApi } from "../../../../blueprints/ax-service";
 import { nativeDevtoolsRef, NativeDevtoolsApi } from "../../../../blueprints/native-devtools";
 import { resolveNativeTargetApp } from "../../../../utils/native-target-app";
 import { parseNativeDescribeScreenResult } from "../../../native-devtools/native-describe-contract";
-import { DescribeResult } from "../../contract";
+import { DescribeTreeData } from "../../contract";
 import { adaptAXDescribeToDescribeResult } from "./ios-ax-adapter";
 import { adaptNativeDescribeToDescribeResult } from "./ios-native-adapter";
 
@@ -23,7 +23,7 @@ export async function describeIos(
   registry: Registry,
   device: DeviceInfo,
   params: DescribeIosParams
-): Promise<DescribeResult> {
+): Promise<DescribeTreeData> {
   const axRef = axServiceRef(device);
   const axApi = await registry.resolveService<AXServiceApi>(axRef.urn, axRef.options);
   const response = await axApi.describe();

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -8,90 +8,30 @@ function leaf(
   return { children: [], ...partial };
 }
 
-function groupHeaders(out: string): string[] {
-  return out.split("\n").filter((l) => /^— Group \d+ —$/.test(l));
-}
-
-function elementLineCount(out: string): number {
-  return out.split("\n").filter((l) => /^ {2}AX|^ {2}\w/.test(l)).length;
+function elementLines(out: string): string[] {
+  return out.split("\n").filter((l) => /^ {2}\S/.test(l));
 }
 
 describe("formatDescribeTree", () => {
-  it("groups a vertically-stacked layout into one cluster per vertical band", () => {
-    // Three bands separated by clear vertical gaps. Each band itself contains
-    // a couple of elements that sit close together in y.
+  it("renders flat ax-service children in reading order, one node per line", () => {
     const root: DescribeNode = {
       role: "AXGroup",
       frame: { x: 0, y: 0, width: 1, height: 1 },
       children: [
-        leaf({ role: "AXButton", label: "Top-A", frame: { x: 0.05, y: 0.05, width: 0.2, height: 0.04 } }),
-        leaf({ role: "AXButton", label: "Top-B", frame: { x: 0.30, y: 0.05, width: 0.2, height: 0.04 } }),
-
-        leaf({ role: "AXStaticText", label: "Mid-A", frame: { x: 0.05, y: 0.45, width: 0.4, height: 0.03 } }),
-        leaf({ role: "AXStaticText", label: "Mid-B", frame: { x: 0.05, y: 0.50, width: 0.4, height: 0.03 } }),
-
-        leaf({ role: "AXButton", label: "Bot-A", frame: { x: 0.05, y: 0.90, width: 0.2, height: 0.05 } }),
+        leaf({ role: "AXButton", label: "C", frame: { x: 0.30, y: 0.50, width: 0.1, height: 0.05 } }),
+        leaf({ role: "AXButton", label: "A", frame: { x: 0.05, y: 0.05, width: 0.1, height: 0.05 } }),
+        leaf({ role: "AXButton", label: "B", frame: { x: 0.20, y: 0.50, width: 0.1, height: 0.05 } }),
       ],
     };
-
     const out = formatDescribeTree(root, { source: "ax-service" });
+    expect(out).toContain("Source: ax-service");
     expect(out).toContain("Mode: flat");
-    expect(groupHeaders(out)).toHaveLength(3);
-    // Reading order: top band first, bottom band last.
-    const topIdx = out.indexOf('"Top-A"');
-    const midIdx = out.indexOf('"Mid-A"');
-    const botIdx = out.indexOf('"Bot-A"');
-    expect(topIdx).toBeLessThan(midIdx);
-    expect(midIdx).toBeLessThan(botIdx);
-  });
-
-  it("applies the same gap rule on x as on y (horizontal layout is not special)", () => {
-    // Three buttons in a horizontal row, all at the same y. Two are close
-    // together; the third sits far across the screen. The cluster algorithm
-    // should split exactly where the x-gap exceeds the threshold — same rule
-    // it applies on the y-axis, with no orientation-specific exception.
-    const root: DescribeNode = {
-      role: "AXGroup",
-      frame: { x: 0, y: 0, width: 1, height: 1 },
-      children: [
-        leaf({ role: "AXButton", label: "L1", frame: { x: 0.05, y: 0.50, width: 0.1, height: 0.05 } }),
-        leaf({ role: "AXButton", label: "L2", frame: { x: 0.18, y: 0.50, width: 0.1, height: 0.05 } }),
-        leaf({ role: "AXButton", label: "R", frame: { x: 0.85, y: 0.50, width: 0.1, height: 0.05 } }),
-      ],
-    };
-
-    const out = formatDescribeTree(root);
-    // L1 and L2 (gap 0.03) stay in one group; R (gap 0.57 from L2) is its own.
-    expect(groupHeaders(out)).toHaveLength(2);
-    expect(elementLineCount(out)).toBe(3);
-    expect(out.indexOf('"L1"')).toBeLessThan(out.indexOf('"L2"'));
-    expect(out.indexOf('"L2"')).toBeLessThan(out.indexOf('"R"'));
-  });
-
-  it("splits a side-by-side layout into a left column and a right column", () => {
-    // Sidebar on the left, content on the right, both spanning the same y
-    // range. Within each column rows sit close together (gap < threshold) so
-    // the column survives as one cluster; the wide horizontal gap between the
-    // two columns is the only break.
-    const root: DescribeNode = {
-      role: "AXGroup",
-      frame: { x: 0, y: 0, width: 1, height: 1 },
-      children: [
-        leaf({ role: "AXButton", label: "Side1", frame: { x: 0.05, y: 0.10, width: 0.15, height: 0.05 } }),
-        leaf({ role: "AXButton", label: "Side2", frame: { x: 0.05, y: 0.16, width: 0.15, height: 0.05 } }),
-        leaf({ role: "AXButton", label: "Side3", frame: { x: 0.05, y: 0.22, width: 0.15, height: 0.05 } }),
-
-        leaf({ role: "AXStaticText", label: "Body1", frame: { x: 0.55, y: 0.10, width: 0.4, height: 0.05 } }),
-        leaf({ role: "AXStaticText", label: "Body2", frame: { x: 0.55, y: 0.16, width: 0.4, height: 0.05 } }),
-        leaf({ role: "AXStaticText", label: "Body3", frame: { x: 0.55, y: 0.22, width: 0.4, height: 0.05 } }),
-      ],
-    };
-
-    const out = formatDescribeTree(root);
-    // The sidebar and the content area should land in different groups.
-    expect(groupHeaders(out).length).toBeGreaterThanOrEqual(2);
-    // Sidebar elements appear before content elements (same top y, smaller x).
-    expect(out.indexOf('"Side1"')).toBeLessThan(out.indexOf('"Body1"'));
+    const lines = elementLines(out);
+    expect(lines).toHaveLength(3);
+    // top-to-bottom, then left-to-right
+    expect(lines[0]).toContain('"A"');
+    expect(lines[1]).toContain('"B"');
+    expect(lines[2]).toContain('"C"');
   });
 
   it("renders a nested uiautomator tree with depth indentation and flags", () => {
@@ -119,7 +59,6 @@ describe("formatDescribeTree", () => {
         },
       ],
     };
-
     const out = formatDescribeTree(root, { source: "uiautomator" });
     expect(out).toContain("Mode: nested");
     expect(out).toContain("ScrollView");
@@ -128,7 +67,7 @@ describe("formatDescribeTree", () => {
     const lines = out.split("\n");
     const buttonLine = lines.find((l) => l.includes('"Like"'))!;
     const scrollLine = lines.find((l) => l.includes("ScrollView"))!;
-    // Child indented deeper than its parent.
+    // child indented deeper than its parent
     expect(buttonLine.search(/\S/)).toBeGreaterThan(scrollLine.search(/\S/));
   });
 
@@ -146,8 +85,7 @@ describe("formatDescribeTree", () => {
     };
     const out = formatDescribeTree(root);
     expect(out).toContain('"Hello\\nWorld"');
-    const lines = out.split("\n");
-    const labelLines = lines.filter((l) => l.includes("Hello"));
+    const labelLines = out.split("\n").filter((l) => l.includes("Hello"));
     expect(labelLines).toHaveLength(1);
   });
 
@@ -160,5 +98,6 @@ describe("formatDescribeTree", () => {
     const out = formatDescribeTree(root);
     expect(out).toContain("Mode: flat");
     expect(out).toContain("ROOT  AXGroup");
+    expect(elementLines(out)).toHaveLength(0);
   });
 });

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { formatDescribeTree } from "../src/tools/describe/format-tree";
+import type { DescribeNode } from "../src/tools/describe/contract";
+
+function leaf(
+  partial: Partial<DescribeNode> & { role: string; frame: DescribeNode["frame"] }
+): DescribeNode {
+  return { children: [], ...partial };
+}
+
+describe("formatDescribeTree", () => {
+  it("renders a flat ax-service tree as zoned sections", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXButton",
+          label: "Messages",
+          frame: { x: 0.04, y: 0.07, width: 0.11, height: 0.05 },
+        }),
+        leaf({
+          role: "AXStaticText",
+          label: "Today",
+          frame: { x: 0.04, y: 0.24, width: 0.92, height: 0.02 },
+        }),
+        leaf({
+          role: "AXButton",
+          label: "add",
+          frame: { x: 0.04, y: 0.55, width: 0.1, height: 0.05 },
+        }),
+        leaf({
+          role: "AXImage",
+          label: "Q",
+          frame: { x: 0.01, y: 0.68, width: 0.1, height: 0.06 },
+        }),
+        leaf({
+          role: "AXImage",
+          label: "W",
+          frame: { x: 0.11, y: 0.68, width: 0.1, height: 0.06 },
+        }),
+        leaf({
+          role: "AXButton",
+          label: "shift",
+          frame: { x: 0.01, y: 0.8, width: 0.13, height: 0.06 },
+        }),
+        leaf({
+          role: "AXButton",
+          label: "Dictate",
+          frame: { x: 0.81, y: 0.92, width: 0.17, height: 0.08 },
+        }),
+      ],
+    };
+
+    const out = formatDescribeTree(root, { source: "ax-service" });
+    expect(out).toContain("Source: ax-service");
+    expect(out).toContain("Mode: flat");
+    expect(out).toContain("— Top bar —");
+    expect(out).toContain('"Messages"');
+    expect(out).toContain("— Body / content —");
+    expect(out).toContain('"Today"');
+    expect(out).toContain("— Composer / predictive / action bar —");
+    expect(out).toContain('"add"');
+    expect(out).toMatch(/Bottom row 1: letters/);
+    expect(out).toMatch(/Bottom row 2: shift \+ letters \+ delete/);
+    expect(out).toMatch(/Bottom row 3: globe \/ dictate/);
+  });
+
+  it("renders a nested uiautomator tree with depth indentation and flags", () => {
+    const root: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        {
+          role: "ScrollView",
+          frame: { x: 0, y: 0.1, width: 1, height: 0.8 },
+          scrollable: true,
+          children: [
+            leaf({
+              role: "Button",
+              label: "Like",
+              frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.1 },
+              clickable: true,
+            }),
+            leaf({
+              role: "WebView",
+              label: "[web-view] About",
+              frame: { x: 0, y: 0.4, width: 1, height: 0.4 },
+            }),
+          ],
+        },
+      ],
+    };
+
+    const out = formatDescribeTree(root, { source: "uiautomator" });
+    expect(out).toContain("Mode: nested");
+    expect(out).toMatch(/Screen\s+/);
+    expect(out).toContain("ScrollView");
+    expect(out).toMatch(/Button\s+"Like".*\[clickable\]/);
+    expect(out).toContain("[web-view] About");
+    const lines = out.split("\n");
+    const buttonLine = lines.find((l) => l.includes('"Like"'))!;
+    const scrollLine = lines.find((l) => l.includes("ScrollView"))!;
+    // The button must be indented deeper than its parent ScrollView.
+    expect(buttonLine.search(/\S/)).toBeGreaterThan(scrollLine.search(/\S/));
+  });
+
+  it("escapes embedded newlines so per-line alignment survives", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXGroup",
+          label: "Hello\nWorld",
+          frame: { x: 0.1, y: 0.2, width: 0.8, height: 0.1 },
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root);
+    expect(out).toContain('"Hello\\nWorld"');
+    // Make sure the original \n didn't leak through.
+    const lines = out.split("\n");
+    const labelLines = lines.filter((l) => l.includes("Hello"));
+    expect(labelLines).toHaveLength(1);
+  });
+
+  it("handles an empty tree without crashing", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [],
+    };
+    const out = formatDescribeTree(root);
+    expect(out).toContain("Mode: flat");
+    expect(out).toContain("ROOT  AXGroup");
+  });
+});

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -8,62 +8,90 @@ function leaf(
   return { children: [], ...partial };
 }
 
+function groupHeaders(out: string): string[] {
+  return out.split("\n").filter((l) => /^— Group \d+ —$/.test(l));
+}
+
+function elementLineCount(out: string): number {
+  return out.split("\n").filter((l) => /^ {2}AX|^ {2}\w/.test(l)).length;
+}
+
 describe("formatDescribeTree", () => {
-  it("renders a flat ax-service tree as zoned sections", () => {
+  it("groups a vertically-stacked layout into one cluster per vertical band", () => {
+    // Three bands separated by clear vertical gaps. Each band itself contains
+    // a couple of elements that sit close together in y.
     const root: DescribeNode = {
       role: "AXGroup",
       frame: { x: 0, y: 0, width: 1, height: 1 },
       children: [
-        leaf({
-          role: "AXButton",
-          label: "Messages",
-          frame: { x: 0.04, y: 0.07, width: 0.11, height: 0.05 },
-        }),
-        leaf({
-          role: "AXStaticText",
-          label: "Today",
-          frame: { x: 0.04, y: 0.24, width: 0.92, height: 0.02 },
-        }),
-        leaf({
-          role: "AXButton",
-          label: "add",
-          frame: { x: 0.04, y: 0.55, width: 0.1, height: 0.05 },
-        }),
-        leaf({
-          role: "AXImage",
-          label: "Q",
-          frame: { x: 0.01, y: 0.68, width: 0.1, height: 0.06 },
-        }),
-        leaf({
-          role: "AXImage",
-          label: "W",
-          frame: { x: 0.11, y: 0.68, width: 0.1, height: 0.06 },
-        }),
-        leaf({
-          role: "AXButton",
-          label: "shift",
-          frame: { x: 0.01, y: 0.8, width: 0.13, height: 0.06 },
-        }),
-        leaf({
-          role: "AXButton",
-          label: "Dictate",
-          frame: { x: 0.81, y: 0.92, width: 0.17, height: 0.08 },
-        }),
+        leaf({ role: "AXButton", label: "Top-A", frame: { x: 0.05, y: 0.05, width: 0.2, height: 0.04 } }),
+        leaf({ role: "AXButton", label: "Top-B", frame: { x: 0.30, y: 0.05, width: 0.2, height: 0.04 } }),
+
+        leaf({ role: "AXStaticText", label: "Mid-A", frame: { x: 0.05, y: 0.45, width: 0.4, height: 0.03 } }),
+        leaf({ role: "AXStaticText", label: "Mid-B", frame: { x: 0.05, y: 0.50, width: 0.4, height: 0.03 } }),
+
+        leaf({ role: "AXButton", label: "Bot-A", frame: { x: 0.05, y: 0.90, width: 0.2, height: 0.05 } }),
       ],
     };
 
     const out = formatDescribeTree(root, { source: "ax-service" });
-    expect(out).toContain("Source: ax-service");
     expect(out).toContain("Mode: flat");
-    expect(out).toContain("— Top bar —");
-    expect(out).toContain('"Messages"');
-    expect(out).toContain("— Body / content —");
-    expect(out).toContain('"Today"');
-    expect(out).toContain("— Composer / predictive / action bar —");
-    expect(out).toContain('"add"');
-    expect(out).toMatch(/Bottom row 1: letters/);
-    expect(out).toMatch(/Bottom row 2: shift \+ letters \+ delete/);
-    expect(out).toMatch(/Bottom row 3: globe \/ dictate/);
+    expect(groupHeaders(out)).toHaveLength(3);
+    // Reading order: top band first, bottom band last.
+    const topIdx = out.indexOf('"Top-A"');
+    const midIdx = out.indexOf('"Mid-A"');
+    const botIdx = out.indexOf('"Bot-A"');
+    expect(topIdx).toBeLessThan(midIdx);
+    expect(midIdx).toBeLessThan(botIdx);
+  });
+
+  it("applies the same gap rule on x as on y (horizontal layout is not special)", () => {
+    // Three buttons in a horizontal row, all at the same y. Two are close
+    // together; the third sits far across the screen. The cluster algorithm
+    // should split exactly where the x-gap exceeds the threshold — same rule
+    // it applies on the y-axis, with no orientation-specific exception.
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({ role: "AXButton", label: "L1", frame: { x: 0.05, y: 0.50, width: 0.1, height: 0.05 } }),
+        leaf({ role: "AXButton", label: "L2", frame: { x: 0.18, y: 0.50, width: 0.1, height: 0.05 } }),
+        leaf({ role: "AXButton", label: "R", frame: { x: 0.85, y: 0.50, width: 0.1, height: 0.05 } }),
+      ],
+    };
+
+    const out = formatDescribeTree(root);
+    // L1 and L2 (gap 0.03) stay in one group; R (gap 0.57 from L2) is its own.
+    expect(groupHeaders(out)).toHaveLength(2);
+    expect(elementLineCount(out)).toBe(3);
+    expect(out.indexOf('"L1"')).toBeLessThan(out.indexOf('"L2"'));
+    expect(out.indexOf('"L2"')).toBeLessThan(out.indexOf('"R"'));
+  });
+
+  it("splits a side-by-side layout into a left column and a right column", () => {
+    // Sidebar on the left, content on the right, both spanning the same y
+    // range. Within each column rows sit close together (gap < threshold) so
+    // the column survives as one cluster; the wide horizontal gap between the
+    // two columns is the only break.
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({ role: "AXButton", label: "Side1", frame: { x: 0.05, y: 0.10, width: 0.15, height: 0.05 } }),
+        leaf({ role: "AXButton", label: "Side2", frame: { x: 0.05, y: 0.16, width: 0.15, height: 0.05 } }),
+        leaf({ role: "AXButton", label: "Side3", frame: { x: 0.05, y: 0.22, width: 0.15, height: 0.05 } }),
+
+        leaf({ role: "AXStaticText", label: "Body1", frame: { x: 0.55, y: 0.10, width: 0.4, height: 0.05 } }),
+        leaf({ role: "AXStaticText", label: "Body2", frame: { x: 0.55, y: 0.16, width: 0.4, height: 0.05 } }),
+        leaf({ role: "AXStaticText", label: "Body3", frame: { x: 0.55, y: 0.22, width: 0.4, height: 0.05 } }),
+      ],
+    };
+
+    const out = formatDescribeTree(root);
+    // The sidebar and the content area should land in different groups.
+    expect(groupHeaders(out).length).toBeGreaterThanOrEqual(2);
+    // Sidebar elements appear before content elements (same top y, smaller x).
+    expect(out.indexOf('"Side1"')).toBeLessThan(out.indexOf('"Body1"'));
   });
 
   it("renders a nested uiautomator tree with depth indentation and flags", () => {
@@ -94,14 +122,13 @@ describe("formatDescribeTree", () => {
 
     const out = formatDescribeTree(root, { source: "uiautomator" });
     expect(out).toContain("Mode: nested");
-    expect(out).toMatch(/Screen\s+/);
     expect(out).toContain("ScrollView");
     expect(out).toMatch(/Button\s+"Like".*\[clickable\]/);
     expect(out).toContain("[web-view] About");
     const lines = out.split("\n");
     const buttonLine = lines.find((l) => l.includes('"Like"'))!;
     const scrollLine = lines.find((l) => l.includes("ScrollView"))!;
-    // The button must be indented deeper than its parent ScrollView.
+    // Child indented deeper than its parent.
     expect(buttonLine.search(/\S/)).toBeGreaterThan(scrollLine.search(/\S/));
   });
 
@@ -119,7 +146,6 @@ describe("formatDescribeTree", () => {
     };
     const out = formatDescribeTree(root);
     expect(out).toContain('"Hello\\nWorld"');
-    // Make sure the original \n didn't leak through.
     const lines = out.split("\n");
     const labelLines = lines.filter((l) => l.includes("Hello"));
     expect(labelLines).toHaveLength(1);

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -18,9 +18,13 @@ describe("formatDescribeTree", () => {
       role: "AXGroup",
       frame: { x: 0, y: 0, width: 1, height: 1 },
       children: [
-        leaf({ role: "AXButton", label: "C", frame: { x: 0.30, y: 0.50, width: 0.1, height: 0.05 } }),
-        leaf({ role: "AXButton", label: "A", frame: { x: 0.05, y: 0.05, width: 0.1, height: 0.05 } }),
-        leaf({ role: "AXButton", label: "B", frame: { x: 0.20, y: 0.50, width: 0.1, height: 0.05 } }),
+        leaf({ role: "AXButton", label: "C", frame: { x: 0.3, y: 0.5, width: 0.1, height: 0.05 } }),
+        leaf({
+          role: "AXButton",
+          label: "A",
+          frame: { x: 0.05, y: 0.05, width: 0.1, height: 0.05 },
+        }),
+        leaf({ role: "AXButton", label: "B", frame: { x: 0.2, y: 0.5, width: 0.1, height: 0.05 } }),
       ],
     };
     const out = formatDescribeTree(root, { source: "ax-service" });

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -87,7 +87,7 @@ describe("formatDescribeTree", () => {
         }),
       ],
     };
-    const out = formatDescribeTree(root);
+    const out = formatDescribeTree(root, { source: "ax-service" });
     expect(out).toContain('"Hello\\nWorld"');
     const labelLines = out.split("\n").filter((l) => l.includes("Hello"));
     expect(labelLines).toHaveLength(1);
@@ -99,9 +99,390 @@ describe("formatDescribeTree", () => {
       frame: { x: 0, y: 0, width: 1, height: 1 },
       children: [],
     };
-    const out = formatDescribeTree(root);
+    const out = formatDescribeTree(root, { source: "ax-service" });
     expect(out).toContain("Mode: flat");
     expect(out).toContain("ROOT  AXGroup");
+    expect(elementLines(out)).toHaveLength(0);
+  });
+
+  // Regression for the user-reported bug: a Bluesky landing screen full of
+  // images was rendering with both images stripped. Any node whose role marks
+  // it as content (AXImage, AXButton, …) must survive even when label is
+  // absent, so the agent at least sees that something is at that frame.
+  it("keeps unlabeled content roles visible in flat mode", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({ role: "AXImage", frame: { x: 0.1, y: 0.1, width: 0.3, height: 0.2 } }),
+        leaf({
+          role: "AXImage",
+          label: "Hero illustration",
+          frame: { x: 0.1, y: 0.3, width: 0.3, height: 0.2 },
+        }),
+        leaf({ role: "AXButton", frame: { x: 0.4, y: 0.5, width: 0.2, height: 0.1 } }),
+        // AXGroup with no label is a pure container — should still be dropped.
+        leaf({ role: "AXGroup", frame: { x: 0.7, y: 0.7, width: 0.2, height: 0.1 } }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "ax-service" });
+    const lines = elementLines(out);
+    expect(lines.some((l) => /^\s*AXImage\b/.test(l) && !l.includes('"'))).toBe(true);
+    expect(lines.some((l) => l.includes('"Hero illustration"'))).toBe(true);
+    expect(lines.some((l) => /^\s*AXButton\b/.test(l) && !l.includes('"'))).toBe(true);
+    expect(lines.some((l) => /^\s*AXGroup\b/.test(l))).toBe(false);
+  });
+
+  // Regression for issue #3 — the header already prints
+  // `ROOT  <role>  <frame>`, so renderNested must not re-emit the root as the
+  // first body line.
+  it("does not duplicate the root node in nested mode", () => {
+    const root: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        {
+          role: "FrameLayout",
+          frame: { x: 0, y: 0.1, width: 1, height: 0.4 },
+          children: [
+            leaf({
+              role: "Button",
+              label: "Tap",
+              frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.1 },
+              clickable: true,
+            }),
+          ],
+        },
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "uiautomator" });
+    // Exactly one mention of Screen — the ROOT header line, never the body.
+    const screenLines = out.split("\n").filter((l) => l.includes("Screen"));
+    expect(screenLines).toHaveLength(1);
+    expect(screenLines[0]).toMatch(/^ROOT\s/);
+  });
+
+  // Regression for issue #5 — iOS reports placeholder text under both `label`
+  // and `value` for text inputs, doubling the byte cost for zero added signal.
+  it("omits value= when value matches label", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXGroup",
+          label: "Username",
+          value: "Username",
+          frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.05 },
+        }),
+        leaf({
+          role: "AXGroup",
+          label: "Password",
+          value: "•••••",
+          frame: { x: 0.1, y: 0.2, width: 0.8, height: 0.05 },
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "ax-service" });
+    const usernameLine = out.split("\n").find((l) => l.includes('"Username"'))!;
+    expect(usernameLine).not.toContain("value=");
+    const passwordLine = out.split("\n").find((l) => l.includes('"Password"'))!;
+    expect(passwordLine).toContain('value="•••••"');
+  });
+
+  // Regression for issue #4 — a long Compose / uiautomator class name no
+  // longer pushes adjacent columns out of alignment. The role is emitted
+  // verbatim (no truncation) with a single space before the rest.
+  it("emits long role names without truncation and without padding-driven misalignment", () => {
+    const root: DescribeNode = {
+      role: "android.widget.FrameLayout",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        {
+          role: "androidx.compose.ui.platform.ComposeView",
+          frame: { x: 0, y: 0.1, width: 1, height: 0.4 },
+          children: [
+            leaf({
+              role: "Image",
+              label: "avatar",
+              frame: { x: 0.1, y: 0.2, width: 0.2, height: 0.2 },
+            }),
+          ],
+        },
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "uiautomator" });
+    expect(out).toContain("androidx.compose.ui.platform.ComposeView");
+    // Each body line: indentation, then the role token, then a single space,
+    // then either annotations + double-space + frame, or directly the frame.
+    for (const line of elementLines(out)) {
+      const match = line.match(/^(\s+)(\S+)( .*)?$/);
+      expect(match).not.toBeNull();
+    }
+  });
+
+  // Regression for issue #7 — mode is decided by `source`, not by counting
+  // grandchildren of the root. A native-devtools fallback that happens to
+  // produce a flat-shaped tree must NOT drop to flat mode, and an ax-service
+  // payload that happens to have a wrapping group with one grandchild must
+  // stay flat.
+  it("picks mode by source, not by tree silhouette", () => {
+    const flatShaped: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({ role: "Button", label: "X", frame: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 } }),
+      ],
+    };
+    expect(formatDescribeTree(flatShaped, { source: "uiautomator" })).toContain("Mode: nested");
+
+    const accidentallyDeep: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        {
+          role: "AXGroup",
+          frame: { x: 0, y: 0, width: 1, height: 0.5 },
+          children: [
+            leaf({
+              role: "AXStaticText",
+              label: "Hi",
+              frame: { x: 0.1, y: 0.1, width: 0.5, height: 0.04 },
+            }),
+          ],
+        },
+      ],
+    };
+    expect(formatDescribeTree(accidentallyDeep, { source: "ax-service" })).toContain("Mode: flat");
+  });
+
+  // The iOS native-devtools fallback shares the flat layout that ax-service
+  // emits, so it should also report `Mode: flat`. (Source line still
+  // distinguishes the two for agents that care.)
+  it("treats native-devtools as flat", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXButton",
+          label: "Settings",
+          frame: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 },
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "native-devtools" });
+    expect(out).toContain("Source: native-devtools");
+    expect(out).toContain("Mode: flat");
+  });
+
+  // The header text is part of the agent-visible response, so it must keep
+  // pointing at gesture-tap / gesture-swipe / gesture-pinch and the centre
+  // formula. If this drifts again the runtime help is silently misleading.
+  it("renders the coordinate-space + tap-formula header on every call", () => {
+    const empty: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [],
+    };
+    const out = formatDescribeTree(empty, { source: "ax-service" });
+    expect(out).toContain("normalized [0,1] fractions of the screen");
+    expect(out).toContain("gesture-tap");
+    expect(out).toContain("tap_x = frame.x + frame.width / 2");
+    expect(out).toContain("tap_y = frame.y + frame.height / 2");
+  });
+
+  // Bluesky-style names mix emoji, ZWJ sequences, and bidirectional isolate
+  // markers (U+202A/U+202C). Those must pass through escapeForLine unchanged
+  // — only ASCII control chars (\\n, \\r, \\t) get backslash-escaped.
+  it("preserves emoji and bidi isolates in labels", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXStaticText",
+          label: "‪Dovewoman 💙 🇺🇦 💙‬",
+          frame: { x: 0.1, y: 0.1, width: 0.5, height: 0.02 },
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "ax-service" });
+    expect(out).toContain("‪Dovewoman 💙 🇺🇦 💙‬");
+    expect(out).not.toContain("\\u");
+  });
+
+  // Combined interactivity flags all need to surface in a single `[…]` group
+  // in a deterministic order, otherwise an LLM cannot pattern-match on them.
+  it("emits all interactivity flags together in a stable order", () => {
+    const root: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "Switch",
+          label: "Wifi",
+          frame: { x: 0.1, y: 0.1, width: 0.3, height: 0.05 },
+          clickable: true,
+          longClickable: true,
+          scrollable: false,
+          checkable: true,
+          checked: true,
+          disabled: true,
+        }),
+        leaf({
+          role: "View",
+          frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.05 },
+          scrollHidden: 7,
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "uiautomator" });
+    expect(out).toMatch(/\[clickable,long-clickable,checked,disabled\]/);
+    expect(out).toMatch(/\[scrollHidden=7\]/);
+  });
+
+  // scrollHidden=0 is the "no clipped children" signal from the Android
+  // parser; emitting the flag at zero would be misleading.
+  it("does not emit scrollHidden when the count is zero", () => {
+    const root: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "Button",
+          label: "Tap",
+          frame: { x: 0.1, y: 0.1, width: 0.3, height: 0.05 },
+          scrollHidden: 0,
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "uiautomator" });
+    expect(out).not.toContain("scrollHidden");
+  });
+
+  // identifier is the Android resource-id (and the iOS native-devtools
+  // accessibility identifier). It's the most stable thing to match on, so it
+  // must round-trip through the formatter verbatim.
+  it("surfaces the identifier as an id= attribute", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXButton",
+          identifier: "com.bluesky:id/like_button",
+          label: "Like",
+          frame: { x: 0.1, y: 0.5, width: 0.2, height: 0.05 },
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "ax-service" });
+    expect(out).toContain('id="com.bluesky:id/like_button"');
+  });
+
+  // The reading-order sort in flat mode must be stable, so two elements that
+  // share the same (y, x) keep their source order. (Bluesky-style timelines
+  // have rows where action buttons sometimes report identical frames.)
+  it("stably sorts equal-frame nodes in flat mode", () => {
+    const sharedFrame = { x: 0.1, y: 0.5, width: 0.2, height: 0.05 };
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({ role: "AXButton", label: "first", frame: sharedFrame }),
+        leaf({ role: "AXButton", label: "second", frame: sharedFrame }),
+        leaf({ role: "AXButton", label: "third", frame: sharedFrame }),
+      ],
+    };
+    const lines = elementLines(formatDescribeTree(root, { source: "ax-service" }));
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain('"first"');
+    expect(lines[1]).toContain('"second"');
+    expect(lines[2]).toContain('"third"');
+  });
+
+  // Frames are always rendered to exactly three decimals. This is the
+  // precision agents pass back to gesture-tap; drifting it would silently
+  // change tap targets across screens.
+  it("always renders frames to three decimal places", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXButton",
+          label: "X",
+          frame: { x: 0.123456789, y: 0.5, width: 0.1, height: 0.05 },
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "ax-service" });
+    expect(out).toMatch(/\(0\.123, 0\.500, 0\.100, 0\.050\)/);
+  });
+
+  // Long Compose / RN trees can stack 200+ wrapper layers. The renderer uses
+  // an iterative DFS specifically to avoid a recursive stack overflow there.
+  it("handles deeply nested trees without recursing the JS stack", () => {
+    let inner: DescribeNode = leaf({
+      role: "Button",
+      label: "deep",
+      frame: { x: 0.4, y: 0.4, width: 0.2, height: 0.05 },
+      clickable: true,
+    });
+    for (let i = 0; i < 500; i++) {
+      inner = {
+        role: "FrameLayout",
+        frame: { x: 0, y: 0, width: 1, height: 1 },
+        children: [inner],
+      };
+    }
+    const root: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [inner],
+    };
+    const out = formatDescribeTree(root, { source: "uiautomator" });
+    expect(out).toContain('"deep"');
+    expect(out.split("\n").length).toBeGreaterThan(500);
+  });
+
+  // The trim rule must only strip "value === label" — value strings that
+  // happen to start with the label (e.g. a search field whose label is
+  // "Search" and value is "Search query") need to survive.
+  it("keeps value when it differs from label even by a suffix", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXTextField",
+          label: "Search",
+          value: "Search ",
+          frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.05 },
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "ax-service" });
+    expect(out).toContain('value="Search "');
+  });
+
+  // hasContent() must NOT count a wrapper as content just because checked is
+  // false — the field defaults to `undefined`, but a node where the
+  // adapter explicitly set checkable=false should still drop out.
+  it("does not treat checkable=false as a content signal", () => {
+    const root: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "AXGroup",
+          frame: { x: 0.1, y: 0.1, width: 0.3, height: 0.05 },
+          checkable: false,
+        }),
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "ax-service" });
     expect(elementLines(out)).toHaveLength(0);
   });
 });

--- a/packages/tool-server/test/describe-tool.test.ts
+++ b/packages/tool-server/test/describe-tool.test.ts
@@ -4,6 +4,15 @@ import type { NativeDevtoolsApi } from "../src/blueprints/native-devtools";
 import { createDescribeTool } from "../src/tools/describe";
 import { __primeDepCacheForTests, __resetDepCacheForTests } from "../src/utils/check-deps";
 
+// The describe tool no longer surfaces the JSON tree — `result.description`
+// is the text rendering produced by format-tree.ts. `elementLineCount` counts
+// the per-element lines (everything indented under a section header), which
+// is what the old `tree.children.length` was effectively measuring once you
+// ignore the root AXGroup wrapper.
+function elementLineCount(description: string): number {
+  return description.split("\n").filter((l) => /^ {2}AX/.test(l)).length;
+}
+
 function makeAXServiceApi(response: AXDescribeResponse): AXServiceApi {
   return {
     describe: async () => response,
@@ -94,9 +103,8 @@ describe("describe tool", () => {
 
     const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
     expect(result.source).toBe("ax-service");
-    expect(result.tree.role).toBe("AXGroup");
-    expect(result.tree.children[0]?.label).toBe("General");
-    expect(result.tree.children[0]?.role).toBe("AXButton");
+    expect(result.description).toContain("ROOT  AXGroup");
+    expect(result.description).toMatch(/AXButton\s+"General"/);
   });
 
   it("returns dialog elements when alertVisible is true", async () => {
@@ -122,10 +130,9 @@ describe("describe tool", () => {
 
     const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
     expect(result.source).toBe("ax-service");
-    expect(result.tree.children).toHaveLength(2);
-    expect(result.tree.children[0]?.label).toBe("Allow Once");
-    expect(result.tree.children[0]?.role).toBe("AXButton");
-    expect(result.tree.children[1]?.label).toBe("Don\u2019t Allow");
+    expect(elementLineCount(result.description)).toBe(2);
+    expect(result.description).toMatch(/AXButton\s+"Allow Once"/);
+    expect(result.description).toMatch(/AXButton\s+"Don\u2019t Allow"/);
   });
 
   it("returns empty root when no elements and no native fallback", async () => {
@@ -139,8 +146,8 @@ describe("describe tool", () => {
 
     const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
     expect(result.source).toBe("ax-service");
-    expect(result.tree.role).toBe("AXGroup");
-    expect(result.tree.children).toHaveLength(0);
+    expect(result.description).toContain("ROOT  AXGroup");
+    expect(elementLineCount(result.description)).toBe(0);
   });
 
   it("uses bundleId for native-devtools fallback when AX returns empty", async () => {
@@ -174,8 +181,7 @@ describe("describe tool", () => {
       { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", bundleId: "com.apple.Preferences" }
     );
     expect(result.source).toBe("native-devtools");
-    expect(result.tree.children[0]?.label).toBe("General");
-    expect(result.tree.children[0]?.role).toBe("AXButton");
+    expect(result.description).toMatch(/AXButton\s+"General"/);
   });
 
   it("falls back to native-devtools with auto-target when AX returns empty", async () => {
@@ -206,7 +212,7 @@ describe("describe tool", () => {
 
     const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
     expect(result.source).toBe("native-devtools");
-    expect(result.tree.children[0]?.label).toBe("Hello World");
+    expect(result.description).toContain('"Hello World"');
     expect(result.should_restart).toBeUndefined();
   });
 
@@ -230,7 +236,7 @@ describe("describe tool", () => {
     );
     expect(result.source).toBe("ax-service");
     expect(result.should_restart).toBe(true);
-    expect(result.tree.children).toHaveLength(0);
+    expect(elementLineCount(result.description)).toBe(0);
   });
 
   it("returns empty AX result when native-devtools is unavailable", async () => {
@@ -245,7 +251,7 @@ describe("describe tool", () => {
 
     const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
     expect(result.source).toBe("ax-service");
-    expect(result.tree.children).toHaveLength(0);
+    expect(elementLineCount(result.description)).toBe(0);
     expect(result.should_restart).toBeUndefined();
   });
 
@@ -287,11 +293,10 @@ describe("describe tool", () => {
 
     const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
     expect(result.source).toBe("ax-service");
-    expect(result.tree.children).toHaveLength(3);
-    expect(result.tree.children[0]?.role).toBe("AXTextField");
-    expect(result.tree.children[0]?.value).toBe("Search");
-    expect(result.tree.children[1]?.role).toBe("AXButton");
-    expect(result.tree.children[2]?.label).toBe("Accessibility");
+    expect(elementLineCount(result.description)).toBe(3);
+    expect(result.description).toMatch(/AXTextField\s+"Search"\s+value="Search"/);
+    expect(result.description).toMatch(/AXButton\s+"General"/);
+    expect(result.description).toMatch(/AXButton\s+"Accessibility"/);
   });
 
   it("resolves ax-service with the correct URN", async () => {
@@ -336,6 +341,6 @@ describe("describe tool", () => {
       { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", bundleId: "com.example.app" }
     );
     expect(result.source).toBe("ax-service");
-    expect(result.tree.children).toHaveLength(0);
+    expect(elementLineCount(result.description)).toBe(0);
   });
 });

--- a/packages/tool-server/test/describe-tool.test.ts
+++ b/packages/tool-server/test/describe-tool.test.ts
@@ -294,7 +294,9 @@ describe("describe tool", () => {
     const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
     expect(result.source).toBe("ax-service");
     expect(elementLineCount(result.description)).toBe(3);
-    expect(result.description).toMatch(/AXTextField\s+"Search"\s+value="Search"/);
+    // value is dropped when it duplicates label — see format-tree.ts hasContent comment
+    expect(result.description).toMatch(/AXTextField\s+"Search"\s+\(/);
+    expect(result.description).not.toMatch(/value="Search"/);
     expect(result.description).toMatch(/AXButton\s+"General"/);
     expect(result.description).toMatch(/AXButton\s+"Accessibility"/);
   });


### PR DESCRIPTION
## Summary
- Move the JSON tree out of the describe tool's response and add an in-between layer (`format-tree.ts`) that converts it to a sectioned text rendering. On a typical iOS screen the new `description` field is ~6× cheaper on the wire than the previous nested tree once braces, keys, and indentation are counted.
- Public response shape becomes `{ description, source, should_restart? }`. All existing pruning (Android v2 trimmer in `uiautomator-parser.ts`, iOS frame clamp in `ios-ax-adapter.ts`) is untouched — the new layer only re-presents what the platform adapters already produced.
- Header now spells out the coordinate space and the tap-point formula so an agent can act on a frame without further docs.

## How it renders
Two modes picked automatically from the tree shape:
- **flat** (iOS ax-service): bucket children by `frame.y` into Top bar / Body / Composer / Bottom; split the bottom zone into keyboard rows by rounded y and classify each row (letters / shift / return / globe-dictate).
- **nested** (Android uiautomator, iOS native-devtools fallback): iterative DFS with depth indentation, preserving `clickable` / `scrollable` / `scrollHidden` / `disabled` / `password` flags inline.

Example (Messages with keyboard up):
```
Source: ax-service
Mode: flat
Coordinates are normalized [0,1] fractions of the screen (x, y, width, height), not pixels — pass them straight to gesture-tap / gesture-swipe / gesture-pinch, which expect this same space. To tap an element, use its centre: tap_x = frame.x + frame.width / 2, tap_y = frame.y + frame.height / 2.

ROOT  AXGroup (0.000, 0.000, 1.000, 1.000)

— Top bar —
  AXButton     "Messages"  (0.040, 0.071, 0.109, 0.050)
  AXButton     "+1 (888) 555-1212"  (0.267, 0.134, 0.466, 0.037)

— Body / content —
  AXStaticText "iMessage ￼ Encrypted"  (0.040, 0.156, 0.920, 0.030)
  ...

— Bottom row 1: letters —
  AXImage      "Q"  (0.012, 0.675, 0.098, 0.062)
  ...
```

## Files
- `packages/tool-server/src/tools/describe/contract.ts` — split into `DescribeTreeData` (internal) and `DescribeResult` (public)
- `packages/tool-server/src/tools/describe/index.ts` — `withDescription(data)` wrapper applied to both platform handlers
- `packages/tool-server/src/tools/describe/format-tree.ts` — the renderer (new)
- `packages/tool-server/src/tools/describe/platforms/{ios,android}/index.ts` — return `DescribeTreeData`
- `packages/tool-server/test/describe-tool.test.ts` — assertions migrated to `result.description` / `result.source` / `result.should_restart`
- `packages/tool-server/test/describe-format-tree.test.ts` — renderer unit tests (new): flat zoning, nested indentation + flags, embedded-newline escaping, empty tree

## Test plan
- [x] `npm test` in `packages/tool-server` — 49 files / 482 tests passing locally
- [x] `tsc --build` at workspace root — clean
- [x] Live MCP sanity check: `argent run describe --udid <booted> --json` returns the new shape; tested against Messages (full keyboard surface), Safari (chrome-only, expected), and a minimal in-process WKWebView host. Existing pruning behaviour unchanged in every case.