### PR TITLE
docs(skills): device selection guidance for list-devices and RN runs

### DIFF
--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -36,6 +36,19 @@ If `describe` fails, **read the exact error before reacting**, follow the recove
 Before starting to interact with the app, read the `argent-device-interact` skill first.
 </tapping_rule>
 
+<device_selection_rule>
+Before booting, running, or interacting with any app, always call `list-devices` first to see what is already running. Platform is a consequence of that observation, not an assumption.
+
+Decision order:
+
+1. **Explicit user intent** - choose the user named platform or device. Look for words "simulator" and "emulator".
+2. **Prefer a running device.** iOS simulators - state `Booted` and Android devices - `state: "device"` come first in `list-devices`.
+3. **Both platforms have ready devices and no explicit intent:** ASK the user which device to use. Do not guess.
+4. **Nothing is running, no explicit intent:**
+   - Single-platform project (per `argent-environment-inspector` flags `is_native_ios`/`is_native_android`, or RN with only one platform configured) → boot that platform.
+   - Cross-platform project → ASK the user before booting.
+</device_selection_rule>
+
 <skill_reading_rule>
 <important>Always read relevant skills for guidance before executing argent-mcp tool - read skill_routing reference</important>
 </skill_reading_rule>

--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -47,7 +47,7 @@ Decision order:
 4. **Nothing is running, no explicit intent:**
    - Single-platform project (per `argent-environment-inspector` flags `is_native_ios`/`is_native_android`, or RN with only one platform configured) → boot that platform.
    - Cross-platform project → ASK the user before booting.
-</device_selection_rule>
+     </device_selection_rule>
 
 <skill_reading_rule>
 <important>Always read relevant skills for guidance before executing argent-mcp tool - read skill_routing reference</important>

--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -37,17 +37,14 @@ Before starting to interact with the app, read the `argent-device-interact` skil
 </tapping_rule>
 
 <device_selection_rule>
-Before booting, running, or interacting with any app, always call `list-devices` first to see what is already running. Platform is a consequence of that observation, not an assumption.
+Before booting, running, or interacting with any app, call `list-devices` first - prefer running devices.
 
 Decision order:
 
 1. **Explicit user intent** - choose the user named platform or device. Look for words "simulator" and "emulator".
 2. **Prefer a running device.** iOS simulators - state `Booted` and Android devices - `state: "device"` come first in `list-devices`.
-3. **Both platforms have ready devices and no explicit intent:** ASK the user which device to use. Do not guess.
-4. **Nothing is running, no explicit intent:**
-   - Single-platform project (per `argent-environment-inspector` flags `is_native_ios`/`is_native_android`, or RN with only one platform configured) → boot that platform.
-   - Cross-platform project → ASK the user before booting.
-     </device_selection_rule>
+3. **Single-platform project:** (per `argent-environment-inspector` flags `is_native_ios`/`is_native_android`, or RN with only one platform configured) → boot that platform.
+   </device_selection_rule>
 
 <skill_reading_rule>
 <important>Always read relevant skills for guidance before executing argent-mcp tool - read skill_routing reference</important>

--- a/packages/skills/skills/argent-react-native-app-workflow/SKILL.md
+++ b/packages/skills/skills/argent-react-native-app-workflow/SKILL.md
@@ -50,7 +50,10 @@ npx react-native run-ios       # iOS
 npx react-native run-android   # Android
 ```
 
-Optional: specify the target device, e.g. `npx react-native run-ios --simulator="iPhone 16"` or `npx react-native run-android --deviceId=<serial>`.
+**Always pass the target device explicitly** — derive it from `list-devices` (see `<device_selection_rule>`):
+
+- iOS: `npx react-native run-ios --simulator="<name>"` (or `--udid <UDID>`).
+- Android: `npx react-native run-android --deviceId=<adb-serial>`.
 
 **Android only**: after install, run `adb -s <serial> reverse tcp:8081 tcp:8081` so the emulator/device can reach Metro on your host. Repeat if the device restarts or adb drops.
 
@@ -58,7 +61,7 @@ Optional: specify the target device, e.g. `npx react-native run-ios --simulator=
 
 - [ ] Metro is already running and shows "ready"
 - [ ] Command run from project root
