### PR TITLE
fix(init): stop cramming homedir into mcp config

### DIFF
--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -35,7 +35,7 @@ function getAvailableToolIds(): string[] {
 export interface McpServerEntry {
   command: string;
   args: string[];
-  env: Record<string, string>;
+  env?: Record<string, string>;
 }
 
 export interface McpConfigAdapter {
@@ -65,16 +65,21 @@ type CodexConfig = {
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
 function buildMcpEntry(): McpServerEntry {
-  const logFile = path.join(homedir(), ".argent", "mcp-calls.log");
+  // No env vars by default: the MCP server falls back to
+  // `${homedir()}/.argent/mcp-calls.log` when ARGENT_MCP_LOG is unset, so we
+  // keep this generated config portable — see issue #238.
   return {
     command: MCP_BINARY_NAME,
     args: ["mcp"],
-    env: { ARGENT_MCP_LOG: logFile },
   };
 }
 
 export function getMcpEntry(): McpServerEntry {
   return buildMcpEntry();
+}
+
+function hasEnv(entry: McpServerEntry): entry is McpServerEntry & { env: Record<string, string> } {
+  return entry.env != null && Object.keys(entry.env).length > 0;
 }
 
 function removeDirIfEmpty(dirPath: string): void {
@@ -158,7 +163,7 @@ const cursorAdapter: McpConfigAdapter = {
     servers[MCP_SERVER_KEY] = {
       command: entry.command,
       args: entry.args,
-      env: entry.env,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
     };
     config.mcpServers = servers;
     writeJson(configPath, config);
@@ -232,7 +237,7 @@ const claudeAdapter: McpConfigAdapter = {
       type: "stdio",
       command: entry.command,
       args: entry.args,
-      env: entry.env,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
     };
     config.mcpServers = servers;
     writeJson(configPath, config);
@@ -286,7 +291,7 @@ const vscodeAdapter: McpConfigAdapter = {
       type: "stdio",
       command: entry.command,
       args: entry.args,
-      env: entry.env,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
     };
     config.servers = servers;
     writeJson(configPath, config);
@@ -329,7 +334,7 @@ const windsurfAdapter: McpConfigAdapter = {
     servers[MCP_SERVER_KEY] = {
       command: entry.command,
       args: entry.args,
-      env: entry.env,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
     };
     config.mcpServers = servers;
     writeJson(configPath, config);
@@ -397,7 +402,7 @@ const zedAdapter: McpConfigAdapter = {
       source: "custom",
       command: entry.command,
       args: entry.args,
-      env: entry.env,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
     });
   },
 
@@ -468,7 +473,7 @@ const geminiAdapter: McpConfigAdapter = {
     servers[MCP_SERVER_KEY] = {
       command: entry.command,
       args: entry.args,
-      env: entry.env,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
     };
     config.mcpServers = servers;
     writeJson(configPath, config);
@@ -546,7 +551,7 @@ const codexAdapter: McpConfigAdapter = {
     servers[MCP_SERVER_KEY] = {
       command: entry.command,
       args: entry.args,
-      env: entry.env,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
     };
     config.mcp_servers = servers;
     writeToml(configPath, config);
@@ -648,7 +653,7 @@ const hermesAdapter: McpConfigAdapter = {
     doc.setIn(["mcp_servers", MCP_SERVER_KEY], {
       command: entry.command,
       args: entry.args,
-      env: entry.env,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
     });
     writeYaml(configPath, doc);
   },
@@ -724,7 +729,7 @@ const openCodeAdapter: McpConfigAdapter = {
       type: "local",
       command: [entry.command, ...entry.args],
       enabled: true,
-      environment: entry.env,
+      ...(hasEnv(entry) ? { environment: entry.env } : {}),
     });
   },
 

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -80,11 +80,14 @@ afterEach(() => {
 // ── getMcpEntry ───────────────────────────────────────────────────────────────
 
 describe("getMcpEntry", () => {
-  it("returns an entry with argent as command", () => {
+  it("returns an entry with argent as command and no env vars", () => {
     const entry = getMcpEntry();
     expect(entry.command).toBe("argent");
     expect(entry.args).toEqual(["mcp"]);
-    expect(entry.env).toHaveProperty("ARGENT_MCP_LOG");
+    // Generated configs are committed and shared, so they must not bake a
+    // per-user log path into ARGENT_MCP_LOG (issue #238). The MCP server
+    // falls back to ${homedir()}/.argent/mcp-calls.log at runtime.
+    expect(entry.env).toBeUndefined();
   });
 });
 
@@ -621,7 +624,8 @@ describe("Hermes adapter", () => {
     const argent = servers.argent as Record<string, unknown>;
     expect(argent.command).toBe("argent");
     expect(argent.args).toEqual(["mcp"]);
-    expect(argent.env).toHaveProperty("ARGENT_MCP_LOG");
+    // No env field unless the entry explicitly carries env vars (issue #238).
+    expect(argent).not.toHaveProperty("env");
   });
 
   it("removes argent entry and drops empty mcp_servers", () => {
@@ -850,7 +854,9 @@ describe("opencode adapter", () => {
     expect(argent.type).toBe("local");
     expect(argent.command).toEqual(["argent", "mcp"]);
     expect(argent.enabled).toBe(true);
-    expect(argent.environment).toHaveProperty("ARGENT_MCP_LOG");
+    // No environment field unless the entry explicitly carries env vars
+    // (issue #238).
+    expect(argent).not.toHaveProperty("environment");
   });
 
   it("removes argent entry and returns true", () => {
@@ -1304,5 +1310,59 @@ describe("injectCodexRules / removeCodexRules", () => {
   it("returns null when rulesDir does not exist", () => {
     const configPath = path.join(tmpDir, "config.toml");
     expect(injectCodexRules(configPath, path.join(tmpDir, "nonexistent"))).toBeNull();
+  });
+});
+
+// ── Portability: generated configs must not embed absolute home paths ───────
+// Regression coverage for issue #238 — every adapter must produce a config
+// that can be checked into git and shared with collaborators on different
+// machines.
+
+describe("generated configs are portable across machines (issue #238)", () => {
+  function readTextFile(filePath: string): string {
+    return fs.readFileSync(filePath, "utf8");
+  }
+
+  // Pin homedir to a fake user path so we can scan written configs for the
+  // literal `/Users/...` segment without false positives from the test
+  // runner's real homedir.
+  const fakeHome = "/Users/pretend-user";
+
+  beforeEach(() => {
+    homedirOverride = fakeHome;
+  });
+
+  afterEach(() => {
+    homedirOverride = undefined;
+  });
+
+  it("no adapter writes an absolute home path into the config", () => {
+    for (const adapter of ALL_ADAPTERS) {
+      // Use each adapter's own project path so we exercise its real write
+      // logic (file extension, key layout) without faking paths.
+      const configPath =
+        adapter.projectPath(tmpDir) ??
+        // Windsurf / Hermes are global-only; route the write into tmp.
+        path.join(tmpDir, adapter.name.replace(/\s+/g, "-"), "config");
+
+      adapter.write(configPath, getMcpEntry());
+      const written = readTextFile(configPath);
+      expect(written, `${adapter.name} embedded a home path: ${written}`).not.toContain(fakeHome);
+      expect(written).not.toContain("ARGENT_MCP_LOG");
+    }
+  });
+
+  it("each adapter still honors env vars when the entry carries them", () => {
+    const customEntry = { ...getMcpEntry(), env: { FOO: "bar" } };
+
+    for (const adapter of ALL_ADAPTERS) {
+      const configPath =
+        adapter.projectPath(tmpDir) ??
+        path.join(tmpDir, adapter.name.replace(/\s+/g, "-"), "config");
+      adapter.write(configPath, customEntry);
+      const written = readTextFile(configPath);
+      expect(written, `${adapter.name} dropped a supplied env var`).toContain("FOO");
+      expect(written).toContain("bar");
+    }
   });
 });


### PR DESCRIPTION
`argent init` was writing `/Users/<username>/.argent/mcp-calls.log` into every generated MCP config (Cursor, Claude Code, VS Code, Windsurf, Zed, Gemini, Codex, Hermes, opencode). Those files get committed and shared, so collaborators ended up with the original author's username pinned into their environment.

Drop the env var from `buildMcpEntry` and have each adapter omit the `env`/`environment` field when the entry carries no env vars. The MCP server already falls back to `${homedir()}/.argent/mcp-calls.log` at runtime, so logging keeps working for every user on their own machine.

Fixes #238