### PR TITLE
fix(init): prefer local devDep bundle paths over running module's

### DIFF
--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -11,9 +11,6 @@ import {
   type McpConfigAdapter,
 } from "./mcp-configs.js";
 import {
-  SKILLS_DIR,
-  RULES_DIR,
-  AGENTS_DIR,
   getInstalledVersion,
   getLatestVersion,
   isGloballyInstalled,
@@ -23,6 +20,7 @@ import {
   detectPackageManager,
   globalInstallCommand,
   formatShellCommand,
+  resolveProjectBundledDir,
   resolveProjectRoot,
   type ShellCommand,
 } from "./utils.js";
@@ -460,27 +458,39 @@ export async function init(args: string[]): Promise<void> {
     skillsMethod = choice as SkillsMethod;
   }
 
+  // Prefer the project's devDep copy of the bundled assets when it
+  // exists. When init runs via `npx @swmansion/argent`, the module-
+  // relative SKILLS_DIR resolves to ~/.npm/_npx/<hash>/... — passing
+  // that to `npx skills add` makes the skills CLI record the npx
+  // hash in skills-lock.json, which is invalid the moment that
+  // cache is evicted (and broken from the start for any teammate
+  // who picks up a committed copy). See resolveProjectBundledDir.
+  const projectRootForBundles = resolveProjectRoot(process.cwd());
+  const skillsBundle = resolveProjectBundledDir(projectRootForBundles, "skills");
+  const rulesBundle = resolveProjectBundledDir(projectRootForBundles, "rules");
+  const agentsBundle = resolveProjectBundledDir(projectRootForBundles, "agents");
+
   if (skillsMethod === "manual") {
     p.note(
       [
         `Skills are bundled at:`,
-        `  ${pc.cyan(SKILLS_DIR)}`,
+        `  ${pc.cyan(skillsBundle)}`,
         ``,
         `To install manually, copy them to your editor's skills directory:`,
         ``,
         `  ${pc.dim("# Claude Code")}`,
-        `  cp -r ${SKILLS_DIR}/* ${scope === "global" ? "~/.claude/skills/" : `${scope === "custom" ? customRoot! : "."}/.claude/skills/`}`,
+        `  cp -r ${skillsBundle}/* ${scope === "global" ? "~/.claude/skills/" : `${scope === "custom" ? customRoot! : "."}/.claude/skills/`}`,
         ``,
         `  ${pc.dim("# Cursor")}`,
-        `  cp -r ${SKILLS_DIR}/* ${scope === "global" ? "~/.cursor/skills/" : `${scope === "custom" ? customRoot! : "."}/.cursor/skills/`}`,
+        `  cp -r ${skillsBundle}/* ${scope === "global" ? "~/.cursor/skills/" : `${scope === "custom" ? customRoot! : "."}/.cursor/skills/`}`,
         ``,
         `  ${pc.dim("# Or use npx skills directly:")}`,
-        `  npx skills add ${SKILLS_DIR}`,
+        `  npx skills add ${skillsBundle}`,
       ].join("\n"),
       "Manual Skills Installation"
     );
   } else {
-    const skillsArgs = ["skills", "add", SKILLS_DIR];
+    const skillsArgs = ["skills", "add", skillsBundle];
 
     if (scope === "global") {
       skillsArgs.push("-g");
@@ -522,8 +532,8 @@ export async function init(args: string[]): Promise<void> {
     selectedAdapters,
     effectiveRoot,
     normalizedScope,
-    RULES_DIR,
-    AGENTS_DIR
+    rulesBundle,
+    agentsBundle
   );
 
   if (copyResults.length > 0) {

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -50,6 +50,43 @@ export const SKILLS_DIR = resolveBundledDir("skills");
 export const RULES_DIR = resolveBundledDir("rules");
 export const AGENTS_DIR = resolveBundledDir("agents");
 
+/**
+ * Prefer the project's locally-installed devDep copy of argent's bundled
+ * assets over the running module's. Falls back to the module-relative
+ * default when no local copy exists.
+ *
+ * Why this exists: when init runs via `npx @swmansion/argent`, the
+ * running module lives in `~/.npm/_npx/<hash>/node_modules/@swmansion/
+ * argent`. Passing the npx path to downstream tooling (e.g. `npx skills
+ * add <dir>`) causes that tooling to record the npx hash into
+ * skills-lock.json:
+ *
+ *   "source": "/Users/me/.npm/_npx/abc123/node_modules/@swmansion/argent/skills"
+ *
+ * The npx cache is per-user, transient, and gets evicted over time.
+ * Once committed to git, that path is broken for every teammate and
+ * eventually for the original author too. Reading from the project's
+ * own node_modules instead gives a stable, version-pinned path that
+ * matches what `npm install` provisions for every checkout.
+ *
+ * Returns the local devDep path iff `<projectRoot>/node_modules/
+ * @swmansion/argent/<kind>` exists as a directory. We don't gate this
+ * on whether argent is declared as a dependency: the running init is
+ * itself argent code, so finding bundled assets at the project-local
+ * path is the strongest possible signal that they should be used.
+ */
+export function resolveProjectBundledDir(
+  projectRoot: string,
+  kind: "skills" | "rules" | "agents"
+): string {
+  const candidate = path.join(projectRoot, "node_modules", "@swmansion", "argent", kind);
+  return dirExists(candidate) ? candidate : moduleBundledDirFor(kind);
+}
+
+function moduleBundledDirFor(kind: "skills" | "rules" | "agents"): string {
+  return kind === "skills" ? SKILLS_DIR : kind === "rules" ? RULES_DIR : AGENTS_DIR;
+}
+
 // Returns the names of the skills that ship with this argent install — each
 // subdirectory of SKILLS_DIR that contains a SKILL.md. Used to detect which
 // skills on the user's machine are argent-owned so we don't touch anything

--- a/packages/argent-installer/test/utils.test.ts
+++ b/packages/argent-installer/test/utils.test.ts
@@ -47,6 +47,7 @@ import {
   isOnline,
   isSkillsCliAvailable,
   listBundledSkills,
+  resolveProjectBundledDir,
   resolveProjectRoot,
   SKILLS_DIR,
   RULES_DIR,
@@ -313,6 +314,58 @@ describe("bundled paths", () => {
 
   it("AGENTS_DIR is a string ending with agents", () => {
     expect(AGENTS_DIR).toMatch(/agents$/);
+  });
+});
+
+// ── resolveProjectBundledDir ────────────────────────────────────────────────
+// Prefer the project's devDep copy over the running module's bundled
+// path. When init runs via `npx @swmansion/argent` the module-relative
+// SKILLS_DIR points at ~/.npm/_npx/<hash>/...; passing that to `npx
+// skills add` leaks the npx hash into skills-lock.json, which becomes
+// useless the moment the cache is evicted.
+
+describe("resolveProjectBundledDir", () => {
+  it("falls back to the module-relative path when no local devDep exists", () => {
+    expect(resolveProjectBundledDir(tmpDir, "skills")).toBe(SKILLS_DIR);
+    expect(resolveProjectBundledDir(tmpDir, "rules")).toBe(RULES_DIR);
+    expect(resolveProjectBundledDir(tmpDir, "agents")).toBe(AGENTS_DIR);
+  });
+
+  it("returns the local devDep skills dir when present", () => {
+    const localSkills = path.join(tmpDir, "node_modules", "@swmansion", "argent", "skills");
+    fs.mkdirSync(localSkills, { recursive: true });
+    expect(resolveProjectBundledDir(tmpDir, "skills")).toBe(localSkills);
+  });
+
+  it("returns the local devDep rules dir when present", () => {
+    const localRules = path.join(tmpDir, "node_modules", "@swmansion", "argent", "rules");
+    fs.mkdirSync(localRules, { recursive: true });
+    expect(resolveProjectBundledDir(tmpDir, "rules")).toBe(localRules);
+  });
+
+  it("returns the local devDep agents dir when present", () => {
+    const localAgents = path.join(tmpDir, "node_modules", "@swmansion", "argent", "agents");
+    fs.mkdirSync(localAgents, { recursive: true });
+    expect(resolveProjectBundledDir(tmpDir, "agents")).toBe(localAgents);
+  });
+
+  it("falls back when only one of the three bundles exists locally", () => {
+    // The team-share workflow expects all three to be present together
+    // (they ship from a single package), but a partially-restored
+    // node_modules shouldn't break the others' resolution.
+    fs.mkdirSync(path.join(tmpDir, "node_modules", "@swmansion", "argent", "skills"), {
+      recursive: true,
+    });
+    expect(resolveProjectBundledDir(tmpDir, "skills")).toContain("node_modules");
+    expect(resolveProjectBundledDir(tmpDir, "rules")).toBe(RULES_DIR);
+    expect(resolveProjectBundledDir(tmpDir, "agents")).toBe(AGENTS_DIR);
+  });
+
+  it("does NOT match a regular file at the expected path (defensive)", () => {
+    const localSkills = path.join(tmpDir, "node_modules", "@swmansion", "argent", "skills");
+    fs.mkdirSync(path.dirname(localSkills), { recursive: true });
+    fs.writeFileSync(localSkills, "this is a file, not a directory");
+    expect(resolveProjectBundledDir(tmpDir, "skills")).toBe(SKILLS_DIR);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing leak that surfaces when `argent init` is run via `npx @swmansion/argent` (the default install recipe in the README). The module-relative `SKILLS_DIR` / `RULES_DIR` / `AGENTS_DIR` resolve to the npx cache directory in that case:

```
~/.npm/_npx/008dffcbe9d304e1/node_modules/@swmansion/argent/skills
```

When init shells out to `npx skills add <SKILLS_DIR>`, the skills CLI records that path verbatim in `skills-lock.json`:

```json
{
  "skills": {
    "argent-android-emulator-setup": {
      "source": "/Users/me/.npm/_npx/008dffcbe9d304e1/node_modules/@swmansion/argent/skills",
      "sourceType": "local",
      ...
    }
  }
}
```

That path is per-developer, per-npx-invocation, and gets evicted from the cache over time. The lock file becomes broken on the original machine (eventually) and is broken from day one for any teammate who picks up a committed copy.

## Fix

New helper `resolveProjectBundledDir(projectRoot, kind)` in `utils.ts`:

- Returns `<projectRoot>/node_modules/@swmansion/argent/<kind>` when that directory exists.
- Falls back to the module-relative `SKILLS_DIR` / `RULES_DIR` / `AGENTS_DIR` otherwise.

init's Step 2 (skills) and Step 3 (rules & agents) now use this helper instead of the module-relative constants. The skills CLI sees a stable, version-pinned project-local path; teammates' `npm install` provisions the same path on every checkout.

The check is intentionally loose — no `package.json` dep declaration required. The running init is itself argent code; finding bundled assets at the project-local path is the strongest possible signal that they should be used. That happens whenever a teammate has argent listed as a dependency (workspace member, regular devDep, or a manual `npm i -D @swmansion/argent`), which is exactly the case where the bug matters.

## Why this isn't part of the team-share PR

The bug exists for **any** `npx`-driven init, not just the `--devdep` flow. Splitting it out so it can land independently:

- A team using the existing `--scope local` (without `--devdep`) can ship this fix without waiting on the team-share PR (#232).
- The team-share PR stays focused on the user-facing feature it advertises.

## Tests

`@argent/installer`: 237 passed (+6 new):

- `resolveProjectBundledDir` returns the local devDep path when present (for `skills` / `rules` / `agents`).
- Returns the module-relative fallback when no local devDep exists.
- Partial-bundle case (only one of the three dirs locally) resolves per-kind correctly.
- Defensive guard: a regular file at the expected path falls back rather than mis-reporting.

## Test plan

- [ ] Run `npx ./swmansion-argent-X.Y.Z.tgz init` in a project that has `@swmansion/argent` declared as a devDep with `node_modules/@swmansion/argent/skills` populated. Verify the resulting `skills-lock.json` `source` field contains `<projectRoot>/node_modules/@swmansion/argent/skills`, not `~/.npm/_npx/...`.
- [ ] Run `npx ./swmansion-argent-X.Y.Z.tgz init` in a project that does NOT have argent locally — verify the existing behavior is preserved (`source` points at whatever the running module resolves to; no functional regression for users who run init once and don't commit the lock file).