### PR TITLE
fix(deps): resolve dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1242,10 +1244,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1267,7 +1271,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1438,7 +1444,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1477,7 +1485,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1694,7 +1704,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -1890,7 +1902,9 @@
       "license": "MIT"
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
Manual dependabot fixes.

## Details

<details>

**Lockfile-only.** `package.json` is unchanged; all bumps are within parents' already-declared semver ranges (API-compatible by semver contract). Refreshing the stale lock to the in-range patched versions:

- `fast-uri` 3.1.0 → **3.1.2** — *shipped*
- `path-to-regexp` 0.1.12 → **0.1.13** — *shipped* (upstream fix = two `backtrack = ''` resets)
- `hono` 4.12.3 → 4.12.19, `@hono/node-server` 1.19.9 → 1.19.14, `express-rate-limit` 8.2.1 → 8.5.2, `router`'s `path-to-regexp` 8.3.0 → 8.4.2 — *not shipped* (SDK HTTP/SSE transport; argent uses stdio only → tree-shaken out of bundles). Same low-risk stale-lock class, bumped in the same pass.
- `ip-address` 10.0.1 → 10.2.0 — benign in-range cascade from `express-rate-limit@8.5.2`'s own manifest.

`npm audit` HIGH for shipped/runtime deps: **7 → 0**.

## Scope

In scope (the QA finding): the two shipped HIGH advisories — fixed and proven present in freshly-built bundles.

Out of scope (deliberately): the remaining ~7 `npm audit` entries are **exclusively the dev-only vitest toolchain** (`vite`, `vite-node`, `esbuild`, `postcss`, `picomatch`, `@vitest/mocker`, `vitest`). Not shipped, not runtime. Their fix requires a `vitest` **semver-major** — a separate, breaking change.

## Verification

- `tsc --build` clean; **998 tests pass** across all 7 workspaces; `prettier --check .` clean.
- Bundles rebuilt from the patched tree; MCP stdio + tool-server E2E confirmed working.
- 4 independent reviews (correctness / scope / edge-cases / ripple): all PASS. Edge-case review ran an **offline differential** of every tool-server express route under 0.1.12 vs 0.1.13 (byte-identical `RegExp` source + keys) and a **live E2E** on the running patched tool-server — route matching is unchanged. `fast-uri` 3.1.2 only rejects more malformed URIs; `ajv` uses it solely for schema `$id`/`$ref`, never runtime data.
- `npm ci` is byte-stable against this lockfile (does not regenerate it); `npm pack --dry-run -w @swmansion/argent` passes.

## Residual `npm audit`

7 vulns remain (2 high, 5 moderate) — all dev-only vitest toolchain, tracked separately (needs `vitest` major).

</details>