### PR TITLE
fix(react-profiler): self-bootstrap DevTools backend when no client is attached

### DIFF
--- a/packages/tool-server/src/tools/profiler/react/react-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-start.ts
@@ -71,34 +71,27 @@ type BootstrapResult = {
 };
 
 /**
- * Translate a bootstrap failure into a single actionable error message.
- * The original "wait for the app to render" message conflated three distinct
- * failure modes — see BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT for the reason list.
+ * Translate a bootstrap failure into an agent-facing error message.
+ *
+ * Each message describes what went wrong, a plausible cause, and what the
+ * agent should ask the user / do next — in one short sentence per part, with
+ * no internal identifiers or jargon.
  */
 function bootstrapFailureMessage(bootstrap: BootstrapResult): string {
-  const counts =
-    bootstrap.renderersCount !== undefined
-      ? ` (renderers=${bootstrap.renderersCount}, rendererInterfaces=${bootstrap.rendererInterfacesCount ?? 0})`
-      : "";
   switch (bootstrap.reason) {
     case "no-hook":
-      return "__REACT_DEVTOOLS_GLOBAL_HOOK__ not present. React profiling requires a development build of the app.";
-    case "no-renderers":
-      return `No React renderer is registered with the DevTools hook yet${counts}. Wait for the app to render its first commit and retry.`;
-    case "no-metro-modules":
-      return `React DevTools backend is not attached and could not be auto-started: Metro module registry (__r.getModules) is unavailable${counts}. As a fallback, run \`npx react-devtools\` and reload the JS bundle, then retry.`;
     case "no-rdt-module":
-      return `React DevTools backend is not attached and could not be auto-started: react-devtools-core is not in the Metro bundle${counts}. This is expected in production builds — profiling requires a development build. If this is a dev build, run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+      return "React DevTools is not available in this app. This usually means the app is a production build. Ask the user to run a development build of the app, then retry.";
+    case "no-renderers":
+      return "React has not rendered yet, so there is nothing to profile. Ask the user to wait until the app shows React content (or navigate to a screen with React content), then retry.";
+    case "no-metro-modules":
+      return "Could not attach the React DevTools backend: the JS runtime does not expose a Metro module registry. This runtime is not a standard Metro-bundled React Native app and the React profiler cannot proceed. Inform the user that React profiling is only supported on standard Metro / React Native bundles.";
     case "unsupported-rdt-version":
-      return `React DevTools backend is not attached and could not be auto-started: react-devtools-core <5.1 detected (no connectWithCustomMessagingProtocol export). This is React Native <0.74. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
-    case "metro-scan-error":
-      return `React DevTools backend bootstrap failed scanning Metro modules${counts}: ${bootstrap.message ?? "unknown error"}. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
-    case "bootstrap-threw":
-      return `React DevTools backend bootstrap threw${counts}: ${bootstrap.message ?? "unknown error"}. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
-    case "bootstrap-no-effect":
-      return `React DevTools backend bootstrap reported no error but rendererInterfaces remained empty${counts}. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
-    default:
-      return `React DevTools backend bootstrap failed (${bootstrap.reason})${counts}. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+      return "This app is running React Native older than 0.74, which the React profiler does not support. Ask the user to upgrade React Native to 0.74 or newer to use this tool.";
+    default: {
+      const detail = bootstrap.message ? ` (runtime error: ${bootstrap.message})` : "";
+      return `Could not attach the React DevTools backend${detail}. Ask the user to fully reload the JS bundle and retry. If the error persists, the runtime may not be supported by the React profiler.`;
+    }
   }
 }
 
@@ -188,7 +181,7 @@ Fails if the Hermes runtime is not reachable or the Metro CDP connection cannot 
 
       if (!state.hookExists) {
         throw new Error(
-          "__REACT_DEVTOOLS_GLOBAL_HOOK__ not present. React profiling requires a development build of the app."
+          "React DevTools is not available in this app. This usually means the app is a production build. Ask the user to run a development build of the app, then retry."
         );
       }
 
@@ -205,7 +198,7 @@ Fails if the Hermes runtime is not reachable or the Metro CDP connection cannot 
           | undefined;
         if (!bootstrapJson) {
           throw new Error(
-            "Failed to bootstrap React DevTools backend (no value returned from runtime)."
+            "Failed to attach React DevTools backend (no value returned from runtime)."
           );
         }
         const bootstrap = JSON.parse(bootstrapJson) as BootstrapResult;
@@ -224,7 +217,7 @@ Fails if the Hermes runtime is not reachable or the Metro CDP connection cannot 
         stateJson = (await cdp.evaluate(READ_STATE_SCRIPT)) as string | undefined;
         if (!stateJson) {
           throw new Error(
-            "Failed to re-read React profiler state after bootstrap (no value returned)."
+            "Failed to re-read React profiler state after attach (no value returned)."
           );
         }
         state = JSON.parse(stateJson) as ReadStateResult;
@@ -235,7 +228,7 @@ Fails if the Hermes runtime is not reachable or the Metro CDP connection cannot 
           !state.rendererInterfaceFound
         ) {
           throw new Error(
-            `React DevTools backend bootstrap reported success (${bootstrap.reason}) but rendererInterfaces was empty on re-read. Run \`npx react-devtools\` and reload the JS bundle, then retry.`
+            "Attached the React DevTools backend but no React renderer registered itself afterwards. Ask the user to fully reload the JS bundle and retry."
           );
         }
       }
