### PR TITLE
feat: refactor android describe to not rely on uiautomator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ packages/argent/dylibs/
 packages/argent/skills/
 packages/argent/agents/
 packages/argent/rules/
+packages/argent/manifest.json
 packages/argent/README.md
 
 # We do intentionally track internal .claude skills. Do not remove them solely based on .gitignore 

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,40 +91,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
@@ -1328,6 +1294,7 @@
       "version": "22.19.11",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1928,6 +1895,7 @@
     "node_modules/express": {
       "version": "4.22.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2219,6 +2187,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
       "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2755,6 +2724,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3263,6 +3233,7 @@
       "version": "0.21.1",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -3368,6 +3339,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3413,6 +3385,7 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3662,6 +3635,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3968,36 +3942,6 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/mcp": {
-      "name": "@swmansion/argent",
-      "version": "0.5.3",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.20.0"
-      },
-      "bin": {
-        "argent": "dist/cli.js",
-        "argent-simulator-server": "bin/simulator-server"
-      },
-      "devDependencies": {
-        "@argent/cli": "file:../argent-cli",
-        "@argent/installer": "file:../argent-installer",
-        "@argent/mcp": "file:../argent-mcp",
-        "@argent/tools-client": "file:../argent-tools-client",
-        "@clack/prompts": "^1.1.0",
-        "@types/node": "^22.0.0",
-        "@types/semver": "^7.7.1",
-        "esbuild": "^0.27.3",
-        "picocolors": "^1.1.1",
-        "semver": "^7.7.4",
-        "smol-toml": "^1.6.1",
-        "typescript": "^5.5.0",
-        "vitest": "^4.0.18",
-        "yaml": "^2.8.3"
-      }
     },
     "packages/native-devtools-android": {
       "name": "@argent/native-devtools-android",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,10 @@
       "resolved": "packages/argent-mcp",
       "link": true
     },
+    "node_modules/@argent/native-devtools-android": {
+      "resolved": "packages/native-devtools-android",
+      "link": true
+    },
     "node_modules/@argent/native-devtools-ios": {
       "resolved": "packages/native-devtools-ios",
       "link": true
@@ -1023,9 +1027,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1043,9 +1044,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,9 +1061,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1083,9 +1078,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,9 +1095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1123,9 +1112,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2457,9 +2443,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2481,9 +2464,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2505,9 +2485,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2529,9 +2506,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3394,7 +3368,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4026,6 +3999,14 @@
         "yaml": "^2.8.3"
       }
     },
