### PR TITLE
fix(describe): wire dialogElements fallback for XPC-hosted prompts (iOS 26+ TCC dialogs)

### DIFF
--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -46,6 +46,13 @@ export interface AXDescribeResponse {
   alertVisible: boolean;
   screenFrame?: { width: number; height: number };
   elements: AXDescribeElement[];
+  // Populated by the daemon (post argent-private#10) only when alertVisible
+  // is true and the primaryApp + systemApplication walks were both empty.
+  // Sourced from `[AXElement currentApplicationsIgnoringSiri]` — the last-
+  // resort sweep that catches XPC-hosted dialogs (e.g. iOS 26+ TCC
+  // permission prompts) which live outside primaryApp and Springboard
+  // alike. Empty/missing on daemon builds that predate that change.
+  dialogElements?: AXDescribeElement[];
 }
 
 export interface AXServiceApi {
@@ -276,6 +283,7 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
           alertVisible: result.alertVisible ?? false,
           screenFrame: result.screenFrame,
           elements: result.elements ?? [],
+          dialogElements: result.dialogElements ?? [],
         };
       },
 

--- a/packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts
@@ -35,9 +35,23 @@ export function adaptAXElement(el: AXDescribeElement): DescribeNode | null {
 }
 
 export function adaptAXDescribeToDescribeResult(response: AXDescribeResponse): DescribeNode {
-  const children = response.elements
+  let children = response.elements
     .map(adaptAXElement)
     .filter((n): n is DescribeNode => n !== null);
+
+  // XPC-hosted dialogs (iOS 26+ TCC permission prompts: "Allow X to use
+  // your location?" etc.) are invisible to every in-app AX walk — neither
+  // primaryApp, applicationAtCoordinate, nor systemApplication reach them.
+  // The daemon's last-resort sweep (`currentApplicationsIgnoringSiri`)
+  // catches them and lands them in `dialogElements`. The daemon only
+  // populates this field when both prior walks were empty, so it never
+  // duplicates content already in `elements`; we still gate on the same
+  // condition here for older daemon builds whose semantics may differ.
+  if (children.length === 0 && response.dialogElements && response.dialogElements.length > 0) {
+    children = response.dialogElements
+      .map(adaptAXElement)
+      .filter((n): n is DescribeNode => n !== null);
+  }
 
   return parseDescribeResult({
     role: "AXGroup",

--- a/packages/tool-server/test/describe-ax-adapter.test.ts
+++ b/packages/tool-server/test/describe-ax-adapter.test.ts
@@ -165,6 +165,74 @@ describe("describe ax-service adapter", () => {
     expect(root.children[1]?.label).toBe("Don\u2019t Allow");
   });
 
+  it("falls back to dialogElements when elements is empty", () => {
+    // Models an iOS 26+ TCC permission prompt \u2014 invisible to primaryApp,
+    // applicationAtCoordinate, and systemApplication walks. The daemon
+    // collects it via currentApplicationsIgnoringSiri and lands it in
+    // dialogElements; the adapter should surface those buttons.
+    const response: AXDescribeResponse = {
+      alertVisible: true,
+      screenFrame: { width: 440, height: 956 },
+      elements: [],
+      dialogElements: [
+        {
+          label: "Allow \u201cMaps\u201d to use your location?",
+          frame: { x: 0.177, y: 0.343, width: 0.647, height: 0.048 },
+          traits: ["staticText"],
+        },
+        {
+          label: "Allow Once",
+          frame: { x: 0.142, y: 0.513, width: 0.716, height: 0.055 },
+          traits: ["button"],
+        },
+        {
+          label: "Allow While Using App",
+          frame: { x: 0.142, y: 0.577, width: 0.716, height: 0.055 },
+          traits: ["button"],
+        },
+        {
+          label: "Don\u2019t Allow",
+          frame: { x: 0.142, y: 0.641, width: 0.716, height: 0.055 },
+          traits: ["button"],
+        },
+      ],
+    };
+
+    const root = adaptAXDescribeToDescribeResult(response);
+    expect(root.children).toHaveLength(4);
+    expect(root.children[0]?.label).toBe("Allow \u201cMaps\u201d to use your location?");
+    expect(root.children[1]?.role).toBe("AXButton");
+    expect(root.children[1]?.label).toBe("Allow Once");
+    expect(root.children[3]?.label).toBe("Don\u2019t Allow");
+  });
+
+  it("prefers elements over dialogElements when both are present", () => {
+    // The daemon only populates dialogElements when prior walks were empty,
+    // but the adapter still defends against older/newer daemon builds: if
+    // elements has anything usable, dialogElements is ignored.
+    const response: AXDescribeResponse = {
+      alertVisible: true,
+      elements: [
+        {
+          label: "From elements",
+          frame: { x: 0.1, y: 0.5, width: 0.5, height: 0.05 },
+          traits: ["button"],
+        },
+      ],
+      dialogElements: [
+        {
+          label: "From dialogElements",
+          frame: { x: 0.1, y: 0.5, width: 0.5, height: 0.05 },
+          traits: ["button"],
+        },
+      ],
+    };
+
+    const root = adaptAXDescribeToDescribeResult(response);
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0]?.label).toBe("From elements");
+  });
+
   it("filters out elements with no visible area", () => {
     const response: AXDescribeResponse = {
       alertVisible: false,


### PR DESCRIPTION
## Summary

Wires through the new \`dialogElements\` wire field added by [argent-private#10](https://github.com/software-mansion/argent-private/pull/10), so \`describe\` can render iOS 26+ TCC permission prompts (\`Allow X to use your location?\` and friends) instead of returning an empty ROOT.

Three changes:

1. **\`packages/tool-server/src/blueprints/ax-service.ts\`** — declare \`dialogElements?: AXDescribeElement[]\` on \`AXDescribeResponse\` and forward it from \`describe()\`.
2. **\`packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts\`** — when the primary \`elements\` walk produces zero usable children, use \`dialogElements\` as a fallback.
3. **\`packages/argent-private\` submodule pointer** — bumped to the branch shipping the daemon change.

Two tests added (Maps-style prompt landing in the fallback, defensive elements-wins precedence).

## Repro before / after

iPhone Air iOS 26.5 simulator, Maps with \`xcrun simctl privacy ... reset location com.apple.Maps\` to force the prompt.

**Before (current main, raw daemon socket):**
\`\`\`json
{ \"alertVisible\": true, \"elements\": [], \"systemElements\": [] }
\`\`\`
→ \`describe\` source=\`ax-service\` returns \`ROOT  AXGroup\` with no children.

**After (this PR + argent-private#10):**
\`\`\`
Source: ax-service
ROOT  AXGroup (0.000, 0.000, 1.000, 1.000)
  AXStaticText \"Allow 'Maps' to use your location?\"  (0.177, 0.343, 0.647, 0.048)
  AXStaticText \"Your location is used to show your position on the map, ...\"  (0.177, 0.400, 0.647, 0.089)
  AXButton \"Allow Once\"  (0.142, 0.513, 0.716, 0.055)
  AXButton \"Allow While Using App\"  (0.142, 0.577, 0.716, 0.055)
  AXButton \"Don't Allow\"  (0.142, 0.641, 0.716, 0.055)
\`\`\`

## Why a separate field and adapter fallback (not folded into \`elements\` / \`systemElements\`)

- \`elements\` has a fixed meaning: result of the primary AX walk on the resolved foreground app. The cross-app sweep that catches XPC dialogs is a different lookup; folding it into \`elements\` would conflate two unrelated sources.
- \`systemElements\` is gated on \`isSystemAppShowingAnAlert\` and sourced from Springboard. The dialogElements sweep enumerates *all* running apps. Different gate, different source.
- Keeping \`dialogElements\` separate lets us surface the source distinction in describe output later if useful, and keeps the wire format honest.
- The adapter only consults \`dialogElements\` when \`elements\` is empty, mirroring the daemon's own gating (\`alertVisible\` AND prior walks empty). So in-process \`UIAlertController\` dialogs never get duplicated, and post-merge builds with both gates behave identically.

## Why this isn't the previously-closed PR #234

[#234](https://github.com/software-mansion/argent/pull/234) wired \`systemElements\` (Springboard tree). Empirically that field is also \`[]\` for the Maps-style TCC dialog because the prompt's buttons aren't in Springboard's tree either. The daemon needed a fourth lookup path; that's what argent-private#10 adds. This PR's TS-side wiring is independent of the systemElements question — happy to land both, but they target different dialog classes.

## Companion PR

[**argent-private#10**](https://github.com/software-mansion/argent-private/pull/10) — daemon change in \`ax_service.m\`. This radon-lite PR is **blocked on** that one landing AND the \`build-native-binaries\` workflow republishing the daemon binary. Without those, the daemon never emits \`dialogElements\` and the adapter fallback is a no-op (but harmless).

## Test plan

- [x] \`npx vitest run packages/tool-server/test/describe-ax-adapter.test.ts\` — 100 pass (2 new).
- [ ] After daemon binary republished: trigger Maps location prompt on iOS 26.5 sim, call \`describe\` from the MCP tool, confirm the five elements above appear under \`source: ax-service\`.
- [ ] Confirm a normal app screen (no alert) still returns \`source: ax-service\` with its usual content.
- [ ] Confirm an in-process \`UIAlertController\` dialog still lands in \`elements\`, no duplication.