### PR TITLE
Fetch argent skills from GitHub for portable lockfiles

### DIFF
--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -14,6 +14,7 @@ import {
   SKILLS_DIR,
   RULES_DIR,
   AGENTS_DIR,
+  buildArgentSkillsSource,
   getInstalledVersion,
   getLatestVersion,
   isGloballyInstalled,
@@ -460,6 +461,10 @@ export async function init(args: string[]): Promise<void> {
     skillsMethod = choice as SkillsMethod;
   }
 
+  // Prefer the GitHub-pinned source. SKILLS_DIR as a fallback.
+  const useGitHubSource = online && !fromTar && version !== "unknown";
+  const skillsSource = useGitHubSource ? buildArgentSkillsSource(version) : SKILLS_DIR;
+
   if (skillsMethod === "manual") {
     p.note(
       [
@@ -475,12 +480,12 @@ export async function init(args: string[]): Promise<void> {
         `  cp -r ${SKILLS_DIR}/* ${scope === "global" ? "~/.cursor/skills/" : `${scope === "custom" ? customRoot! : "."}/.cursor/skills/`}`,
         ``,
         `  ${pc.dim("# Or use npx skills directly:")}`,
-        `  npx skills add ${SKILLS_DIR}`,
+        `  npx skills add ${skillsSource}`,
       ].join("\n"),
       "Manual Skills Installation"
     );
   } else {
-    const skillsArgs = ["skills", "add", SKILLS_DIR];
+    const skillsArgs = ["skills", "add", skillsSource];
 
     if (scope === "global") {
       skillsArgs.push("-g");

--- a/packages/argent-installer/src/skills.ts
+++ b/packages/argent-installer/src/skills.ts
@@ -1,7 +1,9 @@
 import { execFileSync } from "node:child_process";
 import pc from "picocolors";
 import {
+  buildArgentSkillsSource,
   getGlobalSkillLockPath,
+  getInstalledVersion,
   getProjectSkillLockPath,
   listArgentSkillsInLock,
   listBundledSkills,
@@ -25,7 +27,7 @@ export interface SkillScopeResult {
 interface ScopeSpec {
   scope: SkillScope;
   lockPath: string;
-  addArgs: string[];
+  buildAddArgs: (source: string) => string[];
   removeArgs: string[];
 }
 
@@ -34,13 +36,13 @@ function getScopeSpecs(projectRoot: string): ScopeSpec[] {
     {
       scope: "project",
       lockPath: getProjectSkillLockPath(projectRoot),
-      addArgs: ["skills", "add", SKILLS_DIR, "--skill", "*", "-y"],
+      buildAddArgs: (source) => ["skills", "add", source, "--skill", "*", "-y"],
       removeArgs: ["skills", "remove", "-y"],
     },
     {
       scope: "global",
       lockPath: getGlobalSkillLockPath(),
-      addArgs: ["skills", "add", SKILLS_DIR, "--skill", "*", "-y", "-g"],
+      buildAddArgs: (source) => ["skills", "add", source, "--skill", "*", "-y", "-g"],
       removeArgs: ["skills", "remove", "-y", "-g"],
     },
   ];
@@ -52,14 +54,20 @@ function getScopeSpecs(projectRoot: string): ScopeSpec[] {
 // with nothing tracked is skipped, so this never creates a
 // `skills-lock.json` in an unrelated working directory.
 //
+// Sync prefers the GitHub-pinned source (`<repo>/packages/skills/skills#v<ver>`)
+// so the lockfile entry stays portable across machines. If the
+// network install fails, it retries with the bundled SKILLS_DIR so offline
+// users still get re-synced.
+//
 // The choice of `skills add` rather than `skills update` is deliberate:
-// argent ships skills with sourceType="local", and the skills CLI's update
-// command silently skips every local-sourced entry. `skills add` hashes the
-// source on disk and reinstalls anything that changed, which is exactly the
+// `skills update` silently skips any entry with sourceType="local", so a
+// previous-version lock written from SKILLS_DIR would never refresh. `skills
+// add` rewrites the entry from the source we pass, which is exactly the
 // behavior we want after `npm i -g @swmansion/argent@new`.
 export function refreshArgentSkills(projectRoot: string): SkillScopeResult[] {
   const bundled = new Set(listBundledSkills());
   const results: SkillScopeResult[] = [];
+  const primarySource = buildArgentSkillsSource(getInstalledVersion());
 
   for (const spec of getScopeSpecs(projectRoot)) {
     const tracked = listArgentSkillsInLock(spec.lockPath);
@@ -76,10 +84,27 @@ export function refreshArgentSkills(projectRoot: string): SkillScopeResult[] {
 
     if (bundled.size > 0) {
       try {
-        execFileSync("npx", spec.addArgs, { stdio: ["ignore", "pipe", "pipe"] });
+        execFileSync("npx", spec.buildAddArgs(primarySource), {
+          stdio: ["ignore", "pipe", "pipe"],
+        });
         result.synced = bundled.size;
-      } catch (err) {
-        result.syncError = err instanceof Error ? err.message.split("\n")[0] : String(err);
+      } catch (primaryErr) {
+        if (primarySource === SKILLS_DIR) {
+          result.syncError =
+            primaryErr instanceof Error ? primaryErr.message.split("\n")[0] : String(primaryErr);
+        } else {
+          try {
+            execFileSync("npx", spec.buildAddArgs(SKILLS_DIR), {
+              stdio: ["ignore", "pipe", "pipe"],
+            });
+            result.synced = bundled.size;
+          } catch (fallbackErr) {
+            result.syncError =
+              fallbackErr instanceof Error
+                ? fallbackErr.message.split("\n")[0]
+                : String(fallbackErr);
+          }
+        }
       }
     }
 

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -50,6 +50,22 @@ export const SKILLS_DIR = resolveBundledDir("skills");
 export const RULES_DIR = resolveBundledDir("rules");
 export const AGENTS_DIR = resolveBundledDir("agents");
 
+// GitHub source shorthand the `skills` CLI parses to a github-typed entry with
+// `subpath: "packages/skills/skills"` and the supplied ref. Pinning to the
+// installed argent version's git tag is what keeps `skills-lock.json` portable
+// across machines (see issue #208) — install paths stop being absolute and
+// teammates resolve the same SHA.
+export const ARGENT_SKILLS_REPO = "software-mansion/argent/packages/skills/skills";
+
+// Build the `skills add` source argument. Returns the GitHub-pinned shorthand
+// when a clean version is available; falls back to the bundled local SKILLS_DIR
+// when the version is unknown (e.g. dev tarball) so offline / pre-release
+// installs still succeed.
+export function buildArgentSkillsSource(version: string | null | undefined): string {
+  if (!version || version === "unknown") return SKILLS_DIR;
+  return `${ARGENT_SKILLS_REPO}#v${version}`;
+}
+
 // Returns the names of the skills that ship with this argent install — each
 // subdirectory of SKILLS_DIR that contains a SKILL.md. Used to detect which
 // skills on the user's machine are argent-owned so we don't touch anything

--- a/packages/argent-installer/test/init.test.ts
+++ b/packages/argent-installer/test/init.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 import * as path from "node:path";
-import { SKILLS_DIR, RULES_DIR, AGENTS_DIR } from "../src/utils.js";
+import {
+  SKILLS_DIR,
+  RULES_DIR,
+  AGENTS_DIR,
+  ARGENT_SKILLS_REPO,
+  buildArgentSkillsSource,
+} from "../src/utils.js";
 
 // These tests verify the logic used by init.ts without running the full TUI.
 // The actual init flow is interactive and tested via the integration harness.
@@ -24,34 +30,70 @@ describe("init — skills path resolution", () => {
   });
 });
 
-describe("init — skills command construction", () => {
-  it("default method builds correct args with global scope", () => {
-    const scope = "global";
-    const args = ["skills", "add", SKILLS_DIR];
-    if (scope === "global") args.push("-g");
-    args.push("--skill", "*", "-y");
+describe("buildArgentSkillsSource", () => {
+  it("returns the github shorthand pinned to v<version> for a clean semver", () => {
+    expect(buildArgentSkillsSource("0.7.1")).toBe(`${ARGENT_SKILLS_REPO}#v0.7.1`);
+  });
 
+  it("preserves pre-release identifiers in the pinned tag", () => {
+    expect(buildArgentSkillsSource("0.6.0-next.0")).toBe(`${ARGENT_SKILLS_REPO}#v0.6.0-next.0`);
+  });
+
+  it("falls back to SKILLS_DIR when the version is unknown", () => {
+    expect(buildArgentSkillsSource("unknown")).toBe(SKILLS_DIR);
+  });
+
+  it("falls back to SKILLS_DIR when no version is supplied", () => {
+    expect(buildArgentSkillsSource(null)).toBe(SKILLS_DIR);
+    expect(buildArgentSkillsSource(undefined)).toBe(SKILLS_DIR);
+    expect(buildArgentSkillsSource("")).toBe(SKILLS_DIR);
+  });
+});
+
+// Mirrors the args construction in init.ts Step 2. Kept as a regression check
+// against accidental flag reorders that would change `skills add` semantics
+// (e.g. dropping `-y` flipping into an interactive prompt during CI).
+describe("init — skills command construction", () => {
+  function buildArgs(
+    skillsSource: string,
+    scope: "local" | "global",
+    method: "default" | "interactive"
+  ): string[] {
+    const args = ["skills", "add", skillsSource];
+    if (scope === "global") args.push("-g");
+    if (method === "default") args.push("--skill", "*", "-y");
+    return args;
+  }
+
+  it("default method builds correct args with global scope", () => {
+    const source = buildArgentSkillsSource("0.7.1");
+    const args = buildArgs(source, "global", "default");
+
+    expect(args[2]).toBe(source);
     expect(args).toContain("-g");
     expect(args).toContain("--skill");
     expect(args).toContain("*");
     expect(args).toContain("-y");
-    expect(args[2]).toBe(SKILLS_DIR);
   });
 
-  it("default method builds correct args with local scope", () => {
-    const scope = "local";
-    const args = ["skills", "add", SKILLS_DIR];
-    if (scope === "global") args.push("-g");
-    args.push("--skill", "*", "-y");
+  it("default method omits -g for local scope", () => {
+    const args = buildArgs(buildArgentSkillsSource("0.7.1"), "local", "default");
 
     expect(args).not.toContain("-g");
     expect(args).toContain("-y");
   });
 
   it("interactive method passes no extra flags", () => {
-    const args = ["skills", "add", SKILLS_DIR];
+    const args = buildArgs(buildArgentSkillsSource("0.7.1"), "local", "interactive");
+
     expect(args).toHaveLength(3);
     expect(args).not.toContain("-y");
     expect(args).not.toContain("-g");
+  });
+
+  it("falls back to SKILLS_DIR when the version is unknown (e.g. dev tarball)", () => {
+    const args = buildArgs(buildArgentSkillsSource("unknown"), "local", "default");
+
+    expect(args[2]).toBe(SKILLS_DIR);
   });
 });


### PR DESCRIPTION
### Description

Install and sync argent skills from a GitHub-pinned source (`software-mansion/argent/packages/skills/skills#v<version>`) instead of the local bundle when possible, so `skills-lock.json` stays portable across machines. Falls back to the bundled skills directory when offline or the version is unknown.

### Fixes #208