+    "packages/native-devtools-android": {
+      "name": "@argent/native-devtools-android",
+      "version": "0.7.1",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
       "version": "0.7.1",
@@ -4101,6 +4082,7 @@
       "name": "@argent/tool-server",
       "version": "0.7.1",
       "dependencies": {
+        "@argent/native-devtools-android": "file:../native-devtools-android",
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
         "@argent/registry": "file:../registry",
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "start:tool-server": "npm run build -w @argent/registry && npm run dev -w @argent/tool-server",
     "download:simulator-server": "bash scripts/download-simulator-server.sh",
     "download:native-binaries": "bash scripts/download-native-binaries.sh",
+    "build:ios-binaries": "bash packages/native-devtools-ios/scripts/build.sh dev",
+    "build:android-binaries": "bash packages/native-devtools-android/scripts/build.sh",
     "pack": "npm run download:simulator-server && npm run download:native-binaries && npm run build && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
     "pack:mcp": "npm run pack",
+    "pack:mcp:local": "npm run download:simulator-server && npm run build:ios-binaries && npm run build:android-binaries && npm run build && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
     "dev": "node scripts/dev.cjs",
     "format": "prettier --write ."
   },

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -36,6 +36,7 @@
     "skills/",
     "agents/",
     "rules/",
+    "manifest.json",
     "scripts/postinstall.cjs"
   ],
   "dependencies": {

--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -61,6 +61,11 @@ const RULES_SRC = path.resolve(WORKSPACE_ROOT, "packages/skills/rules");
 const RULES_DEST = path.resolve(__dirname, "../rules");
 const AGENTS_SRC = path.resolve(WORKSPACE_ROOT, "packages/skills/agents");
 const AGENTS_DEST = path.resolve(__dirname, "../agents");
+const ANDROID_PKG_DIR = path.resolve(WORKSPACE_ROOT, "packages/native-devtools-android");
+const ANDROID_MANIFEST_SRC = path.join(ANDROID_PKG_DIR, "manifest.json");
+const ANDROID_MANIFEST_DEST = path.resolve(__dirname, "../manifest.json");
+const ANDROID_APK_DIST_SRC = path.join(ANDROID_PKG_DIR, "dist");
+const ANDROID_APK_DEST_DIR = path.resolve(__dirname, "../dist");
 
 // Purge artifact directories so stale files don't survive across builds.
 for (const dir of [BIN_DIR, DYLIBS_DEST, SKILLS_DEST, RULES_DEST, AGENTS_DEST]) {
@@ -164,6 +169,28 @@ if (fs.existsSync(DYLIBS_SRC)) {
   console.log(`✓ Copied ${count} native dylib(s) → ${path.relative(process.cwd(), DYLIBS_DEST)}`);
 } else {
   console.warn(`⚠ Native devtools dylibs not found at ${DYLIBS_SRC} — skipping copy`);
+}
+
+// Copy the Android helper APK + its manifest.json into the published package.
+if (fs.existsSync(ANDROID_MANIFEST_SRC)) {
+  const manifest = JSON.parse(fs.readFileSync(ANDROID_MANIFEST_SRC, "utf8"));
+  const apkName = `argent-android-devtools-${manifest.versionName}.apk`;
+  const apkSrc = path.join(ANDROID_APK_DIST_SRC, apkName);
+  if (fs.existsSync(apkSrc)) {
+    fs.copyFileSync(ANDROID_MANIFEST_SRC, ANDROID_MANIFEST_DEST);
+    fs.copyFileSync(apkSrc, path.join(ANDROID_APK_DEST_DIR, apkName));
+    console.log(
+      `✓ Copied Android helper APK + manifest → ${path.relative(process.cwd(), ANDROID_APK_DEST_DIR)}/${apkName}`
+    );
+  } else {
+    console.warn(
+      `⚠ Android helper APK not found at ${apkSrc} — run ` +
+        `\`bash packages/native-devtools-android/scripts/build.sh\` ` +
+        `or \`bash scripts/download-native-binaries.sh\` first`
+    );
+  }
+} else {
+  console.warn(`⚠ Android manifest not found at ${ANDROID_MANIFEST_SRC} — skipping copy`);
 }
 
 // Copy preview UI (@argent/ui) next to the bundled tool-server so that

--- a/packages/native-devtools-android/.gitattributes
+++ b/packages/native-devtools-android/.gitattributes
@@ -1,0 +1,1 @@
+dist/*.apk binary

--- a/packages/native-devtools-android/manifest.json
+++ b/packages/native-devtools-android/manifest.json
@@ -1,0 +1,10 @@
+{
+  "packageName": "com.argent.androiddevtools",
+  "instrumentationRunner": "com.argent.androiddevtools/.SnapshotInstrumentation",
+  "versionName": "0.1.0",
+  "versionCode": 1,
+  "installFlags": [
+    "-r",
+    "-t"
+  ]
+}

--- a/packages/native-devtools-android/manifest.json
+++ b/packages/native-devtools-android/manifest.json
@@ -3,8 +3,5 @@
   "instrumentationRunner": "com.argent.androiddevtools/.SnapshotInstrumentation",
   "versionName": "0.1.0",
   "versionCode": 1,
-  "installFlags": [
-    "-r",
-    "-t"
-  ]
+  "installFlags": ["-r", "-t"]
 }

--- a/packages/native-devtools-android/package.json
+++ b/packages/native-devtools-android/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@argent/native-devtools-android",
+  "version": "0.7.1",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/*.apk", "dist/index.js", "dist/index.d.ts", "manifest.json"],
+  "scripts": {
+    "build": "rm -rf dist/index.* tsconfig.tsbuildinfo && tsc",
+    "build:native": "bash scripts/build.sh"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/native-devtools-android/package.json
+++ b/packages/native-devtools-android/package.json
@@ -4,7 +4,12 @@
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist/*.apk", "dist/index.js", "dist/index.d.ts", "manifest.json"],
+  "files": [
+    "dist/*.apk",
+    "dist/index.js",
+    "dist/index.d.ts",
+    "manifest.json"
+  ],
   "scripts": {
     "build": "rm -rf dist/index.* tsconfig.tsbuildinfo && tsc",
     "build:native": "bash scripts/build.sh"

--- a/packages/native-devtools-android/scripts/build.sh
+++ b/packages/native-devtools-android/scripts/build.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Build native-devtools-android APK for Argent.
+# Java sources live in the argent-private submodule at
+#   packages/argent-private/packages/native-devtools-android/Sources/AndroidDevtools/
+# Mirrors `packages/native-devtools-ios/scripts/build.sh` shape.
+#
+# Run from the workspace root: bash packages/native-devtools-android/scripts/build.sh
+# Or from this package: bash scripts/build.sh
+#
+# `versionName` and `versionCode` are sourced from manifest.json — bump that
+# file in git when releasing a new helper, then rebuild.
+#
+# Environment:
+#   PREBUILT_ANDROID_DEVTOOLS_APK  if set, copy this path to dist/ instead of
+#                                  building (used by CI / non-Android-SDK hosts)
+#
+# Required tools (resolved via $ANDROID_HOME):
+#   - javac (system)
+#   - $ANDROID_HOME/build-tools/$BUILD_TOOLS/{d8,aapt2,zipalign,apksigner}
+#   - $ANDROID_HOME/platforms/android-$COMPILE_SDK/android.jar
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE_DIR="$(cd "${PKG_DIR}/../.." && pwd)"
+SUBMODULE_DIR="${WORKSPACE_DIR}/packages/argent-private/packages/native-devtools-android"
+SRC_DIR="${SUBMODULE_DIR}/Sources/AndroidDevtools"
+DIST_DIR="${PKG_DIR}/dist"
+BUILD_DIR="${PKG_DIR}/.build"
+
+VERSION="$(node -p "require('${PKG_DIR}/manifest.json').versionName")"
+VERSION_CODE="$(node -p "require('${PKG_DIR}/manifest.json').versionCode")"
+
+APK_OUT="${DIST_DIR}/argent-android-devtools-${VERSION}.apk"
+mkdir -p "${DIST_DIR}"
+
+# If a prebuilt APK is provided (CI on a non-Android host, or local PREBUILT
+# override), copy it and skip the build pipeline.
+if [[ -n "${PREBUILT_ANDROID_DEVTOOLS_APK:-}" ]]; then
+  echo "Using prebuilt APK from PREBUILT_ANDROID_DEVTOOLS_APK"
+  cp "${PREBUILT_ANDROID_DEVTOOLS_APK}" "${APK_OUT}"
+  echo "Done. APK at ${APK_OUT}"
+  exit 0
+fi
+
+# Verify the submodule is initialised before trying to build.
+if [[ ! -d "${SRC_DIR}" ]]; then
+  echo "Error: Android source not found at ${SRC_DIR}" >&2
+  echo "       Run: git submodule update --init packages/argent-private" >&2
+  echo "       Or set PREBUILT_ANDROID_DEVTOOLS_APK=/path/to/argent-android-devtools.apk" >&2
+  exit 1
+fi
+
+if [[ -z "${ANDROID_HOME:-}" ]]; then
+  if [[ -d "${HOME}/Library/Android/sdk" ]]; then
+    export ANDROID_HOME="${HOME}/Library/Android/sdk"
+  elif [[ -d "${HOME}/Android/Sdk" ]]; then
+    export ANDROID_HOME="${HOME}/Android/Sdk"
+  else
+    echo "ANDROID_HOME is not set and no default SDK location found." >&2
+    echo "Set ANDROID_HOME or PREBUILT_ANDROID_DEVTOOLS_APK." >&2
+    exit 1
+  fi
+fi
+
+# Pick the highest-numbered build-tools directory that has d8 + aapt2 + zipalign + apksigner.
+BUILD_TOOLS_DIR=""
+for candidate in $(ls -1 "${ANDROID_HOME}/build-tools" 2>/dev/null | sort -V -r); do
+  bt="${ANDROID_HOME}/build-tools/${candidate}"
+  if [[ -x "${bt}/d8" && -x "${bt}/aapt2" && -x "${bt}/zipalign" && -x "${bt}/apksigner" ]]; then
+    BUILD_TOOLS_DIR="${bt}"
+    break
+  fi
+done
+
+if [[ -z "${BUILD_TOOLS_DIR}" ]]; then
+  echo "Could not locate a build-tools directory under ${ANDROID_HOME}/build-tools that contains d8 + aapt2 + zipalign + apksigner." >&2
+  exit 1
+fi
+
+# Pick the highest android-XX platform that ships android.jar.
+ANDROID_JAR=""
+for candidate in $(ls -1 "${ANDROID_HOME}/platforms" 2>/dev/null | sed 's/android-//' | sort -nr); do
+  jar="${ANDROID_HOME}/platforms/android-${candidate}/android.jar"
+  if [[ -f "${jar}" ]]; then
+    ANDROID_JAR="${jar}"
+    break
+  fi
+done
+
+if [[ -z "${ANDROID_JAR}" ]]; then
+  echo "Could not locate android.jar under ${ANDROID_HOME}/platforms/android-*/." >&2
+  exit 1
+fi
+
+# Keystore lives in the submodule. Rotating it requires a major version bump
+# because `adb install -r` enforces signature match across upgrades.
+KEYSTORE="${SRC_DIR}/debug.keystore"
+if [[ ! -f "${KEYSTORE}" ]]; then
+  echo "Error: keystore missing from submodule at ${KEYSTORE}" >&2
+  exit 1
+fi
+
+echo "→ ANDROID_HOME=${ANDROID_HOME}"
+echo "→ build-tools=${BUILD_TOOLS_DIR}"
+echo "→ android.jar=${ANDROID_JAR}"
+echo "→ submodule src=${SRC_DIR}"
+echo "→ version=${VERSION} (code ${VERSION_CODE})"
+
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}/classes" "${BUILD_DIR}/dex"
+
+echo "→ javac"
+JAVA_SOURCES=$(find "${SRC_DIR}" -name '*.java')
+javac --release 11 \
+  -classpath "${ANDROID_JAR}" \
+  -d "${BUILD_DIR}/classes" \
+  ${JAVA_SOURCES}
+
+echo "→ d8"
+"${BUILD_TOOLS_DIR}/d8" \
+  --min-api 23 \
+  --classpath "${ANDROID_JAR}" \
+  --output "${BUILD_DIR}/dex" \
+  $(find "${BUILD_DIR}/classes" -name '*.class')
+
+echo "→ aapt2 link"
+"${BUILD_TOOLS_DIR}/aapt2" link \
+  --manifest "${SRC_DIR}/AndroidManifest.xml" \
+  -I "${ANDROID_JAR}" \
+  --min-sdk-version 23 \
+  --target-sdk-version 36 \
+  --version-code "${VERSION_CODE}" \
+  --version-name "${VERSION}" \
+  -o "${BUILD_DIR}/unsigned.apk"
+
+echo "→ zip classes.dex into APK"
+(cd "${BUILD_DIR}/dex" && zip -j -q "${BUILD_DIR}/unsigned.apk" classes.dex)
+
+echo "→ zipalign"
+"${BUILD_TOOLS_DIR}/zipalign" -f 4 "${BUILD_DIR}/unsigned.apk" "${BUILD_DIR}/aligned.apk"
+
+echo "→ apksigner"
+"${BUILD_TOOLS_DIR}/apksigner" sign \
+  --ks "${KEYSTORE}" \
+  --ks-pass pass:android \
+  --key-pass pass:android \
+  --out "${APK_OUT}" \
+  "${BUILD_DIR}/aligned.apk"
+
+echo "→ wrote ${APK_OUT} ($(stat -f%z "${APK_OUT}" 2>/dev/null || stat -c%s "${APK_OUT}") bytes)"
+
+rm -rf "${BUILD_DIR}"

--- a/packages/native-devtools-android/src/index.ts
+++ b/packages/native-devtools-android/src/index.ts
@@ -1,0 +1,36 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+// Mirror of @argent/native-devtools-ios's index.ts. ARGENT_NATIVE_DEVTOOLS_ANDROID_DIR
+// lets a launcher override the dist directory (e.g. when ts-node runs from src/).
+const DIST_DIR =
+  process.env.ARGENT_NATIVE_DEVTOOLS_ANDROID_DIR ?? path.join(__dirname, "..", "dist");
+
+interface HelperManifest {
+  packageName: string;
+  instrumentationRunner: string;
+  versionName: string;
+  versionCode: number;
+  installFlags: string[];
+}
+
+let cachedManifest: HelperManifest | null = null;
+
+export function helperManifest(): HelperManifest {
+  if (cachedManifest) return cachedManifest;
+  const manifestPath = path.join(__dirname, "..", "manifest.json");
+  cachedManifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as HelperManifest;
+  return cachedManifest;
+}
+
+export function bundledHelperApkPath(): string {
+  const manifest = helperManifest();
+  const apk = path.join(DIST_DIR, `argent-android-devtools-${manifest.versionName}.apk`);
+  if (!fs.existsSync(apk)) {
+    throw new Error(
+      `Bundled Android devtools helper APK not found at ${apk}. ` +
+        `Run \`bash packages/native-devtools-android/scripts/build.sh\` to build it.`
+    );
+  }
+  return apk;
+}

--- a/packages/native-devtools-android/tsconfig.json
+++ b/packages/native-devtools-android/tsconfig.json
@@ -1,16 +1,11 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "composite": true,
     "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "incremental": true
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/native-devtools-android/tsconfig.json
+++ b/packages/native-devtools-android/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "incremental": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@argent/registry": "file:../registry",
     "@argent/native-devtools-ios": "file:../native-devtools-ios",
+    "@argent/native-devtools-android": "file:../native-devtools-android",
     "@clack/prompts": "^1.1.0",
     "express": "^4.19.2",
     "semver": "^7.7.4",

--- a/packages/tool-server/src/blueprints/android-devtools.ts
+++ b/packages/tool-server/src/blueprints/android-devtools.ts
@@ -1,0 +1,296 @@
+import { spawn, ChildProcess } from "node:child_process";
+import * as readline from "node:readline";
+import {
+  TypedEventEmitter,
+  type DeviceInfo,
+  type ServiceBlueprint,
+  type ServiceInstance,
+  type ServiceEvents,
+} from "@argent/registry";
+import { helperManifest } from "@argent/native-devtools-android";
+import { runAdb } from "../utils/adb";
+import { resolveAndroidBinary } from "../utils/android-binary";
+import { ensureAndroidDevtoolsInstalled } from "../utils/android-helper-install";
+import {
+  connectAndroidDevtoolsClient,
+  type AndroidDevtoolsClient,
+} from "../utils/android-devtools-client";
+
+export const ANDROID_DEVTOOLS_NAMESPACE = "AndroidDevtools";
+
+type AndroidDevtoolsFactoryOptions = Record<string, unknown> & { device: DeviceInfo };
+
+export function androidDevtoolsRef(device: DeviceInfo): {
+  urn: string;
+  options: AndroidDevtoolsFactoryOptions;
+} {
+  return {
+    urn: `${ANDROID_DEVTOOLS_NAMESPACE}:${device.id}`,
+    options: { device },
+  };
+}
+
+export interface GetHierarchyOptions {
+  waitForIdleMs?: number;
+  maxDepth?: number;
+  maxNodes?: number;
+}
+
+export interface HierarchyResult {
+  xml: string;
+  captureMode: string;
+  windowCount: number;
+  nodeCount: number;
+  truncated: boolean;
+  elapsedMs: number;
+}
+
+export interface AndroidDevtoolsApi {
+  isReady(): boolean;
+  getHierarchy(options?: GetHierarchyOptions): Promise<HierarchyResult>;
+  getScreenSize(): Promise<{ width: number; height: number; rotation: number }>;
+  ping(): Promise<{ ok: boolean; idleMs: number; protocol: string }>;
+}
+
+const READY_TIMEOUT_MS = 30_000;
+const HELPER_PORT_MARKER = /^INSTRUMENTATION_STATUS:\s*port=(\d+)/;
+const ADB_FORWARD_PORT_MARKER = /^(\d+)\s*$/;
+
+interface SpawnedHelper {
+  proc: ChildProcess;
+  devicePort: number;
+  localPort: number;
+}
+
+async function spawnHelper(serial: string): Promise<SpawnedHelper> {
+  const manifest = helperManifest();
+  const adbPath = await resolveAndroidBinary("adb");
+  if (!adbPath) {
+    throw new Error(
+      "`adb` not found on PATH or under `$ANDROID_HOME/platform-tools` while spawning android-devtools helper."
+    );
+  }
+
+  const proc = spawn(adbPath, [
+    "-s",
+    serial,
+    "shell",
+    "am",
+    "instrument",
+    "-w",
+    manifest.instrumentationRunner,
+  ], { stdio: ["ignore", "pipe", "pipe"] });
+
+  return new Promise<SpawnedHelper>((resolve, reject) => {
+    let devicePort: number | null = null;
+    let localPort: number | null = null;
+    let settled = false;
+    let stderrBuf = "";
+
+    const settle = (fn: () => void, cleanup?: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      rl.close();
+      cleanup?.();
+      fn();
+    };
+
+    const rl = readline.createInterface({ input: proc.stdout! });
+    rl.on("line", async (rawLine: string) => {
+      const line = rawLine.trim();
+      const portMatch = HELPER_PORT_MARKER.exec(line);
+      if (!portMatch || devicePort !== null) return;
+      devicePort = parseInt(portMatch[1]!, 10);
+
+      // `adb forward tcp:0 tcp:DEVICE_PORT` makes adb pick a free local port
+      // and print it; saves the host-side `net.createServer(0)` dance.
+      try {
+        const { stdout } = await runAdb(
+          ["-s", serial, "forward", "tcp:0", `tcp:${devicePort}`],
+          { timeoutMs: 5_000 }
+        );
+        const lpMatch = ADB_FORWARD_PORT_MARKER.exec(stdout.trim());
+        if (!lpMatch) {
+          throw new Error(`adb forward returned unexpected output: ${stdout.trim()}`);
+        }
+        localPort = parseInt(lpMatch[1]!, 10);
+        settle(() => resolve({ proc, devicePort: devicePort!, localPort: localPort! }));
+      } catch (err) {
+        settle(
+          () => reject(err instanceof Error ? err : new Error(String(err))),
+          () => proc.kill()
+        );
+      }
+    });
+
+    proc.stderr?.on("data", (data: Buffer) => {
+      stderrBuf += data.toString("utf-8");
+      if (stderrBuf.length > 4 * 1024) stderrBuf = stderrBuf.slice(-4 * 1024);
+    });
+
+    proc.on("exit", (code, signal) => {
+      const detail = stderrBuf.trim() ? ` stderr=${stderrBuf.trim().slice(0, 400)}` : "";
+      settle(() =>
+        reject(
+          new Error(
+            `am instrument exited before becoming ready (code=${code} signal=${signal}).${detail}`
+          )
+        )
+      );
+    });
+
+    proc.on("error", (err) => {
+      settle(() => reject(err));
+    });
+
+    const timer = setTimeout(() => {
+      settle(
+        () => reject(new Error("Timed out waiting for android-devtools helper to become ready")),
+        () => proc.kill()
+      );
+    }, READY_TIMEOUT_MS);
+  });
+}
+
+async function removeAdbForward(serial: string, localPort: number): Promise<void> {
+  try {
+    await runAdb(["-s", serial, "forward", "--remove", `tcp:${localPort}`], { timeoutMs: 5_000 });
+  } catch {
+    // Best-effort: adb forward --remove can race with adb daemon restarts.
+    // Leftover forwards are harmless; they'll be re-shadowed on next spawn.
+  }
+}
+
+export const androidDevtoolsBlueprint: ServiceBlueprint<AndroidDevtoolsApi, DeviceInfo> = {
+  namespace: ANDROID_DEVTOOLS_NAMESPACE,
+
+  getURN(device: DeviceInfo) {
+    return `${ANDROID_DEVTOOLS_NAMESPACE}:${device.id}`;
+  },
+
+  async factory(_deps, _payload, options) {
+    const opts = options as unknown as AndroidDevtoolsFactoryOptions | undefined;
+    if (!opts?.device) {
+      throw new Error(
+        `${ANDROID_DEVTOOLS_NAMESPACE}.factory requires a resolved DeviceInfo via options.device. ` +
+          `Use androidDevtoolsRef(device) when registering the service ref, or pass { device } when calling resolveService directly.`
+      );
+    }
+
+    const { device } = opts;
+    if (device.platform !== "android") {
+      throw new Error(
+        `${ANDROID_DEVTOOLS_NAMESPACE} is Android-only. The target '${device.id}' classifies as iOS — use the iOS describe path instead.`
+      );
+    }
+    if (typeof device.id !== "string" || device.id.length === 0) {
+      throw new Error(
+        `${ANDROID_DEVTOOLS_NAMESPACE}.factory requires a non-empty device.id; got ${JSON.stringify(device.id)}.`
+      );
+    }
+
+    const serial = device.id;
+    const events = new TypedEventEmitter<ServiceEvents>();
+
+    await ensureAndroidDevtoolsInstalled(serial);
+
+    const spawned = await spawnHelper(serial);
+    let ready = false;
+    let disposed = false;
+
+    let client: AndroidDevtoolsClient;
+    try {
+      client = await connectAndroidDevtoolsClient(spawned.localPort, (err) => {
+        if (!disposed) {
+          events.emit("terminated", err);
+        }
+      });
+    } catch (err) {
+      try {
+        spawned.proc.kill();
+      } catch {
+        /* ignore */
+      }
+      await removeAdbForward(serial, spawned.localPort);
+      throw err;
+    }
+
+    // Handshake — confirms the socket is talking to our helper, not stale state.
+    try {
+      await client.request("ping");
+      ready = true;
+    } catch (err) {
+      client.close();
+      try {
+        spawned.proc.kill();
+      } catch {
+        /* ignore */
+      }
+      await removeAdbForward(serial, spawned.localPort);
+      throw err;
+    }
+
+    spawned.proc.on("exit", (code, signal) => {
+      if (!disposed) {
+        events.emit(
+          "terminated",
+          new Error(`android-devtools helper exited (code=${code} signal=${signal})`)
+        );
+      }
+    });
+    spawned.proc.on("error", (err) => {
+      if (!disposed) events.emit("terminated", err);
+    });
+
+    const api: AndroidDevtoolsApi = {
+      isReady: () => ready && !disposed,
+      getHierarchy(getOpts: GetHierarchyOptions = {}) {
+        return client.request<HierarchyResult>("getHierarchy", {
+          waitForIdleMs: getOpts.waitForIdleMs ?? 500,
+          maxDepth: getOpts.maxDepth ?? 128,
+          maxNodes: getOpts.maxNodes ?? 5000,
+        });
+      },
+      getScreenSize() {
+        return client.request<{ width: number; height: number; rotation: number }>(
+          "getScreenSize"
+        );
+      },
+      ping() {
+        return client.request<{ ok: boolean; idleMs: number; protocol: string }>("ping");
+      },
+    };
+
+    const instance: ServiceInstance<AndroidDevtoolsApi> = {
+      api,
+      dispose: async () => {
+        disposed = true;
+        ready = false;
+        // Best-effort graceful shutdown — gives the helper a chance to call
+        // `finish(0, ...)` so `am instrument` exits with code 0 and adb
+        // doesn't log a noisy stack trace. Bounded by a tight timeout.
+        try {
+          await Promise.race([
+            client.request("shutdown"),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("shutdown timeout")), 1_000)
+            ),
+          ]);
+        } catch {
+          /* fall through to force-kill */
+        }
+        client.close();
+        try {
+          spawned.proc.kill();
+        } catch {
+          /* ignore */
+        }
+        await removeAdbForward(serial, spawned.localPort);
+      },
+      events,
+    };
+
+    return instance;
+  },
+};

