### PR TITLE
fix(tool-server): resolve project-local argent before spawning update

### DIFF
--- a/packages/tool-server/src/tools/system/update-argent.ts
+++ b/packages/tool-server/src/tools/system/update-argent.ts
@@ -1,8 +1,52 @@
 import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import type { ToolDefinition } from "@argent/registry";
 import { getUpdateState } from "../../utils/update-checker";
 
 let updateScheduled = false;
+
+/**
+ * Resolve which `argent` binary to spawn for the update.
+ *
+ * History: this tool used to call `spawn("argent", ...)` unconditionally,
+ * which does a PATH lookup. That works for globally-installed argent,
+ * but fails silently with ENOENT for users who installed argent as a
+ * project devDependency (the team-share flow) — the binary lives at
+ * `<projectRoot>/node_modules/.bin/argent` and is not on PATH. Combined
+ * with `detached + stdio: "ignore" + unref + no error listener`, the
+ * failure left no trace and the same "update available" notification
+ * kept reappearing every session.
+ *
+ * Resolution order:
+ *   1. `<cwd>/node_modules/.bin/argent` (or `argent.cmd` on Windows) if
+ *      it exists on disk. The MCP server is launched by the editor with
+ *      cwd at the project root, so this is the right place to look.
+ *   2. Plain `"argent"` PATH lookup. Preserves the historical behavior
+ *      for globally-installed users.
+ *
+ * We do NOT walk up the tree looking for a node_modules — keeping it
+ * simple matches what the install side (`argent init --devdep`) commits
+ * to .mcp.json (`./node_modules/.bin/argent`, relative to project root).
+ */
+export function resolveArgentBinary(cwd: string = process.cwd()): {
+  binary: string;
+  spawnCwd?: string;
+} {
+  const isWin = process.platform === "win32";
+  const localBin = path.join(cwd, "node_modules", ".bin", isWin ? "argent.cmd" : "argent");
+  try {
+    if (fs.existsSync(localBin)) {
+      // Run the child from the project root so `argent update` resolves
+      // its own project-relative checks (lockfile detection, dep
+      // declaration probe) consistently with what `argent init` did.
+      return { binary: localBin, spawnCwd: cwd };
+    }
+  } catch {
+    // fs failure is non-fatal — fall through to PATH lookup.
+  }
+  return { binary: "argent" };
+}
 
 export const updateArgentTool: ToolDefinition<void> = {
   id: "update-argent",
@@ -27,14 +71,33 @@ export const updateArgentTool: ToolDefinition<void> = {
 
     updateScheduled = true;
 
+    const { binary, spawnCwd } = resolveArgentBinary();
+
     // Delay the actual update spawn so the HTTP response can be flushed first.
     // The update process calls killToolServer() which sends SIGTERM — we need
     // the response to reach the MCP server before that happens.
     setTimeout(() => {
-      const child = spawn("argent", ["update", "--yes"], {
+      const child = spawn(binary, ["update", "--yes"], {
         detached: true,
         stdio: "ignore",
+        ...(spawnCwd ? { cwd: spawnCwd } : {}),
       });
+
+      // The previous version had no error handler. ENOENT (binary not
+      // on PATH) emits an 'error' event synchronously; without a
+      // listener it was swallowed because the parent never observed it
+      // (detached + unref'd + stdio ignored). Surface it to stderr so a
+      // future failure leaves a trace in the tool-server log instead
+      // of vanishing.
+      child.on("error", (err) => {
+        process.stderr.write(
+          `[argent] failed to spawn '${binary}' for update: ${err.message ?? err}\n`
+        );
+        // Allow another update attempt later — the failed spawn shouldn't
+        // wedge the tool into "already in progress" forever.
+        updateScheduled = false;
+      });
+
       child.unref();
     }, 2000);
 

--- a/packages/tool-server/test/update-argent-tool.test.ts
+++ b/packages/tool-server/test/update-argent-tool.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 // Mock child_process and update-checker before importing the module under test.
 vi.mock("node:child_process", () => ({
@@ -15,8 +18,22 @@ import { getUpdateState } from "../src/utils/update-checker";
 const mockSpawn = vi.mocked(spawn);
 const mockGetUpdateState = vi.mocked(getUpdateState);
 
-function makeChild() {
-  return { unref: vi.fn() } as unknown as ReturnType<typeof spawn>;
+interface FakeChild {
+  unref: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  // captured 'error' handler so tests can replay an ENOENT scenario
+  errorHandler?: (err: Error) => void;
+}
+
+function makeChild(): FakeChild {
+  const child: FakeChild = {
+    unref: vi.fn(),
+    on: vi.fn((event: string, handler: (err: Error) => void) => {
+      if (event === "error") child.errorHandler = handler;
+      return child;
+    }),
+  };
+  return child;
 }
 
 function stateWithUpdate(latestVersion = "99.0.0") {
@@ -38,12 +55,20 @@ function stateUpToDate() {
 describe("update-argent tool", () => {
   // Re-import per test so the module-level `updateScheduled` flag resets.
   let updateArgentTool: typeof import("../src/tools/system/update-argent").updateArgentTool;
+  let originalCwd: () => string;
+  let tmpDir: string;
 
   beforeEach(async () => {
     vi.useFakeTimers();
     vi.resetModules();
-    mockSpawn.mockReturnValue(makeChild());
+    mockSpawn.mockReturnValue(makeChild() as unknown as ReturnType<typeof spawn>);
     mockGetUpdateState.mockReturnValue(stateWithUpdate());
+
+    // Each test gets a fresh tmpDir as a synthetic project root.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "update-argent-tool-"));
+    originalCwd = process.cwd;
+    process.cwd = () => tmpDir;
+
     const mod = await import("../src/tools/system/update-argent");
     updateArgentTool = mod.updateArgentTool;
   });
@@ -51,7 +76,11 @@ describe("update-argent tool", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    process.cwd = originalCwd;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  // ── PATH fallback (no local devDep) ────────────────────────────────────
 
   it("returns a message with current and latest version on success", async () => {
     const result = await updateArgentTool.execute({}, undefined, undefined);
@@ -59,18 +88,18 @@ describe("update-argent tool", () => {
     expect((result as { message: string }).message).toContain("restart");
   });
 
-  it("spawns `argent update --yes` (not npx) after 2 seconds", async () => {
+  it("falls back to PATH lookup ('argent') when no local devDep exists", async () => {
     await updateArgentTool.execute({}, undefined, undefined);
+    vi.advanceTimersByTime(2000);
 
-    vi.advanceTimersByTime(1999);
-    expect(mockSpawn).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(1);
     expect(mockSpawn).toHaveBeenCalledOnce();
-    expect(mockSpawn).toHaveBeenCalledWith("argent", ["update", "--yes"], {
-      detached: true,
-      stdio: "ignore",
-    });
+    const [bin, args, opts] = mockSpawn.mock.calls[0]!;
+    expect(bin).toBe("argent");
+    expect(args).toEqual(["update", "--yes"]);
+    expect(opts).toMatchObject({ detached: true, stdio: "ignore" });
+    // No cwd override when falling back to PATH — let the child inherit
+    // whatever the tool-server's cwd is (preserves historical behavior).
+    expect((opts as { cwd?: string }).cwd).toBeUndefined();
   });
 
   it("does NOT spawn before 2 seconds have elapsed", async () => {
@@ -81,13 +110,96 @@ describe("update-argent tool", () => {
 
   it("calls unref() on the child process", async () => {
     const child = makeChild();
-    mockSpawn.mockReturnValue(child);
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
 
     await updateArgentTool.execute({}, undefined, undefined);
     vi.advanceTimersByTime(2000);
 
     expect(child.unref).toHaveBeenCalledOnce();
   });
+
+  // ── Local devDep resolution ────────────────────────────────────────────
+
+  it("uses the project-local devDep binary when node_modules/.bin/argent exists", async () => {
+    // Stage a fake local install — the file just needs to exist; the
+    // tool doesn't try to execute it during the test (spawn is mocked).
+    const binDir = path.join(tmpDir, "node_modules", ".bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const binName = process.platform === "win32" ? "argent.cmd" : "argent";
+    const localBin = path.join(binDir, binName);
+    fs.writeFileSync(localBin, "");
+
+    await updateArgentTool.execute({}, undefined, undefined);
+    vi.advanceTimersByTime(2000);
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [bin, args, opts] = mockSpawn.mock.calls[0]!;
+    expect(bin).toBe(localBin);
+    expect(args).toEqual(["update", "--yes"]);
+    // The child runs with cwd = project root so `argent update`'s own
+    // project-root resolution (lockfile probe, dep declaration check)
+    // matches what `argent init` saw.
+    expect((opts as { cwd?: string }).cwd).toBe(tmpDir);
+  });
+
+  // ── Error visibility ───────────────────────────────────────────────────
+
+  it("attaches an 'error' handler so future ENOENT failures aren't silent", async () => {
+    const child = makeChild();
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+    await updateArgentTool.execute({}, undefined, undefined);
+    vi.advanceTimersByTime(2000);
+
+    // Verify the handler was registered (not just that .on was called).
+    const errorRegistration = child.on.mock.calls.find((c) => c[0] === "error");
+    expect(errorRegistration).toBeDefined();
+    expect(typeof errorRegistration![1]).toBe("function");
+  });
+
+  it("writes spawn failures to stderr so the log retains a trace", async () => {
+    const child = makeChild();
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await updateArgentTool.execute({}, undefined, undefined);
+    vi.advanceTimersByTime(2000);
+
+    // Replay the kernel sending an ENOENT to the parent process.
+    child.errorHandler?.(Object.assign(new Error("spawn argent ENOENT"), { code: "ENOENT" }));
+
+    expect(stderrWrite).toHaveBeenCalled();
+    const written = stderrWrite.mock.calls[0]![0] as string;
+    expect(written).toContain("[argent]");
+    expect(written).toContain("ENOENT");
+
+    stderrWrite.mockRestore();
+  });
+
+  it("clears the updateScheduled flag on spawn error so the user can retry", async () => {
+    const child = makeChild();
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await updateArgentTool.execute({}, undefined, undefined);
+    vi.advanceTimersByTime(2000);
+    // Replay an ENOENT — without the flag-reset, the tool would
+    // permanently report "update already in progress" until the
+    // tool-server restarted.
+    child.errorHandler?.(new Error("spawn argent ENOENT"));
+
+    // Reset spawn mock so we can observe whether the second call spawns again.
+    mockSpawn.mockClear();
+    mockSpawn.mockReturnValue(makeChild() as unknown as ReturnType<typeof spawn>);
+
+    const second = await updateArgentTool.execute({}, undefined, undefined);
+    vi.advanceTimersByTime(2000);
+
+    expect((second as { message: string }).message).not.toContain("already in progress");
+    expect(mockSpawn).toHaveBeenCalledOnce();
+  });
+
+  // ── Pre-existing behaviors preserved ───────────────────────────────────
 
   it("returns 'already up to date' when no update is available", async () => {
     mockGetUpdateState.mockReturnValue(stateUpToDate());
@@ -107,5 +219,43 @@ describe("update-argent tool", () => {
     vi.advanceTimersByTime(5000);
     // Only one spawn despite two calls.
     expect(mockSpawn).toHaveBeenCalledOnce();
+  });
+});
+
+// ── resolveArgentBinary in isolation ──────────────────────────────────────
+// Unit test the resolver directly so the contract is observable without
+// going through the full tool flow.
+
+describe("resolveArgentBinary", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "resolve-argent-binary-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the plain 'argent' name when no local devDep is on disk", async () => {
+    vi.resetModules();
+    vi.doUnmock("node:child_process");
+    const { resolveArgentBinary } = await import("../src/tools/system/update-argent");
+    const result = resolveArgentBinary(tmpDir);
+    expect(result.binary).toBe("argent");
+    expect(result.spawnCwd).toBeUndefined();
+  });
+
+  it("returns the project-local binary path and cwd when node_modules/.bin/argent exists", async () => {
+    vi.resetModules();
+    vi.doUnmock("node:child_process");
+    const binDir = path.join(tmpDir, "node_modules", ".bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const binName = process.platform === "win32" ? "argent.cmd" : "argent";
+    fs.writeFileSync(path.join(binDir, binName), "");
+
+    const { resolveArgentBinary } = await import("../src/tools/system/update-argent");
+    const result = resolveArgentBinary(tmpDir);
+    expect(result.binary).toBe(path.join(binDir, binName));
+    expect(result.spawnCwd).toBe(tmpDir);
   });
 });


### PR DESCRIPTION
## Summary

Fixes a silent ENOENT in the MCP `update-argent` tool that left users on the team-share (`--devdep`) workflow stuck in an infinite "update available" loop.

### The bug

`packages/tool-server/src/tools/system/update-argent.ts` was unconditionally spawning bare `argent` via PATH:

```ts
const child = spawn("argent", ["update", "--yes"], {
  detached: true,
  stdio: "ignore",
});
child.unref();
```

For a user who installed argent as a project devDependency, the binary lives at `<projectRoot>/node_modules/.bin/argent` and isn't on PATH. The spawn fails with ENOENT — but three things made the failure invisible:

1. `detached: true` + `stdio: "ignore"` + `child.unref()` → parent stops observing the child as soon as `spawn()` returns; non-zero exits vanish.
2. No `on('error', ...)` handler → the synchronous ENOENT `'error'` event hit Node's default path with no diagnostic output (because of #1).
3. The tool had already returned `"Argent update initiated..."` to the user **2 seconds before** the spawn fired, so the response confirmed success while the action silently failed.

Net effect: user clicks "update" → confirmation message → nothing happens → next session shows the same notification → repeat forever.

### Fix

`resolveArgentBinary(cwd)`:
- Probes `<cwd>/node_modules/.bin/argent` (and `argent.cmd` on Windows).
- If present, returns its absolute path AND tells the spawn to run with `cwd = projectRoot` so `argent update`'s own project-root logic (lockfile probe, dep declaration check) sees the same root that `argent init` did.
- Falls back to plain `"argent"` PATH lookup otherwise — preserves the historical behavior for globally-installed users.

Plus minimal error surfacing in the spawn site:
- `child.on('error', ...)` writes failures to stderr so a future regression leaves a trace in the tool-server log instead of disappearing.
- The handler also resets the module-level `updateScheduled` flag — without that, a failed spawn would wedge the tool permanently into the "already in progress" branch until the tool-server restarted.

### Scope

Intentionally minimal:
- No walk-up-the-tree to find `node_modules` — `argent init --devdep` commits a literal `./node_modules/.bin/argent` to `.mcp.json`, so a flat probe matches what's actually installed.
- No `package.json` dep-declaration check — the runtime question is "is there a usable binary here right now". The strict `isLocallyInstalled` (PR #232) is the right check for *config* writes; for spawning, "file exists" is sufficient and the error path catches any remaining mistakes.
- Does not address other pre-existing limitations of `argent update` itself — those live in `@argent/installer` and are covered by PR #232.

### Tests

`@argent/tool-server`: 691 passed (+6 new).

| New test | What it covers |
| --- | --- |
| PATH fallback | `argent` (no override, no cwd) when there's no local install |
| local-devDep resolution | absolute path + `cwd: projectRoot` when `node_modules/.bin/argent` exists |
| error handler registration | `child.on('error', ...)` is wired up (regression guard for the silent-failure bug) |
| stderr surfacing | replays an ENOENT and asserts stderr writes |
| updateScheduled flag reset | replay ENOENT, verify the next call doesn't get the "already in progress" reject |
| resolveArgentBinary unit | direct contract test for the resolver |

## Test plan

- [ ] Manual: in a project with `@swmansion/argent` as a devDep but no global install, trigger the MCP update notification, accept it, and confirm `argent update` actually fires (check that the devDep entry in `package.json` bumps).
- [ ] Manual: in a project with only a global install, repeat — confirm the spawn still routes to PATH and behaves identically to today.
- [ ] Manual: in a project with neither install (broken state), trigger the tool, then inspect the tool-server stderr log to confirm the ENOENT is now logged instead of silently swallowed.

## Related

Builds conceptually on PR #232 (team-share devDep flow), but does not depend on it — this fix is self-contained and can land independently against `main`. After both land, the end-to-end "MCP update notification → user accepts → argent updates → MCP configs preserved" flow works for both topologies.