-- [ ] If the device isn't booted: use `boot-device` with the iOS `udid` or Android `avdName`. Refer to the `argent-ios-simulator-setup` / `argent-android-emulator-setup` skill.
+- [ ] If the device isn't booted yet: use `boot-device` with the iOS `udid` or Android `avdName`. Refer to the `argent-ios-simulator-setup` / `argent-android-emulator-setup` skill.
 - [ ] Android: `adb -s <serial> reverse tcp:8081 tcp:8081` done.
 
 ---

--- a/packages/skills/skills/argent-react-native-app-workflow/SKILL.md
+++ b/packages/skills/skills/argent-react-native-app-workflow/SKILL.md
@@ -45,7 +45,7 @@ In a **separate** terminal (Metro keeps running in the first):
 
 **Use the project's custom build/run script if one exists** (e.g. `npm run ios`, `npm run android`, `yarn ios:debug`). Only fall back to the defaults below if no custom scripts are defined.
 
-**Always pass the target device explicitly** — derive it from `list-devices` (see `<device_selection_rule>`):
+**Pass the target device explicitly** — derive it from `list-devices` (see `<device_selection_rule>`):
 
 ```bash
 npx react-native run-ios --simulator="<name>"        # iOS (or --udid <UDID>)

--- a/packages/skills/skills/argent-react-native-app-workflow/SKILL.md
+++ b/packages/skills/skills/argent-react-native-app-workflow/SKILL.md
@@ -43,17 +43,14 @@ Do NOT default to `npx react-native start` or `npx react-native run-ios` without
 
 In a **separate** terminal (Metro keeps running in the first):
 
-**Use the project's custom build/run script if one exists** (e.g. `npm run ios`, `npm run android`, `yarn ios:debug`). Only fall back to the default if no custom scripts are defined:
-
-```bash
-npx react-native run-ios       # iOS
-npx react-native run-android   # Android
-```
+**Use the project's custom build/run script if one exists** (e.g. `npm run ios`, `npm run android`, `yarn ios:debug`). Only fall back to the defaults below if no custom scripts are defined.
 
 **Always pass the target device explicitly** — derive it from `list-devices` (see `<device_selection_rule>`):
 
-- iOS: `npx react-native run-ios --simulator="<name>"` (or `--udid <UDID>`).
-- Android: `npx react-native run-android --deviceId=<adb-serial>`.
+```bash
+npx react-native run-ios --simulator="<name>"        # iOS (or --udid <UDID>)
+npx react-native run-android --deviceId=<adb-serial> # Android
+```
 
 **Android only**: after install, run `adb -s <serial> reverse tcp:8081 tcp:8081` so the emulator/device can reach Metro on your host. Repeat if the device restarts or adb drops.
 

--- a/packages/skills/skills/argent-test-ui-flow/SKILL.md
+++ b/packages/skills/skills/argent-test-ui-flow/SKILL.md
@@ -7,7 +7,9 @@ description: Autonomously test an app UI (iOS or Android) by running interact-sc
 
 The interaction tool names are identical on iOS and Android — `gesture-tap`, `gesture-swipe`, `describe`, `screenshot`, `launch-app`, etc. — and the tool-server auto-dispatches based on the `udid` you pass (UUID-shape → iOS, adb serial → Android).
 
-Get a `udid` via:
+**Before testing, resolve which device to test on.** Call `list-devices` and follow `<device_selection_rule>`: prefer a running device on any platform;
+
+Once a platform is chosen, the per-platform setup skill takes over:
 
 | Platform | Setup skill                     | Find devices with                                           |
 | -------- | ------------------------------- | ----------------------------------------------------------- |


### PR DESCRIPTION
## Summary

This change improves how Argent skills tell agents to pick and use devices before booting, running Metro, or driving UI. It reduces wrong-platform assumptions and encourages explicit targets derived from `list-devices`.

## Fixes #196

## What changed

- **`packages/skills/rules/argent.md`**: Added a `<device_selection_rule>` block that instructs agents to call `list-devices` first, then follow a clear decision order: explicit user intent → prefer already-running devices → ask when both iOS and Android are ready with no intent → boot or ask for cross-platform vs single-platform projects using environment inspector signals.
- **`argent-react-native-app-workflow/SKILL.md`**: RN run commands now require an explicit simulator name or Android `deviceId` from `list-devices`; minor checklist wording tweak for booting devices.
- **`argent-test-ui-flow/SKILL.md`**: Clarifies resolving the test device via `list-devices` and `<device_selection_rule>` before per-platform setup.

## Motivation

Agents sometimes assumed a platform or picked an arbitrary device. Aligning skills with `list-devices`-first behavior makes device choice observable and consistent with multi-platform workflows.