--- a/packages/tool-server/src/blueprints/android-devtools.ts
+++ b/packages/tool-server/src/blueprints/android-devtools.ts
@@ -71,15 +71,11 @@ async function spawnHelper(serial: string): Promise<SpawnedHelper> {
     );
   }
 
-  const proc = spawn(adbPath, [
-    "-s",
-    serial,
-    "shell",
-    "am",
-    "instrument",
-    "-w",
-    manifest.instrumentationRunner,
-  ], { stdio: ["ignore", "pipe", "pipe"] });
+  const proc = spawn(
+    adbPath,
+    ["-s", serial, "shell", "am", "instrument", "-w", manifest.instrumentationRunner],
+    { stdio: ["ignore", "pipe", "pipe"] }
+  );
 
   return new Promise<SpawnedHelper>((resolve, reject) => {
     let devicePort: number | null = null;
@@ -106,10 +102,9 @@ async function spawnHelper(serial: string): Promise<SpawnedHelper> {
       // `adb forward tcp:0 tcp:DEVICE_PORT` makes adb pick a free local port
       // and print it; saves the host-side `net.createServer(0)` dance.
       try {
-        const { stdout } = await runAdb(
-          ["-s", serial, "forward", "tcp:0", `tcp:${devicePort}`],
-          { timeoutMs: 5_000 }
-        );
+        const { stdout } = await runAdb(["-s", serial, "forward", "tcp:0", `tcp:${devicePort}`], {
+          timeoutMs: 5_000,
+        });
         const lpMatch = ADB_FORWARD_PORT_MARKER.exec(stdout.trim());
         if (!lpMatch) {
           throw new Error(`adb forward returned unexpected output: ${stdout.trim()}`);
@@ -253,9 +248,7 @@ export const androidDevtoolsBlueprint: ServiceBlueprint<AndroidDevtoolsApi, Devi
         });
       },
       getScreenSize() {
-        return client.request<{ width: number; height: number; rotation: number }>(
-          "getScreenSize"
-        );
+        return client.request<{ width: number; height: number; rotation: number }>("getScreenSize");
       },
       ping() {
         return client.request<{ ok: boolean; idleMs: number; protocol: string }>("ping");

--- a/packages/tool-server/src/tools/describe/contract.ts
+++ b/packages/tool-server/src/tools/describe/contract.ts
@@ -52,11 +52,15 @@ export const describeNodeSchema: z.ZodType<DescribeNode> = z.lazy(() =>
 );
 
 // Where the tree came from. "ax-service" / "native-devtools" come from iOS;
-// "uiautomator" is the Android branch's underlying provider. Agents that
-// branch on `source` (e.g. to decide whether to also call `native-find-views`
-// for a richer tree) need to distinguish the Android case from an iOS
-// native-devtools fallback — which the previous shared label hid.
-export type DescribeSource = "ax-service" | "native-devtools" | "uiautomator";
+// "uiautomator" / "android-devtools" come from Android. Agents that branch on
+// `source` (e.g. to decide whether to also call `native-find-views` for a
+// richer tree) need to distinguish the Android cases from an iOS native-
+// devtools fallback — which a shared label would hide.
+export type DescribeSource =
+  | "ax-service"
+  | "native-devtools"
+  | "uiautomator"
+  | "android-devtools";
 
 // Internal shape produced by the per-platform adapters. The `tree` is consumed
 // by the formatter in `format-tree.ts` and then dropped before the tool replies

--- a/packages/tool-server/src/tools/describe/contract.ts
+++ b/packages/tool-server/src/tools/describe/contract.ts
@@ -56,11 +56,7 @@ export const describeNodeSchema: z.ZodType<DescribeNode> = z.lazy(() =>
 // `source` (e.g. to decide whether to also call `native-find-views` for a
 // richer tree) need to distinguish the Android cases from an iOS native-
 // devtools fallback — which a shared label would hide.
-export type DescribeSource =
-  | "ax-service"
-  | "native-devtools"
-  | "uiautomator"
-  | "android-devtools";
+export type DescribeSource = "ax-service" | "native-devtools" | "uiautomator" | "android-devtools";
 
 // Internal shape produced by the per-platform adapters. The `tree` is consumed
 // by the formatter in `format-tree.ts` and then dropped before the tool replies

--- a/packages/tool-server/src/tools/describe/format-tree.ts
+++ b/packages/tool-server/src/tools/describe/format-tree.ts
@@ -11,8 +11,9 @@ import type { DescribeFrame, DescribeNode, DescribeSource } from "./contract";
 //   - "ax-service" and "native-devtools" (the iOS providers) emit a flat list
 //     of leaves under a synthetic root; the flat renderer sorts those in
 //     reading order (top-to-bottom, then left-to-right).
-//   - "uiautomator" (Android) emits a real parent/child tree; the nested
-//     renderer is an iterative DFS that preserves depth via indentation.
+//   - "uiautomator" and "android-devtools" (Android) emit a real parent/child
+//     tree; the nested renderer is an iterative DFS that preserves depth via
+//     indentation.
 // Picking by source (rather than checking `every child has no grandchildren`)
 // keeps behaviour stable for callers that diff two close-in-time describes —
 // a single accidental grandchild used to flip an ax-service response into
@@ -162,7 +163,8 @@ export interface FormatDescribeOptions {
 }
 
 export function formatDescribeTree(root: DescribeNode, opts: FormatDescribeOptions): string {
-  const mode: "flat" | "nested" = opts.source === "uiautomator" ? "nested" : "flat";
+  const mode: "flat" | "nested" =
+    opts.source === "uiautomator" || opts.source === "android-devtools" ? "nested" : "flat";
   const header: string[] = [];
   header.push(`Source: ${opts.source}`);
   header.push(`Mode: ${mode}`);

--- a/packages/tool-server/src/tools/describe/index.ts
+++ b/packages/tool-server/src/tools/describe/index.ts
@@ -90,7 +90,7 @@ For React Native apps, debugger-component-tree returns React component names wit
       android: {
         requires: androidRequires,
         handler: async (_services, params) =>
-          withDescription(await describeAndroid(params.udid, params.bundleId)),
+          withDescription(await describeAndroid(registry, params.udid, params.bundleId)),
       },
     }),
   };

--- a/packages/tool-server/src/tools/describe/platforms/android/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/index.ts
@@ -1,12 +1,53 @@
-import type { ToolDependency } from "@argent/registry";
+import type { Registry, ToolDependency } from "@argent/registry";
 import type { DescribeTreeData } from "../../contract";
 import { adbExecOutBinary } from "../../../../utils/adb";
 import { getAndroidScreenSize } from "../../../../utils/android-screen";
 import { parseUiAutomatorDump } from "./uiautomator-parser";
+import {
+  androidDevtoolsRef,
+  type AndroidDevtoolsApi,
+} from "../../../../blueprints/android-devtools";
 
 export const androidRequires: ToolDependency[] = ["adb"];
 
-export async function describeAndroid(udid: string, _bundleId?: string): Promise<DescribeTreeData> {
+/**
+ * Try the persistent `android-devtools` helper first; on any error fall back
+ * to the legacy `uiautomator dump` path. The fallback exists because the
+ * legacy path has independent failure modes (it can survive an APK install
+ * rejection, a process spawn failure, an adb-forward conflict) and continues
+ * to work for users on locked-down devices that block `adb install -t`.
+ */
+export async function describeAndroid(
+  registry: Registry | undefined,
+  serial: string,
+  _bundleId?: string
+): Promise<DescribeTreeData> {
+  if (registry) {
+    try {
+      const device = { id: serial, platform: "android" as const, kind: "emulator" as const };
+      const ref = androidDevtoolsRef(device);
+      const devtools = await registry.resolveService<AndroidDevtoolsApi>(ref.urn, ref.options);
+      const [{ xml }, size] = await Promise.all([
+        devtools.getHierarchy(),
+        devtools.getScreenSize(),
+      ]);
+      const tree = parseUiAutomatorDump(xml, size.width, size.height);
+      return { tree, source: "android-devtools" };
+    } catch (serviceErr) {
+      // Fall through to the legacy uiautomator path. Every error here is
+      // recoverable because the legacy path has independent failure modes.
+      // Surface at debug level so the failure is observable without leaking
+      // into the per-call result.
+      // eslint-disable-next-line no-console
+      console.debug(
+        `[describe.android] devtools service failed, falling back to uiautomator dump: ${
+          serviceErr instanceof Error ? serviceErr.message : String(serviceErr)
+        }`
+      );
+    }
+  }
+
+  // ── Legacy uiautomator dump fallback ───────────────────────────────────
   // Per-call dump path so concurrent describes on the same serial don't race
   // on /sdcard/window_dump.xml (one call's cat would read the other's dump
   // mid-write). `uiautomator` rejects unwritable paths, so we target
@@ -22,9 +63,9 @@ export async function describeAndroid(udid: string, _bundleId?: string): Promise
   // Trailing `; rm -f` (not `&& rm -f`) so the cleanup fires even when `dump`
   // or `cat` fails — keyguard/MFA flaps used to leak a dump file per attempt.
   const [size, rawBuf] = await Promise.all([
-    getAndroidScreenSize(udid),
+    getAndroidScreenSize(serial),
     adbExecOutBinary(
-      udid,
+      serial,
       `uiautomator dump --compressed ${dumpPath} >/dev/null && cat ${dumpPath}; rm -f ${dumpPath}`,
       { timeoutMs: 20_000 }
     ),

--- a/packages/tool-server/src/tools/simulator/stop-all-simulator-servers.ts
+++ b/packages/tool-server/src/tools/simulator/stop-all-simulator-servers.ts
@@ -2,8 +2,13 @@ import { ServiceState } from "@argent/registry";
 import type { Registry, ToolDefinition } from "@argent/registry";
 import { SIMULATOR_SERVER_NAMESPACE } from "../../blueprints/simulator-server";
 import { NATIVE_DEVTOOLS_NAMESPACE } from "../../blueprints/native-devtools";
+import { ANDROID_DEVTOOLS_NAMESPACE } from "../../blueprints/android-devtools";
 
-const PREFIXES = [`${SIMULATOR_SERVER_NAMESPACE}:`, `${NATIVE_DEVTOOLS_NAMESPACE}:`];
+const PREFIXES = [
+  `${SIMULATOR_SERVER_NAMESPACE}:`,
+  `${NATIVE_DEVTOOLS_NAMESPACE}:`,
+  `${ANDROID_DEVTOOLS_NAMESPACE}:`,
+];
 
 export function createStopAllSimulatorServersTool(
   registry: Registry

--- a/packages/tool-server/src/utils/android-devtools-client.ts
+++ b/packages/tool-server/src/utils/android-devtools-client.ts
@@ -1,0 +1,138 @@
+import * as net from "node:net";
+import * as readline from "node:readline";
+
+/**
+ * Newline-delimited JSON socket client for the android-devtools helper.
+ *
+ * UiAutomation is single-threaded inside the helper, so requests are
+ * serialised here too — every `request` waits for the previous response
+ * before sending. The 5 s per-RPC timeout matches the iOS native-devtools
+ * client (`packages/tool-server/src/blueprints/native-devtools.ts:299`).
+ */
+
+export interface AndroidDevtoolsClient {
+  request<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T>;
+  close(): void;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+const DEFAULT_RPC_TIMEOUT_MS = 5_000;
+const LONG_RPC_TIMEOUT_MS = 15_000;
+
+/**
+ * Connect to the helper over a forwarded TCP socket and return a typed RPC
+ * client. The socket's `close` / `error` events fire onTerminated so the
+ * caller can propagate them to the registry's `terminated` event.
+ */
+export function connectAndroidDevtoolsClient(
+  localPort: number,
+  onTerminated: (error?: Error) => void
+): Promise<AndroidDevtoolsClient> {
+  return new Promise<AndroidDevtoolsClient>((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port: localPort });
+    socket.setNoDelay(true);
+
+    const pending = new Map<number, PendingRequest>();
+    let nextId = 1;
+    let closed = false;
+    // Serial request queue: only one request is in flight at a time. This
+    // matches the helper's single UiAutomation worker thread — sending two
+    // concurrent requests would still be serialised on the device, but the
+    // host-side queue makes timeouts predictable.
+    let chain: Promise<unknown> = Promise.resolve();
+
+    const cleanup = (error?: Error) => {
+      if (closed) return;
+      closed = true;
+      for (const req of pending.values()) {
+        clearTimeout(req.timer);
+        req.reject(error ?? new Error("AndroidDevtools client closed"));
+      }
+      pending.clear();
+      try {
+        socket.destroy();
+      } catch {
+        /* ignore */
+      }
+      onTerminated(error);
+    };
+
+    socket.once("connect", () => {
+      const rl = readline.createInterface({ input: socket });
+      rl.on("line", (line) => {
+        if (!line.trim()) return;
+        let parsed: { id?: number; result?: unknown; error?: { message?: string; type?: string } };
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          return;
+        }
+        if (typeof parsed.id !== "number") return;
+        const req = pending.get(parsed.id);
+        if (!req) return;
+        pending.delete(parsed.id);
+        clearTimeout(req.timer);
+        if (parsed.error) {
+          const message = parsed.error.message ?? "Unknown helper error";
+          const type = parsed.error.type ?? "HelperError";
+          req.reject(new Error(`${type}: ${message}`));
+        } else {
+          req.resolve(parsed.result);
+        }
+      });
+      rl.on("close", () => cleanup());
+
+      resolve({
+        request<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+          const send = (): Promise<T> => {
+            if (closed) return Promise.reject(new Error("AndroidDevtools client closed"));
+            const id = nextId++;
+            const timeoutMs = method === "getHierarchy" ? LONG_RPC_TIMEOUT_MS : DEFAULT_RPC_TIMEOUT_MS;
+            return new Promise<T>((resolveReq, rejectReq) => {
+              const timer = setTimeout(() => {
+                pending.delete(id);
+                rejectReq(new Error(`AndroidDevtools RPC ${method} timed out after ${timeoutMs}ms`));
+              }, timeoutMs);
+              pending.set(id, {
+                resolve: (v) => resolveReq(v as T),
+                reject: rejectReq,
+                timer,
+              });
+              try {
+                socket.write(JSON.stringify({ id, method, params }) + "\n");
+              } catch (err) {
+                clearTimeout(timer);
+                pending.delete(id);
+                rejectReq(err instanceof Error ? err : new Error(String(err)));
+              }
+            });
+          };
+          // Chain so requests serialise; swallow rejection on the chain
+          // pointer so one failure doesn't poison subsequent requests.
+          const result = chain.then(send, send);
+          chain = result.catch(() => undefined);
+          return result;
+        },
+        close() {
+          cleanup();
+        },
+      });
+    });
+
+    socket.once("error", (err) => {
+      if (!closed) {
+        cleanup(err);
+        reject(err);
+      }
+    });
+
+    socket.once("close", () => {
+      if (!closed) cleanup(new Error("AndroidDevtools socket closed unexpectedly"));
+    });
+  });
+}

--- a/packages/tool-server/src/utils/android-devtools-client.ts
+++ b/packages/tool-server/src/utils/android-devtools-client.ts
@@ -92,11 +92,14 @@ export function connectAndroidDevtoolsClient(
           const send = (): Promise<T> => {
             if (closed) return Promise.reject(new Error("AndroidDevtools client closed"));
             const id = nextId++;
-            const timeoutMs = method === "getHierarchy" ? LONG_RPC_TIMEOUT_MS : DEFAULT_RPC_TIMEOUT_MS;
+            const timeoutMs =
+              method === "getHierarchy" ? LONG_RPC_TIMEOUT_MS : DEFAULT_RPC_TIMEOUT_MS;
             return new Promise<T>((resolveReq, rejectReq) => {
               const timer = setTimeout(() => {
                 pending.delete(id);
-                rejectReq(new Error(`AndroidDevtools RPC ${method} timed out after ${timeoutMs}ms`));
+                rejectReq(
+                  new Error(`AndroidDevtools RPC ${method} timed out after ${timeoutMs}ms`)
+                );
               }, timeoutMs);
               pending.set(id, {
                 resolve: (v) => resolveReq(v as T),

--- a/packages/tool-server/src/utils/android-helper-install.ts
+++ b/packages/tool-server/src/utils/android-helper-install.ts
@@ -1,0 +1,110 @@
+import { runAdb, adbShell } from "./adb";
+import { bundledHelperApkPath, helperManifest } from "@argent/native-devtools-android";
+
+/**
+ * Manifest-driven install of the argent-android-devtools helper APK.
+ *
+ * Cached in-process so subsequent calls for the same serial skip the
+ * `cmd package list packages --show-versioncode` probe. The cache key
+ * includes `versionCode` so an upgrade build invalidates entries even if
+ * the serial is reused across process restarts.
+ */
+
+const installedHelpers = new Map<string, true>();
+
+function cacheKey(serial: string, versionCode: number): string {
+  return `${serial}|${versionCode}`;
+}
+
+interface InstalledVersionProbe {
+  installed: boolean;
+  versionCode: number | null;
+}
+
+/**
+ * Probe the installed version code via the same shell command Appium
+ * uses. Returns `{ installed: false }` when the
+ * package is missing; `{ installed: true, versionCode: N }` when present.
+ *
+ * `cmd package list packages --show-versioncode` is faster than `pm path`
+ * and gives us the version in the same round-trip, so we can compare it to
+ * the bundled manifest without a second `dumpsys package` call.
+ */
+async function probeInstalledVersion(
+  serial: string,
+  packageName: string
+): Promise<InstalledVersionProbe> {
+  let out = "";
+  try {
+    out = await adbShell(
+      serial,
+      `cmd package list packages --show-versioncode ${packageName}`,
+      { timeoutMs: 5_000 }
+    );
+  } catch {
+    // `cmd package` only exists on API 24+. Fall back to `pm list packages`.
+    try {
+      out = await adbShell(serial, `pm list packages ${packageName}`, { timeoutMs: 5_000 });
+    } catch {
+      return { installed: false, versionCode: null };
+    }
+  }
+
+  for (const line of out.split("\n")) {
+    const match = line.trim().match(/^package:([^\s]+)(?:\s+versionCode:(\d+))?$/);
+    if (!match) continue;
+    if (match[1] !== packageName) continue;
+    const versionCode = match[2] ? parseInt(match[2], 10) : null;
+    return { installed: true, versionCode: Number.isFinite(versionCode!) ? versionCode! : null };
+  }
+  return { installed: false, versionCode: null };
+}
+
+/**
+ * Ensure the helper APK is installed on the device with at least the
+ * bundled versionCode. On `INSTALL_FAILED_UPDATE_INCOMPATIBLE` we
+ * `pm uninstall` and retry once — that path fires when the local debug
+ * keystore differs from whatever was last installed (e.g. a developer
+ * rotated their keystore).
+ */
+export async function ensureAndroidDevtoolsInstalled(serial: string): Promise<void> {
+  const manifest = helperManifest();
+  const key = cacheKey(serial, manifest.versionCode);
+  if (installedHelpers.has(key)) return;
+
+  const probe = await probeInstalledVersion(serial, manifest.packageName);
+  if (probe.installed && probe.versionCode !== null && probe.versionCode >= manifest.versionCode) {
+    installedHelpers.set(key, true);
+    return;
+  }
+
+  const apkPath = bundledHelperApkPath();
+  const args = ["-s", serial, "install", ...manifest.installFlags, apkPath];
+
+  try {
+    await runAdb(args, { timeoutMs: 60_000 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/INSTALL_FAILED_UPDATE_INCOMPATIBLE/.test(message)) {
+      // Signature mismatch — the device has a same-package APK signed by a
+      // different key. Uninstall the old one and retry. This is the
+      // keystore-rotation footgun the research folder calls out at §5.2.
+      try {
+        await runAdb(["-s", serial, "uninstall", manifest.packageName], { timeoutMs: 30_000 });
+      } catch {
+        // If uninstall itself fails we still want the original install
+        // error to be the surfaced message — fall through.
+      }
+      await runAdb(args, { timeoutMs: 60_000 });
+    } else {
+      throw err;
+    }
+  }
+
+  installedHelpers.set(key, true);
+}
+
+/** Test-only helper to reset the install cache between unit tests. */
+export function __resetAndroidDevtoolsInstallCache(): void {
+  installedHelpers.clear();
+}

--- a/packages/tool-server/src/utils/android-helper-install.ts
+++ b/packages/tool-server/src/utils/android-helper-install.ts
@@ -22,13 +22,9 @@ interface InstalledVersionProbe {
 }
 
 /**
- * Probe the installed version code via the same shell command Appium
- * uses. Returns `{ installed: false }` when the
- * package is missing; `{ installed: true, versionCode: N }` when present.
- *
- * `cmd package list packages --show-versioncode` is faster than `pm path`
- * and gives us the version in the same round-trip, so we can compare it to
- * the bundled manifest without a second `dumpsys package` call.
+ * Probe the installed version code via `cmd package list packages
+ * --show-versioncode` — faster than `pm path` and returns the version in
+ * the same round-trip, avoiding a second `dumpsys package` call.
  */
 async function probeInstalledVersion(
   serial: string,
@@ -64,7 +60,7 @@ async function probeInstalledVersion(
  * Ensure the helper APK is installed on the device with at least the
  * bundled versionCode. On `INSTALL_FAILED_UPDATE_INCOMPATIBLE` we
  * `pm uninstall` and retry once — that path fires when the local debug
- * keystore differs from whatever was last installed (e.g. a developer
+ * keystore differs from whatever was last installed (e.g. the developer
  * rotated their keystore).
  */
 export async function ensureAndroidDevtoolsInstalled(serial: string): Promise<void> {

--- a/packages/tool-server/src/utils/android-helper-install.ts
+++ b/packages/tool-server/src/utils/android-helper-install.ts
@@ -32,11 +32,9 @@ async function probeInstalledVersion(
 ): Promise<InstalledVersionProbe> {
   let out = "";
   try {
-    out = await adbShell(
-      serial,
-      `cmd package list packages --show-versioncode ${packageName}`,
-      { timeoutMs: 5_000 }
-    );
+    out = await adbShell(serial, `cmd package list packages --show-versioncode ${packageName}`, {
+      timeoutMs: 5_000,
+    });
   } catch {
     // `cmd package` only exists on API 24+. Fall back to `pm list packages`.
     try {

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -1,6 +1,7 @@
 import { Registry } from "@argent/registry";
 import { simulatorServerBlueprint } from "../blueprints/simulator-server";
 import { nativeDevtoolsBlueprint } from "../blueprints/native-devtools";
+import { androidDevtoolsBlueprint } from "../blueprints/android-devtools";
 import { axServiceBlueprint } from "../blueprints/ax-service";
 import { nativeDevtoolsStatusTool } from "../tools/native-devtools/native-devtools-status";
 import { nativeNetworkLogsTool } from "../tools/native-devtools/native-network-logs";
@@ -77,6 +78,7 @@ export function createRegistry(): Registry {
   registry.registerBlueprint(reactProfilerSessionBlueprint);
   registry.registerBlueprint(nativeProfilerSessionBlueprint);
   registry.registerBlueprint(nativeDevtoolsBlueprint);
+  registry.registerBlueprint(androidDevtoolsBlueprint);
   registry.registerBlueprint(axServiceBlueprint);
 
   registry.registerTool(listDevicesTool);

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -486,12 +486,8 @@ describe("formatDescribeTree", () => {
     expect(elementLines(out)).toHaveLength(0);
   });
 
-  // Regression: Android's native-devtools helper APK reports source as
-  // "android-devtools", but format-tree previously only switched to nested
-  // mode for "uiautomator". The flat renderer never recurses into children,
-  // so a real Bluesky feed under a top-level ScrollView collapsed to just the
-  // bottom-nav buttons + "Close drawer" overlay — six elements instead of
-  // the ~45 the parser had produced.
+  // Regression: nested mode previously keyed on "uiautomator" only, so
+  // "android-devtools" responses rendered flat and lost all descendants.
   it("renders android-devtools source in nested mode", () => {
     const root: DescribeNode = {
       role: "Screen",

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -485,4 +485,35 @@ describe("formatDescribeTree", () => {
     const out = formatDescribeTree(root, { source: "ax-service" });
     expect(elementLines(out)).toHaveLength(0);
   });
+
+  // Regression: Android's native-devtools helper APK reports source as
+  // "android-devtools", but format-tree previously only switched to nested
+  // mode for "uiautomator". The flat renderer never recurses into children,
+  // so a real Bluesky feed under a top-level ScrollView collapsed to just the
+  // bottom-nav buttons + "Close drawer" overlay — six elements instead of
+  // the ~45 the parser had produced.
+  it("renders android-devtools source in nested mode", () => {
+    const root: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        {
+          role: "ScrollView",
+          frame: { x: 0, y: 0.1, width: 1, height: 0.8 },
+          scrollable: true,
+          children: [
+            leaf({
+              role: "Button",
+              label: "Like",
+              frame: { x: 0.1, y: 0.2, width: 0.3, height: 0.1 },
+              clickable: true,
+            }),
+          ],
+        },
+      ],
+    };
+    const out = formatDescribeTree(root, { source: "android-devtools" });
+    expect(out).toContain("Mode: nested");
+    expect(out).toMatch(/Button\s+"Like"/);
+  });
 });

--- a/packages/tool-server/tsconfig.json
+++ b/packages/tool-server/tsconfig.json
@@ -6,7 +6,11 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "references": [{ "path": "../registry" }, { "path": "../native-devtools-ios" }],
+  "references": [
+    { "path": "../registry" },
+    { "path": "../native-devtools-ios" },
+    { "path": "../native-devtools-android" }
+  ],
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/scripts/download-native-binaries.sh
+++ b/scripts/download-native-binaries.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Downloads signed native binaries (dylibs + ax-service) from argent-private-releases.
+# Downloads signed native binaries from argent-private-releases:
+#   - iOS dylibs + ax-service
+#   - Android argent-android-devtools.apk (helper APK consumed by
+#     packages/native-devtools-android)
 #
 # Usage: ./scripts/download-native-binaries.sh [release-tag]
 #   release-tag  Tag to download from (e.g. argent-v0.5.3). Defaults to argent-main.
@@ -19,12 +22,15 @@ if ! gh release view "${TAG}" --repo "${REPO}" &>/dev/null; then
   echo "Build and publish the native binaries for this version first, then retry." >&2
   exit 1
 fi
+
 DYLIBS_DIR="packages/native-devtools-ios/dylibs"
 BIN_DIR="packages/native-devtools-ios/bin"
+ANDROID_DIST_DIR="packages/native-devtools-android/dist"
+ANDROID_MANIFEST_FILE="packages/native-devtools-android/manifest.json"
 
 echo "Downloading native binaries from ${REPO} (tag: ${TAG})..."
 
-mkdir -p "${DYLIBS_DIR}" "${BIN_DIR}"
+mkdir -p "${DYLIBS_DIR}" "${BIN_DIR}" "${ANDROID_DIST_DIR}"
 
 for DYLIB in libNativeDevtoolsIos.dylib libKeyboardPatch.dylib libArgentInjectionBootstrap.dylib; do
   echo "  Downloading ${DYLIB}..."
@@ -43,10 +49,34 @@ gh release download "${TAG}" \
   --clobber
 chmod +x "${BIN_DIR}/ax-service"
 
-echo "Downloaded native binaries to ${DYLIBS_DIR}/ and ${BIN_DIR}/"
+echo "  Downloading argent-android-devtools.apk..."
+# The release publishes the APK under a stable name (no versioning in the
+# filename) so this script doesn't have to know the version ahead of time;
+# the local copy is renamed to match what manifest.json expects.
+TMP_APK="$(mktemp -t argent-android-devtools.XXXXXX.apk)"
+trap 'rm -f "$TMP_APK"' EXIT
+gh release download "${TAG}" \
+  --repo "${REPO}" \
+  --pattern "argent-android-devtools.apk" \
+  --output "${TMP_APK}" \
+  --clobber
+
+# Read the versionName from the local manifest so the filename matches
+# bundledHelperApkPath()'s expectation.
+ANDROID_VERSION_NAME="$(node -p "require('$PWD/${ANDROID_MANIFEST_FILE}').versionName")"
+ANDROID_TARGET="${ANDROID_DIST_DIR}/argent-android-devtools-${ANDROID_VERSION_NAME}.apk"
+mv -f "${TMP_APK}" "${ANDROID_TARGET}"
+trap - EXIT
+
+echo "Downloaded native binaries to ${DYLIBS_DIR}/, ${BIN_DIR}/, and ${ANDROID_DIST_DIR}/"
 
 if command -v codesign &>/dev/null; then
   for f in "${DYLIBS_DIR}"/*.dylib "${BIN_DIR}/ax-service"; do
     codesign -dvv "$f" 2>&1 || echo "Warning: signature verification failed for $f"
   done
+fi
+
+if command -v "${ANDROID_HOME:-${HOME}/Library/Android/sdk}/build-tools/36.0.0/apksigner" &>/dev/null; then
+  "${ANDROID_HOME:-${HOME}/Library/Android/sdk}/build-tools/36.0.0/apksigner" verify --verbose "${ANDROID_TARGET}" 2>&1 \
+    || echo "Warning: APK signature verification failed"
 fi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "packages/registry" },
     { "path": "packages/native-devtools-ios" },
+    { "path": "packages/native-devtools-android" },
     { "path": "packages/tool-server" },
     { "path": "packages/argent-tools-client" },
     { "path": "packages/argent-installer" },


### PR DESCRIPTION
## Summary

- `formatDescribeTree` was branching on `source === "uiautomator"` to pick nested rendering; the newer `android-devtools` source fell through to flat mode and lost every node below depth 1. Extends the predicate to cover both Android sources so the helper-service path renders with the same hierarchy as the legacy `uiautomator dump` path.
- Bumps `packages/argent-private` to pick up the persistent Android describe service that emits `source: "android-devtools"`, plus its build-and-sign CI workflow.
- Wires the Android helper APK + `manifest.json` into the published `@swmansion/argent` package via `bundle-tools.cjs`, and adds `pack:mcp:local` / `build:android-binaries` so a local tarball can be produced without going through `download:native-binaries`.
- Minor: tightens a couple of comments in `android-helper-install.ts` and `format-tree.ts`.

This is connected to argent-private PR:
https://github.com/software-mansion/argent-private/pull/8