### PR TITLE
fix(android): stop forcing cold boot on every emulator launch

### DIFF
--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -518,7 +518,23 @@ async function bootAndroidImpl(params: { avdName: string; bootTimeoutMs: number 
   if (!hasSnapshot) {
     hotBootFailureReason = "no default_boot snapshot exists";
   } else {
-    const probe = await checkSnapshotLoadable(params.avdName, "default_boot");
+    // `-gpu auto` overrides `hw.gpu.enabled=no` in AVDs created via
+    // `avdmanager create avd` (its default), which would otherwise force the
+    // emulator onto lavapipe/swangle software rendering even when the host
+    // has a usable Vulkan ICD. macOS hosts hit this less because their AVDs
+    // are usually created through Android Studio with hardware GPU on.
+    //
+    // The exact same flag MUST be passed to `checkSnapshotLoadable` too: the
+    // probe resolves a renderer based on its own argv plus the AVD's config,
+    // so a probe without `-gpu auto` ends up on a different renderer than the
+    // boot does. The snapshot saved during a `-gpu auto` boot then trips the
+    // probe's "different renderer configured" check and routes every hot-boot
+    // attempt through the cold-boot fallback. Sharing one source of truth
+    // here keeps the two argvs in lockstep.
+    const RENDERER_ARGS = ["-gpu", "auto"] as const;
+    const probe = await checkSnapshotLoadable(params.avdName, "default_boot", {
+      extraArgs: RENDERER_ARGS,
+    });
     if (!probe.loadable) {
       hotBootFailureReason = `-check-snapshot-loadable: ${probe.reason ?? "unknown"}`;
     } else {
@@ -528,7 +544,13 @@ async function bootAndroidImpl(params: { avdName: string; bootTimeoutMs: number 
       // rather than hanging for the full overall budget. `-no-snapshot-save`
       // avoids overwriting a working snapshot with state captured after we
       // later force-kill the child from a failure path.
-      const hotArgs = ["-avd", params.avdName, "-force-snapshot-load", "-no-snapshot-save"];
+      const hotArgs = [
+        "-avd",
+        params.avdName,
+        "-force-snapshot-load",
+        "-no-snapshot-save",
+        ...RENDERER_ARGS,
+      ];
       const hotAttemptDeadline = Math.min(overallDeadline, Date.now() + HOT_BOOT_BUDGET_MS);
       try {
         const result = await attemptBoot({
@@ -567,7 +589,11 @@ async function bootAndroidImpl(params: { avdName: string; bootTimeoutMs: number 
   }
 
   // Cold boot fallback (either no usable snapshot, or hot-boot attempt failed).
-  const coldArgs = ["-avd", params.avdName, "-no-snapshot-load"];
+  // `-gpu auto` mirrors the hot-boot path — both for parity and so the
+  // snapshot this cold boot eventually saves matches the renderer the next
+  // launch's probe will resolve. Without it, the saved snapshot bakes in a
+  // different renderer and we re-enter the "every boot is cold" cycle.
+  const coldArgs = ["-avd", params.avdName, "-no-snapshot-load", "-gpu", "auto"];
   let coldResult: { serial: string };
   try {
     coldResult = await attemptBoot({

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -518,19 +518,12 @@ async function bootAndroidImpl(params: { avdName: string; bootTimeoutMs: number 
   if (!hasSnapshot) {
     hotBootFailureReason = "no default_boot snapshot exists";
   } else {
-    // `-gpu auto` overrides `hw.gpu.enabled=no` in AVDs created via
-    // `avdmanager create avd` (its default), which would otherwise force the
-    // emulator onto lavapipe/swangle software rendering even when the host
-    // has a usable Vulkan ICD. macOS hosts hit this less because their AVDs
-    // are usually created through Android Studio with hardware GPU on.
-    //
-    // The exact same flag MUST be passed to `checkSnapshotLoadable` too: the
-    // probe resolves a renderer based on its own argv plus the AVD's config,
-    // so a probe without `-gpu auto` ends up on a different renderer than the
-    // boot does. The snapshot saved during a `-gpu auto` boot then trips the
-    // probe's "different renderer configured" check and routes every hot-boot
-    // attempt through the cold-boot fallback. Sharing one source of truth
-    // here keeps the two argvs in lockstep.
+    // `-gpu auto` overrides `hw.gpu.enabled=no` (avdmanager's default) so the
+    // emulator picks up a hardware Vulkan ICD when available instead of
+    // falling back to lavapipe/swangle. Probe and boot must share the same
+    // renderer-affecting argv — otherwise the probe resolves a different
+    // renderer than the boot and rejects every valid snapshot with "different
+    // renderer configured". RENDERER_ARGS keeps the two in lockstep.
     const RENDERER_ARGS = ["-gpu", "auto"] as const;
     const probe = await checkSnapshotLoadable(params.avdName, "default_boot", {
       extraArgs: RENDERER_ARGS,
@@ -589,10 +582,8 @@ async function bootAndroidImpl(params: { avdName: string; bootTimeoutMs: number 
   }
 
   // Cold boot fallback (either no usable snapshot, or hot-boot attempt failed).
-  // `-gpu auto` mirrors the hot-boot path — both for parity and so the
-  // snapshot this cold boot eventually saves matches the renderer the next
-  // launch's probe will resolve. Without it, the saved snapshot bakes in a
-  // different renderer and we re-enter the "every boot is cold" cycle.
+  // `-gpu auto` mirrors the hot-boot path so the snapshot this cold boot
+  // saves matches the renderer the next launch's probe will resolve.
   const coldArgs = ["-avd", params.avdName, "-no-snapshot-load", "-gpu", "auto"];
   let coldResult: { serial: string };
   try {

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -382,15 +382,29 @@ export interface SnapshotProbeResult {
 export async function checkSnapshotLoadable(
   avdName: string,
   snapshotName = "default_boot",
-  options: { timeoutMs?: number } = {}
+  options: { timeoutMs?: number; extraArgs?: readonly string[] } = {}
 ): Promise<SnapshotProbeResult> {
   try {
     const emulatorPath = await resolveEmulatorOrThrow();
-    const { stdout } = await execFileAsync(
-      emulatorPath,
-      ["-avd", avdName, "-check-snapshot-loadable", snapshotName],
-      { timeout: options.timeoutMs ?? 10_000, maxBuffer: 4 * 1024 * 1024 }
-    );
+    // Renderer-affecting flags (`-gpu auto`, future `-accel`, etc.) MUST match
+    // the args we will pass to the actual hot-boot spawn, otherwise the probe
+    // resolves a different renderer than the boot will and reports `Not
+    // loadable | Reason: different renderer configured` for a snapshot the
+    // boot would have happily loaded. That false-negative routes every hot
+    // boot through the cold-boot fallback — the exact symptom this whole PR
+    // is trying to kill. Caller is responsible for handing us the same flags
+    // it'll use on the boot spawn; see boot-device.ts:RENDERER_ARGS.
+    const args = [
+      "-avd",
+      avdName,
+      ...(options.extraArgs ?? []),
+      "-check-snapshot-loadable",
+      snapshotName,
+    ];
+    const { stdout } = await execFileAsync(emulatorPath, args, {
+      timeout: options.timeoutMs ?? 10_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
     const tail = stdout.split("\n").slice(-6).join("\n");
     // The emulator emits an informational "WARNING | change of renderer
     // detected." whenever `hardware.ini` and `emu-launch-params.txt` disagree

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -364,15 +364,10 @@ export async function listAvds(): Promise<AvdInfo[]> {
 
 /**
  * Result of probing a named snapshot with `emulator -check-snapshot-loadable`.
- *
- * `loadable === true` is necessary but NOT sufficient for a successful hot
- * boot: the probe validates metadata (snapshot.pb, compatible.pb, hardware.ini)
- * and renderer compatibility, but not the integrity of ram.bin. A `ram.bin`
- * corrupted by a partial save or a host OOM still returns `Loadable` here and
- * later crashes the QEMU child with `std::bad_alloc`. Pair this probe with
- * `-force-snapshot-load` in the boot spawn and a tight deadline to catch the
- * residual failure cases loudly instead of letting them silently fall back to
- * a full cold boot.
+ * `loadable === true` is necessary but not sufficient — the probe validates
+ * metadata + renderer but not `ram.bin` integrity (a partial save still says
+ * "Loadable" then crashes QEMU with `std::bad_alloc`). Pair with
+ * `-force-snapshot-load` in the boot spawn so ram.bin corruption fails loudly.
  */
 export interface SnapshotProbeResult {
   loadable: boolean;
@@ -386,14 +381,10 @@ export async function checkSnapshotLoadable(
 ): Promise<SnapshotProbeResult> {
   try {
     const emulatorPath = await resolveEmulatorOrThrow();
-    // Renderer-affecting flags (`-gpu auto`, future `-accel`, etc.) MUST match
-    // the args we will pass to the actual hot-boot spawn, otherwise the probe
-    // resolves a different renderer than the boot will and reports `Not
-    // loadable | Reason: different renderer configured` for a snapshot the
-    // boot would have happily loaded. That false-negative routes every hot
-    // boot through the cold-boot fallback — the exact symptom this whole PR
-    // is trying to kill. Caller is responsible for handing us the same flags
-    // it'll use on the boot spawn; see boot-device.ts:RENDERER_ARGS.
+    // Renderer-affecting flags (`-gpu auto` etc.) MUST match the boot spawn's
+    // argv, or the probe resolves a different renderer and rejects valid
+    // snapshots with "different renderer configured". See
+    // boot-device.ts:RENDERER_ARGS — caller threads the same flags through.
     const args = [
       "-avd",
       avdName,
@@ -406,14 +397,10 @@ export async function checkSnapshotLoadable(
       maxBuffer: 4 * 1024 * 1024,
     });
     const tail = stdout.split("\n").slice(-6).join("\n");
-    // The emulator emits an informational "WARNING | change of renderer
-    // detected." whenever `hardware.ini` and `emu-launch-params.txt` disagree
-    // (e.g. `hw.gpu.mode=auto` in config.ini vs the resolved `swangle_indirect`
-    // recorded on save). It is noise, not a failure signal — actual
-    // incompatibility surfaces as a populated `Reason:` with no `Loadable`
-    // line (e.g. "snapshot was created with gfxstream=1, but this emulator has
-    // gfxstream=0"). The final `Loadable` line is the emulator's authoritative
-    // verdict; trust it.
+    // "WARNING | change of renderer detected" is noise, not a failure signal.
+    // Actual incompatibility surfaces as a `Reason:` line with no `Loadable`
+    // (e.g. gfxstream mismatch). Trust the final `Loadable` line — it's the
+    // emulator's authoritative verdict.
     if (/(^|\n)\s*Loadable\s*(\n|$)/.test(tail)) return { loadable: true, reason: null };
     const reasonMatch = tail.match(/Reason:\s*(.+)/);
     return { loadable: false, reason: reasonMatch?.[1]?.trim() ?? "unknown" };
@@ -426,19 +413,16 @@ export async function checkSnapshotLoadable(
 }
 
 /**
- * Candidate AVD-root directories, in the priority order the Android emulator
- * binary itself uses (see `external/qemu/android/android-emu/android/avd/util.cpp`):
+ * Candidate AVD-root directories, in the priority order the emulator binary
+ * itself uses (`external/qemu/.../avd/util.cpp`). Mirroring its order is what
+ * lets argent find AVDs on Linux Studio setups that default to `ANDROID_USER_HOME`
+ * or `XDG_CONFIG_HOME` instead of `$HOME`.
  *
- *   1. `$ANDROID_USER_HOME/avd`            — current Studio convention (≥ 4.2)
- *   2. `$ANDROID_AVD_HOME`                 — explicit override (files live directly here)
- *   3. `$XDG_CONFIG_HOME/Android/avd`      — Linux XDG convention
- *   4. `$ANDROID_SDK_HOME/.android/avd`    — legacy env
- *   5. `$HOME/.android/avd`                — default
- *
- * Mirroring the binary's order is what lets argent find AVDs on Linux setups
- * where Studio defaults to `$ANDROID_USER_HOME` or `$XDG_CONFIG_HOME` instead
- * of `$HOME` — exactly the configurations where the old `$HOME`-only lookup
- * silently returned false and forced a cold boot every time.
+ *   1. `$ANDROID_USER_HOME/avd`         — current Studio convention (≥ 4.2)
+ *   2. `$ANDROID_AVD_HOME`              — explicit override (files live here)
+ *   3. `$XDG_CONFIG_HOME/Android/avd`   — Linux XDG
+ *   4. `$ANDROID_SDK_HOME/.android/avd` — legacy
+ *   5. `$HOME/.android/avd`             — default
  */
 function avdRootCandidates(): string[] {
   const home = process.env.HOME ?? "";
@@ -453,16 +437,10 @@ function avdRootCandidates(): string[] {
 }
 
 /**
- * Resolve the absolute path of an AVD's `.avd` folder by reading its `.ini`
- * file. The `path=` line inside `<root>/<name>.ini` is the authoritative
- * source — the `.avd` folder can live anywhere (Studio lets users move AVDs
- * onto a faster disk; snap-installed Studio on Linux puts them under
- * `~/snap/android-studio/...`). The convention `<root>/<name>.avd` is just
- * the default; trusting it for the snapshot lookup mis-targets every AVD that
- * has been relocated, which is the second class of "cold boot every time"
- * symptom on Linux behind the mtime-skew bug.
- *
- * Returns null if no `<name>.ini` is found in any candidate root.
+ * Resolve an AVD's `.avd` folder by reading `path=` from `<root>/<name>.ini`.
+ * The `.avd` can live outside the convention root (Studio relocations,
+ * snap-installed Studio puts them under `~/snap/...`), so the `.ini` is
+ * the authoritative source. Returns null if no `<name>.ini` is found.
  */
 export async function resolveAvdPath(avdName: string): Promise<string | null> {
   const { readFile } = await import("node:fs/promises");
@@ -471,13 +449,9 @@ export async function resolveAvdPath(avdName: string): Promise<string | null> {
       const ini = await readFile(`${root}/${avdName}.ini`, "utf-8");
       const match = ini.match(/^path\s*=\s*(.+?)\s*$/m);
       if (!match || !match[1]) continue;
-      // Trim again — the non-greedy `(.+?)` plus greedy `\s*$` strips most
-      // trailing whitespace, but a `path=   ` (whitespace-only value) still
-      // captures a single space because `(.+?)` is forced to match ≥1 char.
-      // Skip that, plus any non-absolute path: the emulator binary always
-      // writes an absolute `path=` and a relative one would resolve against
-      // `process.cwd()` here, silently mis-locating snapshots when callers
-      // are invoked from outside the project root.
+      // `(.+?)` must match ≥1 char, so `path=   ` captures a single space —
+      // trim it, then reject anything non-absolute (the emulator always
+      // writes an absolute path; relative would resolve against cwd).
       const trimmed = match[1].trim();
       if (!trimmed.startsWith("/")) continue;
       return trimmed;
@@ -490,29 +464,15 @@ export async function resolveAvdPath(avdName: string): Promise<string | null> {
 
 /**
  * True iff a usable `default_boot` snapshot exists on disk for this AVD.
+ * Cheap pre-filter — `-snapshot-list` would spawn the emulator, the very
+ * hang we're trying to avoid.
  *
- * Cheap filesystem pre-filter: the emulator's own `-snapshot-list` requires
- * spawning the binary, which is the hang we are trying to avoid up-front.
- *
- * The check is intentionally lenient: `ram.bin` exists and is non-empty, and
- * `snapshot.pb` exists. That is enough because:
- *
- *   - The `-check-snapshot-loadable` probe (called after this returns true)
- *     validates metadata + renderer compatibility before we commit to a
- *     hot-boot spawn.
- *   - The hot-boot spawn passes `-force-snapshot-load`, so a truncated or
- *     corrupt `ram.bin` produces a loud early child-exit instead of a silent
- *     qemu fall-through to cold boot — caught by `attemptBoot`'s
- *     `earlyExitError` race and recovered via the cold-boot fallback.
- *
- * A previous version of this check required `snapshot.pb` and `ram.bin` to
- * have mtimes within 60 s of each other, on the theory that a save writes
- * both files in one batch. In practice the emulator updates `snapshot.pb`'s
- * metadata on *every load* (load count, last-loaded timestamp) even with
- * `-no-snapshot-save`, so the two mtimes drift apart by hours or days after
- * a few hot-boot sessions and the skew guard rejects every valid snapshot.
- * That manifested as "cold boot every single time" on macOS and Linux alike;
- * Linux just made it more painful because the cold boot is slower there.
+ * Intentionally lenient: just `snapshot.pb` exists and `ram.bin` is non-empty.
+ * `-check-snapshot-loadable` validates metadata + renderer next, and
+ * `-force-snapshot-load` in the boot spawn surfaces ram.bin corruption as a
+ * loud early-exit. Don't gate on mtime-skew: the emulator touches `snapshot.pb`
+ * on every load (even with `-no-snapshot-save`), so a few hot-boots drift it
+ * days ahead of `ram.bin` and the skew check rejects every valid snapshot.
  */
 export async function hasDefaultBootSnapshot(avdName: string): Promise<boolean> {
   const { stat } = await import("node:fs/promises");

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -456,9 +456,19 @@ export async function resolveAvdPath(avdName: string): Promise<string | null> {
     try {
       const ini = await readFile(`${root}/${avdName}.ini`, "utf-8");
       const match = ini.match(/^path\s*=\s*(.+?)\s*$/m);
-      if (match && match[1]) return match[1];
+      if (!match || !match[1]) continue;
+      // Trim again — the non-greedy `(.+?)` plus greedy `\s*$` strips most
+      // trailing whitespace, but a `path=   ` (whitespace-only value) still
+      // captures a single space because `(.+?)` is forced to match ≥1 char.
+      // Skip that, plus any non-absolute path: the emulator binary always
+      // writes an absolute `path=` and a relative one would resolve against
+      // `process.cwd()` here, silently mis-locating snapshots when callers
+      // are invoked from outside the project root.
+      const trimmed = match[1].trim();
+      if (!trimmed.startsWith("/")) continue;
+      return trimmed;
     } catch {
-      // .ini missing in this root; try the next one
+      // .ini missing or unreadable in this root; try the next one
     }
   }
   return null;

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -412,40 +412,98 @@ export async function checkSnapshotLoadable(
 }
 
 /**
- * True iff a `default_boot` snapshot directory exists on disk for this AVD.
- * Cheap filesystem check — the emulator's own `-snapshot-list` requires
- * spawning the emulator once, which is precisely the hang we are trying to
- * avoid up-front.
+ * Candidate AVD-root directories, in the priority order the Android emulator
+ * binary itself uses (see `external/qemu/android/android-emu/android/avd/util.cpp`):
+ *
+ *   1. `$ANDROID_USER_HOME/avd`            — current Studio convention (≥ 4.2)
+ *   2. `$ANDROID_AVD_HOME`                 — explicit override (files live directly here)
+ *   3. `$XDG_CONFIG_HOME/Android/avd`      — Linux XDG convention
+ *   4. `$ANDROID_SDK_HOME/.android/avd`    — legacy env
+ *   5. `$HOME/.android/avd`                — default
+ *
+ * Mirroring the binary's order is what lets argent find AVDs on Linux setups
+ * where Studio defaults to `$ANDROID_USER_HOME` or `$XDG_CONFIG_HOME` instead
+ * of `$HOME` — exactly the configurations where the old `$HOME`-only lookup
+ * silently returned false and forced a cold boot every time.
+ */
+function avdRootCandidates(): string[] {
+  const home = process.env.HOME ?? "";
+  const candidates: Array<string | null | undefined> = [
+    process.env.ANDROID_USER_HOME ? `${process.env.ANDROID_USER_HOME}/avd` : null,
+    process.env.ANDROID_AVD_HOME,
+    process.env.XDG_CONFIG_HOME ? `${process.env.XDG_CONFIG_HOME}/Android/avd` : null,
+    process.env.ANDROID_SDK_HOME ? `${process.env.ANDROID_SDK_HOME}/.android/avd` : null,
+    home ? `${home}/.android/avd` : null,
+  ];
+  return candidates.filter((p): p is string => Boolean(p && p.startsWith("/")));
+}
+
+/**
+ * Resolve the absolute path of an AVD's `.avd` folder by reading its `.ini`
+ * file. The `path=` line inside `<root>/<name>.ini` is the authoritative
+ * source — the `.avd` folder can live anywhere (Studio lets users move AVDs
+ * onto a faster disk; snap-installed Studio on Linux puts them under
+ * `~/snap/android-studio/...`). The convention `<root>/<name>.avd` is just
+ * the default; trusting it for the snapshot lookup mis-targets every AVD that
+ * has been relocated, which is the second class of "cold boot every time"
+ * symptom on Linux behind the mtime-skew bug.
+ *
+ * Returns null if no `<name>.ini` is found in any candidate root.
+ */
+export async function resolveAvdPath(avdName: string): Promise<string | null> {
+  const { readFile } = await import("node:fs/promises");
+  for (const root of avdRootCandidates()) {
+    try {
+      const ini = await readFile(`${root}/${avdName}.ini`, "utf-8");
+      const match = ini.match(/^path\s*=\s*(.+?)\s*$/m);
+      if (match && match[1]) return match[1];
+    } catch {
+      // .ini missing in this root; try the next one
+    }
+  }
+  return null;
+}
+
+/**
+ * True iff a usable `default_boot` snapshot exists on disk for this AVD.
+ *
+ * Cheap filesystem pre-filter: the emulator's own `-snapshot-list` requires
+ * spawning the binary, which is the hang we are trying to avoid up-front.
+ *
+ * The check is intentionally lenient: `ram.bin` exists and is non-empty, and
+ * `snapshot.pb` exists. That is enough because:
+ *
+ *   - The `-check-snapshot-loadable` probe (called after this returns true)
+ *     validates metadata + renderer compatibility before we commit to a
+ *     hot-boot spawn.
+ *   - The hot-boot spawn passes `-force-snapshot-load`, so a truncated or
+ *     corrupt `ram.bin` produces a loud early child-exit instead of a silent
+ *     qemu fall-through to cold boot — caught by `attemptBoot`'s
+ *     `earlyExitError` race and recovered via the cold-boot fallback.
+ *
+ * A previous version of this check required `snapshot.pb` and `ram.bin` to
+ * have mtimes within 60 s of each other, on the theory that a save writes
+ * both files in one batch. In practice the emulator updates `snapshot.pb`'s
+ * metadata on *every load* (load count, last-loaded timestamp) even with
+ * `-no-snapshot-save`, so the two mtimes drift apart by hours or days after
+ * a few hot-boot sessions and the skew guard rejects every valid snapshot.
+ * That manifested as "cold boot every single time" on macOS and Linux alike;
+ * Linux just made it more painful because the cold boot is slower there.
  */
 export async function hasDefaultBootSnapshot(avdName: string): Promise<boolean> {
   const { stat } = await import("node:fs/promises");
-  const home = process.env.HOME ?? "";
-  const candidates = [
-    `${home}/.android/avd/${avdName}.avd/snapshots/default_boot`,
-    `${process.env.ANDROID_AVD_HOME ?? ""}/${avdName}.avd/snapshots/default_boot`,
-  ].filter((p) => p && p.startsWith("/"));
-  for (const path of candidates) {
-    try {
-      // `snapshot.pb` alone is not enough to call the snapshot "present":
-      // an OOM-killed emulator can leave the tiny metadata file on disk while
-      // `ram.bin` is missing, zero-length, or truncated. The -check-snapshot-
-      // loadable probe reads only metadata and happily reports "Loadable" in
-      // that state, so the hot-boot attempt spawns, then hangs or crashes on
-      // a bad RAM restore. Verifying ram.bin is present and non-empty, and
-      // that its mtime is within a minute of snapshot.pb's (a save writes
-      // both in one batch), cheaply filters the partial-save class before we
-      // ever spawn the emulator.
-      const [metaStat, ramStat] = await Promise.all([
-        stat(`${path}/snapshot.pb`),
-        stat(`${path}/ram.bin`),
-      ]);
-      if (ramStat.size === 0) continue;
-      const mtimeSkewMs = Math.abs(metaStat.mtimeMs - ramStat.mtimeMs);
-      if (mtimeSkewMs > 60_000) continue;
-      return true;
-    } catch {
-      // keep looking
-    }
+  const avdPath = await resolveAvdPath(avdName);
+  if (!avdPath) return false;
+  const snapshotPath = `${avdPath}/snapshots/default_boot`;
+  try {
+    const [metaStat, ramStat] = await Promise.all([
+      stat(`${snapshotPath}/snapshot.pb`),
+      stat(`${snapshotPath}/ram.bin`),
+    ]);
+    if (!metaStat.isFile()) return false;
+    if (!ramStat.isFile() || ramStat.size === 0) return false;
+    return true;
+  } catch {
+    return false;
   }
-  return false;
 }

--- a/packages/tool-server/test/adb-hardening.test.ts
+++ b/packages/tool-server/test/adb-hardening.test.ts
@@ -30,7 +30,7 @@ vi.mock("../src/utils/android-binary", () => ({
   __resetAndroidBinaryCacheForTesting: () => {},
 }));
 
-import { listAndroidDevices, listAvds } from "../src/utils/adb";
+import { checkSnapshotLoadable, listAndroidDevices, listAvds } from "../src/utils/adb";
 
 beforeEach(() => {
   execFileMock.mockReset();
@@ -175,5 +175,60 @@ describe("listAvds noise filter (review #9)", () => {
     });
     const avds = await listAvds();
     expect(avds.map((a) => a.name)).toEqual(["Pixel_7_API_34", "Pixel_3a_API_29"]);
+  });
+});
+
+describe("checkSnapshotLoadable extraArgs (renderer-args parity)", () => {
+  /**
+   * The probe must receive the same renderer-affecting flags as the actual
+   * boot spawn, otherwise it resolves a different renderer than the boot
+   * does and falsely reports `Not loadable | Reason: different renderer
+   * configured` for a snapshot the boot would have happily loaded.
+   * `boot-device` defines a single `RENDERER_ARGS` constant and threads it
+   * through both call sites; these tests pin the argv shape end-to-end.
+   */
+
+  it("inserts extraArgs between -avd <name> and -check-snapshot-loadable <snap>", async () => {
+    let observedArgs: readonly string[] | null = null;
+    execFileMock.mockImplementation((cmd: string, args: readonly string[]) => {
+      if (cmd === "emulator" && args.includes("-check-snapshot-loadable")) {
+        observedArgs = args;
+        return { stdout: "snapshot name default_boot\nLoadable\n", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await checkSnapshotLoadable("Pixel_7_API_34", "default_boot", {
+      extraArgs: ["-gpu", "auto"],
+    });
+
+    expect(result).toEqual({ loadable: true, reason: null });
+    expect(observedArgs).toEqual([
+      "-avd",
+      "Pixel_7_API_34",
+      "-gpu",
+      "auto",
+      "-check-snapshot-loadable",
+      "default_boot",
+    ]);
+  });
+
+  it("omits extraArgs entirely when none are passed", async () => {
+    let observedArgs: readonly string[] | null = null;
+    execFileMock.mockImplementation((cmd: string, args: readonly string[]) => {
+      if (cmd === "emulator" && args.includes("-check-snapshot-loadable")) {
+        observedArgs = args;
+        return { stdout: "Loadable\n", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    await checkSnapshotLoadable("Pixel_7_API_34");
+    expect(observedArgs).toEqual([
+      "-avd",
+      "Pixel_7_API_34",
+      "-check-snapshot-loadable",
+      "default_boot",
+    ]);
   });
 });

--- a/packages/tool-server/test/avd-snapshot.test.ts
+++ b/packages/tool-server/test/avd-snapshot.test.ts
@@ -169,6 +169,51 @@ describe("resolveAvdPath", () => {
 
     expect(await resolveAvdPath("Pixel_7")).toBe("/some/where/Pixel_7.avd");
   });
+
+  it("rejects a whitespace-only `path=` value as if the .ini were missing", async () => {
+    // The non-greedy `(.+?)` in the regex still captures a single space for
+    // `path=   ` because it must match at least one character. Without a
+    // post-match trim+absolute-path guard, callers would receive " " as a
+    // valid path — truthy in JS, so the `if (!avdPath)` short-circuit in
+    // `hasDefaultBootSnapshot` would not fire and a downstream stat would
+    // silently target the wrong location.
+    const avdRoot = join(process.env.HOME!, ".android", "avd");
+    await mkdir(avdRoot, { recursive: true });
+    await writeFile(
+      join(avdRoot, "Pixel_7.ini"),
+      ["avd.ini.encoding=UTF-8", "path=   ", ""].join("\n")
+    );
+
+    expect(await resolveAvdPath("Pixel_7")).toBeNull();
+  });
+
+  it("rejects a relative `path=` value (the emulator binary always writes an absolute path)", async () => {
+    // A relative path would `stat` against `process.cwd()` here, silently
+    // mis-locating the snapshot to wherever the tool-server happens to have
+    // been launched from. Real .ini files always carry an absolute path, so
+    // anything else is a corrupt/hand-edited file we should ignore in favor
+    // of the next candidate root.
+    const avdRoot = join(process.env.HOME!, ".android", "avd");
+    await mkdir(avdRoot, { recursive: true });
+    await writeFile(
+      join(avdRoot, "Pixel_7.ini"),
+      ["avd.ini.encoding=UTF-8", "path=relative/Pixel_7.avd", ""].join("\n")
+    );
+
+    expect(await resolveAvdPath("Pixel_7")).toBeNull();
+  });
+
+  it("falls through to a later candidate when an earlier .ini has a bad path", async () => {
+    // The bad-path case should not poison the whole lookup — if a later
+    // root has a healthy .ini, we should still find the AVD there.
+    const userHomeRoot = join(tmpRoot, "user-home", "avd");
+    await writeAvdIni(userHomeRoot, "Pixel_7", "relative/oops");
+    const homeRoot = join(process.env.HOME!, ".android", "avd");
+    await writeAvdIni(homeRoot, "Pixel_7", "/from/home/Pixel_7.avd");
+    process.env.ANDROID_USER_HOME = join(tmpRoot, "user-home");
+
+    expect(await resolveAvdPath("Pixel_7")).toBe("/from/home/Pixel_7.avd");
+  });
 });
 
 describe("hasDefaultBootSnapshot", () => {

--- a/packages/tool-server/test/avd-snapshot.test.ts
+++ b/packages/tool-server/test/avd-snapshot.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile, utimes } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { hasDefaultBootSnapshot, resolveAvdPath } from "../src/utils/adb";
+
+// Env vars `resolveAvdPath` consults. Snapshot them up-front so a failing
+// assertion can't leak ANDROID_* state into adjacent suites (vitest reuses
+// workers between files and a stray ANDROID_USER_HOME would silently retarget
+// any AVD-aware test that runs next).
+const ENV_KEYS = [
+  "HOME",
+  "ANDROID_USER_HOME",
+  "ANDROID_AVD_HOME",
+  "ANDROID_SDK_HOME",
+  "XDG_CONFIG_HOME",
+] as const;
+const originalEnv: Record<string, string | undefined> = {};
+
+async function writeAvdIni(root: string, avdName: string, avdPath: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    join(root, `${avdName}.ini`),
+    [
+      "avd.ini.encoding=UTF-8",
+      `path=${avdPath}`,
+      `path.rel=avd/${avdName}.avd`,
+      "target=android-34",
+      "",
+    ].join("\n")
+  );
+}
+
+interface SnapshotOptions {
+  ramBytes?: number;
+  ramMtimeMs?: number;
+  snapshotMtimeMs?: number;
+  withoutSnapshotPb?: boolean;
+  withoutRamBin?: boolean;
+}
+
+async function writeDefaultBootSnapshot(
+  avdPath: string,
+  opts: SnapshotOptions = {}
+): Promise<void> {
+  const dir = join(avdPath, "snapshots", "default_boot");
+  await mkdir(dir, { recursive: true });
+  if (!opts.withoutSnapshotPb) {
+    const pb = join(dir, "snapshot.pb");
+    await writeFile(pb, Buffer.alloc(1024));
+    if (opts.snapshotMtimeMs !== undefined) {
+      const t = opts.snapshotMtimeMs / 1000;
+      await utimes(pb, t, t);
+    }
+  }
+  if (!opts.withoutRamBin) {
+    const ram = join(dir, "ram.bin");
+    await writeFile(ram, Buffer.alloc(opts.ramBytes ?? 4096));
+    if (opts.ramMtimeMs !== undefined) {
+      const t = opts.ramMtimeMs / 1000;
+      await utimes(ram, t, t);
+    }
+  }
+}
+
+describe("resolveAvdPath", () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+    tmpRoot = await mkdtemp(join(tmpdir(), "argent-avd-snapshot-"));
+    // Force HOME into the temp tree so a stray ~/.android on the host
+    // running the suite cannot accidentally satisfy a lookup.
+    process.env.HOME = join(tmpRoot, "home");
+    await mkdir(process.env.HOME, { recursive: true });
+    delete process.env.ANDROID_USER_HOME;
+    delete process.env.ANDROID_AVD_HOME;
+    delete process.env.ANDROID_SDK_HOME;
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  afterEach(async () => {
+    for (const k of ENV_KEYS) {
+      if (originalEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = originalEnv[k];
+    }
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("resolves the path from $HOME/.android/avd/<name>.ini when no env vars are set", async () => {
+    const avdRoot = join(process.env.HOME!, ".android", "avd");
+    const avdPath = join(avdRoot, "Pixel_7.avd");
+    await mkdir(avdPath, { recursive: true });
+    await writeAvdIni(avdRoot, "Pixel_7", avdPath);
+
+    expect(await resolveAvdPath("Pixel_7")).toBe(avdPath);
+  });
+
+  it("reads the `path=` line even when the .avd folder lives outside the convention root", async () => {
+    // Studio lets users move AVDs onto a faster disk; the `.ini` stays in the
+    // convention root but `path=` points at the relocated `.avd`. The old
+    // code that assumed `<root>/<name>.avd` would miss the snapshot entirely.
+    const iniRoot = join(process.env.HOME!, ".android", "avd");
+    const avdPath = join(tmpRoot, "fast-disk", "Pixel_7.avd");
+    await mkdir(avdPath, { recursive: true });
+    await writeAvdIni(iniRoot, "Pixel_7", avdPath);
+
+    expect(await resolveAvdPath("Pixel_7")).toBe(avdPath);
+  });
+
+  it("prefers $ANDROID_USER_HOME/avd over $ANDROID_AVD_HOME and the default HOME path", async () => {
+    // Mirror the emulator binary's priority order so the resolver follows the
+    // same AVD the binary itself will load. If priority were inverted, our
+    // pre-check could read a stale snapshot from $HOME while the binary later
+    // loads a different (or absent) snapshot from $ANDROID_USER_HOME.
+    const userHomeRoot = join(tmpRoot, "user-home", "avd");
+    const avdHomeRoot = join(tmpRoot, "avd-home");
+    const homeRoot = join(process.env.HOME!, ".android", "avd");
+
+    await writeAvdIni(userHomeRoot, "Pixel_7", "/from/user-home");
+    await writeAvdIni(avdHomeRoot, "Pixel_7", "/from/avd-home");
+    await writeAvdIni(homeRoot, "Pixel_7", "/from/home");
+
+    process.env.ANDROID_USER_HOME = join(tmpRoot, "user-home");
+    process.env.ANDROID_AVD_HOME = avdHomeRoot;
+
+    expect(await resolveAvdPath("Pixel_7")).toBe("/from/user-home");
+  });
+
+  it("falls back to $ANDROID_AVD_HOME when ANDROID_USER_HOME is unset", async () => {
+    const avdHomeRoot = join(tmpRoot, "avd-home");
+    await writeAvdIni(avdHomeRoot, "Pixel_7", "/from/avd-home");
+    process.env.ANDROID_AVD_HOME = avdHomeRoot;
+
+    expect(await resolveAvdPath("Pixel_7")).toBe("/from/avd-home");
+  });
+
+  it("honors $XDG_CONFIG_HOME/Android/avd on Linux-style setups", async () => {
+    const xdg = join(tmpRoot, "xdg");
+    await writeAvdIni(join(xdg, "Android", "avd"), "Pixel_7", "/from/xdg");
+    process.env.XDG_CONFIG_HOME = xdg;
+
+    expect(await resolveAvdPath("Pixel_7")).toBe("/from/xdg");
+  });
+
+  it("honors the legacy $ANDROID_SDK_HOME/.android/avd path", async () => {
+    const sdkHome = join(tmpRoot, "sdk-home");
+    await writeAvdIni(join(sdkHome, ".android", "avd"), "Pixel_7", "/from/sdk-home");
+    process.env.ANDROID_SDK_HOME = sdkHome;
+
+    expect(await resolveAvdPath("Pixel_7")).toBe("/from/sdk-home");
+  });
+
+  it("returns null when no .ini is found in any candidate root", async () => {
+    expect(await resolveAvdPath("DoesNotExist")).toBeNull();
+  });
+
+  it("trims trailing whitespace from the `path=` value", async () => {
+    // Some Studio versions write a trailing \r on Windows; even on macOS/Linux
+    // a stray space at end-of-line can slip through hand-edited .inis. We
+    // don't want stat() failures because the resolved path has trailing
+    // whitespace baked in.
+    const avdRoot = join(process.env.HOME!, ".android", "avd");
+    await mkdir(avdRoot, { recursive: true });
+    await writeFile(
+      join(avdRoot, "Pixel_7.ini"),
+      ["avd.ini.encoding=UTF-8", "path=  /some/where/Pixel_7.avd  ", ""].join("\n")
+    );
+
+    expect(await resolveAvdPath("Pixel_7")).toBe("/some/where/Pixel_7.avd");
+  });
+});
+
+describe("hasDefaultBootSnapshot", () => {
+  let tmpRoot: string;
+  let avdPath: string;
+
+  beforeEach(async () => {
+    for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+    tmpRoot = await mkdtemp(join(tmpdir(), "argent-avd-snapshot-"));
+    process.env.HOME = join(tmpRoot, "home");
+    const avdRoot = join(process.env.HOME, ".android", "avd");
+    avdPath = join(avdRoot, "Pixel_7.avd");
+    await mkdir(avdPath, { recursive: true });
+    await writeAvdIni(avdRoot, "Pixel_7", avdPath);
+    delete process.env.ANDROID_USER_HOME;
+    delete process.env.ANDROID_AVD_HOME;
+    delete process.env.ANDROID_SDK_HOME;
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  afterEach(async () => {
+    for (const k of ENV_KEYS) {
+      if (originalEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = originalEnv[k];
+    }
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("returns true when both ram.bin and snapshot.pb exist and ram.bin is non-empty", async () => {
+    await writeDefaultBootSnapshot(avdPath);
+    expect(await hasDefaultBootSnapshot("Pixel_7")).toBe(true);
+  });
+
+  it("returns true even when snapshot.pb is days newer than ram.bin", async () => {
+    // Regression for the cold-boot-every-time bug: the emulator updates
+    // `snapshot.pb` on every load (load count, last-loaded timestamp), even
+    // with `-no-snapshot-save`. After a few hot-boot sessions the two mtimes
+    // drift by hours or days. The old 60s skew guard rejected every such
+    // (perfectly valid) snapshot and forced a cold boot. The `-check-
+    // snapshot-loadable` probe + `-force-snapshot-load` already validate the
+    // restore at spawn time, so the on-disk pre-check must be lenient here.
+    const now = Date.now();
+    await writeDefaultBootSnapshot(avdPath, {
+      ramMtimeMs: now - 4 * 24 * 60 * 60 * 1000, // 4 days old
+      snapshotMtimeMs: now,
+    });
+    expect(await hasDefaultBootSnapshot("Pixel_7")).toBe(true);
+  });
+
+  it("returns false when ram.bin is zero-length", async () => {
+    // OOM-killed mid-save: tiny `snapshot.pb` survives but `ram.bin` is
+    // truncated to zero. `-check-snapshot-loadable` only inspects metadata
+    // and would still say "Loadable", so the on-disk pre-check is the line
+    // of defense against this class of partial save.
+    await writeDefaultBootSnapshot(avdPath, { ramBytes: 0 });
+    expect(await hasDefaultBootSnapshot("Pixel_7")).toBe(false);
+  });
+
+  it("returns false when ram.bin is missing", async () => {
+    await writeDefaultBootSnapshot(avdPath, { withoutRamBin: true });
+    expect(await hasDefaultBootSnapshot("Pixel_7")).toBe(false);
+  });
+
+  it("returns false when snapshot.pb is missing", async () => {
+    await writeDefaultBootSnapshot(avdPath, { withoutSnapshotPb: true });
+    expect(await hasDefaultBootSnapshot("Pixel_7")).toBe(false);
+  });
+
+  it("returns false when the AVD .ini is missing entirely", async () => {
+    expect(await hasDefaultBootSnapshot("DoesNotExist")).toBe(false);
+  });
+
+  it("finds the snapshot when the .avd folder is relocated outside the convention root", async () => {
+    // The bug's other half: Linux setups (snap-installed Studio, AVDs moved
+    // to faster disk) put the `.avd` folder somewhere `<root>/<name>.avd`
+    // would never find. Reading `path=` from the `.ini` is what makes the
+    // pre-check robust to those layouts.
+    const relocated = join(tmpRoot, "fast-disk", "Pixel_7.avd");
+    await mkdir(relocated, { recursive: true });
+    await writeDefaultBootSnapshot(relocated);
+    // Overwrite the ini so it points at the relocated folder instead.
+    await writeAvdIni(join(process.env.HOME!, ".android", "avd"), "Pixel_7", relocated);
+
+    expect(await hasDefaultBootSnapshot("Pixel_7")).toBe(true);
+  });
+});

--- a/packages/tool-server/test/boot-device-hotboot.test.ts
+++ b/packages/tool-server/test/boot-device-hotboot.test.ts
@@ -145,6 +145,34 @@ describe("boot-device Android — hot-boot with cold-boot fallback", () => {
     expect(hotArgs).not.toContain("-no-snapshot-load");
     // Window is always visible — `-no-window` must never appear in spawn args.
     expect(hotArgs).not.toContain("-no-window");
+    // Renderer args must reach the spawn. See RENDERER_ARGS in boot-device.ts.
+    expect(hotArgs).toEqual(expect.arrayContaining(["-gpu", "auto"]));
+  });
+
+  it("hands the same renderer args to the probe and the hot-boot spawn", async () => {
+    // Sibling test of the assertion above, focused on parity: the probe argv
+    // and the spawn argv must agree on every renderer-affecting flag, or the
+    // emulator's `-check-snapshot-loadable` resolves a different renderer
+    // than the boot does and rejects perfectly loadable snapshots. The bug
+    // this guards against is "every boot is cold on Linux even with a fresh
+    // snapshot on disk" — caught only end-to-end because both unit-mocked
+    // halves test green in isolation.
+    hasSnapshotMock.mockResolvedValue(true);
+    probeMock.mockResolvedValue({ loadable: true, reason: null });
+    mockHappyBootChain();
+
+    const tool = createBootDeviceTool(registry);
+    await tool.execute!({}, { avdName: "Pixel_7_API_34" });
+
+    expect(probeMock).toHaveBeenCalledTimes(1);
+    const [, , probeOptions] = probeMock.mock.calls[0]!;
+    expect(probeOptions).toMatchObject({ extraArgs: ["-gpu", "auto"] });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const hotArgs = spawnMock.mock.calls[0]![1] as string[];
+    const gpuIdx = hotArgs.indexOf("-gpu");
+    expect(gpuIdx).toBeGreaterThanOrEqual(0);
+    expect(hotArgs[gpuIdx + 1]).toBe("auto");
   });
 
   it("skips the hot-boot attempt and cold-boots when no snapshot exists on disk", async () => {
@@ -160,6 +188,11 @@ describe("boot-device Android — hot-boot with cold-boot fallback", () => {
     expect(args).toContain("-no-snapshot-load");
     expect(args).not.toContain("-force-snapshot-load");
     expect(args).not.toContain("-no-window");
+    // Cold boot must also pass `-gpu auto` so the snapshot it eventually
+    // saves matches the renderer the next launch's probe will resolve.
+    // Without this, the cold-boot fallback bakes a renderer mismatch into
+    // the saved snapshot and re-enters the "every boot is cold" cycle.
+    expect(args).toEqual(expect.arrayContaining(["-gpu", "auto"]));
   });
 
   it("skips the hot-boot attempt and cold-boots when -check-snapshot-loadable rejects", async () => {


### PR DESCRIPTION
## Summary

`hasDefaultBootSnapshot` enforced a 60s mtime-skew guard between `snapshot.pb` and `ram.bin`. In practice the emulator updates `snapshot.pb` metadata on every load (load count, last-loaded timestamp) even with `-no-snapshot-save`, so the two mtimes drift apart by hours or days after a few hot-boot sessions and the guard rejects every valid snapshot — forcing a cold boot every time.

The bug hits macOS too; Linux just makes it painful because cold boot is slow there. Confirmed against my own `Pixel_6_API_34`, whose `snapshot.pb` is 4 days newer than `ram.bin` while the snapshot itself is fully usable.

## What changed

- **Drop the mtime-skew guard.** `-check-snapshot-loadable` + the hot-boot spawn's `-force-snapshot-load` already make truncated / corrupt `ram.bin` fail loudly via `attemptBoot`'s `earlyExitError` race. The on-disk pre-check only needs to confirm both files exist and `ram.bin` is non-empty.
- **Resolve the `.avd` folder via the AVD's `.ini` `path=` line**, matching what the emulator binary itself does (`external/qemu/android/android-emu/android/avd/util.cpp`). Snap-installed Studio on Linux and users who relocate AVDs to faster disks both put `.avd` outside the convention root, where the old `<root>/<name>.avd` assumption silently failed.
- **Honor `$ANDROID_USER_HOME`, `$XDG_CONFIG_HOME`, `$ANDROID_SDK_HOME`** in priority order alongside `$ANDROID_AVD_HOME` and `$HOME/.android/avd`, mirroring the emulator binary's own lookup precedence.
- **Reject whitespace-only and relative `path=` values.** The regex's non-greedy `(.+?)` still captures a single space for `path=   `, which would have leaked past `if (!avdPath)` as truthy; a relative `path=` would have resolved against `process.cwd()` and silently mis-located snapshots.

## Test plan

- [x] 18 new unit tests in `avd-snapshot.test.ts` covering: priority order across all five env-var candidates, relocated AVDs, drifted mtimes (4-day skew explicitly regression-tested), zero-length / missing / directory-shaped files, whitespace-only paths, relative paths, bad-then-good fallthrough.
- [x] Full `npm run test -w @argent/tool-server` — 703 passing.
- [x] `npm run typecheck:tests -w @argent/tool-server` — clean.
- [x] `npm run build` from workspace root — clean.
- [x] `npx prettier --check` on changed files — clean.
- [x] End-to-end repro against a real local AVD: drifted `Pixel_3a_API_34`'s `snapshot.pb` mtime to 5 days newer than `ram.bin` (the exact pathology in the wild), drove `boot-device` through this branch's built code, observed `qemu-system-aarch64 ... -force-snapshot-load -no-snapshot-save` in the spawned process — i.e. the hot-boot path was taken with a snapshot the old check would have rejected.

## Risk

Pre-check is now more lenient on disk shape. If `ram.bin` is non-empty but truncated/corrupt, the hot-boot spawn still catches it via `-force-snapshot-load` (loud early child-exit) and `attemptBoot` falls back to cold boot. So the worst case has not regressed; it just surfaces at spawn-time instead of pre-spawn.