### PR TITLE
feat: per-step delayMs on flow steps

### DIFF
--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -131,14 +131,13 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
   ): Promise<{ result: unknown; outputHint?: string; note?: string }> {
     const tools = await fetchTools();
     const meta = tools.find((t) => t.name === name);
-    const longRunning = name === "run-sequence" || name === "flow-execute";
     const res = await fetchWithReconnect(() => `${TOOLS_URL}/tools/${name}`, reconnect, {
       init: {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(args ?? {}),
       },
-      fetchTimeoutMs: longRunning ? null : FETCH_TIMEOUT_MS,
+      fetchTimeoutMs: meta?.longRunning ? null : FETCH_TIMEOUT_MS,
     });
 
     const json = (await res.json()) as ToolAPIResponse;

--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -25,7 +25,7 @@ export async function fetchWithReconnect(
     init?: RequestInit;
     expBackoffBase?: number;
     maxRetries?: number;
-    fetchTimeoutMs?: number;
+    fetchTimeoutMs?: number | null;
   }
 ): Promise<Response> {
   const {
@@ -40,7 +40,7 @@ export async function fetchWithReconnect(
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const controller = new AbortController();
     const timer =
-      fetchTimeoutMs > 0 ? setTimeout(() => controller.abort(), fetchTimeoutMs) : undefined;
+      fetchTimeoutMs !== null ? setTimeout(() => controller.abort(), fetchTimeoutMs) : undefined;
     try {
       return await fetch(getUrl(), { ...init, signal: controller.signal });
     } catch (err) {
@@ -138,7 +138,7 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(args ?? {}),
       },
-      fetchTimeoutMs: longRunning ? 0 : FETCH_TIMEOUT_MS,
+      fetchTimeoutMs: longRunning ? null : FETCH_TIMEOUT_MS,
     });
 
     const json = (await res.json()) as ToolAPIResponse;

--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -39,7 +39,8 @@ export async function fetchWithReconnect(
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), fetchTimeoutMs);
+    const timer =
+      fetchTimeoutMs > 0 ? setTimeout(() => controller.abort(), fetchTimeoutMs) : undefined;
     try {
       return await fetch(getUrl(), { ...init, signal: controller.signal });
     } catch (err) {
@@ -130,12 +131,14 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
   ): Promise<{ result: unknown; outputHint?: string; note?: string }> {
     const tools = await fetchTools();
     const meta = tools.find((t) => t.name === name);
+    const longRunning = name === "run-sequence" || name === "flow-execute";
     const res = await fetchWithReconnect(() => `${TOOLS_URL}/tools/${name}`, reconnect, {
       init: {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(args ?? {}),
       },
+      fetchTimeoutMs: longRunning ? 0 : FETCH_TIMEOUT_MS,
     });
 
     const json = (await res.json()) as ToolAPIResponse;

--- a/packages/argent-mcp/test/fetch-timeout.test.ts
+++ b/packages/argent-mcp/test/fetch-timeout.test.ts
@@ -92,4 +92,25 @@ describe("fetch timeout in fetchWithReconnect", () => {
 
     server.close();
   });
+
+  it("disables the per-attempt timeout when fetchTimeoutMs is 0", async () => {
+    const server = http.createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      }, 200);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+
+    const res = await fetchWithReconnect(
+      () => `http://127.0.0.1:${port}/slow`,
+      mockSuccessfulReconnect,
+      { fetchTimeoutMs: 0 }
+    );
+    expect(res.ok).toBe(true);
+
+    server.close();
+  });
 });

--- a/packages/argent-mcp/test/fetch-timeout.test.ts
+++ b/packages/argent-mcp/test/fetch-timeout.test.ts
@@ -93,7 +93,7 @@ describe("fetch timeout in fetchWithReconnect", () => {
     server.close();
   });
 
