### PR TITLE
fix(ax-service): remove unnecessary AutomationEnabled pref write

### DIFF
--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -1,6 +1,5 @@
 import * as net from "node:net";
 import * as fs from "node:fs";
-import { promisify } from "node:util";
 import { execFile, ChildProcess } from "node:child_process";
 import {
   TypedEventEmitter,
@@ -10,9 +9,6 @@ import {
   type ServiceEvents,
 } from "@argent/registry";
 import { axServiceBinaryPath } from "@argent/native-devtools-ios";
-import { SIMCTL_SPAWN_TIMEOUT_MS } from "../utils/simctl-config";
-
-const execFileAsync = promisify(execFile);
 
 export const AX_SERVICE_NAMESPACE = "AXService";
 
@@ -105,24 +101,6 @@ async function pingDaemon(socketPath: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-export async function ensureAutomationEnabled(udid: string): Promise<void> {
-  await execFileAsync(
-    "xcrun",
-    [
-      "simctl",
-      "spawn",
-      udid,
-      "defaults",
-      "write",
-      "com.apple.Accessibility",
-      "AutomationEnabled",
-      "-bool",
-      "true",
-    ],
-    { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
-  );
 }
 
 async function killExistingDaemon(socketPath: string): Promise<void> {
@@ -244,7 +222,6 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
     const socketPath = getSocketPath(udid);
     const events = new TypedEventEmitter<ServiceEvents>();
 
-    await ensureAutomationEnabled(udid);
     await killExistingDaemon(socketPath);
 
     const proc = await spawnDaemon(udid, socketPath);

--- a/packages/tool-server/src/blueprints/simulator-server.ts
+++ b/packages/tool-server/src/blueprints/simulator-server.ts
@@ -8,7 +8,6 @@ import {
   type ServiceEvents,
 } from "@argent/registry";
 import { simulatorServerBinaryPath, simulatorServerBinaryDir } from "@argent/native-devtools-ios";
-import { ensureAutomationEnabled } from "./ax-service";
 import { ensureDep } from "../utils/check-deps";
 
 export const SIMULATOR_SERVER_NAMESPACE = "SimulatorServer";
@@ -162,13 +161,7 @@ export const simulatorServerBlueprint: ServiceBlueprint<SimulatorServerApi, Devi
       );
     }
 
-    if (device.platform === "ios") {
-      // Enable accessibility automation before any app is launched so that apps
-      // start with their AX server running. If this is called after apps are already
-      // running (e.g. a pre-booted simulator), those apps won't pick up the flag
-      // until restarted — but new launches will work correctly.
-      await ensureAutomationEnabled(device.id).catch(() => {});
-    } else {
+    if (device.platform === "android") {
       await ensureDep("adb");
     }
 

--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -12,7 +12,7 @@ export interface DescribeIosParams {
 }
 
 // describe on iOS resolves the ax-service via Registry; the blueprint factory
-// shells out to `xcrun simctl spawn` (ensureAutomationEnabled + spawnDaemon).
+// shells out to `xcrun simctl spawn` (spawnDaemon).
 // Without xcrun on PATH the spawn ENOENTs deep inside the factory and the
 // HTTP layer returns a 500 with a raw "spawn xcrun ENOENT" message — declare
 // the dep here so the preflight emits a 424 with the install hint instead,

--- a/packages/tool-server/test/describe-missing-xcrun-424.test.ts
+++ b/packages/tool-server/test/describe-missing-xcrun-424.test.ts
@@ -1,9 +1,9 @@
 /**
  * `describe` on iOS shells out to xcrun via the ax-service blueprint factory
- * (`ensureAutomationEnabled` → `xcrun simctl spawn ...`). When xcrun is
- * missing — Linux runner, broken Xcode toolchain, etc. — the spawn rejects
- * with ENOENT and the error bubbles up to the HTTP layer as a 500 with a raw
- * "spawn xcrun ENOENT" message.
+ * (`spawnDaemon` → `xcrun simctl spawn ...`). When xcrun is missing — Linux
+ * runner, broken Xcode toolchain, etc. — the spawn rejects with ENOENT and
+ * the error bubbles up to the HTTP layer as a 500 with a raw "spawn xcrun
+ * ENOENT" message.
  *
  * Every other cross-platform iOS tool (`launch-app`, `restart-app`,
  * `open-url`, `reinstall-app`) declares `requires: ["xcrun"]` on its

--- a/packages/tool-server/test/simulator-server-blueprint.test.ts
+++ b/packages/tool-server/test/simulator-server-blueprint.test.ts
@@ -6,13 +6,12 @@ import type { DeviceInfo } from "@argent/registry";
 // ─── Mocks ───────────────────────────────────────────────────────────
 //
 // We mock at the module-boundary layer so the real blueprint factory runs —
-// this is a repro of the dispatch, stdio and AX-automation behaviour, not a
-// shape check. If any of these are quietly regressed, hands-on Android
-// sessions will start failing before this test does, so the assertions below
-// are deliberately specific (argv, stdio, ensureAutomationEnabled call count).
+// this is a repro of the dispatch and stdio behaviour, not a shape check.
+// If any of these are quietly regressed, hands-on Android sessions will start
+// failing before this test does, so the assertions below are deliberately
+// specific (argv, stdio).
 
 const spawnMock = vi.fn();
-const ensureAutomationEnabledMock = vi.fn();
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
@@ -21,10 +20,6 @@ vi.mock("node:child_process", async () => {
     spawn: spawnMock,
   };
 });
-
-vi.mock("../src/blueprints/ax-service", () => ({
-  ensureAutomationEnabled: ensureAutomationEnabledMock,
-}));
 
 vi.mock("@argent/native-devtools-ios", () => ({
   simulatorServerBinaryPath: () => "/fake/bin/simulator-server",
@@ -67,7 +62,6 @@ function androidDevice(serial: string): DeviceInfo {
 describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInfo", () => {
   beforeEach(async () => {
     spawnMock.mockReset();
-    ensureAutomationEnabledMock.mockReset().mockResolvedValue(undefined);
     // Pre-warm the dep cache so the Android branch's `ensureDep('adb')` doesn't
     // shell out to `command -v adb` — CI Linux runners don't have adb on PATH
     // and the real probe would surface as a DependencyMissingError unrelated
@@ -83,7 +77,7 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
     vi.clearAllMocks();
   });
 
-  it("spawns the `ios` subcommand and warms the AX automation flag for an iOS device", async () => {
+  it("spawns the `ios` subcommand for an iOS device", async () => {
     const fakeProc = makeFakeProc();
     spawnMock.mockReturnValue(fakeProc);
 
@@ -106,9 +100,6 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
     // as soon as the tool-server pipes /dev/null.
     expect(opts?.stdio).toEqual(["pipe", "pipe", "pipe"]);
 
-    expect(ensureAutomationEnabledMock).toHaveBeenCalledTimes(1);
-    expect(ensureAutomationEnabledMock).toHaveBeenCalledWith(udid);
-
     expect(instance.api.apiUrl).toBe("http://127.0.0.1:55555");
     expect(typeof instance.api.pressKey).toBe("function");
 
@@ -116,7 +107,7 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
     expect(fakeProc.kill).toHaveBeenCalledTimes(1);
   });
 
-  it("spawns the `android` subcommand and skips the iOS AX automation flag for an Android device", async () => {
+  it("spawns the `android` subcommand for an Android device", async () => {
     const fakeProc = makeFakeProc();
     spawnMock.mockReturnValue(fakeProc);
 
@@ -130,9 +121,6 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(spawnMock.mock.calls[0]![1]).toEqual(["android", "--id", serial]);
-
-    // No xcrun AX flag on Android — it is iOS-only and would error out.
-    expect(ensureAutomationEnabledMock).not.toHaveBeenCalled();
   });
 
   it("trusts the supplied DeviceInfo and does not reclassify the id", async () => {
@@ -152,7 +140,6 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
     await factoryPromise;
 
     expect(spawnMock.mock.calls[0]![1]![0]).toBe("android");
-    expect(ensureAutomationEnabledMock).not.toHaveBeenCalled();
   });
 
   it("pressKey writes the shared stdin command protocol regardless of platform", async () => {
@@ -170,23 +157,6 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
 
     expect(fakeProc.stdin.write).toHaveBeenNthCalledWith(1, "key Down 41\n");
     expect(fakeProc.stdin.write).toHaveBeenNthCalledWith(2, "key Up 41\n");
-  });
-
-  it("swallows an iOS AX-automation failure — the server must still start", async () => {
-    // ensureAutomationEnabled is best-effort: if xcrun isn't on PATH, or the
-    // simulator is pre-booted with the flag set already, we must continue.
-    ensureAutomationEnabledMock.mockRejectedValueOnce(new Error("xcrun missing"));
-
-    const fakeProc = makeFakeProc();
-    spawnMock.mockReturnValue(fakeProc);
-    const { simulatorServerBlueprint } = await import("../src/blueprints/simulator-server");
-
-    const device = iosDevice("22222222-3333-4444-5555-666666666666");
-    const factoryPromise = simulatorServerBlueprint.factory({}, device, { device });
-    signalReady(fakeProc, 55559);
-    const instance = await factoryPromise;
-
-    expect(instance.api.apiUrl).toBe("http://127.0.0.1:55559");
   });
 
   it("rejects when the caller forgets to pass DeviceInfo via options", async () => {


### PR DESCRIPTION
## Summary
- Removes the `ensureAutomationEnabled` function and all its call sites
- The ax-service binary uses `AXRuntime`/`AXSpringBoardServer` private frameworks directly and does not need the `AutomationEnabled` preference on iOS 26.x simulators
- Writing it pre-boot into the Accessibility plist actively breaks the AX subsystem by interfering with `cfprefsd` domain initialization, causing `describe` queries to hang

## Investigation

Tested on erased sims across five device types (iPhone 17e, iPhone 17, iPhone Air, iPad mini, iPad Pro 11-inch) on iOS 26.5 (runtime `23F77`):

1. **No plist at all** → `describe` returns full hierarchy including SpringBoard-hosted TCC dialogs ✅
2. **Empty plist** → works ✅
3. **Plist with `AutomationEnabled=true`** → `describe` hangs indefinitely ❌

The pref was originally added in #98 (April 2026) likely cargo-culted from older iOS automation patterns. On iOS 26.x the `AXSpringBoardServer` MIG interface accepts connections from the ax-service binary without it.

## Test plan
- [x] TypeScript clean
- [x] All affected tests pass (simulator-server-blueprint, describe-missing-xcrun-424)
- [x] E2E: erased sim → boot → launch Maps → `describe` returns TCC dialog with all buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)