### PR TITLE
chore: add Dependabot config (npm workspaces + GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,64 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 version: 2
+
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # npm: root + every workspace package (packages/*)
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/*"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      # Batch all minor + patch updates into one PR per week to cut noise.
+      npm-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Keep majors grouped but separate, since they typically need human review.
+      npm-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      # Group security updates across all directories.
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions used by workflows under .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable weekly version + security updates.
- Covers the **npm workspaces monorepo** (`/` + `/packages/*`) and **GitHub Actions** used in `.github/workflows`.
- Groups updates to keep PR noise low:
  - `npm-minor-patch` — one PR/week bundling all minor/patch bumps across the workspace.
  - `npm-major` — separate grouped PR for majors (typically needs human review).
  - `npm-security` — grouped security updates across all directories.
  - `github-actions` — one PR/week for all Actions bumps.
- Uses `directories:` (plural) with the `/packages/*` glob so every workspace package is monitored; majors stay separate from minor/patch so reviewers can triage breaking changes without blocking routine bumps.
- `gitsubmodule` ecosystem was intentionally **not** enabled — `packages/argent-private` is an internal submodule maintained by the same org, so SHA-bump PRs would be noise rather than signal.

## Notes
- Schedule: weekly, Monday 06:00 UTC.
- Commit prefixes follow the existing `chore(...)` convention used in this repo (`chore(deps)`, `chore(deps-dev)`, `chore(ci)`).
- `open-pull-requests-limit` set to 10 (npm) / 5 (actions) to bound the queue.

## Test plan
- [ ] Merge to `main`; confirm Dependabot picks up the file (visible under repo *Insights → Dependency graph → Dependabot*).
- [ ] First scheduled run on the following Monday produces grouped PRs (or trigger immediately via *Check for updates* in the Dependabot tab).
- [ ] Verify a sample PR's diff touches the expected workspace `package.json` + root `package-lock.json`.