### PR TITLE
fix(describe): unlock iOS 26.5 SpringBoard-hosted dialogs via IgnoreAXServerEntitlements

### DIFF
--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -123,6 +123,69 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
     ],
     { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
   );
+
+  // iOS 26.5+ gates cross-process AX queries — the SpringBoard-hosted AX
+  // server rejects MIG requests from non-UIApplication clients (the ax-service
+  // daemon is a `simctl spawn`-launched CLI) with kAXError -25215, so
+  // `describe` returns an empty ROOT for any dialog presented by SpringBoard
+  // (TCC permission prompts: "Allow X to use your location?" etc.).
+  //
+  // Apple ships a debug switch for exactly this: AccessibilityUtilities reads
+  // `com.apple.Accessibility/IgnoreAXServerEntitlements` and skips the server-
+  // side entitlement check when it's true. SB caches the value at AX-server
+  // init, so a freshly-set pref doesn't take effect until SB re-reads — which
+  // means we have to kickstart SB the FIRST time we set it. The pref persists
+  // on the sim's disk, so subsequent ax-service spawns see it already true and
+  // skip the kickstart (avoiding the disruptive app-icon reflow on every run).
+  const isAlreadySet = await execFileAsync(
+    "xcrun",
+    [
+      "simctl",
+      "spawn",
+      udid,
+      "defaults",
+      "read",
+      "com.apple.Accessibility",
+      "IgnoreAXServerEntitlements",
+    ],
+    { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+  )
+    .then(({ stdout }) => stdout.trim() === "1")
+    .catch(() => false);
+
+  if (!isAlreadySet) {
+    await execFileAsync(
+      "xcrun",
+      [
+        "simctl",
+        "spawn",
+        udid,
+        "defaults",
+        "write",
+        "com.apple.Accessibility",
+        "IgnoreAXServerEntitlements",
+        "-bool",
+        "true",
+      ],
+      { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+    );
+    // launchctl emits a warning ("Please switch to user/foreground/...") but
+    // still restarts the process; tolerate non-zero exit because the restart
+    // is what we want.
+    await execFileAsync(
+      "xcrun",
+      [
+        "simctl",
+        "spawn",
+        udid,
+        "launchctl",
+        "kickstart",
+        "-k",
+        "system/com.apple.SpringBoard",
+      ],
+      { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+    ).catch(() => undefined);
+  }
 }
 
 async function killExistingDaemon(socketPath: string): Promise<void> {

--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -1,5 +1,8 @@
 import * as net from "node:net";
 import * as fs from "node:fs";
+import * as fsAsync from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { promisify } from "node:util";
 import { execFile, ChildProcess } from "node:child_process";
 import {
@@ -128,8 +131,13 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
   // (this `simctl spawn`-launched CLI) with kAXError -25215, so `describe` sees an empty
   // ROOT for any SB-hosted dialog (TCC prompts etc.). The debug pref
   // `com.apple.Accessibility/IgnoreAXServerEntitlements` disables the check, but SB caches
-  // it at AX-server init — so we kickstart SB only on first set. The pref persists on disk,
-  // so later runs skip the disruptive icon-reflow restart.
+  // it at AX-server init — so we must restart SB after setting it. boot-device's iOS path
+  // writes the pref directly to the host plist BEFORE `simctl boot`, so SB starts with
+  // the bypass already cached and never needs the kickstart. This function is the
+  // post-boot fallback: a simulator that was already booted when argent first touched it
+  // (e.g. started by Xcode) won't have the pref cached, and the only way to enable
+  // describe for SB-hosted dialogs on it is to kickstart SB now — losing the foreground
+  // app and any in-flight system alert in the process.
   const isAlreadySet = await execFileAsync(
     "xcrun",
     [
@@ -162,6 +170,15 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
       ],
       { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
     );
+    // Loud, single line so the calling agent sees in its tool output that SB is being
+    // restarted — any foreground app launched between boot and this point is gone.
+    process.stderr.write(
+      `[ax ${udid.slice(0, 8)}] restarting SpringBoard to enable describe ` +
+        `for SB-hosted dialogs (TCC prompts etc.). This dismisses any foreground app ` +
+        `or in-flight system alert. boot-device avoids this by setting the pref ` +
+        `pre-boot — reaching this path means the simulator was already booted ` +
+        `outside of argent.\n`
+    );
     // launchctl warns ("Please switch to user/foreground/...") but still restarts SB;
     // tolerate the non-zero exit.
     await execFileAsync(
@@ -169,6 +186,77 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
       ["simctl", "spawn", udid, "launchctl", "kickstart", "-k", "system/com.apple.SpringBoard"],
       { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
     ).catch(() => undefined);
+    // Block until SB has finished respawning so a subsequent tool call doesn't race
+    // the kickstart and observe a half-up system UI.
+    await execFileAsync("xcrun", ["simctl", "bootstatus", udid, "-b"], {
+      timeout: SIMCTL_SPAWN_TIMEOUT_MS,
+    }).catch(() => undefined);
+  }
+}
+
+/**
+ * Path of the simulator's host-side `com.apple.Accessibility` preference plist.
+ * Lives inside the device's data container — writeable while the sim is
+ * Shutdown, but overwritten by cfprefsd once the sim is Booted.
+ */
+function accessibilityPlistPath(udid: string): string {
+  return path.join(
+    os.homedir(),
+    "Library/Developer/CoreSimulator/Devices",
+    udid,
+    "data/Library/Preferences/com.apple.Accessibility.plist"
+  );
+}
+
+/**
+ * Set the four Accessibility prefs SpringBoard needs at boot directly on the
+ * simulator's host-side preference plist BEFORE `simctl boot`. SpringBoard's
+ * AX server reads these at first init and caches them for the lifetime of
+ * the SB process — by setting them on disk pre-boot, SB starts with the
+ * bypass already cached and no `launchctl kickstart -k system/com.apple.SpringBoard`
+ * is ever needed. That kickstart kills any foreground app (e.g. a Maps launch
+ * in flight) and dismisses any in-flight system alert (e.g. TCC prompts), so
+ * eliminating it makes describe usable mid-launch without disrupting the agent.
+ *
+ * All four keys are required for the path to work on a freshly-erased sim:
+ * - `IgnoreAXServerEntitlements` — bypasses the iOS 26.5+ kAXErrorNotEntitled
+ *   check that rejects non-Apple-internal AX clients.
+ * - `AutomationEnabled` — opt-in for the simctl-spawned ax-service binary
+ *   to act as an accessibility client at all.
+ * - `AccessibilityEnabled` + `ApplicationAccessibilityEnabled` — gate the
+ *   AT subsystem bootstrap. Without them, SpringBoard never spawns
+ *   `AccessibilityUIServer` (the LaunchAngel that owns the on-screen
+ *   hierarchy), and describe queries return an empty ROOT even though the
+ *   entitlement check passes. Hands-on confirmed on a wiped iPhone 17e
+ *   sim: with only the first two prefs set, `AccessibilityUIServer`'s
+ *   `active count` stayed at 0 and describe returned 0 elements; with all
+ *   four set the daemon spawned automatically at boot and describe
+ *   returned the full hierarchy.
+ *
+ * Caller must ensure the sim is currently Shutdown — cfprefsd inside a
+ * booted sim caches preference values in memory and rewrites this file on
+ * flush, which would silently undo this write.
+ */
+export async function setAccessibilityPrefsPreBoot(udid: string): Promise<void> {
+  const plistPath = accessibilityPlistPath(udid);
+  await fsAsync.mkdir(path.dirname(plistPath), { recursive: true });
+  const exists = await fsAsync
+    .access(plistPath)
+    .then(() => true)
+    .catch(() => false);
+  if (!exists) {
+    // `plutil -create binary1` produces an empty dict in the same binary format
+    // SpringBoard reads at boot. -replace below adds each key regardless of
+    // whether the file already had it.
+    await execFileAsync("plutil", ["-create", "binary1", plistPath]);
+  }
+  for (const key of [
+    "AutomationEnabled",
+    "IgnoreAXServerEntitlements",
+    "AccessibilityEnabled",
+    "ApplicationAccessibilityEnabled",
+  ]) {
+    await execFileAsync("plutil", ["-replace", key, "-bool", "true", plistPath]);
   }
 }
 

--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -52,6 +52,8 @@ export interface AXDescribeResponse {
 }
 
 export interface AXServiceApi {
+  /** True when AX prefs were written but SB hasn't picked them up yet (sim booted outside argent). */
+  degraded: boolean;
   describe(): Promise<AXDescribeResponse>;
   alertCheck(): Promise<boolean>;
   ping(): Promise<boolean>;
@@ -110,7 +112,9 @@ async function pingDaemon(socketPath: string): Promise<boolean> {
   }
 }
 
-export async function ensureAutomationEnabled(udid: string): Promise<void> {
+export async function ensureAutomationEnabled(
+  udid: string
+): Promise<{ prefsAlreadyActive: boolean }> {
   await execFileAsync(
     "xcrun",
     [
@@ -129,8 +133,10 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
 
   // iOS 26.5+: SB's AX server rejects unentitled MIG clients with kAXError -25215;
   // `IgnoreAXServerEntitlements` disables the check but SB caches it at init.
-  // boot-device pre-writes the pref to the host plist so the common path skips this
-  // branch entirely; this branch only runs when the sim was booted outside argent.
+  // boot-device pre-writes the pref to the host plist so the common path skips
+  // this branch entirely; this branch only fires when the sim was booted outside
+  // argent, and we intentionally do NOT kickstart SpringBoard — we accept
+  // degraded describe quality and surface a hint instead.
   const isAlreadySet = await execFileAsync(
     "xcrun",
     [
@@ -163,26 +169,9 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
       ],
       { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
     );
-    // Surface the disruption in tool output — foreground app and any in-flight
-    // system alert are about to disappear.
-    process.stderr.write(
-      `[ax ${udid.slice(0, 8)}] restarting SpringBoard to enable describe for ` +
-        `SB-hosted dialogs; dismisses any foreground app or in-flight alert. ` +
-        `boot-device avoids this via pre-boot pref write — reaching this path ` +
-        `means the sim was booted outside argent.\n`
-    );
-    // launchctl warns ("Please switch to user/foreground/...") but the kickstart
-    // still lands; tolerate the non-zero exit.
-    await execFileAsync(
-      "xcrun",
-      ["simctl", "spawn", udid, "launchctl", "kickstart", "-k", "system/com.apple.SpringBoard"],
-      { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
-    ).catch(() => undefined);
-    // Wait for SB to be back so the next tool call doesn't race a half-up system UI.
-    await execFileAsync("xcrun", ["simctl", "bootstatus", udid, "-b"], {
-      timeout: SIMCTL_SPAWN_TIMEOUT_MS,
-    }).catch(() => undefined);
   }
+
+  return { prefsAlreadyActive: isAlreadySet };
 }
 
 /**
@@ -355,7 +344,7 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
     const socketPath = getSocketPath(udid);
     const events = new TypedEventEmitter<ServiceEvents>();
 
-    await ensureAutomationEnabled(udid);
+    const { prefsAlreadyActive } = await ensureAutomationEnabled(udid);
     await killExistingDaemon(socketPath);
 
     const proc = await spawnDaemon(udid, socketPath);
@@ -378,6 +367,8 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
     }
 
     const api: AXServiceApi = {
+      degraded: !prefsAlreadyActive,
+
       async describe(): Promise<AXDescribeResponse> {
         const result = (await query("describe")) as AXDescribeResponse & {
           error?: string;

--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -131,20 +131,18 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
 }
 
 /**
- * iOS 26.5+: SB's AX server rejects unentitled MIG clients with
- * kAXError -25215. `IgnoreAXServerEntitlements` disables the check, but
- * SB caches it at init — so writing it post-boot only takes effect after
- * the next SB restart.
+ * Check whether `IgnoreAXServerEntitlements` is active on this sim.
  *
- * boot-device pre-writes the pref to the host plist before boot (the
- * happy path). This function is the post-boot fallback: it writes the
- * pref but does NOT kickstart SpringBoard, returning whether the pref
- * was already active so the caller can surface a degraded-quality hint.
+ * iOS 26.5+: SB's AX server rejects unentitled MIG clients with
+ * kAXError -25215. The pref disables the check, but SB caches it at
+ * init — writing it post-boot has no effect until the next restart.
+ * The only effective path is the pre-boot plist write in boot-device.
+ *
+ * This read-only probe tells the caller whether the pre-boot write
+ * happened so describe can surface a degraded-quality hint when it didn't.
  */
-export async function ensureEntitlementBypass(
-  udid: string
-): Promise<{ alreadyActive: boolean }> {
-  const alreadyActive = await execFileAsync(
+export async function isEntitlementBypassActive(udid: string): Promise<boolean> {
+  return execFileAsync(
     "xcrun",
     [
       "simctl",
@@ -159,26 +157,6 @@ export async function ensureEntitlementBypass(
   )
     .then(({ stdout }) => stdout.trim() === "1")
     .catch(() => false);
-
-  if (!alreadyActive) {
-    await execFileAsync(
-      "xcrun",
-      [
-        "simctl",
-        "spawn",
-        udid,
-        "defaults",
-        "write",
-        "com.apple.Accessibility",
-        "IgnoreAXServerEntitlements",
-        "-bool",
-        "true",
-      ],
-      { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
-    );
-  }
-
-  return { alreadyActive };
 }
 
 /**
@@ -352,7 +330,7 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
     const events = new TypedEventEmitter<ServiceEvents>();
 
     await ensureAutomationEnabled(udid);
-    const { alreadyActive: entitlementBypassActive } = await ensureEntitlementBypass(udid);
+    const entitlementBypassActive = await isEntitlementBypassActive(udid);
     await killExistingDaemon(socketPath);
 
     const proc = await spawnDaemon(udid, socketPath);

--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -124,19 +124,12 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
     { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
   );
 
-  // iOS 26.5+ gates cross-process AX queries — the SpringBoard-hosted AX
-  // server rejects MIG requests from non-UIApplication clients (the ax-service
-  // daemon is a `simctl spawn`-launched CLI) with kAXError -25215, so
-  // `describe` returns an empty ROOT for any dialog presented by SpringBoard
-  // (TCC permission prompts: "Allow X to use your location?" etc.).
-  //
-  // Apple ships a debug switch for exactly this: AccessibilityUtilities reads
-  // `com.apple.Accessibility/IgnoreAXServerEntitlements` and skips the server-
-  // side entitlement check when it's true. SB caches the value at AX-server
-  // init, so a freshly-set pref doesn't take effect until SB re-reads — which
-  // means we have to kickstart SB the FIRST time we set it. The pref persists
-  // on the sim's disk, so subsequent ax-service spawns see it already true and
-  // skip the kickstart (avoiding the disruptive app-icon reflow on every run).
+  // iOS 26.5+: SpringBoard's AX server rejects MIG queries from non-UIApplication clients
+  // (this `simctl spawn`-launched CLI) with kAXError -25215, so `describe` sees an empty
+  // ROOT for any SB-hosted dialog (TCC prompts etc.). The debug pref
+  // `com.apple.Accessibility/IgnoreAXServerEntitlements` disables the check, but SB caches
+  // it at AX-server init — so we kickstart SB only on first set. The pref persists on disk,
+  // so later runs skip the disruptive icon-reflow restart.
   const isAlreadySet = await execFileAsync(
     "xcrun",
     [
@@ -169,20 +162,11 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
       ],
       { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
     );
-    // launchctl emits a warning ("Please switch to user/foreground/...") but
-    // still restarts the process; tolerate non-zero exit because the restart
-    // is what we want.
+    // launchctl warns ("Please switch to user/foreground/...") but still restarts SB;
+    // tolerate the non-zero exit.
     await execFileAsync(
       "xcrun",
-      [
-        "simctl",
-        "spawn",
-        udid,
-        "launchctl",
-        "kickstart",
-        "-k",
-        "system/com.apple.SpringBoard",
-      ],
+      ["simctl", "spawn", udid, "launchctl", "kickstart", "-k", "system/com.apple.SpringBoard"],
       { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
     ).catch(() => undefined);
   }

--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -127,17 +127,10 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
     { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
   );
 
-  // iOS 26.5+: SpringBoard's AX server rejects MIG queries from non-UIApplication clients
-  // (this `simctl spawn`-launched CLI) with kAXError -25215, so `describe` sees an empty
-  // ROOT for any SB-hosted dialog (TCC prompts etc.). The debug pref
-  // `com.apple.Accessibility/IgnoreAXServerEntitlements` disables the check, but SB caches
-  // it at AX-server init — so we must restart SB after setting it. boot-device's iOS path
-  // writes the pref directly to the host plist BEFORE `simctl boot`, so SB starts with
-  // the bypass already cached and never needs the kickstart. This function is the
-  // post-boot fallback: a simulator that was already booted when argent first touched it
-  // (e.g. started by Xcode) won't have the pref cached, and the only way to enable
-  // describe for SB-hosted dialogs on it is to kickstart SB now — losing the foreground
-  // app and any in-flight system alert in the process.
+  // iOS 26.5+: SB's AX server rejects unentitled MIG clients with kAXError -25215;
+  // `IgnoreAXServerEntitlements` disables the check but SB caches it at init.
+  // boot-device pre-writes the pref to the host plist so the common path skips this
+  // branch entirely; this branch only runs when the sim was booted outside argent.
   const isAlreadySet = await execFileAsync(
     "xcrun",
     [
@@ -170,24 +163,22 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
       ],
       { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
     );
-    // Loud, single line so the calling agent sees in its tool output that SB is being
-    // restarted — any foreground app launched between boot and this point is gone.
+    // Surface the disruption in tool output — foreground app and any in-flight
+    // system alert are about to disappear.
     process.stderr.write(
-      `[ax ${udid.slice(0, 8)}] restarting SpringBoard to enable describe ` +
-        `for SB-hosted dialogs (TCC prompts etc.). This dismisses any foreground app ` +
-        `or in-flight system alert. boot-device avoids this by setting the pref ` +
-        `pre-boot — reaching this path means the simulator was already booted ` +
-        `outside of argent.\n`
+      `[ax ${udid.slice(0, 8)}] restarting SpringBoard to enable describe for ` +
+        `SB-hosted dialogs; dismisses any foreground app or in-flight alert. ` +
+        `boot-device avoids this via pre-boot pref write — reaching this path ` +
+        `means the sim was booted outside argent.\n`
     );
-    // launchctl warns ("Please switch to user/foreground/...") but still restarts SB;
-    // tolerate the non-zero exit.
+    // launchctl warns ("Please switch to user/foreground/...") but the kickstart
+    // still lands; tolerate the non-zero exit.
     await execFileAsync(
       "xcrun",
       ["simctl", "spawn", udid, "launchctl", "kickstart", "-k", "system/com.apple.SpringBoard"],
       { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
     ).catch(() => undefined);
-    // Block until SB has finished respawning so a subsequent tool call doesn't race
-    // the kickstart and observe a half-up system UI.
+    // Wait for SB to be back so the next tool call doesn't race a half-up system UI.
     await execFileAsync("xcrun", ["simctl", "bootstatus", udid, "-b"], {
       timeout: SIMCTL_SPAWN_TIMEOUT_MS,
     }).catch(() => undefined);
@@ -195,9 +186,8 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
 }
 
 /**
- * Path of the simulator's host-side `com.apple.Accessibility` preference plist.
- * Lives inside the device's data container — writeable while the sim is
- * Shutdown, but overwritten by cfprefsd once the sim is Booted.
+ * Host-side `com.apple.Accessibility` plist inside the sim's data container.
+ * Writeable while Shutdown; in-sim cfprefsd overwrites it once Booted.
  */
 function accessibilityPlistPath(udid: string): string {
   return path.join(
@@ -209,33 +199,21 @@ function accessibilityPlistPath(udid: string): string {
 }
 
 /**
- * Set the four Accessibility prefs SpringBoard needs at boot directly on the
- * simulator's host-side preference plist BEFORE `simctl boot`. SpringBoard's
- * AX server reads these at first init and caches them for the lifetime of
- * the SB process — by setting them on disk pre-boot, SB starts with the
- * bypass already cached and no `launchctl kickstart -k system/com.apple.SpringBoard`
- * is ever needed. That kickstart kills any foreground app (e.g. a Maps launch
- * in flight) and dismisses any in-flight system alert (e.g. TCC prompts), so
- * eliminating it makes describe usable mid-launch without disrupting the agent.
+ * Write the four AX prefs to the sim's host plist BEFORE `simctl boot` so SB
+ * caches them at AX-server init and never needs the disruptive kickstart
+ * (which kills the foreground app and dismisses in-flight system alerts).
  *
- * All four keys are required for the path to work on a freshly-erased sim:
- * - `IgnoreAXServerEntitlements` — bypasses the iOS 26.5+ kAXErrorNotEntitled
- *   check that rejects non-Apple-internal AX clients.
- * - `AutomationEnabled` — opt-in for the simctl-spawned ax-service binary
- *   to act as an accessibility client at all.
- * - `AccessibilityEnabled` + `ApplicationAccessibilityEnabled` — gate the
- *   AT subsystem bootstrap. Without them, SpringBoard never spawns
- *   `AccessibilityUIServer` (the LaunchAngel that owns the on-screen
- *   hierarchy), and describe queries return an empty ROOT even though the
- *   entitlement check passes. Hands-on confirmed on a wiped iPhone 17e
- *   sim: with only the first two prefs set, `AccessibilityUIServer`'s
- *   `active count` stayed at 0 and describe returned 0 elements; with all
- *   four set the daemon spawned automatically at boot and describe
- *   returned the full hierarchy.
+ * All four are required on a freshly-erased sim:
+ * - `IgnoreAXServerEntitlements` bypasses the iOS 26.5+ kAXErrorNotEntitled check.
+ * - `AutomationEnabled` opts the simctl-spawned ax-service in as an AX client.
+ * - `AccessibilityEnabled` + `ApplicationAccessibilityEnabled` gate the AT
+ *   subsystem bootstrap. Without them SB never spawns `AccessibilityUIServer`
+ *   and describe returns an empty ROOT even though the entitlement check passes
+ *   (reproduced on a wiped iPhone 17e: AccessibilityUIServer active count = 0
+ *   without these two; auto-spawns at boot with them).
  *
- * Caller must ensure the sim is currently Shutdown — cfprefsd inside a
- * booted sim caches preference values in memory and rewrites this file on
- * flush, which would silently undo this write.
+ * Caller must ensure the sim is Shutdown — in-sim cfprefsd would otherwise
+ * overwrite this file on flush.
  */
 export async function setAccessibilityPrefsPreBoot(udid: string): Promise<void> {
   const plistPath = accessibilityPlistPath(udid);
@@ -245,9 +223,7 @@ export async function setAccessibilityPrefsPreBoot(udid: string): Promise<void> 
     .then(() => true)
     .catch(() => false);
   if (!exists) {
-    // `plutil -create binary1` produces an empty dict in the same binary format
-    // SpringBoard reads at boot. -replace below adds each key regardless of
-    // whether the file already had it.
+    // Empty binary plist in the format SB expects; -replace below adds the keys.
     await execFileAsync("plutil", ["-create", "binary1", plistPath]);
   }
   for (const key of [

--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -112,9 +112,7 @@ async function pingDaemon(socketPath: string): Promise<boolean> {
   }
 }
 
-export async function ensureAutomationEnabled(
-  udid: string
-): Promise<{ prefsAlreadyActive: boolean }> {
+export async function ensureAutomationEnabled(udid: string): Promise<void> {
   await execFileAsync(
     "xcrun",
     [
@@ -130,14 +128,23 @@ export async function ensureAutomationEnabled(
     ],
     { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
   );
+}
 
-  // iOS 26.5+: SB's AX server rejects unentitled MIG clients with kAXError -25215;
-  // `IgnoreAXServerEntitlements` disables the check but SB caches it at init.
-  // boot-device pre-writes the pref to the host plist so the common path skips
-  // this branch entirely; this branch only fires when the sim was booted outside
-  // argent, and we intentionally do NOT kickstart SpringBoard — we accept
-  // degraded describe quality and surface a hint instead.
-  const isAlreadySet = await execFileAsync(
+/**
+ * iOS 26.5+: SB's AX server rejects unentitled MIG clients with
+ * kAXError -25215. `IgnoreAXServerEntitlements` disables the check, but
+ * SB caches it at init — so writing it post-boot only takes effect after
+ * the next SB restart.
+ *
+ * boot-device pre-writes the pref to the host plist before boot (the
+ * happy path). This function is the post-boot fallback: it writes the
+ * pref but does NOT kickstart SpringBoard, returning whether the pref
+ * was already active so the caller can surface a degraded-quality hint.
+ */
+export async function ensureEntitlementBypass(
+  udid: string
+): Promise<{ alreadyActive: boolean }> {
+  const alreadyActive = await execFileAsync(
     "xcrun",
     [
       "simctl",
@@ -153,7 +160,7 @@ export async function ensureAutomationEnabled(
     .then(({ stdout }) => stdout.trim() === "1")
     .catch(() => false);
 
-  if (!isAlreadySet) {
+  if (!alreadyActive) {
     await execFileAsync(
       "xcrun",
       [
@@ -171,7 +178,7 @@ export async function ensureAutomationEnabled(
     );
   }
 
-  return { prefsAlreadyActive: isAlreadySet };
+  return { alreadyActive };
 }
 
 /**
@@ -344,7 +351,8 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
     const socketPath = getSocketPath(udid);
     const events = new TypedEventEmitter<ServiceEvents>();
 
-    const { prefsAlreadyActive } = await ensureAutomationEnabled(udid);
+    await ensureAutomationEnabled(udid);
+    const { alreadyActive: entitlementBypassActive } = await ensureEntitlementBypass(udid);
     await killExistingDaemon(socketPath);
 
     const proc = await spawnDaemon(udid, socketPath);
@@ -367,7 +375,7 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
     }
 
     const api: AXServiceApi = {
-      degraded: !prefsAlreadyActive,
+      degraded: !entitlementBypassActive,
 
       async describe(): Promise<AXDescribeResponse> {
         const result = (await query("describe")) as AXDescribeResponse & {

--- a/packages/tool-server/src/tools/describe/contract.ts
+++ b/packages/tool-server/src/tools/describe/contract.ts
@@ -65,6 +65,7 @@ export interface DescribeTreeData {
   tree: DescribeNode;
   source: DescribeSource;
   should_restart?: boolean;
+  hint?: string;
 }
 
 // Public describe-tool response. The full JSON `tree` (the previous payload's
@@ -76,6 +77,7 @@ export interface DescribeResult {
   description: string;
   source: DescribeSource;
   should_restart?: boolean;
+  hint?: string;
 }
 
 export function parseDescribeResult(input: unknown): DescribeNode {

--- a/packages/tool-server/src/tools/describe/index.ts
+++ b/packages/tool-server/src/tools/describe/index.ts
@@ -17,6 +17,7 @@ function withDescription(data: DescribeTreeData): DescribeResult {
     source: data.source,
   };
   if (data.should_restart) out.should_restart = data.should_restart;
+  if (data.hint) out.hint = data.hint;
   return out;
 }
 

--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -29,8 +29,12 @@ export async function describeIos(
   const response = await axApi.describe();
   const tree = adaptAXDescribeToDescribeResult(response);
 
+  const hint = axApi.degraded
+    ? "This simulator was not started with boot-device — accessibility settings are applied but not yet active. System dialogs and native modals may be missing. Restart the simulator with boot-device for full describe coverage."
+    : undefined;
+
   if (tree.children.length > 0) {
-    return { tree, source: "ax-service" };
+    return { tree, source: "ax-service", hint };
   }
 
   // AX returned zero elements — attempt native-devtools fallback
@@ -41,7 +45,7 @@ export async function describeIos(
     const target = await resolveNativeTargetApp(nativeApi, params.bundleId);
 
     if (await nativeApi.requiresAppRestart(target.bundleId)) {
-      return { tree, source: "ax-service", should_restart: true };
+      return { tree, source: "ax-service", should_restart: true, hint };
     }
 
     const rawResult = (await nativeApi.queryViewHierarchy(
@@ -50,14 +54,14 @@ export async function describeIos(
     )) as { screenFrame?: unknown; elements?: unknown[]; error?: string };
 
     if (rawResult.error) {
-      return { tree, source: "ax-service" };
+      return { tree, source: "ax-service", hint };
     }
 
     const parsed = parseNativeDescribeScreenResult(rawResult);
     const nativeTree = adaptNativeDescribeToDescribeResult(parsed);
-    return { tree: nativeTree, source: "native-devtools" };
+    return { tree: nativeTree, source: "native-devtools", hint };
   } catch {
     // Native devtools unavailable or no connected app — return the empty AX result
-    return { tree, source: "ax-service" };
+    return { tree, source: "ax-service", hint };
   }
 }

--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -3,9 +3,20 @@ import { axServiceRef, AXServiceApi } from "../../../../blueprints/ax-service";
 import { nativeDevtoolsRef, NativeDevtoolsApi } from "../../../../blueprints/native-devtools";
 import { resolveNativeTargetApp } from "../../../../utils/native-target-app";
 import { parseNativeDescribeScreenResult } from "../../../native-devtools/native-describe-contract";
-import { DescribeTreeData } from "../../contract";
+import { DescribeTreeData, parseDescribeResult, type DescribeNode } from "../../contract";
 import { adaptAXDescribeToDescribeResult } from "./ios-ax-adapter";
 import { adaptNativeDescribeToDescribeResult } from "./ios-native-adapter";
+
+const DEGRADED_HINT =
+  "This simulator was not booted through argent — system dialogs and native modals may not appear. Call boot-device with force=true to restart the simulator and apply full accessibility settings.";
+
+function emptyTree(): DescribeNode {
+  return parseDescribeResult({
+    role: "AXGroup",
+    frame: { x: 0, y: 0, width: 1, height: 1 },
+    children: [],
+  });
+}
 
 export interface DescribeIosParams {
   bundleId?: string;
@@ -24,20 +35,27 @@ export async function describeIos(
   device: DeviceInfo,
   params: DescribeIosParams
 ): Promise<DescribeTreeData> {
-  const axRef = axServiceRef(device);
-  const axApi = await registry.resolveService<AXServiceApi>(axRef.urn, axRef.options);
-  const response = await axApi.describe();
-  const tree = adaptAXDescribeToDescribeResult(response);
+  let tree: DescribeNode;
+  let hint: string | undefined;
 
-  const hint = axApi.degraded
-    ? "This simulator was not booted through argent — system dialogs and native modals may not appear. Call boot-device with force=true to restart the simulator and apply full accessibility settings."
-    : undefined;
+  try {
+    const axRef = axServiceRef(device);
+    const axApi = await registry.resolveService<AXServiceApi>(axRef.urn, axRef.options);
+    const response = await axApi.describe();
+    tree = adaptAXDescribeToDescribeResult(response);
+    hint = axApi.degraded ? DEGRADED_HINT : undefined;
+  } catch {
+    // ax-service failed to start or timed out — treat as degraded with an
+    // empty tree so we still attempt the native-devtools fallback below.
+    tree = emptyTree();
+    hint = DEGRADED_HINT;
+  }
 
   if (tree.children.length > 0) {
     return { tree, source: "ax-service", hint };
   }
 
-  // AX returned zero elements — attempt native-devtools fallback
+  // AX returned zero elements (or failed entirely) — attempt native-devtools fallback
   try {
     const ndRef = nativeDevtoolsRef(device);
     const nativeApi = await registry.resolveService<NativeDevtoolsApi>(ndRef.urn, ndRef.options);

--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -30,7 +30,7 @@ export async function describeIos(
   const tree = adaptAXDescribeToDescribeResult(response);
 
   const hint = axApi.degraded
-    ? "This simulator was not started with boot-device — accessibility settings are applied but not yet active. System dialogs and native modals may be missing. Restart the simulator with boot-device for full describe coverage."
+    ? "This simulator was not booted through argent — system dialogs and native modals may not appear. Call boot-device with force=true to restart the simulator and apply full accessibility settings."
     : undefined;
 
   if (tree.children.length > 0) {

--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -8,7 +8,7 @@ import { adaptAXDescribeToDescribeResult } from "./ios-ax-adapter";
 import { adaptNativeDescribeToDescribeResult } from "./ios-native-adapter";
 
 const DEGRADED_HINT =
-  "This simulator was not booted through argent — system dialogs and native modals may not appear. Call boot-device with force=true to restart the simulator and apply full accessibility settings.";
+  "This simulator was not booted through argent — system dialogs and native modals may not appear. You MUST call boot-device with force=true now to restart the simulator and apply full accessibility settings before continuing.";
 
 function emptyTree(): DescribeNode {
   return parseDescribeResult({

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -195,15 +195,11 @@ async function bootIos(
 ): Promise<{ platform: "ios"; udid: string; booted: true } | NativeDevtoolsInitFailedResult> {
   await ensureDep("xcrun");
 
-  // iOS 26.5+ AX entitlement bypass — happy path. When the sim is currently
-  // Shutdown, write `IgnoreAXServerEntitlements`/`AutomationEnabled` directly
-  // to the host-side preference plist BEFORE `simctl boot`. SpringBoard reads
-  // and caches the pref at AX-server init, so this avoids the kickstart that
-  // ensureAutomationEnabled would otherwise need to issue post-boot — a
-  // kickstart that kills any foreground app and dismisses any in-flight TCC
-  // prompt. The state probe is best-effort: if `simctl list` is unavailable
-  // or the udid is unknown, fall through to the post-boot ensureAutomationEnabled
-  // path so the bypass still gets applied, just with the disruption.
+  // iOS 26.5+ AX bypass — happy path. If the sim is Shutdown, pre-write the
+  // AX prefs to the host plist so SB caches them at init and the kickstart
+  // never fires. Probe is best-effort: an unknown state falls through to the
+  // post-boot ensureAutomationEnabled fallback which still applies the bypass
+  // (with the SB-restart disruption).
   const wasShutdown = await listIosSimulators()
     .then((sims) => sims.find((s) => s.udid === udid)?.state === "Shutdown")
     .catch(() => false);
@@ -212,7 +208,7 @@ async function bootIos(
       process.stderr.write(
         `[boot-device ${udid.slice(0, 8)}] pre-boot AX pref write failed (${
           err instanceof Error ? err.message : String(err)
-        }); falling back to post-boot kickstart path which will restart SpringBoard.\n`
+        }); falling back to post-boot kickstart which restarts SpringBoard.\n`
       );
     });
   }
@@ -227,18 +223,11 @@ async function bootIos(
   // `bootstatus -b` blocks until the simulator is fully ready for env setup.
   await execFileAsync("xcrun", ["simctl", "bootstatus", udid, "-b"]);
 
-  // iOS 26.5+ AX entitlement bypass — fallback path. If the sim was already
-  // Booted before this call (or the pre-boot write was skipped/failed),
-  // SpringBoard's AX server has already cached the pref as its boot-time
-  // value. The only way to flip it now is to kickstart SB — which terminates
-  // the foreground app and any in-flight system alert. We do that work HERE,
-  // during boot-device, rather than letting it land lazily inside the
-  // simulator-server / ax-service factory on the agent's first interactive
-  // tool call. That way the disruption hits when the agent is explicitly
-  // preparing the device, not when it's mid-launch on the first app.
-  // ensureAutomationEnabled itself checks if the pref is already set and
-  // skips the kickstart in that case, so the common path (host plist
-  // pre-write succeeded → SB already has it cached) is a fast no-op.
+  // iOS 26.5+ AX bypass — fallback. No-op on the happy path (pref already
+  // cached from pre-boot write). When the sim was Booted before boot-device,
+  // SB cached the unset pref at its prior init — flip it via kickstart now,
+  // during boot-device, so the disruption (foreground app + in-flight alerts
+  // gone) lands here instead of lazily during the agent's first launch-app.
   await ensureAutomationEnabled(udid).catch(() => undefined);
 
   const ndRef = nativeDevtoolsRef({ id: udid, platform: "ios", kind: "simulator" });

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -8,6 +8,7 @@ import {
   type NativeDevtoolsApi,
   type NativeDevtoolsInitFailedResult,
 } from "../../blueprints/native-devtools";
+import { ensureAutomationEnabled, setAccessibilityPrefsPreBoot } from "../../blueprints/ax-service";
 import {
   adbShell,
   checkSnapshotLoadable,
@@ -19,6 +20,7 @@ import {
   waitForBootCompleted,
 } from "../../utils/adb";
 import { ensureDep } from "../../utils/check-deps";
+import { listIosSimulators } from "../../utils/ios-devices";
 
 const execFileAsync = promisify(execFile);
 
@@ -192,6 +194,29 @@ async function bootIos(
   registry: Registry
 ): Promise<{ platform: "ios"; udid: string; booted: true } | NativeDevtoolsInitFailedResult> {
   await ensureDep("xcrun");
+
+  // iOS 26.5+ AX entitlement bypass — happy path. When the sim is currently
+  // Shutdown, write `IgnoreAXServerEntitlements`/`AutomationEnabled` directly
+  // to the host-side preference plist BEFORE `simctl boot`. SpringBoard reads
+  // and caches the pref at AX-server init, so this avoids the kickstart that
+  // ensureAutomationEnabled would otherwise need to issue post-boot — a
+  // kickstart that kills any foreground app and dismisses any in-flight TCC
+  // prompt. The state probe is best-effort: if `simctl list` is unavailable
+  // or the udid is unknown, fall through to the post-boot ensureAutomationEnabled
+  // path so the bypass still gets applied, just with the disruption.
+  const wasShutdown = await listIosSimulators()
+    .then((sims) => sims.find((s) => s.udid === udid)?.state === "Shutdown")
+    .catch(() => false);
+  if (wasShutdown) {
+    await setAccessibilityPrefsPreBoot(udid).catch((err: unknown) => {
+      process.stderr.write(
+        `[boot-device ${udid.slice(0, 8)}] pre-boot AX pref write failed (${
+          err instanceof Error ? err.message : String(err)
+        }); falling back to post-boot kickstart path which will restart SpringBoard.\n`
+      );
+    });
+  }
+
   await execFileAsync("xcrun", ["simctl", "boot", udid]).catch((err: unknown) => {
     const message = err instanceof Error ? err.message : String(err);
     // `simctl boot` errors when the device is already booted — treat as success.
@@ -201,6 +226,21 @@ async function bootIos(
   });
   // `bootstatus -b` blocks until the simulator is fully ready for env setup.
   await execFileAsync("xcrun", ["simctl", "bootstatus", udid, "-b"]);
+
+  // iOS 26.5+ AX entitlement bypass — fallback path. If the sim was already
+  // Booted before this call (or the pre-boot write was skipped/failed),
+  // SpringBoard's AX server has already cached the pref as its boot-time
+  // value. The only way to flip it now is to kickstart SB — which terminates
+  // the foreground app and any in-flight system alert. We do that work HERE,
+  // during boot-device, rather than letting it land lazily inside the
+  // simulator-server / ax-service factory on the agent's first interactive
+  // tool call. That way the disruption hits when the agent is explicitly
+  // preparing the device, not when it's mid-launch on the first app.
+  // ensureAutomationEnabled itself checks if the pref is already set and
+  // skips the kickstart in that case, so the common path (host plist
+  // pre-write succeeded → SB already has it cached) is a fast no-op.
+  await ensureAutomationEnabled(udid).catch(() => undefined);
+
   const ndRef = nativeDevtoolsRef({ id: udid, platform: "ios", kind: "simulator" });
   const ndApi = await registry.resolveService<NativeDevtoolsApi>(ndRef.urn, ndRef.options);
   const initFailure = ndApi.getInitFailure();

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -441,7 +441,11 @@ export function __resetInFlightBootsForTesting(): void {
   inFlightBoots.clear();
 }
 
-async function bootAndroid(params: { avdName: string; bootTimeoutMs: number }): Promise<{
+async function bootAndroid(params: {
+  avdName: string;
+  bootTimeoutMs: number;
+  force?: boolean;
+}): Promise<{
   platform: "android";
   serial: string;
   avdName: string;
@@ -456,7 +460,11 @@ async function bootAndroid(params: { avdName: string; bootTimeoutMs: number }): 
   return promise;
 }
 
-async function bootAndroidImpl(params: { avdName: string; bootTimeoutMs: number }): Promise<{
+async function bootAndroidImpl(params: {
+  avdName: string;
+  bootTimeoutMs: number;
+  force?: boolean;
+}): Promise<{
   platform: "android";
   serial: string;
   avdName: string;
@@ -514,34 +522,40 @@ async function bootAndroidImpl(params: { avdName: string; bootTimeoutMs: number 
     (d) => d.isEmulator && d.avdName === params.avdName && d.state === "device"
   );
   if (alreadyRunning) {
-    // BUG GUARD — wedged-framebuffer detection on the reuse path.
-    // A long-running emulator can drift into the same sticky-blank
-    // SurfaceFlinger state that `assertScreencapAlive` defends against on a
-    // hot-boot restore (see its docstring): every Android-side readiness
-    // probe still passes, but `screencap` only returns null bytes — meaning
-    // the caller would silently get a serial whose screenshots are all
-    // black. Without this probe the fast-path returns that wedged serial
-    // forever and there is no way back, since `coldBoot` was removed.
-    // On failure the helper kills the wedged emulator; we then fall through
-    // to the snapshot/probe pipeline so the caller still gets a usable boot.
-    try {
-      await assertScreencapAlive(alreadyRunning.serial);
-      return {
-        platform: "android",
-        serial: alreadyRunning.serial,
-        avdName: params.avdName,
-        booted: true,
-      };
-    } catch (err) {
-      hotBootFailureReason = `running AVD framebuffer was wedged (${
-        err instanceof Error ? err.message : String(err)
-      }), respawning`;
-      // assertScreencapAlive already killed the emulator; refresh the
-      // existing-devices snapshot so the killed serial is included in
-      // serialsBefore (matching the hot-boot catch refresh below) and the
-      // upcoming spawn's "new serial" diff stays correct.
+    if (params.force) {
+      await killEmulatorQuietly(alreadyRunning.serial);
       const refreshed = await listAndroidDevices().catch(() => existingDevices);
       existingDevices.splice(0, existingDevices.length, ...refreshed);
+    } else {
+      // BUG GUARD — wedged-framebuffer detection on the reuse path.
+      // A long-running emulator can drift into the same sticky-blank
+      // SurfaceFlinger state that `assertScreencapAlive` defends against on a
+      // hot-boot restore (see its docstring): every Android-side readiness
+      // probe still passes, but `screencap` only returns null bytes — meaning
+      // the caller would silently get a serial whose screenshots are all
+      // black. Without this probe the fast-path returns that wedged serial
+      // forever and there is no way back, since `coldBoot` was removed.
+      // On failure the helper kills the wedged emulator; we then fall through
+      // to the snapshot/probe pipeline so the caller still gets a usable boot.
+      try {
+        await assertScreencapAlive(alreadyRunning.serial);
+        return {
+          platform: "android",
+          serial: alreadyRunning.serial,
+          avdName: params.avdName,
+          booted: true,
+        };
+      } catch (err) {
+        hotBootFailureReason = `running AVD framebuffer was wedged (${
+          err instanceof Error ? err.message : String(err)
+        }), respawning`;
+        // assertScreencapAlive already killed the emulator; refresh the
+        // existing-devices snapshot so the killed serial is included in
+        // serialsBefore (matching the hot-boot catch refresh below) and the
+        // upcoming spawn's "new serial" diff stays correct.
+        const refreshed = await listAndroidDevices().catch(() => existingDevices);
+        existingDevices.splice(0, existingDevices.length, ...refreshed);
+      }
     }
   }
   const serialsBefore = new Set(existingDevices.map((d) => d.serial));
@@ -712,6 +726,7 @@ Android boots take 2–10 minutes depending on machine and cold/warm state; the 
       return bootAndroid({
         avdName: params.avdName!,
         bootTimeoutMs: params.bootTimeoutMs ?? 480_000,
+        force: params.force,
       });
     },
   };

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -8,7 +8,11 @@ import {
   type NativeDevtoolsApi,
   type NativeDevtoolsInitFailedResult,
 } from "../../blueprints/native-devtools";
-import { ensureAutomationEnabled, setAccessibilityPrefsPreBoot } from "../../blueprints/ax-service";
+import {
+  ensureAutomationEnabled,
+  isEntitlementBypassActive,
+  setAccessibilityPrefsPreBoot,
+} from "../../blueprints/ax-service";
 import {
   adbShell,
   checkSnapshotLoadable,
@@ -53,6 +57,10 @@ const zodSchema = z.object({
     .describe(
       "Android-only: overall budget for the full boot sequence. Defaults to 480000 (8 min). Clamped to [30s, 15min]. Ignored on iOS."
     ),
+  force: z
+    .boolean()
+    .optional()
+    .describe("Shut down and re-boot the device even if already running."),
 });
 
 type BootDeviceParams = z.infer<typeof zodSchema>;
@@ -191,19 +199,22 @@ async function listNewEmulatorSerials(before: Set<string>): Promise<string[]> {
 
 async function bootIos(
   udid: string,
-  registry: Registry
+  registry: Registry,
+  force?: boolean
 ): Promise<{ platform: "ios"; udid: string; booted: true } | NativeDevtoolsInitFailedResult> {
   await ensureDep("xcrun");
 
-  // iOS 26.5+ AX bypass — happy path. If the sim is Shutdown, pre-write the
-  // AX prefs to the host plist so SB caches them at init. This is the only
-  // path that fully activates the prefs; if missed (sim already booted),
-  // ensureAutomationEnabled writes them best-effort but SB won't read them
-  // until the next restart — describe surfaces a hint in that case.
-  const wasShutdown = await listIosSimulators()
-    .then((sims) => sims.find((s) => s.udid === udid)?.state === "Shutdown")
-    .catch(() => false);
-  if (wasShutdown) {
+  const simState = await listIosSimulators()
+    .then((sims) => sims.find((s) => s.udid === udid)?.state)
+    .catch(() => undefined);
+
+  // force=true on a running sim: shut it down so we can pre-write AX prefs.
+  if (force && simState === "Booted") {
+    await execFileAsync("xcrun", ["simctl", "shutdown", udid]);
+  }
+
+  const needsPreBoot = simState === "Shutdown" || (force && simState === "Booted");
+  if (needsPreBoot) {
     await setAccessibilityPrefsPreBoot(udid).catch((err: unknown) => {
       process.stderr.write(
         `[boot-device ${udid.slice(0, 8)}] pre-boot AX pref write failed (${
@@ -215,18 +226,16 @@ async function bootIos(
 
   await execFileAsync("xcrun", ["simctl", "boot", udid]).catch((err: unknown) => {
     const message = err instanceof Error ? err.message : String(err);
-    // `simctl boot` errors when the device is already booted — treat as success.
     if (!message.includes("Unable to boot device in current state: Booted")) {
       throw err;
     }
   });
-  // `bootstatus -b` blocks until the simulator is fully ready for env setup.
   await execFileAsync("xcrun", ["simctl", "bootstatus", udid, "-b"]);
 
   // Best-effort fallback: no-op on the happy path (pref already cached from
-  // pre-boot write). When the sim was already Booted, writes the prefs via
-  // `defaults write` — SB won't pick them up until next restart, but describe
-  // surfaces a hint about it.
+  // pre-boot write). When the sim was already Booted without force, writes
+  // prefs via `defaults write` — SB won't pick them up until next restart,
+  // but describe surfaces a hint about it.
   await ensureAutomationEnabled(udid).catch(() => undefined);
 
   const ndRef = nativeDevtoolsRef({ id: udid, platform: "ios", kind: "simulator" });
@@ -698,7 +707,7 @@ Android boots take 2–10 minutes depending on machine and cold/warm state; the 
         throw new Error("Provide exactly one of `udid` (iOS) or `avdName` (Android).");
       }
       if (hasUdid) {
-        return bootIos(params.udid!, registry);
+        return bootIos(params.udid!, registry, params.force);
       }
       return bootAndroid({
         avdName: params.avdName!,

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -196,10 +196,10 @@ async function bootIos(
   await ensureDep("xcrun");
 
   // iOS 26.5+ AX bypass — happy path. If the sim is Shutdown, pre-write the
-  // AX prefs to the host plist so SB caches them at init and the kickstart
-  // never fires. Probe is best-effort: an unknown state falls through to the
-  // post-boot ensureAutomationEnabled fallback which still applies the bypass
-  // (with the SB-restart disruption).
+  // AX prefs to the host plist so SB caches them at init. This is the only
+  // path that fully activates the prefs; if missed (sim already booted),
+  // ensureAutomationEnabled writes them best-effort but SB won't read them
+  // until the next restart — describe surfaces a hint in that case.
   const wasShutdown = await listIosSimulators()
     .then((sims) => sims.find((s) => s.udid === udid)?.state === "Shutdown")
     .catch(() => false);
@@ -208,7 +208,7 @@ async function bootIos(
       process.stderr.write(
         `[boot-device ${udid.slice(0, 8)}] pre-boot AX pref write failed (${
           err instanceof Error ? err.message : String(err)
-        }); falling back to post-boot kickstart which restarts SpringBoard.\n`
+        }); ensureAutomationEnabled will write prefs post-boot but SB won't pick them up until next restart.\n`
       );
     });
   }
@@ -223,11 +223,10 @@ async function bootIos(
   // `bootstatus -b` blocks until the simulator is fully ready for env setup.
   await execFileAsync("xcrun", ["simctl", "bootstatus", udid, "-b"]);
 
-  // iOS 26.5+ AX bypass — fallback. No-op on the happy path (pref already
-  // cached from pre-boot write). When the sim was Booted before boot-device,
-  // SB cached the unset pref at its prior init — flip it via kickstart now,
-  // during boot-device, so the disruption (foreground app + in-flight alerts
-  // gone) lands here instead of lazily during the agent's first launch-app.
+  // Best-effort fallback: no-op on the happy path (pref already cached from
+  // pre-boot write). When the sim was already Booted, writes the prefs via
+  // `defaults write` — SB won't pick them up until next restart, but describe
+  // surfaces a hint about it.
   await ensureAutomationEnabled(udid).catch(() => undefined);
 
   const ndRef = nativeDevtoolsRef({ id: udid, platform: "ios", kind: "simulator" });

--- a/packages/tool-server/test/boot-device.test.ts
+++ b/packages/tool-server/test/boot-device.test.ts
@@ -21,11 +21,10 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-// Mock the iOS 26.5+ AX-bypass plumbing at the module boundary so this test
-// pins boot-device's dispatch contract (state probe → pre-boot if shutdown →
-// boot → ensureAutomationEnabled fallback → native-devtools → open) without
-// dragging the plist/kickstart implementation into the exec-call assertions.
-// Implementation behaviour for those helpers is covered by ax-service tests.
+// Mock the AX-bypass helpers at the module boundary so this file asserts
+// boot-device's dispatch (state probe → pre-boot if shutdown → boot →
+// ensureAutomationEnabled fallback → native-devtools → open) without pulling
+// plist/kickstart internals into the exec-call sequence.
 const listIosSimulatorsMock = vi.fn();
 const setAccessibilityPrefsPreBootMock = vi.fn();
 const ensureAutomationEnabledMock = vi.fn();
@@ -53,8 +52,8 @@ describe("boot-device — iOS path", () => {
       getCallback(args)(null, "", "");
       return {} as never;
     });
-    // Default: sim is Shutdown so the happy path (pre-boot plist write, no
-    // post-boot kickstart needed) runs. Individual tests override.
+    // Default state: 11111111 + 33333333 Shutdown (happy path), 22222222
+    // Booted (kickstart-fallback path). Individual tests override.
     listIosSimulatorsMock.mockReset().mockResolvedValue([
       { udid: "11111111-1111-1111-1111-111111111111", state: "Shutdown" },
       { udid: "22222222-2222-2222-2222-222222222222", state: "Booted" },
@@ -80,8 +79,9 @@ describe("boot-device — iOS path", () => {
       booted: true,
     });
 
-    // Pre-boot plist write must fire BEFORE simctl boot — that's the whole
-    // point of approach (B): SpringBoard reads the pref at first init.
+    // Pre-boot write must precede `simctl boot` so SB inherits the bypass at
+    // first init; ensureAutomationEnabled then runs as a defense-in-depth
+    // no-op (pref already cached, kickstart branch skipped).
     expect(setAccessibilityPrefsPreBootMock).toHaveBeenCalledTimes(1);
     expect(setAccessibilityPrefsPreBootMock).toHaveBeenCalledWith(
       "11111111-1111-1111-1111-111111111111"
@@ -89,8 +89,6 @@ describe("boot-device — iOS path", () => {
     expect(setAccessibilityPrefsPreBootMock.mock.invocationCallOrder[0]).toBeLessThan(
       mockExecFile.mock.invocationCallOrder[0]
     );
-    // ensureAutomationEnabled still fires as a defense-in-depth no-op, but the
-    // pref is already set on disk so its internal kickstart-branch is skipped.
     expect(ensureAutomationEnabledMock).toHaveBeenCalledTimes(1);
     expect(ensureAutomationEnabledMock).toHaveBeenCalledWith(
       "11111111-1111-1111-1111-111111111111"
@@ -132,10 +130,9 @@ describe("boot-device — iOS path", () => {
 
     await tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222" });
 
-    // Sim was Booted before we touched it: SB's AX server already cached the
-    // pref at its prior boot, so the pre-boot write would be undone by
-    // cfprefsd flushes. Skip it; rely on ensureAutomationEnabled's
-    // kickstart-if-needed branch to flip the bypass live.
+    // Already-Booted sim: in-sim cfprefsd would overwrite the host write, so
+    // skip it and let ensureAutomationEnabled's kickstart branch flip the
+    // bypass live.
     expect(setAccessibilityPrefsPreBootMock).not.toHaveBeenCalled();
     expect(ensureAutomationEnabledMock).toHaveBeenCalledWith(
       "22222222-2222-2222-2222-222222222222"
@@ -143,9 +140,8 @@ describe("boot-device — iOS path", () => {
   });
 
   it("still runs the fallback ensureAutomationEnabled when the state probe fails", async () => {
-    // simctl unavailable or udid unknown — listIosSimulators returns []
-    // (its own try/catch swallows errors). We must not block boot on the
-    // probe; let it fall through and rely on ensureAutomationEnabled, which
+    // listIosSimulators returns [] on xcrun failure / unknown udid; boot must
+    // not block on the probe — fall through to ensureAutomationEnabled which
     // self-detects whether a kickstart is needed.
     listIosSimulatorsMock.mockResolvedValueOnce([]);
 
@@ -162,9 +158,8 @@ describe("boot-device — iOS path", () => {
   });
 
   it("does not block boot on a pre-boot plist write failure", async () => {
-    // If plutil is missing or the data container is read-only, log to stderr
-    // and keep going — ensureAutomationEnabled will still apply the bypass
-    // (with a kickstart) on the post-boot side.
+    // plutil missing / data container read-only: log and continue;
+    // ensureAutomationEnabled applies the bypass post-boot with a kickstart.
     setAccessibilityPrefsPreBootMock.mockRejectedValueOnce(new Error("plutil missing"));
 
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));

--- a/packages/tool-server/test/boot-device.test.ts
+++ b/packages/tool-server/test/boot-device.test.ts
@@ -60,7 +60,7 @@ describe("boot-device — iOS path", () => {
       { udid: "33333333-3333-3333-3333-333333333333", state: "Shutdown" },
     ]);
     setAccessibilityPrefsPreBootMock.mockReset().mockResolvedValue(undefined);
-    ensureAutomationEnabledMock.mockReset().mockResolvedValue({ prefsAlreadyActive: true });
+    ensureAutomationEnabledMock.mockReset().mockResolvedValue(undefined);
   });
 
   it("pre-boots AX prefs on a Shutdown sim then waits for boot completion and native-devtools init", async () => {

--- a/packages/tool-server/test/boot-device.test.ts
+++ b/packages/tool-server/test/boot-device.test.ts
@@ -21,6 +21,24 @@ vi.mock("node:child_process", async () => {
   };
 });
 
+// Mock the iOS 26.5+ AX-bypass plumbing at the module boundary so this test
+// pins boot-device's dispatch contract (state probe → pre-boot if shutdown →
+// boot → ensureAutomationEnabled fallback → native-devtools → open) without
+// dragging the plist/kickstart implementation into the exec-call assertions.
+// Implementation behaviour for those helpers is covered by ax-service tests.
+const listIosSimulatorsMock = vi.fn();
+const setAccessibilityPrefsPreBootMock = vi.fn();
+const ensureAutomationEnabledMock = vi.fn();
+
+vi.mock("../src/utils/ios-devices", () => ({
+  listIosSimulators: (...args: unknown[]) => listIosSimulatorsMock(...args),
+}));
+
+vi.mock("../src/blueprints/ax-service", () => ({
+  setAccessibilityPrefsPreBoot: (...args: unknown[]) => setAccessibilityPrefsPreBootMock(...args),
+  ensureAutomationEnabled: (...args: unknown[]) => ensureAutomationEnabledMock(...args),
+}));
+
 import { createBootDeviceTool } from "../src/tools/devices/boot-device";
 import { __primeDepCacheForTests, __resetDepCacheForTests } from "../src/utils/check-deps";
 
@@ -35,9 +53,18 @@ describe("boot-device — iOS path", () => {
       getCallback(args)(null, "", "");
       return {} as never;
     });
+    // Default: sim is Shutdown so the happy path (pre-boot plist write, no
+    // post-boot kickstart needed) runs. Individual tests override.
+    listIosSimulatorsMock.mockReset().mockResolvedValue([
+      { udid: "11111111-1111-1111-1111-111111111111", state: "Shutdown" },
+      { udid: "22222222-2222-2222-2222-222222222222", state: "Booted" },
+      { udid: "33333333-3333-3333-3333-333333333333", state: "Shutdown" },
+    ]);
+    setAccessibilityPrefsPreBootMock.mockReset().mockResolvedValue(undefined);
+    ensureAutomationEnabledMock.mockReset().mockResolvedValue(undefined);
   });
 
-  it("waits for boot completion and native-devtools init before returning", async () => {
+  it("pre-boots AX prefs on a Shutdown sim then waits for boot completion and native-devtools init", async () => {
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
     const registry = {
       resolveService,
@@ -52,6 +79,22 @@ describe("boot-device — iOS path", () => {
       udid: "11111111-1111-1111-1111-111111111111",
       booted: true,
     });
+
+    // Pre-boot plist write must fire BEFORE simctl boot — that's the whole
+    // point of approach (B): SpringBoard reads the pref at first init.
+    expect(setAccessibilityPrefsPreBootMock).toHaveBeenCalledTimes(1);
+    expect(setAccessibilityPrefsPreBootMock).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111"
+    );
+    expect(setAccessibilityPrefsPreBootMock.mock.invocationCallOrder[0]).toBeLessThan(
+      mockExecFile.mock.invocationCallOrder[0]
+    );
+    // ensureAutomationEnabled still fires as a defense-in-depth no-op, but the
+    // pref is already set on disk so its internal kickstart-branch is skipped.
+    expect(ensureAutomationEnabledMock).toHaveBeenCalledTimes(1);
+    expect(ensureAutomationEnabledMock).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111"
+    );
 
     expect(mockExecFile.mock.calls.map(([file, args]) => [file, args])).toEqual([
       ["xcrun", ["simctl", "boot", "11111111-1111-1111-1111-111111111111"]],
@@ -80,6 +123,63 @@ describe("boot-device — iOS path", () => {
     expect(resolveService.mock.invocationCallOrder[0]).toBeLessThan(
       mockExecFile.mock.invocationCallOrder[2]
     );
+  });
+
+  it("skips pre-boot plist write when the sim is already Booted and falls back to ensureAutomationEnabled", async () => {
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const registry = { resolveService } as unknown as Registry;
+    const tool = createBootDeviceTool(registry);
+
+    await tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222" });
+
+    // Sim was Booted before we touched it: SB's AX server already cached the
+    // pref at its prior boot, so the pre-boot write would be undone by
+    // cfprefsd flushes. Skip it; rely on ensureAutomationEnabled's
+    // kickstart-if-needed branch to flip the bypass live.
+    expect(setAccessibilityPrefsPreBootMock).not.toHaveBeenCalled();
+    expect(ensureAutomationEnabledMock).toHaveBeenCalledWith(
+      "22222222-2222-2222-2222-222222222222"
+    );
+  });
+
+  it("still runs the fallback ensureAutomationEnabled when the state probe fails", async () => {
+    // simctl unavailable or udid unknown — listIosSimulators returns []
+    // (its own try/catch swallows errors). We must not block boot on the
+    // probe; let it fall through and rely on ensureAutomationEnabled, which
+    // self-detects whether a kickstart is needed.
+    listIosSimulatorsMock.mockResolvedValueOnce([]);
+
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const registry = { resolveService } as unknown as Registry;
+    const tool = createBootDeviceTool(registry);
+
+    await tool.execute!({}, { udid: "44444444-4444-4444-4444-444444444444" });
+
+    expect(setAccessibilityPrefsPreBootMock).not.toHaveBeenCalled();
+    expect(ensureAutomationEnabledMock).toHaveBeenCalledWith(
+      "44444444-4444-4444-4444-444444444444"
+    );
+  });
+
+  it("does not block boot on a pre-boot plist write failure", async () => {
+    // If plutil is missing or the data container is read-only, log to stderr
+    // and keep going — ensureAutomationEnabled will still apply the bypass
+    // (with a kickstart) on the post-boot side.
+    setAccessibilityPrefsPreBootMock.mockRejectedValueOnce(new Error("plutil missing"));
+
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const registry = { resolveService } as unknown as Registry;
+    const tool = createBootDeviceTool(registry);
+
+    await expect(
+      tool.execute!({}, { udid: "11111111-1111-1111-1111-111111111111" })
+    ).resolves.toEqual({
+      platform: "ios",
+      udid: "11111111-1111-1111-1111-111111111111",
+      booted: true,
+    });
+
+    expect(ensureAutomationEnabledMock).toHaveBeenCalled();
   });
 
   it("returns a structured init_failed result when native-devtools has given up", async () => {

--- a/packages/tool-server/test/boot-device.test.ts
+++ b/packages/tool-server/test/boot-device.test.ts
@@ -60,7 +60,7 @@ describe("boot-device — iOS path", () => {
       { udid: "33333333-3333-3333-3333-333333333333", state: "Shutdown" },
     ]);
     setAccessibilityPrefsPreBootMock.mockReset().mockResolvedValue(undefined);
-    ensureAutomationEnabledMock.mockReset().mockResolvedValue(undefined);
+    ensureAutomationEnabledMock.mockReset().mockResolvedValue({ prefsAlreadyActive: true });
   });
 
   it("pre-boots AX prefs on a Shutdown sim then waits for boot completion and native-devtools init", async () => {
@@ -131,8 +131,7 @@ describe("boot-device — iOS path", () => {
     await tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222" });
 
     // Already-Booted sim: in-sim cfprefsd would overwrite the host write, so
-    // skip it and let ensureAutomationEnabled's kickstart branch flip the
-    // bypass live.
+    // skip it. ensureAutomationEnabled writes prefs best-effort (no kickstart).
     expect(setAccessibilityPrefsPreBootMock).not.toHaveBeenCalled();
     expect(ensureAutomationEnabledMock).toHaveBeenCalledWith(
       "22222222-2222-2222-2222-222222222222"
@@ -142,7 +141,7 @@ describe("boot-device — iOS path", () => {
   it("still runs the fallback ensureAutomationEnabled when the state probe fails", async () => {
     // listIosSimulators returns [] on xcrun failure / unknown udid; boot must
     // not block on the probe — fall through to ensureAutomationEnabled which
-    // self-detects whether a kickstart is needed.
+    // writes prefs best-effort.
     listIosSimulatorsMock.mockResolvedValueOnce([]);
 
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
@@ -159,7 +158,7 @@ describe("boot-device — iOS path", () => {
 
   it("does not block boot on a pre-boot plist write failure", async () => {
     // plutil missing / data container read-only: log and continue;
-    // ensureAutomationEnabled applies the bypass post-boot with a kickstart.
+    // ensureAutomationEnabled writes prefs best-effort post-boot.
     setAccessibilityPrefsPreBootMock.mockRejectedValueOnce(new Error("plutil missing"));
 
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));

--- a/packages/tool-server/test/boot-device.test.ts
+++ b/packages/tool-server/test/boot-device.test.ts
@@ -28,6 +28,7 @@ vi.mock("node:child_process", async () => {
 const listIosSimulatorsMock = vi.fn();
 const setAccessibilityPrefsPreBootMock = vi.fn();
 const ensureAutomationEnabledMock = vi.fn();
+const isEntitlementBypassActiveMock = vi.fn();
 
 vi.mock("../src/utils/ios-devices", () => ({
   listIosSimulators: (...args: unknown[]) => listIosSimulatorsMock(...args),
@@ -36,6 +37,7 @@ vi.mock("../src/utils/ios-devices", () => ({
 vi.mock("../src/blueprints/ax-service", () => ({
   setAccessibilityPrefsPreBoot: (...args: unknown[]) => setAccessibilityPrefsPreBootMock(...args),
   ensureAutomationEnabled: (...args: unknown[]) => ensureAutomationEnabledMock(...args),
+  isEntitlementBypassActive: (...args: unknown[]) => isEntitlementBypassActiveMock(...args),
 }));
 
 import { createBootDeviceTool } from "../src/tools/devices/boot-device";
@@ -61,6 +63,7 @@ describe("boot-device — iOS path", () => {
     ]);
     setAccessibilityPrefsPreBootMock.mockReset().mockResolvedValue(undefined);
     ensureAutomationEnabledMock.mockReset().mockResolvedValue(undefined);
+    isEntitlementBypassActiveMock.mockReset().mockResolvedValue(true);
   });
 
   it("pre-boots AX prefs on a Shutdown sim then waits for boot completion and native-devtools init", async () => {
@@ -231,6 +234,48 @@ describe("boot-device — iOS path", () => {
       "NativeDevtools:22222222-2222-2222-2222-222222222222",
       { device: { id: "22222222-2222-2222-2222-222222222222", platform: "ios", kind: "simulator" } }
     );
+  });
+
+  it("force=true on a Booted sim triggers shutdown → pre-boot write → boot", async () => {
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const registry = { resolveService } as unknown as Registry;
+    const tool = createBootDeviceTool(registry);
+
+    await expect(
+      tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222", force: true })
+    ).resolves.toEqual({
+      platform: "ios",
+      udid: "22222222-2222-2222-2222-222222222222",
+      booted: true,
+    });
+
+    expect(setAccessibilityPrefsPreBootMock).toHaveBeenCalledWith(
+      "22222222-2222-2222-2222-222222222222"
+    );
+    const execCalls = mockExecFile.mock.calls.map(([file, args]) => [file, args]);
+    expect(execCalls[0]).toEqual([
+      "xcrun",
+      ["simctl", "shutdown", "22222222-2222-2222-2222-222222222222"],
+    ]);
+    expect(execCalls[1]).toEqual([
+      "xcrun",
+      ["simctl", "boot", "22222222-2222-2222-2222-222222222222"],
+    ]);
+  });
+
+  it("force not set on a Booted sim does not shut down", async () => {
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const registry = { resolveService } as unknown as Registry;
+    const tool = createBootDeviceTool(registry);
+
+    await tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222" });
+
+    expect(setAccessibilityPrefsPreBootMock).not.toHaveBeenCalled();
+    const execCalls = mockExecFile.mock.calls.map(([, args]) => args);
+    const hasShutdown = execCalls.some(
+      (args: unknown[]) => Array.isArray(args) && args[1] === "shutdown"
+    );
+    expect(hasShutdown).toBe(false);
   });
 });
 

--- a/packages/tool-server/test/describe-tool.test.ts
+++ b/packages/tool-server/test/describe-tool.test.ts
@@ -13,8 +13,12 @@ function elementLineCount(description: string): number {
   return description.split("\n").filter((l) => /^ {2}AX/.test(l)).length;
 }
 
-function makeAXServiceApi(response: AXDescribeResponse): AXServiceApi {
+function makeAXServiceApi(
+  response: AXDescribeResponse,
+  options?: { degraded?: boolean }
+): AXServiceApi {
   return {
+    degraded: options?.degraded ?? false,
     describe: async () => response,
     alertCheck: async () => response.alertVisible,
     ping: async () => true,
@@ -323,6 +327,51 @@ describe("describe tool", () => {
       "AXService:BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
       { device: { id: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB", platform: "ios", kind: "simulator" } }
     );
+  });
+
+  it("includes hint when ax-service is degraded (sim booted outside argent)", async () => {
+    const axApi = makeAXServiceApi(
+      {
+        alertVisible: false,
+        screenFrame: { width: 440, height: 956 },
+        elements: [
+          {
+            label: "General",
+            frame: { x: 0.045, y: 0.337, width: 0.909, height: 0.046 },
+            traits: ["button"],
+          },
+        ],
+      },
+      { degraded: true }
+    );
+
+    const registry = makeMockRegistry({ axService: axApi });
+    const tool = createDescribeTool(registry);
+
+    const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
+    expect(result.source).toBe("ax-service");
+    expect(result.hint).toMatch(/boot-device/);
+    expect(result.hint).toMatch(/system dialogs/i);
+  });
+
+  it("omits hint when ax-service is not degraded", async () => {
+    const axApi = makeAXServiceApi({
+      alertVisible: false,
+      screenFrame: { width: 440, height: 956 },
+      elements: [
+        {
+          label: "General",
+          frame: { x: 0.045, y: 0.337, width: 0.909, height: 0.046 },
+          traits: ["button"],
+        },
+      ],
+    });
+
+    const registry = makeMockRegistry({ axService: axApi });
+    const tool = createDescribeTool(registry);
+
+    const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
+    expect(result.hint).toBeUndefined();
   });
 
   it("returns empty AX result when native queryViewHierarchy returns an error", async () => {

--- a/packages/tool-server/test/describe-tool.test.ts
+++ b/packages/tool-server/test/describe-tool.test.ts
@@ -260,13 +260,14 @@ describe("describe tool", () => {
     expect(result.should_restart).toBeUndefined();
   });
 
-  it("throws when ax-service is unavailable", async () => {
+  it("returns degraded result with hint when ax-service is unavailable", async () => {
     const registry = makeMockRegistry({});
     const tool = createDescribeTool(registry);
 
-    await expect(
-      tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" })
-    ).rejects.toThrow("ax-service not available");
+    const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
+    expect(result.source).toBe("ax-service");
+    expect(result.hint).toMatch(/boot-device/);
+    expect(elementLineCount(result.description)).toBe(0);
   });
 
   it("returns multiple elements with correct roles", async () => {

--- a/packages/tool-server/test/simulator-server-blueprint.test.ts
+++ b/packages/tool-server/test/simulator-server-blueprint.test.ts
@@ -67,7 +67,7 @@ function androidDevice(serial: string): DeviceInfo {
 describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInfo", () => {
   beforeEach(async () => {
     spawnMock.mockReset();
-    ensureAutomationEnabledMock.mockReset().mockResolvedValue({ prefsAlreadyActive: true });
+    ensureAutomationEnabledMock.mockReset().mockResolvedValue(undefined);
     // Pre-warm the dep cache so the Android branch's `ensureDep('adb')` doesn't
     // shell out to `command -v adb` — CI Linux runners don't have adb on PATH
     // and the real probe would surface as a DependencyMissingError unrelated

--- a/packages/tool-server/test/simulator-server-blueprint.test.ts
+++ b/packages/tool-server/test/simulator-server-blueprint.test.ts
@@ -67,7 +67,7 @@ function androidDevice(serial: string): DeviceInfo {
 describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInfo", () => {
   beforeEach(async () => {
     spawnMock.mockReset();
-    ensureAutomationEnabledMock.mockReset().mockResolvedValue(undefined);
+    ensureAutomationEnabledMock.mockReset().mockResolvedValue({ prefsAlreadyActive: true });
     // Pre-warm the dep cache so the Android branch's `ensureDep('adb')` doesn't
     // shell out to `command -v adb` — CI Linux runners don't have adb on PATH
     // and the real probe would surface as a DependencyMissingError unrelated


### PR DESCRIPTION
## Summary

iOS 26.5 tightened cross-process AX access: SpringBoard's AX server rejects MIG queries from non-UIApplication clients with kAXError \`-25215\`. Our \`ax-service\` daemon is a \`simctl spawn\`-launched CLI binary, so it fails the new check, and \`describe\` returns an empty ROOT for any SpringBoard-hosted dialog — most visibly the TCC permission prompts (\`Allow X to use your location?\`, camera, contacts, photos, microphone, notifications). On iOS 26.4 the same daemon code works fine.

Apple ships a debug switch in \`AccessibilityUtilities\` for exactly this case: the \`com.apple.Accessibility/IgnoreAXServerEntitlements\` preference. When set, the server skips the entitlement check, and our existing \`-[AXElement explorerElements]\` walk returns the dialog tree as expected.

This PR wires the pref next to the existing \`AutomationEnabled\` write in \`ensureAutomationEnabled\`, plus a one-time SpringBoard kickstart so SB re-reads its AX-server config. The pref persists on the sim's disk, so subsequent ax-service spawns detect it's already set and skip the kickstart — avoiding the disruptive app-icon reflow on every argent run.

## Before / after on iOS 26.5

**Before** (raw socket dump for the Maps location prompt):
\`\`\`
{ \"alertVisible\": true, \"elements\": [], \"systemElements\": [], ... }
\`\`\`
→ describe returns \`source: ax-service ROOT  AXGroup\` with no children.

**After**:
\`\`\`
Source: ax-service
ROOT  AXGroup (0.000, 0.000, 1.000, 1.000)
  AXStaticText \"Allow 'Maps' to use your location?\"
  AXStaticText \"Your location is used to show your position on the map, ...\"
  AXButton \"Allow Once\"
  AXButton \"Allow While Using App\"
  AXButton \"Don't Allow\"
  ...
\`\`\`

Matches iOS 26.4 behaviour. Same daemon binary, no entitlement claims, no resigning.

## What I changed

Single file: \`packages/tool-server/src/blueprints/ax-service.ts\` — added \~50 lines to \`ensureAutomationEnabled\` that:

1. Read the current value of \`IgnoreAXServerEntitlements\` from \`com.apple.Accessibility\`.
2. If it isn't \`1\` already: \`defaults write\` it true, then \`launchctl kickstart -k system/com.apple.SpringBoard\` so SB re-reads.
3. \`kickstart\` emits a warning about user/foreground service identifier on iOS 26 — tolerated with \`.catch(() => undefined)\`; the restart still happens.

## Cost characterisation

| Scenario | Cost |
|---|---|
| Fresh sim never touched by argent | One SpringBoard restart (~3-5s, apps reflow, status bar blinks) |
| Sim with the pref already on disk (post-first-run, post-reboot, etc.) | Zero — just one \`defaults read\` |
| Sim shut down when argent first targets it | Pref is written, SB picks it up on next boot — no restart needed |
| iOS < 26.5 sim | Pref-write is harmless; \`_shouldValidateEntitlements\` doesn't read it on older versions |

The kickstart fires at most once per sim, ever. The pref is per-sim in CoreSimulator data; \`simctl erase\` wipes it (next run sets it again).

## Background — why this is the right layer

Briefly investigated:

- **Daemon code-path tweaks** (enumerating \`currentApplicationsIgnoringSiri\`, fresh \`_AXUIElementCreateAppElementWithPid\`, etc.) — all hit the same server-side gate and return \`-25215\`. Cf. closed software-mansion/argent-private#10 and software-mansion/argent#243.
- **Sign daemon with private AX entitlements** — sim AMFI rejects (\`Security policy issue\` 163) for anything stricter than what we already have.
- **Re-host daemon as UIApplication** — would pass the new check but is a substantial refactor (Info.plist, scene config, background-task management for the socket server, install/launch instead of spawn). Not worth it when a one-line debug-pref unlocks the same outcome.

The IgnoreAXServerEntitlements path is the only one that's small, contained, and reversible.

## Test plan

- [x] \`vitest run\` in tool-server passes (175/175)
- [x] \`tsc --noEmit\` clean on tool-server
- [x] Manual verify on iPhone Air iOS 26.5: Maps location prompt now returns 5 AX elements from \`describe\` with \`source: ax-service\`
- [x] Manual verify on iPhone 17 Pro iOS 26.4: still works (pref-write is a no-op for the gating logic on that version)
- [ ] CI / unit coverage for the new conditional kickstart path

## Files

- \`packages/tool-server/src/blueprints/ax-service.ts\` — extended \`ensureAutomationEnabled\`