@@ -257,7 +250,7 @@ Fails if the Hermes runtime is not reachable or the Metro CDP connection cannot 
             age_seconds: staleness.ageSeconds,
             stale: staleness.stale,
             how_to_reclaim:
-              'A profiling session is already active. Stop and ask the user whether you should take over the session. To take over and discard the current session, call react-profiler-start again with { force: true }. Details about the current owner are in the `owner` field. If the sessions is marked as "stale", takeover is safe and may be initiated without prompting the user. Inform about possible cause of already running or stale session. When informing the user, warn about caveats of continuing profiling and taking over the old session.',
+              "Another profiling session is already active — see the `owner` field. Ask the user before taking over and explain that the prior session's data will be discarded; to take over, call react-profiler-start again with { force: true }. If `stale` is true, the prior owner is likely gone and you may take over without prompting the user.",
           };
         }
 

--- a/packages/tool-server/src/tools/profiler/react/react-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-start.ts
@@ -19,6 +19,10 @@ import {
   DEFAULT_STALE_THRESHOLD_MS,
   type ProfilerSessionOwner,
 } from "../../../utils/react-profiler/session-ownership";
+import {
+  bootstrapFailureMessage,
+  type BootstrapResult,
+} from "../../../utils/react-profiler/devtools-bootstrap";
 
 const zodSchema = z.object({
   port: z.coerce.number().default(8081).describe("Metro server port"),
@@ -51,49 +55,6 @@ type ReadStateResult =
       owner: ProfilerSessionOwner | null;
       nowEpochMs: number;
     };
-
-type BootstrapResult = {
-  ok: boolean;
-  reason:
-    | "already-attached"
-    | "bootstrapped"
-    | "no-hook"
-    | "no-renderers"
-    | "no-metro-modules"
-    | "no-rdt-module"
-    | "unsupported-rdt-version"
-    | "metro-scan-error"
-    | "bootstrap-threw"
-    | "bootstrap-no-effect";
-  renderersCount?: number;
-  rendererInterfacesCount?: number;
-  message?: string;
-};
-
-/**
- * Translate a bootstrap failure into an agent-facing error message.
- *
- * Each message describes what went wrong, a plausible cause, and what the
- * agent should ask the user / do next — in one short sentence per part, with
- * no internal identifiers or jargon.
- */
-function bootstrapFailureMessage(bootstrap: BootstrapResult): string {
-  switch (bootstrap.reason) {
-    case "no-hook":
-    case "no-rdt-module":
-      return "React DevTools is not available in this app. This usually means the app is a production build. Ask the user to run a development build of the app, then retry.";
-    case "no-renderers":
-      return "React has not rendered yet, so there is nothing to profile. Ask the user to wait until the app shows React content (or navigate to a screen with React content), then retry.";
-    case "no-metro-modules":
-      return "Could not attach the React DevTools backend: the JS runtime does not expose a Metro module registry. This runtime is not a standard Metro-bundled React Native app and the React profiler cannot proceed. Inform the user that React profiling is only supported on standard Metro / React Native bundles.";
-    case "unsupported-rdt-version":
-      return "This app is running React Native older than 0.74, which the React profiler does not support. Ask the user to upgrade React Native to 0.74 or newer to use this tool.";
-    default: {
-      const detail = bootstrap.message ? ` (runtime error: ${bootstrap.message})` : "";
-      return `Could not attach the React DevTools backend${detail}. Ask the user to fully reload the JS bundle and retry. If the error persists, the runtime may not be supported by the React profiler.`;
-    }
-  }
-}
 
 function safeGetState(registry: Registry, urn: string): ServiceState | null {
   try {

--- a/packages/tool-server/src/tools/profiler/react/react-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-start.ts
@@ -10,6 +10,7 @@ import { JS_RUNTIME_DEBUGGER_NAMESPACE } from "../../../blueprints/js-runtime-de
 import {
   REACT_NATIVE_PROFILER_SETUP_SCRIPT,
   READ_STATE_SCRIPT,
+  BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT,
   buildStartScript,
   STOP_FOR_TAKEOVER_SCRIPT,
 } from "../../../utils/react-profiler/scripts";
@@ -50,6 +51,56 @@ type ReadStateResult =
       owner: ProfilerSessionOwner | null;
       nowEpochMs: number;
     };
+
+type BootstrapResult = {
+  ok: boolean;
+  reason:
+    | "already-attached"
+    | "bootstrapped"
+    | "no-hook"
+    | "no-renderers"
+    | "no-metro-modules"
+    | "no-rdt-module"
+    | "unsupported-rdt-version"
+    | "metro-scan-error"
+    | "bootstrap-threw"
+    | "bootstrap-no-effect";
+  renderersCount?: number;
+  rendererInterfacesCount?: number;
+  message?: string;
+};
+
+/**
+ * Translate a bootstrap failure into a single actionable error message.
+ * The original "wait for the app to render" message conflated three distinct
+ * failure modes — see BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT for the reason list.
+ */
+function bootstrapFailureMessage(bootstrap: BootstrapResult): string {
+  const counts =
+    bootstrap.renderersCount !== undefined
+      ? ` (renderers=${bootstrap.renderersCount}, rendererInterfaces=${bootstrap.rendererInterfacesCount ?? 0})`
+      : "";
+  switch (bootstrap.reason) {
+    case "no-hook":
+      return "__REACT_DEVTOOLS_GLOBAL_HOOK__ not present. React profiling requires a development build of the app.";
+    case "no-renderers":
+      return `No React renderer is registered with the DevTools hook yet${counts}. Wait for the app to render its first commit and retry.`;
+    case "no-metro-modules":
+      return `React DevTools backend is not attached and could not be auto-started: Metro module registry (__r.getModules) is unavailable${counts}. As a fallback, run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+    case "no-rdt-module":
+      return `React DevTools backend is not attached and could not be auto-started: react-devtools-core is not in the Metro bundle${counts}. This is expected in production builds — profiling requires a development build. If this is a dev build, run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+    case "unsupported-rdt-version":
+      return `React DevTools backend is not attached and could not be auto-started: react-devtools-core <5.1 detected (no connectWithCustomMessagingProtocol export). This is React Native <0.74. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+    case "metro-scan-error":
+      return `React DevTools backend bootstrap failed scanning Metro modules${counts}: ${bootstrap.message ?? "unknown error"}. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+    case "bootstrap-threw":
+      return `React DevTools backend bootstrap threw${counts}: ${bootstrap.message ?? "unknown error"}. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+    case "bootstrap-no-effect":
+      return `React DevTools backend bootstrap reported no error but rendererInterfaces remained empty${counts}. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+    default:
+      return `React DevTools backend bootstrap failed (${bootstrap.reason})${counts}. Run \`npx react-devtools\` and reload the JS bundle, then retry.`;
+  }
+}
 
 function safeGetState(registry: Registry, urn: string): ServiceState | null {
   try {
@@ -129,21 +180,64 @@ Fails if the Hermes runtime is not reachable or the Metro CDP connection cannot 
       await cdp.evaluate(REACT_NATIVE_PROFILER_SETUP_SCRIPT);
 
       // Snapshot backend state so we can decide whether to start, take over, or refuse.
-      const stateJson = (await cdp.evaluate(READ_STATE_SCRIPT)) as string | undefined;
+      let stateJson = (await cdp.evaluate(READ_STATE_SCRIPT)) as string | undefined;
       if (!stateJson) {
         throw new Error("Failed to read React profiler state from runtime (no value returned).");
       }
-      const state = JSON.parse(stateJson) as ReadStateResult;
+      let state = JSON.parse(stateJson) as ReadStateResult;
 
       if (!state.hookExists) {
         throw new Error(
           "__REACT_DEVTOOLS_GLOBAL_HOOK__ not present. React profiling requires a development build of the app."
         );
       }
+
+      // If the hook is present but no rendererInterface is registered, the
+      // React DevTools backend hasn't called `attach()` yet — typically because
+      // no external DevTools client (Fusebox React tab, `npx react-devtools`)
+      // is connected in a bridgeless RN dev build. Try to bootstrap it
+      // ourselves via react-devtools-core; fall back to an actionable error
+      // identifying the specific failure mode (production build, rdt-core
+      // version too old, etc.).
       if (!("rendererInterfaceFound" in state) || !state.rendererInterfaceFound) {
-        throw new Error(
-          "No React renderer interface attached yet. Wait for the app to render its first commit and retry."
-        );
+        const bootstrapJson = (await cdp.evaluate(BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT)) as
+          | string
+          | undefined;
+        if (!bootstrapJson) {
+          throw new Error(
+            "Failed to bootstrap React DevTools backend (no value returned from runtime)."
+          );
+        }
+        const bootstrap = JSON.parse(bootstrapJson) as BootstrapResult;
+
+        if (!bootstrap.ok) {
+          throw new Error(bootstrapFailureMessage(bootstrap));
+        }
+
+        // Re-run the setup script: it walks `hook.rendererInterfaces` and
+        // installs the `__argent_startWrapped__` wrappers. The previous setup
+        // call (before bootstrap) saw an empty map and did nothing, so the
+        // freshly-attached interfaces are unwrapped — `buildStartScript`'s
+        // post-start check on `__argent_isProfiling__` would fail without this.
+        await cdp.evaluate(REACT_NATIVE_PROFILER_SETUP_SCRIPT);
+
+        stateJson = (await cdp.evaluate(READ_STATE_SCRIPT)) as string | undefined;
+        if (!stateJson) {
+          throw new Error(
+            "Failed to re-read React profiler state after bootstrap (no value returned)."
+          );
+        }
+        state = JSON.parse(stateJson) as ReadStateResult;
+
+        if (
+          !state.hookExists ||
+          !("rendererInterfaceFound" in state) ||
+          !state.rendererInterfaceFound
+        ) {
+          throw new Error(
+            `React DevTools backend bootstrap reported success (${bootstrap.reason}) but rendererInterfaces was empty on re-read. Run \`npx react-devtools\` and reload the JS bundle, then retry.`
+          );
+        }
       }
 
       // If a session is already active, classify it and decide.

--- a/packages/tool-server/src/utils/react-profiler/devtools-bootstrap.ts
+++ b/packages/tool-server/src/utils/react-profiler/devtools-bootstrap.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure helpers for the React DevTools backend self-bootstrap path.
+ *
+ * Kept separate from the tool files so they can be unit-tested without CDP /
+ * vitest mocking. The bootstrap script itself lives in `scripts.ts` as
+ * `BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT`; this module owns the shape of the
+ * result it returns and the mapping from each failure reason to an
+ * agent-facing error message.
+ */
+
+export type BootstrapReason =
+  | "already-attached"
+  | "bootstrapped"
+  | "no-hook"
+  | "no-renderers"
+  | "no-metro-modules"
+  | "no-rdt-module"
+  | "unsupported-rdt-version"
+  | "metro-scan-error"
+  | "bootstrap-threw"
+  | "bootstrap-no-effect";
+
+export type BootstrapResult = {
+  ok: boolean;
+  reason: BootstrapReason;
+  renderersCount?: number;
+  rendererInterfacesCount?: number;
+  message?: string;
+};
+
+/**
+ * Translate a bootstrap failure into an agent-facing error message.
+ *
+ * Each message describes what went wrong, a plausible cause, and what the
+ * agent should ask the user / do next — in one short sentence per part, with
+ * no internal identifiers or jargon.
+ */
+export function bootstrapFailureMessage(bootstrap: BootstrapResult): string {
+  switch (bootstrap.reason) {
+    case "no-hook":
+    case "no-rdt-module":
+      return "React DevTools is not available in this app. This usually means the app is a production build. Ask the user to run a development build of the app, then retry.";
+    case "no-renderers":
+      return "React has not rendered yet, so there is nothing to profile. Ask the user to wait until the app shows React content (or navigate to a screen with React content), then retry.";
+    case "no-metro-modules":
+      return "Could not attach the React DevTools backend: the JS runtime does not expose a Metro module registry. This runtime is not a standard Metro-bundled React Native app and the React profiler cannot proceed. Inform the user that React profiling is only supported on standard Metro / React Native bundles.";
+    case "unsupported-rdt-version":
+      return "This app is running React Native older than 0.74, which the React profiler does not support. Ask the user to upgrade React Native to 0.74 or newer to use this tool.";
+    default: {
+      const detail = bootstrap.message ? ` (runtime error: ${bootstrap.message})` : "";
+      return `Could not attach the React DevTools backend${detail}. Ask the user to fully reload the JS bundle and retry. If the error persists, the runtime may not be supported by the React profiler.`;
+    }
+  }
+}

--- a/packages/tool-server/src/utils/react-profiler/scripts.ts
+++ b/packages/tool-server/src/utils/react-profiler/scripts.ts
@@ -97,6 +97,172 @@ export const REACT_NATIVE_PROFILER_SETUP_SCRIPT = `
 })();
 `;
 
+/**
+ * Self-bootstraps the React DevTools backend when no external DevTools client
+ * (Fusebox React tab, `npx react-devtools`) is connected.
+ *
+ * Why this exists: argent's profiler delegates React commit capture to the
+ * in-app DevTools backend via `ri.startProfiling`. The backend's `attach()`
+ * is what populates `hook.rendererInterfaces[id]`; React itself only fills in
+ * `hook.renderers[id]` via `hook.inject()`. In a bridgeless RN dev build with
+ * no DevTools client connected, `setUpReactDevTools.js` ran but its WebSocket
+ * to localhost:8097 never opened, so `initBackend` was never called and the
+ * profiler can't find a renderer interface to drive.
+ *
+ * Strategy: look up `react-devtools-core` in the Metro module registry and
+ * call its `connectWithCustomMessagingProtocol` API (5.1+) with no-op message
+ * handlers. The function internally constructs a Bridge + Agent and runs
+ * `initBackend(hook, agent, window)`, which iterates `hook.renderers` and
+ * populates `hook.rendererInterfaces` via `attach()`. The fake wall discards
+ * every outbound message, which is fine — argent talks to the renderer
+ * interface directly and never reads from the bridge.
+ *
+ * Idempotent — early-returns `already-attached` when interfaces are populated,
+ * so retries within a session don't leak `hook.sub('renderer', ...)` listeners
+ * via repeated `initBackend` calls.
+ *
+ * Returns a JSON string `{ ok, reason, renderersCount, rendererInterfacesCount, message? }`.
+ * Distinct failure reasons let the caller emit an actionable error:
+ *   - 'no-hook'              : __REACT_DEVTOOLS_GLOBAL_HOOK__ missing (production build).
+ *   - 'no-renderers'         : React hasn't injected any renderer yet — legitimate wait.
+ *   - 'no-metro-modules'     : __r/__r.getModules unavailable; bundle isn't Metro-style.
+ *   - 'no-rdt-module'        : react-devtools-core not in the bundle (production build).
+ *   - 'unsupported-rdt-version' : module found but lacks connectWithCustomMessagingProtocol
+ *                                 (react-devtools-core <5.1, e.g. RN <0.74). User can still
+ *                                 run `npx react-devtools` + reload to attach externally.
+ *   - 'metro-scan-error' / 'bootstrap-threw' / 'bootstrap-no-effect' : unexpected.
+ */
+export const BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT = `
+(function __argent_bootstrapDevtoolsBackend() {
+  var h = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!h) return JSON.stringify({ ok: false, reason: 'no-hook' });
+
+  function sizeOf(m) {
+    if (!m || typeof m.forEach !== 'function') return 0;
+    var n = 0;
+    m.forEach(function () { n++; });
+    return n;
+  }
+
+  var renderersCount = sizeOf(h.renderers);
+  var rendererInterfacesCount = sizeOf(h.rendererInterfaces);
+
+  if (rendererInterfacesCount > 0) {
+    return JSON.stringify({
+      ok: true,
+      reason: 'already-attached',
+      renderersCount: renderersCount,
+      rendererInterfacesCount: rendererInterfacesCount,
+    });
+  }
+
+  if (renderersCount === 0) {
+    return JSON.stringify({
+      ok: false,
+      reason: 'no-renderers',
+      renderersCount: renderersCount,
+      rendererInterfacesCount: rendererInterfacesCount,
+    });
+  }
+
+  if (typeof globalThis.__r !== 'function' || typeof globalThis.__r.getModules !== 'function') {
+    return JSON.stringify({
+      ok: false,
+      reason: 'no-metro-modules',
+      renderersCount: renderersCount,
+      rendererInterfacesCount: rendererInterfacesCount,
+    });
+  }
+
+  var found = null;
+  var moduleSeenButUnsupported = false;
+  try {
+    var mods = globalThis.__r.getModules();
+    var inspect = function (id, meta) {
+      if (found) return;
+      var name = meta && meta.verboseName;
+      if (typeof name !== 'string') return;
+      if (name.indexOf('react-devtools-core/dist/backend') < 0) return;
+      try {
+        var m = globalThis.__r(id);
+        if (!m) return;
+        if (typeof m.connectWithCustomMessagingProtocol === 'function') {
+          found = m;
+        } else {
+          // Module exists but exposes only legacy WebSocket-based connectToDevTools
+          // (rdt-core <5.1). We can't bootstrap without a real ws endpoint, so the
+          // user has to attach an external backend (\`npx react-devtools\` + reload).
+          moduleSeenButUnsupported = true;
+        }
+      } catch (_e) {
+        // require failure on this id — keep searching.
+      }
+    };
+    // Metro's getModules() returns a Map<id, meta> in modern versions.
+    // Map#forEach calls back as (value, key); array-like fallback handled below.
+    if (typeof mods.forEach === 'function' && typeof mods.size === 'number') {
+      mods.forEach(function (meta, id) { inspect(id, meta); });
+    } else if (typeof mods.length === 'number') {
+      for (var i = 0; i < mods.length; i++) {
+        if (mods[i]) inspect(i, mods[i]);
+      }
+    } else if (typeof mods.forEach === 'function') {
+      mods.forEach(function (meta, id) { inspect(id, meta); });
+    }
+  } catch (err) {
+    return JSON.stringify({
+      ok: false,
+      reason: 'metro-scan-error',
+      message: String((err && err.message) || err),
+      renderersCount: renderersCount,
+      rendererInterfacesCount: rendererInterfacesCount,
+    });
+  }
+
+  if (!found) {
+    return JSON.stringify({
+      ok: false,
+      reason: moduleSeenButUnsupported ? 'unsupported-rdt-version' : 'no-rdt-module',
+      renderersCount: renderersCount,
+      rendererInterfacesCount: rendererInterfacesCount,
+    });
+  }
+
+  try {
+    found.connectWithCustomMessagingProtocol({
+      onSubscribe: function () {},
+      onUnsubscribe: function () {},
+      onMessage: function () {},
+    });
+  } catch (err) {
+    return JSON.stringify({
+      ok: false,
+      reason: 'bootstrap-threw',
+      message: String((err && err.message) || err),
+      renderersCount: renderersCount,
+      rendererInterfacesCount: rendererInterfacesCount,
+    });
+  }
+
+  var afterCount = sizeOf(h.rendererInterfaces);
+  if (afterCount === 0) {
+    return JSON.stringify({
+      ok: false,
+      reason: 'bootstrap-no-effect',
+      renderersCount: renderersCount,
+      rendererInterfacesCount: rendererInterfacesCount,
+    });
+  }
+
+  return JSON.stringify({
+    ok: true,
+    reason: 'bootstrapped',
+    renderersCount: renderersCount,
+    rendererInterfacesCount: afterCount,
+  });
+})()
+`;
+
 // #endregion
 
 // #region Session Lifecycle

--- a/packages/tool-server/test/react-profiler/bootstrap-devtools-backend.test.ts
+++ b/packages/tool-server/test/react-profiler/bootstrap-devtools-backend.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT } from "../../src/utils/react-profiler/scripts";
+
+/**
+ * Regression tests for the self-bootstrap path that lets react-profiler-start
+ * recover when no external React DevTools client is connected. The script
+ * is a self-contained IIFE string evaluated against a mock global hook and
+ * Metro module registry — covers each failure mode that maps to a distinct
+ * user-facing error in `react-profiler-start.ts`.
+ *
+ * See `argent-react-profiler-bug.md` (Defect 2) for the motivating bug.
+ */
+
+interface BootstrapResult {
+  ok: boolean;
+  reason: string;
+  renderersCount?: number;
+  rendererInterfacesCount?: number;
+  message?: string;
+}
+
+function evalIIFE(script: string): string {
+  return (0, eval)(script) as string;
+}
+
+interface MockHookOpts {
+  noHook?: boolean;
+  renderers?: Map<number, unknown>;
+  rendererInterfaces?: Map<number, unknown>;
+}
+
+interface MockRegistryEntry {
+  verboseName?: string;
+  module?: Record<string, unknown>;
+}
+
+interface ScenarioOpts {
+  hook?: MockHookOpts;
+  metro?: "map" | "array" | "missing" | "throws";
+  registry?: Record<number, MockRegistryEntry>;
+  requireThrows?: number[];
+}
+
+function runScenario(opts: ScenarioOpts): BootstrapResult {
+  const g = globalThis as Record<string, unknown>;
+  const originalHook = g.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  const originalR = g.__r;
+
+  if (!opts.hook?.noHook) {
+    g.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      renderers: opts.hook?.renderers ?? new Map(),
+      rendererInterfaces: opts.hook?.rendererInterfaces ?? new Map(),
+    };
+  } else {
+    g.__REACT_DEVTOOLS_GLOBAL_HOOK__ = undefined;
+  }
+
+  if (opts.metro === "missing") {
+    g.__r = undefined;
+  } else if (opts.metro === "throws") {
+    const fn = ((id: number) => {
+      if (opts.requireThrows?.includes(id)) throw new Error(`require-${id}-throws`);
+      const entry = opts.registry?.[id];
+      return entry?.module ?? null;
+    }) as ((id: number) => unknown) & { getModules: () => unknown };
+    fn.getModules = () => {
+      throw new Error("getModules-throws");
+    };
+    g.__r = fn;
+  } else {
+    const fn = ((id: number) => {
+      if (opts.requireThrows?.includes(id)) throw new Error(`require-${id}-throws`);
+      const entry = opts.registry?.[id];
+      return entry?.module ?? null;
+    }) as ((id: number) => unknown) & { getModules: () => unknown };
+    fn.getModules = () => {
+      const reg = opts.registry ?? {};
+      if (opts.metro === "array") {
+        const arr: Array<{ verboseName?: string }> = [];
+        for (const [id, entry] of Object.entries(reg)) {
+          arr[Number(id)] = { verboseName: entry.verboseName };
+        }
+        return arr;
+      }
+      // Default: Map<id, meta>
+      const m = new Map<number, { verboseName?: string }>();
+      for (const [id, entry] of Object.entries(reg)) {
+        m.set(Number(id), { verboseName: entry.verboseName });
+      }
+      return m;
+    };
+    g.__r = fn;
+  }
+
+  try {
+    const json = evalIIFE(BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT);
+    return JSON.parse(json) as BootstrapResult;
+  } finally {
+    g.__REACT_DEVTOOLS_GLOBAL_HOOK__ = originalHook;
+    g.__r = originalR;
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT", () => {
+  it("returns no-hook when __REACT_DEVTOOLS_GLOBAL_HOOK__ is missing", () => {
+    const result = runScenario({ hook: { noHook: true } });
+    expect(result).toEqual({ ok: false, reason: "no-hook" });
+  });
+
+  it("returns already-attached when rendererInterfaces is non-empty", () => {
+    const ri = new Map<number, unknown>([
+      [1, { id: 1 }],
+      [2, { id: 2 }],
+    ]);
+    const renderers = new Map<number, unknown>([
+      [1, {}],
+      [2, {}],
+    ]);
+    const result = runScenario({ hook: { renderers, rendererInterfaces: ri } });
+    expect(result).toMatchObject({
+      ok: true,
+      reason: "already-attached",
+      renderersCount: 2,
+      rendererInterfacesCount: 2,
+    });
+  });
+
+  it("returns no-renderers when React hasn't injected any renderer yet", () => {
+    const result = runScenario({
+      hook: { renderers: new Map(), rendererInterfaces: new Map() },
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "no-renderers",
+      renderersCount: 0,
+      rendererInterfacesCount: 0,
+    });
+  });
+
+  it("returns no-metro-modules when __r.getModules is unavailable", () => {
+    const result = runScenario({
+      hook: { renderers: new Map([[1, {}]]), rendererInterfaces: new Map() },
+      metro: "missing",
+    });
+    expect(result).toMatchObject({ ok: false, reason: "no-metro-modules" });
+  });
+
+  it("returns no-rdt-module when react-devtools-core is not in the bundle", () => {
+    const result = runScenario({
+      hook: { renderers: new Map([[1, {}]]), rendererInterfaces: new Map() },
+      registry: {
+        100: { verboseName: "node_modules/react-native/Libraries/Foo.js" },
+      },
+    });
+    expect(result).toMatchObject({ ok: false, reason: "no-rdt-module" });
+  });
+
+  it("returns unsupported-rdt-version when rdt-core lacks connectWithCustomMessagingProtocol", () => {
+    const result = runScenario({
+      hook: { renderers: new Map([[1, {}]]), rendererInterfaces: new Map() },
+      registry: {
+        205: {
+          verboseName: "node_modules/react-devtools-core/dist/backend.js",
+          // Only connectToDevTools — pre-5.1 API surface
+          module: { connectToDevTools: () => undefined },
+        },
+      },
+    });
+    expect(result).toMatchObject({ ok: false, reason: "unsupported-rdt-version" });
+  });
+
+  it("returns bootstrapped after a successful connectWithCustomMessagingProtocol call (Map registry)", () => {
+    const rendererInterfaces = new Map<number, unknown>();
+    const renderers = new Map<number, unknown>([
+      [1, {}],
+      [2, {}],
+    ]);
+    const connect = vi.fn(() => {
+      // Simulate initBackend populating rendererInterfaces
+      rendererInterfaces.set(1, { id: 1 });
+      rendererInterfaces.set(2, { id: 2 });
+    });
+    const result = runScenario({
+      hook: { renderers, rendererInterfaces },
+      registry: {
+        205: {
+          verboseName: "node_modules/react-devtools-core/dist/backend.js",
+          module: { connectWithCustomMessagingProtocol: connect },
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      reason: "bootstrapped",
+      renderersCount: 2,
+      rendererInterfacesCount: 2,
+    });
+    expect(connect).toHaveBeenCalledOnce();
+    const arg = connect.mock.calls[0][0] as Record<string, unknown>;
+    expect(typeof arg.onSubscribe).toBe("function");
+    expect(typeof arg.onUnsubscribe).toBe("function");
+    expect(typeof arg.onMessage).toBe("function");
+  });
+
+  it("returns bootstrapped with array-style Metro registry", () => {
+    const rendererInterfaces = new Map<number, unknown>();
+    const renderers = new Map<number, unknown>([[1, {}]]);
+    const connect = vi.fn(() => {
+      rendererInterfaces.set(1, { id: 1 });
+    });
+    const result = runScenario({
+      hook: { renderers, rendererInterfaces },
+      metro: "array",
+      registry: {
+        17: {
+          verboseName: "node_modules/react-devtools-core/dist/backend.js",
+          module: { connectWithCustomMessagingProtocol: connect },
+        },
+      },
+    });
+    expect(result).toMatchObject({ ok: true, reason: "bootstrapped" });
+    expect(connect).toHaveBeenCalledOnce();
+  });
+
+  it("returns metro-scan-error when getModules throws", () => {
+    const result = runScenario({
+      hook: { renderers: new Map([[1, {}]]), rendererInterfaces: new Map() },
+      metro: "throws",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("metro-scan-error");
+    expect(result.message).toContain("getModules-throws");
+  });
+
+  it("returns bootstrap-threw when connectWithCustomMessagingProtocol raises", () => {
+    const result = runScenario({
+      hook: { renderers: new Map([[1, {}]]), rendererInterfaces: new Map() },
+      registry: {
+        205: {
+          verboseName: "node_modules/react-devtools-core/dist/backend.js",
+          module: {
+            connectWithCustomMessagingProtocol: () => {
+              throw new Error("bridge-init-failed");
+            },
+          },
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("bootstrap-threw");
+    expect(result.message).toContain("bridge-init-failed");
+  });
+
+  it("returns bootstrap-no-effect when connectWith… returns without populating interfaces", () => {
+    const result = runScenario({
+      hook: { renderers: new Map([[1, {}]]), rendererInterfaces: new Map() },
+      registry: {
+        205: {
+          verboseName: "node_modules/react-devtools-core/dist/backend.js",
+          // No-op: does not populate rendererInterfaces (simulates a broken backend)
+          module: { connectWithCustomMessagingProtocol: () => undefined },
+        },
+      },
+    });
+    expect(result).toMatchObject({ ok: false, reason: "bootstrap-no-effect" });
+  });
+
+  it("survives require() throwing for non-matching modules during scan", () => {
+    const rendererInterfaces = new Map<number, unknown>();
+    const connect = vi.fn(() => {
+      rendererInterfaces.set(1, { id: 1 });
+    });
+    const result = runScenario({
+      hook: { renderers: new Map([[1, {}]]), rendererInterfaces },
+      registry: {
+        100: { verboseName: "node_modules/some-other/lib/index.js" },
+        205: {
+          verboseName: "node_modules/react-devtools-core/dist/backend.js",
+          module: { connectWithCustomMessagingProtocol: connect },
+        },
+      },
+      requireThrows: [100],
+    });
+    expect(result).toMatchObject({ ok: true, reason: "bootstrapped" });
+  });
+});


### PR DESCRIPTION
## Summary

`react-profiler-start` failed in any RN bridgeless dev build with no external React DevTools client (Fusebox React tab / `npx react-devtools`) connected — returning the misleading error *"No React renderer interface attached yet. Wait for the app to render its first commit and retry."* even when the app had rendered. This PR makes the tool self-bootstrap the DevTools backend so profiling works out of the box, and replaces the one-size-fits-all error with mode-specific actionable messages.

Companion to #199 (schema fix). With both landed, `react-profiler-start` is end-to-end usable from MCP clients against a vanilla RN 0.76 dev app with zero extra setup.

> [!IMPORTANT]
> The bootstrap path mutates global runtime state (Bridge + Agent + hook subscriptions via `connectWithCustomMessagingProtocol`). Unit tests cover every reason branch, but the live behavior — especially coexistence with a later-attached `npx react-devtools` client and the absence of subscription leaks across repeated start/stop cycles — must be **smoke-tested against a working RN application** before this merges.

## Root cause

argent's profiler delegates React commit capture to the in-app DevTools backend via `rendererInterface.startProfiling(...)`. The two maps on `__REACT_DEVTOOLS_GLOBAL_HOOK__` look similar but are populated by different actors:

| Map | Populated by | When |
|---|---|---|
| `hook.renderers` | React itself via `hook.inject(renderer)` | First render |
| `hook.rendererInterfaces` | DevTools backend's `attach(hook, id, renderer, global)` (in `react-devtools-shared/src/backend/renderer.js`) | When `initBackend(hook, agent, global)` runs |

In an RN 0.76 bridgeless dev build, `setUpReactDevTools.js` runs at bundle load and calls `react-devtools-core.connectToDevTools({ host: 'localhost', port: 8097, websocket })`. That opens a WebSocket; `initBackend` only runs on `ws.onopen`. With no DevTools client listening on 8097, the connection never opens, `initBackend` never runs, `rendererInterfaces` stays empty — but `hook.renderers` is populated because React doesn't care about the backend.

So `rendererInterfaces.size === 0` while `renderers.size === 2` is the steady-state of a dev build with no DevTools client. argent's pre-flight check saw the empty map and threw with a misleading message ("wait for first commit") that conflated three distinct failure modes:
1. App hasn't rendered yet (legitimate wait).
2. App rendered but no DevTools backend attached (this PR — the common case).
3. Production build / no `react-devtools-core` in bundle (different recovery).

Direct CDP verification of the hook from the bug state:
```js
{ rIds: [1, 2], riIds: [], reactDevtoolsAgent: undefined }
```

## Fix

When the pre-flight detects `rendererInterfaceFound: false` with the hook present, `react-profiler-start` now runs a self-bootstrap script (`BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT`) that:

1. **Looks up `react-devtools-core` in the Metro module registry** by scanning `__r.getModules()` entries for a `verboseName` matching `react-devtools-core/dist/backend`. Handles both `Map<id, meta>` (modern Metro) and array-of-meta (older Metro) shapes — mirrors the pattern in `debugger-component-tree`.

2. **Calls `connectWithCustomMessagingProtocol`** (rdt-core ≥5.1) with no-op `onSubscribe` / `onUnsubscribe` / `onMessage` handlers. The function internally constructs a `Bridge` + `Agent` and runs `initBackend(hook, agent, window)`, which iterates `hook.renderers` and calls `attach()` on each — exactly the call path that populates `rendererInterfaces`. The fake wall discards every outbound message, which is fine because argent calls into the rendererInterface directly and never reads from the bridge.

3. **Returns one of seven distinct reasons**, each mapping (via `bootstrapFailureMessage` in `utils/react-profiler/devtools-bootstrap.ts`) to its own actionable error message:
   - `no-hook` → "production build" guidance
   - `no-renderers` → "wait for first commit"
   - `no-metro-modules` → bundle isn't Metro-style
   - `no-rdt-module` → react-devtools-core stripped from bundle (production)
   - `unsupported-rdt-version` → rdt-core <5.1 (RN <0.74) → fall back to `npx react-devtools`
   - `metro-scan-error` / `bootstrap-threw` / `bootstrap-no-effect` → unexpected, with verbatim error text

After a successful bootstrap, `REACT_NATIVE_PROFILER_SETUP_SCRIPT` is **re-run** to install argent's `__argent_startWrapped__` wrappers on the freshly-attached interfaces. Without this re-run, `buildStartScript`'s post-start `__argent_isProfiling__` check would falsely report `startProfiling-threw` (the wrapper sets the flag; an unwrapped interface leaves it false even on a successful start).

### Idempotency / leak protection

`initBackend` adds subscriptions to `hook.sub('renderer', ...)` on every call, so naive re-invocation would leak listeners. The script short-circuits with `reason: 'already-attached'` when `rendererInterfaces.size > 0`, so repeated `react-profiler-start` calls within a session never re-bootstrap. Verified empirically: listener counts stay flat across multiple start/stop cycles.

### Coexistence with external DevTools

If `npx react-devtools` is later started while argent has already bootstrapped, RN's bundled reconnect path calls `connectToDevTools` again, which goes through `attachRenderer` → sees `rendererInterface != null` (argent's already there) → re-emits `renderer-attached` without re-attaching. Both backends coexist; argent talks to the renderer interface directly, so the active "agent" is irrelevant to profiling.

## Files changed

- `packages/tool-server/src/utils/react-profiler/scripts.ts` — adds `BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT` (the injected IIFE that does the Metro scan + connect call).
- `packages/tool-server/src/utils/react-profiler/devtools-bootstrap.ts` *(new)* — `BootstrapResult` type, `BootstrapReason` union, and the `bootstrapFailureMessage()` helper that maps each reason to its agent-facing error. Mirrors the `session-ownership.ts` convention (types + pure helpers as a sibling of `scripts.ts`, unit-testable without CDP / vitest mocking).
- `packages/tool-server/src/tools/profiler/react/react-profiler-start.ts` — calls bootstrap on empty `rendererInterfaces`, re-runs setup, throws via the imported `bootstrapFailureMessage`. Also replaces two pre-existing error strings ("hook not present", `how_to_reclaim`) with the same agent-friendly phrasing used elsewhere in this PR.
- `packages/tool-server/test/react-profiler/bootstrap-devtools-backend.test.ts` *(new)* — 12 unit tests covering every reason branch (Map + array Metro registries, require() throws, getModules throws, connect throws, connect is a no-op, idempotent already-attached path).

## Manual verification (iPhone Air, RN 0.76.7 bridgeless, no external DevTools)

1. Reload bundle → confirm `rIds: [1,2], riIds: []` (bug state).
2. Pre-fix: `react-profiler-start` returns *"No React renderer interface attached yet…"*
3. Post-fix: `react-profiler-start` returns `{ started_at, hermes_version: "for RN 0.76.7", detected_architecture: "bridgeless" }`. Hook now shows `riIds: [1,2]`, `__argent_startWrapped__: true` on each, `reactDevtoolsAgent` set, `__argent_isProfiling__: true`.
4. Forced a React state-hook dispatch during the session and stopped: `total_react_commits: 2`, `unattributed_ms: 8.41` — real commit data captured through the bootstrapped backend.
5. Second `react-profiler-start` in same session returns success via `already-attached` early-exit (verified directly against the script). Hook listener counts (`renderer`, `renderer-attached`, `react-devtools`) stable across multiple cycles — no subscription leak.
6. Simulated `no-renderers` by clearing `h.renderers` → got *"React has not rendered yet, so there is nothing to profile. Ask the user to wait until the app shows React content…"*