### PR TITLE
fix(installer): set 10-minute default for SKILLS_CLONE_TIMEOUT_MS during skills install

### DIFF
--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -592,6 +592,10 @@ function runNpxSkills(args: string[], interactive: boolean, cwd?: string): Promi
       stdio: interactive ? "inherit" : ["ignore", "pipe", "pipe"],
       shell: process.platform === "win32",
       ...(cwd ? { cwd } : {}),
+      env: {
+        ...process.env,
+        SKILLS_CLONE_TIMEOUT_MS: process.env.SKILLS_CLONE_TIMEOUT_MS ?? "600000",
+      },
     });
 
     let stdout = "";


### PR DESCRIPTION
## Summary

- `argent init` spawns `npx skills add` with no `SKILLS_CLONE_TIMEOUT_MS` env var set, so the `skills` tool uses its hardcoded 300s default
- Cloning the argent repo just for the skills subdirectory exceeds 300s on normal connections, causing `argent init` to report "Skills installation failed"
- Fix passes `SKILLS_CLONE_TIMEOUT_MS=600000` (10 min) to the spawn env; users can still override it by setting the var in their own environment before running `argent init`

Closes #258

## Test plan

- [ ] `pnpm test` in `packages/argent-installer` — all 216 tests pass (pre-existing unrelated failure in `uninstall.test.ts` due to missing `@argent/tools-client` build)
- [ ] Run `argent init` on a slow connection — skills installation no longer times out at 300s
- [ ] Confirm `SKILLS_CLONE_TIMEOUT_MS=120000 argent init` still respects the user-set value

🤖 Generated with [Claude Code](https://claude.com/claude-code)