-  it("disables the per-attempt timeout when fetchTimeoutMs is 0", async () => {
+  it("disables the per-attempt timeout when fetchTimeoutMs is null", async () => {
     const server = http.createServer((_req, res) => {
       setTimeout(() => {
         res.writeHead(200, { "Content-Type": "application/json" });
@@ -107,7 +107,7 @@ describe("fetch timeout in fetchWithReconnect", () => {
     const res = await fetchWithReconnect(
       () => `http://127.0.0.1:${port}/slow`,
       mockSuccessfulReconnect,
-      { fetchTimeoutMs: 0 }
+      { fetchTimeoutMs: null }
     );
     expect(res.ok).toBe(true);
 

--- a/packages/argent-tools-client/src/tools-client.ts
+++ b/packages/argent-tools-client/src/tools-client.ts
@@ -7,6 +7,7 @@ export interface ToolMeta {
   outputHint?: string;
   alwaysLoad?: boolean;
   searchHint?: string;
+  longRunning?: boolean;
 }
 
 export interface ToolInvocationResult {

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -144,6 +144,13 @@ export interface ToolDefinition<TParams = void, TResult = unknown> {
    * via `_meta["anthropic/searchHint"]`.
    */
   searchHint?: string;
+  /**
+   * When true, signals that an invocation may legitimately run for a long time
+   * (e.g. orchestrators that replay many sub-tools). The MCP adapter disables
+   * its per-request fetch timeout for these so long invocations don't get
+   * aborted mid-flight.
+   */
+  longRunning?: boolean;
   /** Per-platform support declaration. Cross-platform tools assert against this before dispatching. */
   capability?: ToolCapability;
   /**

--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -99,7 +99,7 @@ flow-execute   { name: "open-settings", project_root: "/Users/dev/MyApp", prereq
 Flow files use YAML. The top-level is an object with `executionPrerequisite` (describes required state) and `steps` (array of actions):
 
 - `- echo: <message>` — a label
-- `- tool: <name>` with optional `args:` — a tool call
+- `- tool: <name>` with optional `args:` — a tool call. Add `delayMs: <ms>` to sleep that long before the step runs (use sparingly — only when the app needs a fixed wait between actions).
 
 Example `.yaml` file:
 

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -88,6 +88,7 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
         outputHint?: string;
         alwaysLoad?: boolean;
         searchHint?: string;
+        longRunning?: boolean;
       } = {
         name: id,
         description: def?.description ?? "",
@@ -96,6 +97,7 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
       if (def?.outputHint) entry.outputHint = def.outputHint;
       if (def?.alwaysLoad) entry.alwaysLoad = true;
       if (def?.searchHint) entry.searchHint = def.searchHint;
+      if (def?.longRunning) entry.longRunning = true;
       return entry;
     });
     res.json({ tools });

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { Registry, ToolDefinition } from "@argent/registry";
-import { getFlowPath, getActiveFlow, appendStep } from "./flow-utils";
+import { getFlowPath, getActiveFlow, appendStep, type FlowStep } from "./flow-utils";
 
 const zodSchema = z.object({
   command: z.string().describe('MCP tool name (e.g. "tap", "screenshot", "launch-app")'),
@@ -10,6 +10,12 @@ const zodSchema = z.object({
     .describe(
       'Tool arguments as a JSON string, e.g. \'{"udid": "ABC", "x": 0.5, "y": 0.3}\'. Omit for tools with no arguments.'
     ),
+  delayMs: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Milliseconds to sleep before executing this step during replay."),
 });
 
 export function createFlowAddStepTool(
@@ -30,11 +36,9 @@ export function createFlowAddStepTool(
 
       const toolResult = await registry.invokeTool(params.command, args);
 
-      const flowFile = await appendStep(filePath, {
-        kind: "tool",
-        name: params.command,
-        args,
-      });
+      const step: FlowStep = { kind: "tool", name: params.command, args };
+      if (params.delayMs !== undefined) step.delayMs = params.delayMs;
+      const flowFile = await appendStep(filePath, step);
 
       return {
         message: `Step added to "${flowName}" flow`,

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { Registry, ToolDefinition } from "@argent/registry";
-import { getFlowPath, getActiveFlow, appendStep, type FlowStep } from "./flow-utils";
+import { getFlowPath, getActiveFlow, appendStep } from "./flow-utils";
 
 const zodSchema = z.object({
   command: z.string().describe('MCP tool name (e.g. "tap", "screenshot", "launch-app")'),
@@ -36,9 +36,12 @@ export function createFlowAddStepTool(
 
       const toolResult = await registry.invokeTool(params.command, args);
 
-      const step: FlowStep = { kind: "tool", name: params.command, args };
-      if (params.delayMs !== undefined) step.delayMs = params.delayMs;
-      const flowFile = await appendStep(filePath, step);
+      const flowFile = await appendStep(filePath, {
+        kind: "tool",
+        name: params.command,
+        args,
+        delayMs: params.delayMs,
+      });
 
       return {
         message: `Step added to "${flowName}" flow`,

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -78,6 +78,8 @@ Use flow-read-prerequisite to inspect the prerequisite beforehand.`,
           continue;
         }
 
+        if (step.delayMs) await sleep(step.delayMs);
+
         const toolDef = registry.getTool(step.name);
 
         try {

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import * as fs from "node:fs/promises";
 import type { Registry, ToolDefinition } from "@argent/registry";
 import { getFlowPath, parseFlow, setActiveProjectRoot, type FlowStep } from "./flow-utils";
-import { sleep, DEFAULT_INTER_STEP_DELAY_MS } from "../../utils/timing";
+import { sleep } from "../../utils/timing";
 
 const zodSchema = z.object({
   name: z.string().describe('Name of the flow to run (e.g. "settings-explore")'),
@@ -50,6 +50,7 @@ Fails if the flow file does not exist or a step tool raises an error (execution 
 If the flow has an execution prerequisite and prerequisiteAcknowledged is not
 set to true, the tool returns a notice with the prerequisite instead of running.
 Use flow-read-prerequisite to inspect the prerequisite beforehand.`,
+    longRunning: true,
     zodSchema,
     services: () => ({}),
     async execute(_services, params) {
@@ -95,8 +96,6 @@ Use flow-read-prerequisite to inspect the prerequisite beforehand.`,
           steps.push({ kind: "tool", tool: step.name, error });
           break;
         }
-
-        await sleep(DEFAULT_INTER_STEP_DELAY_MS);
       }
 
       return {

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -43,7 +43,8 @@ export function createRunFlowTool(
     id: "flow-execute",
     description: `Run a saved flow from the .argent/flows/ directory.
 Each step is executed in order: tool calls are dispatched through the registry,
-echo steps print a message. Returns the result of every step, including images.
+echo steps print a message. A tool step may carry \`delayMs: <ms>\` to sleep
+that long before the step runs. Returns the result of every step, including images.
 Use when you want to replay a recorded flow or run a scripted sequence of simulator actions.
 Fails if the flow file does not exist or a step tool raises an error (execution stops at that step).
 

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -2,8 +2,7 @@ import { z } from "zod";
 import * as fs from "node:fs/promises";
 import type { Registry, ToolDefinition } from "@argent/registry";
 import { getFlowPath, parseFlow, setActiveProjectRoot, type FlowStep } from "./flow-utils";
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+import { sleep, DEFAULT_INTER_STEP_DELAY_MS } from "../../utils/timing";
 
 const zodSchema = z.object({
   name: z.string().describe('Name of the flow to run (e.g. "settings-explore")'),
@@ -95,7 +94,7 @@ Use flow-read-prerequisite to inspect the prerequisite beforehand.`,
           break;
         }
 
-        await sleep(100);
+        await sleep(DEFAULT_INTER_STEP_DELAY_MS);
       }
 
       return {

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -3,6 +3,8 @@ import * as fs from "node:fs/promises";
 import type { Registry, ToolDefinition } from "@argent/registry";
 import { getFlowPath, parseFlow, setActiveProjectRoot, type FlowStep } from "./flow-utils";
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 const zodSchema = z.object({
   name: z.string().describe('Name of the flow to run (e.g. "settings-explore")'),
   project_root: z
@@ -92,6 +94,8 @@ Use flow-read-prerequisite to inspect the prerequisite beforehand.`,
           steps.push({ kind: "tool", tool: step.name, error });
           break;
         }
+
+        await sleep(100);
       }
 
       return {

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -66,7 +66,7 @@ export function clearActiveFlow(): void {
 // ── Types ────────────────────────────────────────────────────────────
 
 export type FlowStep =
-  | { kind: "tool"; name: string; args: Record<string, unknown> }
+  | { kind: "tool"; name: string; args: Record<string, unknown>; delayMs?: number }
   | { kind: "echo"; message: string };
 
 export type FlowFile = {
@@ -74,7 +74,9 @@ export type FlowFile = {
   steps: FlowStep[];
 };
 
-type YamlStep = { echo: string } | { tool: string; args?: Record<string, unknown> };
+type YamlStep =
+  | { echo: string }
+  | { tool: string; args?: Record<string, unknown>; delayMs?: number };
 
 type YamlFlowFile = {
   executionPrerequisite: string;
@@ -87,15 +89,21 @@ function toYamlStep(step: FlowStep): YamlStep {
   if (step.kind === "echo") {
     return { echo: step.message };
   }
-  const hasArgs = Object.keys(step.args).length > 0;
-  return hasArgs ? { tool: step.name, args: step.args } : { tool: step.name };
+  const yaml: { tool: string; args?: Record<string, unknown>; delayMs?: number } = {
+    tool: step.name,
+  };
+  if (Object.keys(step.args).length > 0) yaml.args = step.args;
+  if (step.delayMs !== undefined) yaml.delayMs = step.delayMs;
+  return yaml;
 }
 
 function fromYamlStep(raw: YamlStep): FlowStep {
   if ("echo" in raw) {
     return { kind: "echo", message: raw.echo };
   }
-  return { kind: "tool", name: raw.tool, args: raw.args ?? {} };
+  const step: FlowStep = { kind: "tool", name: raw.tool, args: raw.args ?? {} };
+  if (raw.delayMs !== undefined) step.delayMs = raw.delayMs;
+  return step;
 }
 
 // ── Serialisation ────────────────────────────────────────────────────

--- a/packages/tool-server/src/tools/gesture-pinch/index.ts
+++ b/packages/tool-server/src/tools/gesture-pinch/index.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import type { ToolCapability, ToolDefinition } from "@argent/registry";
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
-import { sleep, sendTouchEvent } from "../../utils/gesture-utils";
+import { sendTouchEvent } from "../../utils/gesture-utils";
+import { sleep } from "../../utils/timing";
 
 const zodSchema = z.object({
   udid: z.string().describe("Target device id from `list-devices` (iOS UDID or Android serial)."),

--- a/packages/tool-server/src/tools/gesture-rotate/index.ts
+++ b/packages/tool-server/src/tools/gesture-rotate/index.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import type { ToolCapability, ToolDefinition } from "@argent/registry";
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
-import { sleep, sendTouchEvent } from "../../utils/gesture-utils";
+import { sendTouchEvent } from "../../utils/gesture-utils";
+import { sleep } from "../../utils/timing";
 
 const zodSchema = z.object({
   udid: z.string().describe("Target device id from `list-devices` (iOS UDID or Android serial)."),

--- a/packages/tool-server/src/tools/run-sequence/index.ts
+++ b/packages/tool-server/src/tools/run-sequence/index.ts
@@ -2,8 +2,7 @@ import { z } from "zod";
 import type { Registry, ToolCapability, ToolDefinition } from "@argent/registry";
 import { simulatorServerRef } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+import { sleep, DEFAULT_INTER_STEP_DELAY_MS } from "../../utils/timing";
 
 const ALLOWED_TOOLS = new Set([
   "gesture-tap",
@@ -36,7 +35,9 @@ const zodSchema = z.object({
         delayMs: z
           .number()
           .optional()
-          .describe("Wait time in ms after this step before the next (default 100)"),
+          .describe(
+            `Wait time in ms after this step before the next (default ${DEFAULT_INTER_STEP_DELAY_MS})`
+          ),
       })
     )
     .min(1)
@@ -135,7 +136,7 @@ Stops on the first error and returns partial results.`,
           break;
         }
 
-        const delay = step.delayMs ?? 100;
+        const delay = step.delayMs ?? DEFAULT_INTER_STEP_DELAY_MS;
         if (delay > 0) await sleep(delay);
       }
 

--- a/packages/tool-server/src/tools/run-sequence/index.ts
+++ b/packages/tool-server/src/tools/run-sequence/index.ts
@@ -105,6 +105,7 @@ Example — type text and submit:
 
 Stops on the first error and returns partial results.`,
     alwaysLoad: true,
+    longRunning: true,
     searchHint: "batch sequence multiple gesture steps sequentially",
     zodSchema,
     capability,

--- a/packages/tool-server/src/utils/gesture-utils.ts
+++ b/packages/tool-server/src/utils/gesture-utils.ts
@@ -1,8 +1,6 @@
 import type { SimulatorServerApi } from "../blueprints/simulator-server";
 import { sendCommand } from "./simulator-client";
 
-export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
 interface TouchPoint {
   x: number;
   y: number;

--- a/packages/tool-server/src/utils/timing.ts
+++ b/packages/tool-server/src/utils/timing.ts
@@ -1,0 +1,3 @@
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export const DEFAULT_INTER_STEP_DELAY_MS = 100;

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Registry } from "../../../registry/src/index";
+import type { Registry } from "@argent/registry";
 
 import { flowStartRecordingTool } from "../../src/tools/flows/flow-start-recording";
 import { flowInsertEchoTool } from "../../src/tools/flows/flow-insert-echo";

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -728,6 +728,27 @@ describe("flow-execute", () => {
     });
   });
 
+  it("sleeps 100ms after each successful tool step", async () => {
+    const registry = createMockRegistry({ tap: { result: { tapped: true } } });
+    const runFlow = createRunFlowTool(registry);
+    const dir = path.join(tmpDir, ".argent", "flows");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "delay.yaml"),
+      serializeFlow({
+        executionPrerequisite: "",
+        steps: [
+          { kind: "tool", name: "tap", args: { x: 0.1 } },
+          { kind: "tool", name: "tap", args: { x: 0.2 } },
+          { kind: "tool", name: "tap", args: { x: 0.3 } },
+        ],
+      })
+    );
+    const start = Date.now();
+    await runFlow.execute({}, { name: "delay", project_root: tmpDir });
+    expect(Date.now() - start).toBeGreaterThanOrEqual(290);
+  });
+
   it("does not interfere with active recording state", async () => {
     const registry = createMockRegistry({
       tap: { result: { ok: true } },

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -745,27 +745,6 @@ describe("flow-execute", () => {
     expect(Date.now() - start).toBeGreaterThanOrEqual(290);
   });
 
-  it("sleeps 100ms after each successful tool step", async () => {
-    const registry = createMockRegistry({ tap: { result: { tapped: true } } });
-    const runFlow = createRunFlowTool(registry);
-    const dir = path.join(tmpDir, ".argent", "flows");
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(
-      path.join(dir, "delay.yaml"),
-      serializeFlow({
-        executionPrerequisite: "",
-        steps: [
-          { kind: "tool", name: "tap", args: { x: 0.1 } },
-          { kind: "tool", name: "tap", args: { x: 0.2 } },
-          { kind: "tool", name: "tap", args: { x: 0.3 } },
-        ],
-      })
-    );
-    const start = Date.now();
-    await runFlow.execute({}, { name: "delay", project_root: tmpDir });
-    expect(Date.now() - start).toBeGreaterThanOrEqual(290);
-  });
-
   it("does not interfere with active recording state", async () => {
     const registry = createMockRegistry({
       tap: { result: { ok: true } },

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -728,6 +728,23 @@ describe("flow-execute", () => {
     });
   });
 
+  it("sleeps the step's delayMs before executing it", async () => {
+    const registry = createMockRegistry({ tap: { result: { tapped: true } } });
+    const runFlow = createRunFlowTool(registry);
+    const dir = path.join(tmpDir, ".argent", "flows");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "pre-delay.yaml"),
+      serializeFlow({
+        executionPrerequisite: "",
+        steps: [{ kind: "tool", name: "tap", args: { x: 0.5 }, delayMs: 300 }],
+      })
+    );
+    const start = Date.now();
+    await runFlow.execute({}, { name: "pre-delay", project_root: tmpDir });
+    expect(Date.now() - start).toBeGreaterThanOrEqual(290);
+  });
+
   it("sleeps 100ms after each successful tool step", async () => {
     const registry = createMockRegistry({ tap: { result: { tapped: true } } });
     const runFlow = createRunFlowTool(registry);


### PR DESCRIPTION
- Tool steps in a flow YAML may carry an optional `delayMs` that sleeps that long *before* the step runs; `flow-add-step` exposes the same field.
- New `longRunning?: boolean` field on `ToolDefinition`; when set, the MCP fetch wrapper bypasses its 30s per-request timeout (`fetchTimeoutMs: null`) so long invocations aren't aborted. `run-sequence` and `flow-execute` opt in.