### PR TITLE
fix(registry): emit JSON Schema type for ZodDefault fields

### DIFF
--- a/packages/registry/src/zod-to-json-schema.ts
+++ b/packages/registry/src/zod-to-json-schema.ts
@@ -24,6 +24,9 @@ function zodTypeToJsonSchema(type: z.ZodTypeAny): Record<string, unknown> {
   if (type instanceof z.ZodNumber) return { type: "number" };
   if (type instanceof z.ZodBoolean) return { type: "boolean" };
   if (type instanceof z.ZodOptional) return zodTypeToJsonSchema(type.unwrap());
+  if (type instanceof z.ZodDefault) {
+    return { ...zodTypeToJsonSchema(type._def.innerType), default: type._def.defaultValue() };
+  }
   if (type instanceof z.ZodArray) {
     return { type: "array", items: zodTypeToJsonSchema(type.element) };
   }
@@ -40,5 +43,5 @@ function zodTypeToJsonSchema(type: z.ZodTypeAny): Record<string, unknown> {
 }
 
 function isOptional(type: z.ZodTypeAny): boolean {
-  return type instanceof z.ZodOptional;
+  return type instanceof z.ZodOptional || type instanceof z.ZodDefault;
 }

--- a/packages/registry/tests/zod-to-json-schema.test.ts
+++ b/packages/registry/tests/zod-to-json-schema.test.ts
@@ -35,7 +35,7 @@ describe("zodObjectToJsonSchema", () => {
 
   it("emits number type for z.coerce.number().int().positive().default(100)", () => {
     const schema = zodObjectToJsonSchema(
-      z.object({ sample_interval_us: z.coerce.number().int().positive().default(100) }),
+      z.object({ sample_interval_us: z.coerce.number().int().positive().default(100) })
     );
     expect((schema.properties as any).sample_interval_us).toEqual({ type: "number", default: 100 });
     expect(schema.required).toBeUndefined();
@@ -48,7 +48,7 @@ describe("zodObjectToJsonSchema", () => {
         port: z.number().default(8081),
         force: z.boolean().default(false),
         label: z.string().optional(),
-      }),
+      })
     );
     expect(schema).toEqual({
       type: "object",

--- a/packages/registry/tests/zod-to-json-schema.test.ts
+++ b/packages/registry/tests/zod-to-json-schema.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { zodObjectToJsonSchema } from "../src/zod-to-json-schema";
+
+describe("zodObjectToJsonSchema", () => {
+  it("emits number type and marks field required for z.number()", () => {
+    const schema = zodObjectToJsonSchema(z.object({ value: z.number() }));
+    expect((schema.properties as any).value).toEqual({ type: "number" });
+    expect(schema.required).toEqual(["value"]);
+  });
+
+  it("emits boolean type and marks field required for z.boolean()", () => {
+    const schema = zodObjectToJsonSchema(z.object({ value: z.boolean() }));
+    expect((schema.properties as any).value).toEqual({ type: "boolean" });
+    expect(schema.required).toEqual(["value"]);
+  });
+
+  it("emits string type and omits optional field from required", () => {
+    const schema = zodObjectToJsonSchema(z.object({ value: z.string().optional() }));
+    expect((schema.properties as any).value).toEqual({ type: "string" });
+    expect(schema.required).toBeUndefined();
+  });
+
+  it("emits number type with default and omits defaulted field from required", () => {
+    const schema = zodObjectToJsonSchema(z.object({ port: z.number().default(8081) }));
+    expect((schema.properties as any).port).toEqual({ type: "number", default: 8081 });
+    expect(schema.required).toBeUndefined();
+  });
+
+  it("emits boolean type with default and omits defaulted field from required", () => {
+    const schema = zodObjectToJsonSchema(z.object({ force: z.boolean().default(false) }));
+    expect((schema.properties as any).force).toEqual({ type: "boolean", default: false });
+    expect(schema.required).toBeUndefined();
+  });
+
+  it("emits number type for z.coerce.number().int().positive().default(100)", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({ sample_interval_us: z.coerce.number().int().positive().default(100) }),
+    );
+    expect((schema.properties as any).sample_interval_us).toEqual({ type: "number", default: 100 });
+    expect(schema.required).toBeUndefined();
+  });
+
+  it("produces expected JSON Schema for a mixed object with required/optional/default fields", () => {
+    const schema = zodObjectToJsonSchema(
+      z.object({
+        name: z.string(),
+        port: z.number().default(8081),
+        force: z.boolean().default(false),
+        label: z.string().optional(),
+      }),
+    );
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        port: { type: "number", default: 8081 },
+        force: { type: "boolean", default: false },
+        label: { type: "string" },
+      },
+      required: ["name"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`zodTypeToJsonSchema` in `packages/registry/src/zod-to-json-schema.ts` did not handle `z.ZodDefault`. Any tool input field declared as `z.X().default(...)` fell through to `{}`, dropping the type. Downstream, the MCP harness sent values for those fields as strings, and the tool-server's strict Zod validators rejected them with `Expected number, received string` / `Expected boolean, received string`.

Also fixes a related issue in the same file: `isOptional` returned `false` for `ZodDefault`, so defaulted fields were pushed into `required` even though the caller doesn't have to provide them.

Tools that misbehave in practice today because of this and start working after this fix:
- `stop-metro` — `port`
- `react-profiler-start` — `port`, `force`, `sample_interval_us`
- `debugger-component-tree` — `onScreenOnly`, `includeSkipped`

(Reproduced against the published `argent 0.6.1` MCP server while profiling an Expo app — the `argent run <tool> --args '<json>'` CLI path is unaffected because it doesn't go through the published JSON Schema.)

## Changes

- `packages/registry/src/zod-to-json-schema.ts`: handle `ZodDefault` (recurse into `_def.innerType`, attach `default: defaultValue()`); treat `ZodDefault` as optional.
- `packages/registry/tests/zod-to-json-schema.test.ts`: new file. Covers `z.number()`, `z.boolean()`, `z.string().optional()`, `z.number().default(...)`, `z.boolean().default(...)`, `z.coerce.number().int().positive().default(...)`, and a mixed-object happy path.

## Test plan

- [x] `npx vitest run` in `packages/registry` — 64 passed, 0 failed (4 files; the new test file contributes 7 cases).
- [ ] Reviewer sanity check: load the rebuilt MCP server and confirm a tool with a `.default(...)` numeric/boolean field now publishes the correct \`type\` in its input schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)