### PR TITLE
fix(describe): fall back to systemElements when primaryApp walk is empty

### DIFF
--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -45,6 +45,13 @@ export interface AXDescribeResponse {
   alertVisible: boolean;
   screenFrame?: { width: number; height: number };
   elements: AXDescribeElement[];
+  // Populated by the daemon only when `isSystemAppShowingAnAlert` is true.
+  // Walks Springboard's tree, so it picks up dialogs that are not in the
+  // foreground app's `primaryApp` AX tree (e.g. XPC-presented sheets). For
+  // the dialogs `primaryApp` already carries — like a UIAlertController
+  // presented in-process — the same buttons appear in both arrays, so this
+  // field is only consumed by the adapter as a fallback.
+  systemElements?: AXDescribeElement[];
 }
 
 export interface AXServiceApi {
@@ -271,6 +278,7 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
           alertVisible: result.alertVisible ?? false,
           screenFrame: result.screenFrame,
           elements: result.elements ?? [],
+          systemElements: result.systemElements ?? [],
         };
       },
 

--- a/packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts
@@ -35,9 +35,7 @@ export function adaptAXElement(el: AXDescribeElement): DescribeNode | null {
 }
 
 export function adaptAXDescribeToDescribeResult(response: AXDescribeResponse): DescribeNode {
-  let children = response.elements
-    .map(adaptAXElement)
-    .filter((n): n is DescribeNode => n !== null);
+  let children = response.elements.map(adaptAXElement).filter((n): n is DescribeNode => n !== null);
 
   // Springboard-hosted overlays (e.g. AKAppleIDAuthentication sheets) can be
   // invisible to the `primaryApp` AX walk while still being reachable from

--- a/packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts
@@ -35,9 +35,21 @@ export function adaptAXElement(el: AXDescribeElement): DescribeNode | null {
 }
 
 export function adaptAXDescribeToDescribeResult(response: AXDescribeResponse): DescribeNode {
-  const children = response.elements
+  let children = response.elements
     .map(adaptAXElement)
     .filter((n): n is DescribeNode => n !== null);
+
+  // Springboard-hosted overlays (e.g. AKAppleIDAuthentication sheets) can be
+  // invisible to the `primaryApp` AX walk while still being reachable from
+  // `systemApplication`. The daemon already collects that tree as
+  // `systemElements` when `isSystemAppShowingAnAlert` is true, but for every
+  // in-process dialog the same buttons appear in `elements` and we'd just be
+  // duplicating them. Fall back only when the primary walk produced nothing.
+  if (children.length === 0 && response.systemElements && response.systemElements.length > 0) {
+    children = response.systemElements
+      .map(adaptAXElement)
+      .filter((n): n is DescribeNode => n !== null);
+  }
 
   return parseDescribeResult({
     role: "AXGroup",

--- a/packages/tool-server/test/describe-ax-adapter.test.ts
+++ b/packages/tool-server/test/describe-ax-adapter.test.ts
@@ -165,6 +165,104 @@ describe("describe ax-service adapter", () => {
     expect(root.children[1]?.label).toBe("Don\u2019t Allow");
   });
 
+  it("falls back to systemElements when elements is empty", () => {
+    // Models a Springboard-hosted overlay that did not propagate into
+    // primaryApp — the daemon collected it into systemElements and the
+    // adapter should surface those buttons instead of returning empty.
+    const response: AXDescribeResponse = {
+      alertVisible: true,
+      screenFrame: { width: 440, height: 956 },
+      elements: [],
+      systemElements: [
+        {
+          label: "Sign in",
+          frame: { x: 0.1, y: 0.7, width: 0.8, height: 0.05 },
+          traits: ["button"],
+        },
+        {
+          label: "Cancel",
+          frame: { x: 0.1, y: 0.76, width: 0.8, height: 0.05 },
+          traits: ["button"],
+        },
+      ],
+    };
+
+    const root = adaptAXDescribeToDescribeResult(response);
+    expect(root.children).toHaveLength(2);
+    expect(root.children[0]?.label).toBe("Sign in");
+    expect(root.children[1]?.label).toBe("Cancel");
+  });
+
+  it("ignores systemElements when elements produced any usable child", () => {
+    // The in-process dialog case (UIAlertController, Settings sheets): both
+    // arrays carry the same buttons, so the fallback would just duplicate.
+    const response: AXDescribeResponse = {
+      alertVisible: true,
+      screenFrame: { width: 440, height: 956 },
+      elements: [
+        {
+          label: "Allow",
+          frame: { x: 0.1, y: 0.5, width: 0.8, height: 0.05 },
+          traits: ["button"],
+        },
+      ],
+      systemElements: [
+        {
+          label: "12:14",
+          frame: { x: 0.13, y: 0.025, width: 0.1, height: 0.02 },
+          traits: ["staticText"],
+        },
+        {
+          label: "Allow",
+          frame: { x: 0.1, y: 0.5, width: 0.8, height: 0.05 },
+          traits: ["button"],
+        },
+      ],
+    };
+
+    const root = adaptAXDescribeToDescribeResult(response);
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0]?.label).toBe("Allow");
+  });
+
+  it("falls back to systemElements when elements is non-empty but all entries get filtered", () => {
+    // primaryApp returned junk (off-screen / zero-area frames) so the
+    // foreground walk effectively gave us nothing — fallback should fire.
+    const response: AXDescribeResponse = {
+      alertVisible: true,
+      screenFrame: { width: 440, height: 956 },
+      elements: [
+        {
+          label: "Hidden",
+          frame: { x: 1.5, y: 1.5, width: 0.1, height: 0.1 },
+          traits: ["button"],
+        },
+      ],
+      systemElements: [
+        {
+          label: "OK",
+          frame: { x: 0.1, y: 0.5, width: 0.8, height: 0.05 },
+          traits: ["button"],
+        },
+      ],
+    };
+
+    const root = adaptAXDescribeToDescribeResult(response);
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0]?.label).toBe("OK");
+  });
+
+  it("returns empty when both elements and systemElements are empty", () => {
+    const response: AXDescribeResponse = {
+      alertVisible: false,
+      elements: [],
+      systemElements: [],
+    };
+
+    const root = adaptAXDescribeToDescribeResult(response);
+    expect(root.children).toHaveLength(0);
+  });
+
   it("filters out elements with no visible area", () => {
     const response: AXDescribeResponse = {
       alertVisible: false,


### PR DESCRIPTION
## Status: empirically validated as a NO-OP for the reported case

I built this branch + installed it, then ran the reporter's actual trigger (News app → "Get News+" → "Get Started" → Apple Account auth sheet from `StoreKitUISceneService` XPC) against both this branch and main. **`describe` returns the same empty output on both branches.**

Saving the empirical artifact: both branches return `{ "source": "ax-service", ROOT: AXGroup with 0 children }` for the StoreKit auth sheet. The daemon emits neither `elements` (because `[AXElement primaryApp]` returns nothing for the XPC-hosted sheet) nor `systemElements` (because `[AXSpringBoardServer isSystemAppShowingAnAlert]` returns false — this sheet is not a Springboard alert), so the TS-side `systemElements` fallback this PR adds has nothing to fall back to.

The only existing code path that ever surfaced the dialog's buttons during testing was the **separate** `native-devtools` fallback (the dylib injected into the foreground app). That fallback is on `main` already, and its behavior is unchanged by this PR. It was also unreliable — it succeeded once, then `requiresAppRestart: true` on subsequent calls, then plain failure on the next launch.

## Summary (unchanged from before)

The ax-service daemon collects two AX trees per `describe` call: `elements` (foreground app via `primaryApp`) and `systemElements` (Springboard via `systemApplication`, gated on `isSystemAppShowingAnAlert`). The TS blueprint silently drops `systemElements` — the field isn't even declared on `AXDescribeResponse`. This PR forwards it and uses it as a fallback when the `primaryApp` walk yields zero usable children.

**What the PR is, accurately:** a structural cleanup of a dropped wire-format field, with a tightly-scoped fallback that fires only when `primaryApp` is empty. No behavior change for any in-process dialog I could trigger (Maps/Wallet permission alerts, Settings → Apple Account sheets, UIAlertController errors). And no behavior change for the StoreKit auth sheet — that case needs daemon work, not adapter work.

## What would actually fix the reporter's case

The dialog content lives in `com.apple.StoreKitUISceneService`, a separate process from both News (`primaryApp`) and Springboard (`systemApplication`). To make `describe` see it via ax-service, the daemon would need to walk *all* running apps' AX trees — e.g. via `+[AXElement applications]` or by enumerating from `AXSpringBoardServer` — and the wire format would need a new array for those. This is a daemon change requiring a binary rebuild + reship.

Alternatively, the `native-devtools` fallback (injected dylib walking the app's view hierarchy through `_UIRemoteViewController`) does see the content but is currently unreliable. Stabilising that would be the other path.

## Test plan

- [x] `npx vitest run -r packages/tool-server` — 679/679 pass
- [x] `npm run build` — clean
- [x] `npx prettier --check` — clean (fixed in `13cbc7e`)
- [x] Built tarball, installed globally, ran `argent run describe` against the reporter's exact trigger on an erased iOS 26.5 sim. Captured raw ax-service socket dumps.
- [x] Diffed PR-branch vs main-branch describe output for the auth sheet: **identical**, 427 bytes each, both empty ROOT under source `ax-service`.

## Recommendation

Two reasonable options:
1. **Land it anyway**, framed as a structural cleanup. Cheap, tested, won't regress anything I could find empirically. Doesn't fix the reporter's case, doesn't claim to.
2. **Close it**, pivot to daemon-side work (walk all applications + drop the `alertVisible` gate, or stabilise native-devtools for `_UIRemoteViewController`). The pivot is where the actual bilalq fix lives.

Marking the PR as a no-op for the StoreKit case rather than as a fix.