### PR TITLE
feat: add link and unlink commands for remote tool-server management

### DIFF
--- a/packages/argent-cli/package.json
+++ b/packages/argent-cli/package.json
@@ -11,7 +11,9 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@argent/tools-client": "file:../argent-tools-client"
+    "@argent/tools-client": "file:../argent-tools-client",
+    "@clack/prompts": "^1.1.0",
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/argent-cli/src/index.ts
+++ b/packages/argent-cli/src/index.ts
@@ -1,3 +1,4 @@
 export { run, type RunCommandOptions } from "./run.js";
 export { tools, type ToolsCommandOptions } from "./tools.js";
 export { server } from "./server.js";
+export { link, unlink } from "./link.js";

--- a/packages/argent-cli/src/link.ts
+++ b/packages/argent-cli/src/link.ts
@@ -1,0 +1,458 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import {
+  readLinkConfig,
+  writeLinkConfig,
+  clearLinkConfig,
+  formatToolsServerUrl,
+  type LinkConfig,
+} from "@argent/tools-client";
+import { parsePort, StartFlagError } from "./server.js";
+
+interface LinkFlags {
+  host: string | null;
+  port: number | null;
+  yes: boolean;
+  noVerify: boolean;
+  help: boolean;
+}
+
+interface UnlinkFlags {
+  yes: boolean;
+  help: boolean;
+}
+
+const WILDCARD_HOSTS = new Set(["0.0.0.0", "::", "::0", ""]);
+
+function isLoopback(host: string): boolean {
+  return host === "127.0.0.1" || host === "localhost" || host === "::1";
+}
+
+function validateHost(raw: string): string {
+  const trimmed = raw.trim();
+  if (WILDCARD_HOSTS.has(trimmed)) {
+    throw new StartFlagError(
+      `--host ${trimmed === "" ? '""' : trimmed} is a bind address, not a connect address — use 127.0.0.1 or the actual reachable host.`
+    );
+  }
+  return trimmed;
+}
+
+function validateConnectPort(raw: string): number {
+  // Reuse parsePort for digits/range, then additionally reject 0 — you can
+  // bind to "pick a free port" but never connect to port 0.
+  const port = parsePort(raw);
+  if (port === 0) {
+    throw new StartFlagError(`--port must be 1..65535 for a connect target, got "${raw}"`);
+  }
+  return port;
+}
+
+export function parseLinkFlags(argv: string[]): LinkFlags {
+  const flags: LinkFlags = {
+    host: null,
+    port: null,
+    yes: false,
+    noVerify: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i]!;
+    const takeValue = (name: string): string => {
+      const v = argv[i + 1];
+      if (v === undefined) throw new StartFlagError(`${name} requires a value`);
+      i += 1;
+      return v;
+    };
+    if (tok === "--help" || tok === "-h") {
+      flags.help = true;
+      continue;
+    }
+    if (tok === "--yes" || tok === "-y") {
+      flags.yes = true;
+      continue;
+    }
+    if (tok === "--no-verify") {
+      flags.noVerify = true;
+      continue;
+    }
+    if (tok === "--host") {
+      flags.host = validateHost(takeValue("--host"));
+      continue;
+    }
+    if (tok.startsWith("--host=")) {
+      flags.host = validateHost(tok.slice("--host=".length));
+      continue;
+    }
+    if (tok === "--port" || tok === "-p") {
+      flags.port = validateConnectPort(takeValue("--port"));
+      continue;
+    }
+    if (tok.startsWith("--port=")) {
+      flags.port = validateConnectPort(tok.slice("--port=".length));
+      continue;
+    }
+    throw new StartFlagError(`Unknown flag: ${tok}`);
+  }
+
+  return flags;
+}
+
+export function parseUnlinkFlags(argv: string[]): UnlinkFlags {
+  const flags: UnlinkFlags = { yes: false, help: false };
+  for (const tok of argv) {
+    if (tok === "--help" || tok === "-h") {
+      flags.help = true;
+      continue;
+    }
+    if (tok === "--yes" || tok === "-y") {
+      flags.yes = true;
+      continue;
+    }
+    throw new StartFlagError(`Unknown flag: ${tok}`);
+  }
+  return flags;
+}
+
+export function printLinkHelp(): void {
+  console.log(`Usage: argent link [flags]
+
+Route argent client requests (argent tools / run / mcp) to a remote tool-server
+instead of auto-spawning a local one. The target is persisted to ~/.argent/link.json
+and survives shell restarts.
+
+Resolution order for the tool-server URL:
+  1. ARGENT_TOOLS_URL environment variable (highest precedence)
+  2. ~/.argent/link.json (this command)
+  3. Auto-spawn a local tool-server (default)
+
+Flags:
+  --host <h>        Remote host or IP to connect to. Prompts interactively if
+                    omitted. Wildcards (0.0.0.0, ::) are bind addresses, not
+                    connect targets, and are rejected — use 127.0.0.1 or the
+                    actual reachable host.
+  --port, -p <n>    Remote port (1..65535). Defaults to 3001. Prompts if omitted.
+  --no-verify       Skip the pre-flight GET /tools health check.
+  --yes, -y         Non-interactive. Requires --host (port defaults to 3001).
+                    Fails if --host is missing.
+  --help, -h        Show this help.
+
+Examples:
+  argent link                                Interactive prompts for host and port.
+  argent link --host 10.0.0.42 --port 3001   Confirms interactively, then saves.
+  argent link --host 10.0.0.42 --yes         Saves without confirmation.
+  argent link --host 10.0.0.42 --yes --no-verify
+                                             Saves immediately, no health check.
+
+Security:
+  This command does not configure authentication, TLS, or CORS. Treat any
+  non-loopback link as trusted-network-only.
+
+Notes:
+  - If ARGENT_TOOLS_URL is also set in your environment, it overrides the link.
+  - To stop using the remote target, run \`argent unlink\`.
+  - \`argent server start/stop/status\` manage the local tool-server lifecycle
+    and are unaffected by linking.
+  - Restart your editor (Claude / Cursor / VS Code) afterwards — a running
+    \`argent mcp\` process caches the target at startup and won't pick up the
+    new link until it's relaunched.
+`);
+}
+
+export function printUnlinkHelp(): void {
+  console.log(`Usage: argent unlink [flags]
+
+Remove the persisted remote tool-server link (~/.argent/link.json) and return
+to default local auto-spawn behaviour.
+
+Flags:
+  --yes, -y     Skip the confirmation prompt.
+  --help, -h    Show this help.
+
+Examples:
+  argent unlink         Confirms, then removes the link.
+  argent unlink --yes   Removes without confirmation. Safe in scripts.
+
+Notes:
+  - No-op (exit 0) if no link is currently set.
+  - If ARGENT_TOOLS_URL is also set in your environment, it still takes
+    precedence after unlinking — unset it manually for fully local behaviour.
+  - This does not stop or start any tool-server process. Use
+    \`argent server stop\` if you also want to terminate a running local server.
+  - Restart your editor afterwards — a running \`argent mcp\` process won't
+    revert to local auto-spawn until it's relaunched.
+`);
+}
+
+async function promptHost(existing: LinkConfig | null, initial?: string): Promise<string> {
+  const hostInput = await p.text({
+    message: "Remote host or IP to connect to",
+    placeholder: existing?.host ?? "127.0.0.1",
+    initialValue: initial ?? existing?.host,
+    validate(value) {
+      if (!value || !value.trim()) return "Host cannot be empty.";
+      const trimmed = value.trim();
+      if (WILDCARD_HOSTS.has(trimmed)) {
+        return `${trimmed} is a bind address, not a connect address — use 127.0.0.1 or the actual reachable host.`;
+      }
+    },
+  });
+  if (p.isCancel(hostInput)) {
+    p.cancel("Link cancelled.");
+    process.exit(0);
+  }
+  return (hostInput as string).trim();
+}
+
+async function promptPort(existing: LinkConfig | null, initial?: number): Promise<number> {
+  const defaultPort = initial ?? existing?.port ?? 3001;
+  const portInput = await p.text({
+    message: "Remote port",
+    placeholder: String(defaultPort),
+    initialValue: String(defaultPort),
+    validate(value) {
+      if (!value || !value.trim()) return "Port cannot be empty.";
+      try {
+        validateConnectPort(value.trim());
+      } catch (err) {
+        if (err instanceof StartFlagError) return err.message;
+        throw err;
+      }
+    },
+  });
+  if (p.isCancel(portInput)) {
+    p.cancel("Link cancelled.");
+    process.exit(0);
+  }
+  return validateConnectPort((portInput as string).trim());
+}
+
+async function preflightHealth(url: string): Promise<{ ok: boolean; error?: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3_000);
+  try {
+    const res = await fetch(`${url}/tools`, { signal: controller.signal });
+    if (!res.ok) return { ok: false, error: `${res.status} ${res.statusText}` };
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function printRestartHint(): void {
+  console.log(
+    pc.dim(
+      "Restart your editor to apply the change to any running `argent mcp` session."
+    )
+  );
+}
+
+function printSecurityCaveat(host: string): void {
+  if (isLoopback(host)) return;
+  process.stderr.write(
+    pc.yellow(
+      `WARNING: linked target ${host} is non-loopback — tool calls travel over plain HTTP ` +
+        `with no auth. Treat this link as trusted-network-only.\n`
+    )
+  );
+}
+
+export async function link(argv: string[]): Promise<void> {
+  let flags: LinkFlags;
+  try {
+    flags = parseLinkFlags(argv);
+  } catch (err) {
+    if (err instanceof StartFlagError) {
+      console.error(`Error: ${err.message}\n`);
+      printLinkHelp();
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  if (flags.help) {
+    printLinkHelp();
+    return;
+  }
+
+  if (flags.yes && flags.host === null) {
+    console.error("Error: --yes requires --host (port defaults to 3001).\n");
+    printLinkHelp();
+    process.exit(2);
+  }
+
+  const existing = await readLinkConfig();
+
+  // Resolve host
+  let host: string;
+  if (flags.host !== null) {
+    host = flags.host;
+  } else {
+    p.intro(pc.bgCyan(pc.black(" argent link ")));
+    if (existing) {
+      p.log.info(`Current link: ${pc.cyan(existing.url)} (${existing.createdAt})`);
+    }
+    host = await promptHost(existing);
+  }
+
+  // Resolve port
+  let port: number;
+  if (flags.port !== null) {
+    port = flags.port;
+  } else if (flags.yes) {
+    // --yes with --host but no --port → default 3001
+    port = 3001;
+  } else {
+    port = await promptPort(existing);
+  }
+
+  let url = formatToolsServerUrl(host, port);
+
+  // Overwrite confirmation (interactive only)
+  if (!flags.yes && existing) {
+    if (existing.url === url) {
+      p.log.info(`Already linked to ${pc.cyan(url)}.`);
+      p.outro("No changes.");
+      return;
+    }
+    const overwrite = await p.confirm({
+      message: `Replace existing link ${pc.dim(existing.url)} with ${pc.cyan(url)}?`,
+      initialValue: true,
+    });
+    if (p.isCancel(overwrite) || !overwrite) {
+      p.cancel("Link cancelled.");
+      process.exit(0);
+    }
+  }
+
+  // Pre-flight health check (unless --no-verify)
+  if (!flags.noVerify) {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const spinnerActive = !flags.yes;
+      let spinner: ReturnType<typeof p.spinner> | null = null;
+      if (spinnerActive) {
+        spinner = p.spinner();
+        spinner.start(`Verifying tool-server at ${url}...`);
+      }
+      const result = await preflightHealth(url);
+      if (result.ok) {
+        if (spinner) spinner.stop(pc.green("Tool-server reachable."));
+        break;
+      }
+
+      if (spinner) spinner.stop(pc.red("Verification failed."));
+      const detail = result.error ? ` (${result.error})` : "";
+
+      if (flags.yes) {
+        // Non-interactive: can't prompt, keep original fail-fast behaviour.
+        console.error(
+          `Error: pre-flight GET ${url}/tools failed${detail}. ` +
+            `Make sure the remote tool-server is running, or pass --no-verify to skip.`
+        );
+        process.exit(1);
+      }
+
+      p.log.error(`pre-flight GET ${url}/tools failed${detail}.`);
+
+      const action = await p.select({
+        message: "How would you like to proceed?",
+        options: [
+          { value: "retry", label: "Retry verification" },
+          { value: "modify", label: "Modify host and port, then retry" },
+          { value: "skip", label: "Skip verification and save anyway" },
+          { value: "cancel", label: "Cancel" },
+        ],
+        initialValue: "retry",
+      });
+
+      if (p.isCancel(action) || action === "cancel") {
+        p.cancel("Link cancelled.");
+        process.exit(0);
+      }
+      if (action === "skip") break;
+      if (action === "modify") {
+        host = await promptHost(existing, host);
+        port = await promptPort(existing, port);
+        url = formatToolsServerUrl(host, port);
+      }
+      // "retry" (or after "modify") loops and re-runs preflightHealth.
+    }
+  }
+
+  const cfg: LinkConfig = {
+    url,
+    host,
+    port,
+    createdAt: new Date().toISOString(),
+  };
+  await writeLinkConfig(cfg);
+
+  if (existing && existing.url !== url) {
+    console.log(`${pc.green("✓")} Link updated: ${pc.dim(existing.url)} → ${pc.cyan(url)}`);
+  } else {
+    console.log(`${pc.green("✓")} Linked: ${pc.cyan(url)}`);
+  }
+  printSecurityCaveat(host);
+  if (process.env.ARGENT_TOOLS_URL) {
+    console.log(
+      pc.yellow(
+        `Note: ARGENT_TOOLS_URL=${process.env.ARGENT_TOOLS_URL} is set in your environment ` +
+          `and takes precedence over the link.`
+      )
+    );
+  }
+  printRestartHint();
+}
+
+export async function unlink(argv: string[]): Promise<void> {
+  let flags: UnlinkFlags;
+  try {
+    flags = parseUnlinkFlags(argv);
+  } catch (err) {
+    if (err instanceof StartFlagError) {
+      console.error(`Error: ${err.message}\n`);
+      printUnlinkHelp();
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  if (flags.help) {
+    printUnlinkHelp();
+    return;
+  }
+
+  const existing = await readLinkConfig();
+  if (!existing) {
+    console.log("Not currently linked — already using local tool-server.");
+    return;
+  }
+
+  if (!flags.yes) {
+    const confirmed = await p.confirm({
+      message: `Remove link to ${pc.cyan(existing.url)}?`,
+      initialValue: true,
+    });
+    if (p.isCancel(confirmed) || !confirmed) {
+      p.cancel("Unlink cancelled.");
+      process.exit(0);
+    }
+  }
+
+  await clearLinkConfig();
+
+  console.log(`${pc.green("✓")} Unlinked from ${pc.dim(existing.url)}.`);
+  if (process.env.ARGENT_TOOLS_URL) {
+    console.log(
+      pc.yellow(
+        `The env var ARGENT_TOOLS_URL is also set in your shell (=${process.env.ARGENT_TOOLS_URL}) ` +
+          `and takes precedence — unset it manually if you want fully local behaviour.`
+      )
+    );
+  }
+  printRestartHint();
+}

--- a/packages/argent-cli/src/link.ts
+++ b/packages/argent-cli/src/link.ts
@@ -244,9 +244,7 @@ async function preflightHealth(url: string): Promise<{ ok: boolean; error?: stri
 
 function printRestartHint(): void {
   console.log(
-    pc.dim(
-      "Restart your editor to apply the change to any running `argent mcp` session."
-    )
+    pc.dim("Restart your editor to apply the change to any running `argent mcp` session.")
   );
 }
 

--- a/packages/argent-cli/test/parse-link-flags.test.ts
+++ b/packages/argent-cli/test/parse-link-flags.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { parseLinkFlags, parseUnlinkFlags } from "../src/link.js";
+import { StartFlagError } from "../src/server.js";
+
+describe("parseLinkFlags — defaults", () => {
+  it("returns documented defaults for an empty argv", () => {
+    expect(parseLinkFlags([])).toEqual({
+      host: null,
+      port: null,
+      yes: false,
+      noVerify: false,
+      help: false,
+    });
+  });
+});
+
+describe("parseLinkFlags — flag forms", () => {
+  it("parses --host in space and equals form", () => {
+    expect(parseLinkFlags(["--host", "10.0.0.42"]).host).toBe("10.0.0.42");
+    expect(parseLinkFlags(["--host=10.0.0.42"]).host).toBe("10.0.0.42");
+  });
+
+  it("parses --port/-p in space and equals form", () => {
+    expect(parseLinkFlags(["--port", "4000"]).port).toBe(4000);
+    expect(parseLinkFlags(["-p", "4000"]).port).toBe(4000);
+    expect(parseLinkFlags(["--port=4000"]).port).toBe(4000);
+  });
+
+  it("parses boolean flags --yes/-y, --no-verify, --help/-h", () => {
+    expect(parseLinkFlags(["--yes"]).yes).toBe(true);
+    expect(parseLinkFlags(["-y"]).yes).toBe(true);
+    expect(parseLinkFlags(["--no-verify"]).noVerify).toBe(true);
+    expect(parseLinkFlags(["--help"]).help).toBe(true);
+    expect(parseLinkFlags(["-h"]).help).toBe(true);
+  });
+
+  it("combines multiple flags in a single invocation", () => {
+    const flags = parseLinkFlags(["--host", "10.0.0.42", "--port=4567", "--yes", "--no-verify"]);
+    expect(flags).toEqual({
+      host: "10.0.0.42",
+      port: 4567,
+      yes: true,
+      noVerify: true,
+      help: false,
+    });
+  });
+});
+
+describe("parseLinkFlags — error paths", () => {
+  it("throws StartFlagError on unknown flags", () => {
+    expect(() => parseLinkFlags(["--bogus"])).toThrow(StartFlagError);
+    expect(() => parseLinkFlags(["--bogus"])).toThrow(/Unknown flag: --bogus/);
+  });
+
+  it("throws when a value-taking flag is missing its value", () => {
+    expect(() => parseLinkFlags(["--host"])).toThrow(/--host requires a value/);
+    expect(() => parseLinkFlags(["--port"])).toThrow(/--port requires a value/);
+    expect(() => parseLinkFlags(["-p"])).toThrow(/--port requires a value/);
+  });
+
+  it("does not consume the next token as a value for boolean flags", () => {
+    // `--yes` must NOT swallow the next token; here `--no-verify` is a separate flag.
+    expect(parseLinkFlags(["--yes", "--no-verify"])).toMatchObject({
+      yes: true,
+      noVerify: true,
+    });
+  });
+});
+
+describe("parseLinkFlags — host validation (wildcard rejection)", () => {
+  // The four documented wildcards: empty, 0.0.0.0, ::, ::0.
+  // These are bind addresses, not connect targets — link() refuses them so
+  // users don't persist a target they can't reach.
+  it.each([["0.0.0.0"], ["::"], ["::0"], [""]])("rejects wildcard host %p", (wildcard) => {
+    expect(() => parseLinkFlags(["--host", wildcard])).toThrow(StartFlagError);
+    expect(() => parseLinkFlags(["--host", wildcard])).toThrow(
+      /bind address, not a connect address/
+    );
+  });
+
+  it("rejects wildcards in --host=value form too", () => {
+    expect(() => parseLinkFlags(["--host=0.0.0.0"])).toThrow(StartFlagError);
+    expect(() => parseLinkFlags(["--host=::"])).toThrow(StartFlagError);
+  });
+
+  it("trims whitespace before validating (so '  0.0.0.0  ' is still rejected)", () => {
+    expect(() => parseLinkFlags(["--host", "  0.0.0.0  "])).toThrow(
+      /bind address, not a connect address/
+    );
+  });
+
+  it("trims whitespace from valid hosts and stores the trimmed value", () => {
+    expect(parseLinkFlags(["--host", "  10.0.0.42  "]).host).toBe("10.0.0.42");
+  });
+
+  it("accepts normal loopback and routable hosts", () => {
+    expect(parseLinkFlags(["--host", "127.0.0.1"]).host).toBe("127.0.0.1");
+    expect(parseLinkFlags(["--host", "localhost"]).host).toBe("localhost");
+    expect(parseLinkFlags(["--host", "::1"]).host).toBe("::1");
+    expect(parseLinkFlags(["--host", "tools.example.com"]).host).toBe("tools.example.com");
+    expect(parseLinkFlags(["--host", "10.0.0.42"]).host).toBe("10.0.0.42");
+  });
+});
+
+describe("parseLinkFlags — port validation (connect-target rules)", () => {
+  // validateConnectPort intentionally diverges from parseStartFlags' parsePort:
+  // `server start --port 0` means "pick a free port", but you can never
+  // *connect* to port 0, so `link --port 0` must be rejected.
+  it("rejects port 0 (the bind-time 'pick a free port' sentinel)", () => {
+    expect(() => parseLinkFlags(["--port", "0"])).toThrow(StartFlagError);
+    expect(() => parseLinkFlags(["--port", "0"])).toThrow(/1\.\.65535/);
+    expect(() => parseLinkFlags(["--port=0"])).toThrow(StartFlagError);
+  });
+
+  it("accepts 1..65535", () => {
+    expect(parseLinkFlags(["--port", "1"]).port).toBe(1);
+    expect(parseLinkFlags(["--port", "3001"]).port).toBe(3001);
+    expect(parseLinkFlags(["--port", "65535"]).port).toBe(65535);
+  });
+
+  it("rejects out-of-range values (inherited from parsePort)", () => {
+    expect(() => parseLinkFlags(["--port", "65536"])).toThrow(/0\.\.65535/);
+    expect(() => parseLinkFlags(["--port", "-1"])).toThrow(StartFlagError);
+  });
+
+  it("rejects garbage values that parseInt would silently truncate", () => {
+    expect(() => parseLinkFlags(["--port", "123abc"])).toThrow(/got "123abc"/);
+    expect(() => parseLinkFlags(["--port", "3.14"])).toThrow(StartFlagError);
+  });
+});
+
+describe("parseUnlinkFlags", () => {
+  it("returns documented defaults for an empty argv", () => {
+    expect(parseUnlinkFlags([])).toEqual({ yes: false, help: false });
+  });
+
+  it("parses --yes/-y and --help/-h", () => {
+    expect(parseUnlinkFlags(["--yes"]).yes).toBe(true);
+    expect(parseUnlinkFlags(["-y"]).yes).toBe(true);
+    expect(parseUnlinkFlags(["--help"]).help).toBe(true);
+    expect(parseUnlinkFlags(["-h"]).help).toBe(true);
+  });
+
+  it("throws StartFlagError on unknown flags (no positional args allowed)", () => {
+    expect(() => parseUnlinkFlags(["--bogus"])).toThrow(StartFlagError);
+    expect(() => parseUnlinkFlags(["--bogus"])).toThrow(/Unknown flag: --bogus/);
+    // Unlink takes no positional args either — anything not --yes/--help fails.
+    expect(() => parseUnlinkFlags(["foo"])).toThrow(/Unknown flag: foo/);
+  });
+});

--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -4,7 +4,13 @@ import { homedir } from "node:os";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { Server } from "@modelcontextprotocol/sdk/server";
-import { ensureToolsServer, type ToolMeta, type ToolsServerPaths } from "@argent/tools-client";
+import {
+  ensureToolsServer,
+  getResolvedToolsUrl,
+  isRemoteRouted,
+  type ToolMeta,
+  type ToolsServerPaths,
+} from "@argent/tools-client";
 import { toMcpContent, flowRunToMcpContent, type FlowExecuteResult } from "./content.js";
 import {
   autoScreenshotEnabled,
@@ -69,8 +75,9 @@ export interface StartMcpServerOptions {
 
 export async function startMcpServer(options: StartMcpServerOptions): Promise<void> {
   let TOOLS_URL: string;
-  if (process.env.ARGENT_TOOLS_URL) {
-    TOOLS_URL = process.env.ARGENT_TOOLS_URL;
+  const resolved = await getResolvedToolsUrl();
+  if (resolved.url) {
+    TOOLS_URL = resolved.url;
   } else {
     try {
       TOOLS_URL = await ensureToolsServer(options.paths);
@@ -83,7 +90,7 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
   let reconnectPromise: Promise<void> | null = null;
 
   async function reconnect(): Promise<void> {
-    if (process.env.ARGENT_TOOLS_URL) return;
+    if (await isRemoteRouted()) return;
     if (!reconnectPromise) {
       reconnectPromise = ensureToolsServer(options.paths)
         .then((url) => {
@@ -258,8 +265,10 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
 
   await server.connect(new StdioServerTransport());
 
-  // Proactive health monitoring — restart tool server if it dies between requests
-  if (!process.env.ARGENT_TOOLS_URL) {
+  // Proactive health monitoring — restart tool server if it dies between requests.
+  // Only run for auto-spawned servers; remote-routed targets (env var or link)
+  // are the user's responsibility, and a silent local respawn would mask outages.
+  if (!(await isRemoteRouted())) {
     const HEALTH_INTERVAL_MS = 30_000;
     const healthInterval = setInterval(async () => {
       try {

--- a/packages/argent-tools-client/src/index.ts
+++ b/packages/argent-tools-client/src/index.ts
@@ -25,3 +25,15 @@ export {
   type ToolInvocationResult,
   type CreateToolsClientOptions,
 } from "./tools-client.js";
+
+export {
+  readLinkConfig,
+  writeLinkConfig,
+  clearLinkConfig,
+  getResolvedToolsUrl,
+  isRemoteRouted,
+  LINK_PATHS,
+  type LinkConfig,
+  type ResolvedToolsUrl,
+  type ToolsUrlSource,
+} from "./link-config.js";

--- a/packages/argent-tools-client/src/link-config.ts
+++ b/packages/argent-tools-client/src/link-config.ts
@@ -1,0 +1,101 @@
+import * as path from "node:path";
+import { homedir } from "node:os";
+import { mkdir, writeFile, readFile, unlink } from "node:fs/promises";
+
+const LINK_DIR = path.join(homedir(), ".argent");
+const LINK_FILE = path.join(LINK_DIR, "link.json");
+
+export interface LinkConfig {
+  /** Canonical resolved URL — readers consume this verbatim. */
+  url: string;
+  host: string;
+  port: number;
+  createdAt: string;
+}
+
+export async function readLinkConfig(): Promise<LinkConfig | null> {
+  try {
+    const raw = await readFile(LINK_FILE, "utf8");
+    const parsed = JSON.parse(raw) as Partial<LinkConfig>;
+    if (
+      !parsed ||
+      typeof parsed.url !== "string" ||
+      typeof parsed.host !== "string" ||
+      typeof parsed.port !== "number" ||
+      typeof parsed.createdAt !== "string"
+    ) {
+      return null;
+    }
+    return {
+      url: parsed.url,
+      host: parsed.host,
+      port: parsed.port,
+      createdAt: parsed.createdAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function writeLinkConfig(cfg: LinkConfig): Promise<void> {
+  await mkdir(LINK_DIR, { recursive: true });
+  await writeFile(LINK_FILE, JSON.stringify(cfg, null, 2) + "\n", "utf8");
+}
+
+export async function clearLinkConfig(): Promise<void> {
+  try {
+    await unlink(LINK_FILE);
+  } catch {
+    // already gone
+  }
+}
+
+export type ToolsUrlSource = "env" | "link" | "none";
+
+export interface ResolvedToolsUrl {
+  /** Resolved tool-server URL, or null when no override is configured. */
+  url: string | null;
+  /** Which configuration source produced this URL. */
+  source: ToolsUrlSource;
+  /**
+   * When `source === "env"` and a link file *also* exists, this holds the
+   * link config that was shadowed by the env var. Lets callers warn the user
+   * that their persisted link is currently being overridden — without changing
+   * precedence. Undefined in all other cases.
+   */
+  shadowedLink?: LinkConfig;
+}
+
+/**
+ * Resolution order:
+ *   1. ARGENT_TOOLS_URL env var (highest precedence) → source: "env"
+ *   2. ~/.argent/link.json                            → source: "link"
+ *   3. null                                           → source: "none"
+ *      (caller falls back to auto-spawn)
+ */
+export async function getResolvedToolsUrl(): Promise<ResolvedToolsUrl> {
+  const envUrl = process.env.ARGENT_TOOLS_URL;
+  if (envUrl) {
+    const link = await readLinkConfig();
+    return {
+      url: envUrl,
+      source: "env",
+      ...(link ? { shadowedLink: link } : {}),
+    };
+  }
+  const link = await readLinkConfig();
+  if (link) return { url: link.url, source: "link" };
+  return { url: null, source: "none" };
+}
+
+/**
+ * True when an env var or link file routes requests to an external tool-server.
+ * Used by the MCP server to gate auto-spawn / health-monitor logic — when a
+ * caller chose a remote target, we must NOT silently fall back to a local spawn.
+ */
+export async function isRemoteRouted(): Promise<boolean> {
+  const { url } = await getResolvedToolsUrl();
+  return url !== null;
+}
+
+export const LINK_PATHS = { LINK_DIR, LINK_FILE };

--- a/packages/argent-tools-client/src/tools-client.ts
+++ b/packages/argent-tools-client/src/tools-client.ts
@@ -1,4 +1,5 @@
 import { ensureToolsServer, type ToolsServerPaths } from "./launcher.js";
+import { getResolvedToolsUrl } from "./link-config.js";
 
 export interface ToolMeta {
   name: string;
@@ -36,7 +37,8 @@ export function createToolsClient(options: CreateToolsClientOptions = {}): Tools
   let cached: string | null = null;
 
   async function baseUrl(): Promise<string> {
-    if (process.env.ARGENT_TOOLS_URL) return process.env.ARGENT_TOOLS_URL;
+    const resolved = await getResolvedToolsUrl();
+    if (resolved.url) return resolved.url;
     if (cached) return cached;
     if (!options.paths) {
       throw new Error(

--- a/packages/argent-tools-client/test/link-config.test.ts
+++ b/packages/argent-tools-client/test/link-config.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// link-config.ts captures LINK_DIR/LINK_FILE from `homedir()` at module load.
+// Same HOME-redirection pattern as launcher-state.test.ts so all writes land in
+// an isolated temp dir and the developer's real ~/.argent/link.json is safe.
+let linkConfig: typeof import("../src/link-config.js");
+let TEST_HOME: string;
+let LINK_FILE: string;
+
+beforeAll(async () => {
+  TEST_HOME = mkdtempSync(join(tmpdir(), "argent-link-config-test-"));
+  process.env.HOME = TEST_HOME;
+  vi.resetModules();
+  linkConfig = await import("../src/link-config.js");
+  LINK_FILE = linkConfig.LINK_PATHS.LINK_FILE;
+  expect(LINK_FILE.startsWith(TEST_HOME)).toBe(true);
+});
+
+afterAll(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await linkConfig.clearLinkConfig();
+});
+
+// `getResolvedToolsUrl` reads ARGENT_TOOLS_URL on every call (not at load), so
+// any test that touches precedence must save & restore the variable.
+let savedEnvUrl: string | undefined;
+beforeEach(() => {
+  savedEnvUrl = process.env.ARGENT_TOOLS_URL;
+  delete process.env.ARGENT_TOOLS_URL;
+});
+afterEach(() => {
+  if (savedEnvUrl === undefined) delete process.env.ARGENT_TOOLS_URL;
+  else process.env.ARGENT_TOOLS_URL = savedEnvUrl;
+});
+
+const sampleConfig = {
+  url: "http://10.0.0.42:3001",
+  host: "10.0.0.42",
+  port: 3001,
+  createdAt: "2026-05-12T10:00:00.000Z",
+};
+
+describe("writeLinkConfig ↔ readLinkConfig round-trip", () => {
+  it("persists every documented field", async () => {
+    await linkConfig.writeLinkConfig(sampleConfig);
+    const read = await linkConfig.readLinkConfig();
+    expect(read).toEqual(sampleConfig);
+  });
+
+  it("creates the .argent directory if it does not exist", async () => {
+    rmSync(join(TEST_HOME, ".argent"), { recursive: true, force: true });
+    await linkConfig.writeLinkConfig(sampleConfig);
+    expect(existsSync(LINK_FILE)).toBe(true);
+  });
+
+  it("overwrites prior config on subsequent writes", async () => {
+    await linkConfig.writeLinkConfig(sampleConfig);
+    await linkConfig.writeLinkConfig({ ...sampleConfig, port: 9999, url: "http://10.0.0.42:9999" });
+    const read = await linkConfig.readLinkConfig();
+    expect(read?.port).toBe(9999);
+    expect(read?.url).toBe("http://10.0.0.42:9999");
+  });
+
+  it("writes pretty-printed JSON with a trailing newline (human-editable on disk)", async () => {
+    await linkConfig.writeLinkConfig(sampleConfig);
+    const raw = readFileSync(LINK_FILE, "utf8");
+    expect(raw.endsWith("\n")).toBe(true);
+    // Pretty-printing puts each top-level field on its own line.
+    expect(raw.split("\n").length).toBeGreaterThan(3);
+  });
+});
+
+describe("readLinkConfig — failure & validation paths", () => {
+  it("returns null when the file does not exist", async () => {
+    expect(await linkConfig.readLinkConfig()).toBeNull();
+  });
+
+  it("returns null on malformed JSON instead of throwing", async () => {
+    writeFileSync(LINK_FILE, "{ this is not json }", "utf8");
+    expect(await linkConfig.readLinkConfig()).toBeNull();
+  });
+
+  // The reader hard-validates the schema. Each required field must be present
+  // and have the documented type — partial files are treated as corrupt
+  // (return null) so callers fall back to auto-spawn instead of dispatching
+  // requests to a bogus URL.
+  it.each([["url"], ["host"], ["port"], ["createdAt"]])(
+    "returns null when required field %p is missing",
+    async (field) => {
+      const partial: Record<string, unknown> = { ...sampleConfig };
+      delete partial[field];
+      writeFileSync(LINK_FILE, JSON.stringify(partial), "utf8");
+      expect(await linkConfig.readLinkConfig()).toBeNull();
+    }
+  );
+
+  it.each([
+    ["url", 42],
+    ["host", null],
+    ["port", "3001"], // string where number expected
+    ["createdAt", 12345],
+  ])("returns null when field %p has the wrong type", async (field, wrongValue) => {
+    const corrupt = { ...sampleConfig, [field]: wrongValue };
+    writeFileSync(LINK_FILE, JSON.stringify(corrupt), "utf8");
+    expect(await linkConfig.readLinkConfig()).toBeNull();
+  });
+});
+
+describe("clearLinkConfig", () => {
+  it("removes the link file", async () => {
+    await linkConfig.writeLinkConfig(sampleConfig);
+    expect(existsSync(LINK_FILE)).toBe(true);
+    await linkConfig.clearLinkConfig();
+    expect(existsSync(LINK_FILE)).toBe(false);
+  });
+
+  it("is a no-op when the file is already gone (idempotent)", async () => {
+    await expect(linkConfig.clearLinkConfig()).resolves.toBeUndefined();
+    await expect(linkConfig.clearLinkConfig()).resolves.toBeUndefined();
+  });
+});
+
+describe("getResolvedToolsUrl — precedence chain", () => {
+  it("returns source 'none' with null url when neither env nor link is set", async () => {
+    const resolved = await linkConfig.getResolvedToolsUrl();
+    expect(resolved).toEqual({ url: null, source: "none" });
+  });
+
+  it("returns source 'link' when only a link file exists", async () => {
+    await linkConfig.writeLinkConfig(sampleConfig);
+    const resolved = await linkConfig.getResolvedToolsUrl();
+    expect(resolved.source).toBe("link");
+    expect(resolved.url).toBe(sampleConfig.url);
+    // No shadowedLink when env was not the winning source.
+    expect(resolved.shadowedLink).toBeUndefined();
+  });
+
+  it("returns source 'env' when only ARGENT_TOOLS_URL is set", async () => {
+    process.env.ARGENT_TOOLS_URL = "http://override.example:9000";
+    const resolved = await linkConfig.getResolvedToolsUrl();
+    expect(resolved.source).toBe("env");
+    expect(resolved.url).toBe("http://override.example:9000");
+    expect(resolved.shadowedLink).toBeUndefined();
+  });
+
+  it("env wins over link, AND reports the shadowed link so callers can warn", async () => {
+    await linkConfig.writeLinkConfig(sampleConfig);
+    process.env.ARGENT_TOOLS_URL = "http://override.example:9000";
+
+    const resolved = await linkConfig.getResolvedToolsUrl();
+    expect(resolved.source).toBe("env");
+    expect(resolved.url).toBe("http://override.example:9000");
+    // The whole point of shadowedLink: surface the persisted target that is
+    // currently being overridden, without changing precedence.
+    expect(resolved.shadowedLink).toEqual(sampleConfig);
+  });
+
+  it("ignores an empty ARGENT_TOOLS_URL (falsy string → falls through to link/none)", async () => {
+    process.env.ARGENT_TOOLS_URL = "";
+    await linkConfig.writeLinkConfig(sampleConfig);
+    const resolved = await linkConfig.getResolvedToolsUrl();
+    expect(resolved.source).toBe("link");
+    expect(resolved.url).toBe(sampleConfig.url);
+  });
+
+  it("a corrupt link file degrades gracefully when env is also set (no shadowedLink, no throw)", async () => {
+    writeFileSync(LINK_FILE, "{ not json", "utf8");
+    process.env.ARGENT_TOOLS_URL = "http://override.example:9000";
+    const resolved = await linkConfig.getResolvedToolsUrl();
+    expect(resolved.source).toBe("env");
+    expect(resolved.url).toBe("http://override.example:9000");
+    expect(resolved.shadowedLink).toBeUndefined();
+  });
+
+  it("a corrupt link file with no env falls through to source 'none'", async () => {
+    writeFileSync(LINK_FILE, "{ not json", "utf8");
+    const resolved = await linkConfig.getResolvedToolsUrl();
+    expect(resolved).toEqual({ url: null, source: "none" });
+  });
+});
+
+describe("isRemoteRouted", () => {
+  it("returns false when neither env nor link is configured", async () => {
+    expect(await linkConfig.isRemoteRouted()).toBe(false);
+  });
+
+  it("returns true when a link file is configured", async () => {
+    await linkConfig.writeLinkConfig(sampleConfig);
+    expect(await linkConfig.isRemoteRouted()).toBe(true);
+  });
+
+  it("returns true when ARGENT_TOOLS_URL is set (regardless of link presence)", async () => {
+    process.env.ARGENT_TOOLS_URL = "http://override.example:9000";
+    expect(await linkConfig.isRemoteRouted()).toBe(true);
+  });
+
+  it("is gated on a *valid* link file — corrupt JSON does not count as routed", async () => {
+    writeFileSync(LINK_FILE, "{ not json", "utf8");
+    expect(await linkConfig.isRemoteRouted()).toBe(false);
+  });
+});

--- a/packages/argent/src/cli.ts
+++ b/packages/argent/src/cli.ts
@@ -19,6 +19,8 @@
  *   argent run <tool> [flags]     Invoke a tool by name
  *   argent server start [flags]   Spawn a long-lived tool-server (foreground by default)
  *   argent server status|stop|logs   Manage the shared tool-server
+ *   argent link [flags]           Route client requests to a remote tool-server
+ *   argent unlink                 Remove the persisted remote link
  */
 
 import * as fs from "node:fs";
@@ -73,6 +75,8 @@ Commands:
   tools       List tools exposed by the tool-server
   run         Invoke a tool by name (use \`argent run <tool> --help\` for flags)
   server      Manage the shared tool-server (start / status / stop / logs)
+  link        Route client requests to a remote tool-server
+  unlink      Remove the persisted remote tool-server link
 
 Options:
   --help, -h     Show this help message
@@ -118,6 +122,10 @@ async function main(): Promise<void> {
       return (await loadCli()).run(rest, { paths: BUNDLED_RUNTIME_PATHS });
     case "server":
       return (await loadCli()).server(rest, { paths: BUNDLED_RUNTIME_PATHS });
+    case "link":
+      return (await loadCli()).link(rest);
+    case "unlink":
+      return (await loadCli()).unlink(rest);
     case "--version":
     case "-v":
       console.log(getInstalledVersion() ?? "unknown");


### PR DESCRIPTION
## Summary

- Adds `argent link` / `argent unlink` CLI commands that persist a remote tool-server target to `~/.argent/link.json`
- Introduces a `link-config.ts` module in `argent-tools-client` with a three-tier resolution order: `ARGENT_TOOLS_URL` env var → `~/.argent/link.json` → auto-spawn local server
- Updates `mcp-server.ts` and `tools-client.ts` to use `getResolvedToolsUrl` / `isRemoteRouted` instead of reading `process.env.ARGENT_TOOLS_URL` directly, so link-file routing is honoured transparently everywhere

## Details

`argent link` supports:
- Interactive prompts (via `@clack/prompts`) with host/port validation — wildcards (`0.0.0.0`, `::`) rejected as bind addresses
- `--host`, `--port`, `--yes` (non-interactive), `--no-verify` flags
- Pre-flight `GET /tools` health check with a retry/modify/skip prompt on failure
- Overwrite confirmation when a link already exists
- Non-loopback security warning

`argent unlink` removes `~/.argent/link.json` and is a no-op if no link is set.

The MCP health-monitor and reconnect logic now skips auto-respawn when a remote target is configured — a silent local fallback would mask remote outages.