### PR TITLE
fix: profiler attribution on older React DevTools backends

### DIFF
--- a/packages/tool-server/src/tools/profiler/react/react-profiler-stop.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-stop.ts
@@ -31,6 +31,12 @@ const zodSchema = z.object({
 interface StopReadResult {
   live: ProfilingDataBackend | null;
   displayNameById: Record<string, string | null>;
+  // False when every renderer interface lacked both getDisplayNameForElementID
+  // and getDisplayNameForFiberID — typically a react-devtools-core version we
+  // don't recognize. When false, every fiber is dropped as unattributed even
+  // though commits were captured; surfaced in the response so the operator
+  // doesn't mistake it for a transient-unmount race.
+  displayNameApiAvailable?: boolean;
 }
 
 interface FiberMetaEntry {
@@ -346,6 +352,14 @@ Fails if no active profiling session exists or the CDP connection was lost durin
           response["unattributed_ms"] = Math.round(totalMs * 100) / 100;
           response["unattributed_fiber_count"] = totalFibers;
           response["unattributed_commit_count"] = unattributedByCommit.length;
+          // Distinguish "API missing" from "transient-unmount race". When the
+          // backend never exposed a display-name accessor, every fiber is
+          // unattributed by construction — telling the operator to look for
+          // race conditions in their component lifecycle would be wrong.
+          if (stopRead.displayNameApiAvailable === false) {
+            response["unattributed_reason"] =
+              "react-devtools backend in this app does not expose a recognized display-name accessor (neither getDisplayNameForElementID nor getDisplayNameForFiberID). The component breakdown is unavailable for this profiling session; commit-level timing data remains correct.";
+          }
         }
       }
 

--- a/packages/tool-server/src/utils/react-profiler/scripts.ts
+++ b/packages/tool-server/src/utils/react-profiler/scripts.ts
@@ -47,7 +47,25 @@ export const REACT_NATIVE_PROFILER_SETUP_SCRIPT = `
   if (!h.rendererInterfaces || typeof h.rendererInterfaces.forEach !== 'function') return;
 
   h.rendererInterfaces.forEach(function (ri) {
-    if (!ri || ri.__argent_startWrapped__) return;
+    if (!ri) return;
+
+    // Resolve the display-name accessor once per ri and stash it. The API
+    // was renamed in react-devtools-core 6.x: older bundles (RN ≤0.75-ish)
+    // expose getDisplayNameForFiberID; newer bundles expose
+    // getDisplayNameForElementID. Resolving here means every call site
+    // can do a single function lookup instead of branching, and the bug
+    // where calling the absent name silently throws and drops every fiber
+    // into the "unattributed" bucket goes away. Re-run on every setup
+    // invocation (idempotent — same function ref each time) so the stash
+    // is also populated for ris that weren't wrapped yet, e.g. ones that
+    // appeared only after BOOTSTRAP_DEVTOOLS_BACKEND_SCRIPT attached.
+    if (typeof ri.getDisplayNameForElementID === 'function') {
+      ri.__argent_getDisplayName__ = ri.getDisplayNameForElementID.bind(ri);
+    } else if (typeof ri.getDisplayNameForFiberID === 'function') {
+      ri.__argent_getDisplayName__ = ri.getDisplayNameForFiberID.bind(ri);
+    }
+
+    if (ri.__argent_startWrapped__) return;
     ri.__argent_startWrapped__ = true;
     if (typeof ri.__argent_isProfiling__ !== 'boolean') {
       ri.__argent_isProfiling__ = false;
@@ -420,13 +438,20 @@ export const STOP_FOR_TAKEOVER_SCRIPT = `
  * This is the only reliable way to recover names for transient components
  * (modals, popovers, navigation screens) that unmount between the profiled
  * interaction and `STOP_AND_READ_SCRIPT`: once a fiber is unmounted the
- * DevTools backend drops it from `idToDevToolsInstanceMap`, so
- * `getDisplayNameForElementID` returns null at stop time. Reading the name
- * right after React's own `handleCommitFiberRoot` runs (synchronous inside
+ * DevTools backend drops it from `idToDevToolsInstanceMap`, so the
+ * display-name accessor returns null at stop time. Reading the name right
+ * after React's own `handleCommitFiberRoot` runs (synchronous inside
  * `orig.call`) guarantees the fiber is still present. Fiber IDs are
  * monotonically increasing and never reused within a renderer; keying the
  * cache by `ri` identity isolates each renderer's IDs from collisions across
  * the multi-renderer (Fabric + Paper) topology.
+ *
+ * Uses `ri.__argent_getDisplayName__` (resolved by the setup wrapper) so the
+ * tracker works against both `getDisplayNameForElementID` (modern
+ * react-devtools-core) and `getDisplayNameForFiberID` (older versions
+ * bundled with RN ≤0.75-ish). Falls back to a direct lookup of either name
+ * if setup hasn't stashed the accessor yet — defensive against injection
+ * ordering.
  */
 export const FIBER_ROOT_TRACKER_SCRIPT = `
 (function() {
@@ -456,6 +481,15 @@ export const FIBER_ROOT_TRACKER_SCRIPT = `
       var pd = ri.getProfilingData ? ri.getProfilingData() : null;
       if (!pd || !pd.dataForRoots) return;
 
+      var getName = (typeof ri.__argent_getDisplayName__ === 'function')
+        ? ri.__argent_getDisplayName__
+        : (typeof ri.getDisplayNameForElementID === 'function')
+          ? ri.getDisplayNameForElementID.bind(ri)
+          : (typeof ri.getDisplayNameForFiberID === 'function')
+            ? ri.getDisplayNameForFiberID.bind(ri)
+            : null;
+      if (!getName) return;
+
       var cacheRoot = globalThis.__argent_fiberNames__;
       var bucket = cacheRoot.get(ri);
       if (!bucket) {
@@ -473,7 +507,7 @@ export const FIBER_ROOT_TRACKER_SCRIPT = `
           var fiberID = entry[0];
           if (bucket[fiberID] !== undefined) continue;
           try {
-            var name = ri.getDisplayNameForElementID(fiberID);
+            var name = getName(fiberID);
             if (typeof name === 'string' && name.length > 0) {
               bucket[fiberID] = name;
             }
@@ -517,15 +551,23 @@ export const STOP_AND_READ_SCRIPT = `
   var allRoots = [];
   var displayNameById = {};
   var anySaw = false;
+  // Set to true if at least one ri exposed a usable display-name accessor.
+  // Stays false when every ri lacks both API names — useful diagnostic
+  // surfaced by the stop tool to distinguish "API missing" from
+  // "transient-unmount race" failures.
+  var anyNameApi = false;
 
-  function resolveName(ri, id, out, bucket) {
+  function resolveName(getName, id, out, bucket) {
     if (out[id] !== undefined) return;
-    try {
-      var n = ri.getDisplayNameForElementID(Number(id));
-      if (typeof n === 'string' && n.length > 0) { out[id] = n; return; }
-    } catch (_e) {}
-    // Live resolution failed — fiber was likely unmounted before stop
-    // (transient component). Fall back to the per-ri commit-time cache.
+    if (getName) {
+      try {
+        var n = getName(Number(id));
+        if (typeof n === 'string' && n.length > 0) { out[id] = n; return; }
+      } catch (_e) {}
+    }
+    // Live resolution failed or unavailable — fiber was likely unmounted
+    // before stop (transient component) or the renderer never exposed an
+    // accessor. Fall back to the per-ri commit-time cache.
     var cached = bucket ? bucket[id] : undefined;
     out[id] = (typeof cached === 'string' && cached.length > 0) ? cached : null;
   }
@@ -541,6 +583,17 @@ export const STOP_AND_READ_SCRIPT = `
       ? (nameCache.get(ri) || null)
       : null;
 
+    // Resolve the display-name accessor lazily — setup may not have run
+    // for this ri (e.g. an external caller invoked stop without start).
+    var getName = (typeof ri.__argent_getDisplayName__ === 'function')
+      ? ri.__argent_getDisplayName__
+      : (typeof ri.getDisplayNameForElementID === 'function')
+        ? ri.getDisplayNameForElementID.bind(ri)
+        : (typeof ri.getDisplayNameForFiberID === 'function')
+          ? ri.getDisplayNameForFiberID.bind(ri)
+          : null;
+    if (getName) anyNameApi = true;
+
     for (var i = 0; i < pd.dataForRoots.length; i++) {
       var root = pd.dataForRoots[i];
       allRoots.push(root);
@@ -549,11 +602,11 @@ export const STOP_AND_READ_SCRIPT = `
       for (var j = 0; j < cd.length; j++) {
         var fa = cd[j].fiberActualDurations || [];
         for (var k = 0; k < fa.length; k++) if (fa[k]) {
-          resolveName(ri, fa[k][0], displayNameById, bucket);
+          resolveName(getName, fa[k][0], displayNameById, bucket);
         }
         var cds = cd[j].changeDescriptions || [];
         for (var k2 = 0; k2 < cds.length; k2++) if (cds[k2]) {
-          resolveName(ri, cds[k2][0], displayNameById, bucket);
+          resolveName(getName, cds[k2][0], displayNameById, bucket);
         }
       }
     }
@@ -562,7 +615,11 @@ export const STOP_AND_READ_SCRIPT = `
   if (!anySaw) {
     return JSON.stringify({ live: null, displayNameById: {} });
   }
-  return JSON.stringify({ live: { dataForRoots: allRoots }, displayNameById: displayNameById });
+  return JSON.stringify({
+    live: { dataForRoots: allRoots },
+    displayNameById: displayNameById,
+    displayNameApiAvailable: anyNameApi,
+  });
 })()
 `;
 

--- a/packages/tool-server/test/react-profiler/scripts-multi-renderer.test.ts
+++ b/packages/tool-server/test/react-profiler/scripts-multi-renderer.test.ts
@@ -31,7 +31,12 @@ interface MockRi {
   startProfiling: ReturnType<typeof vi.fn>;
   stopProfiling: ReturnType<typeof vi.fn>;
   getProfilingData: ReturnType<typeof vi.fn>;
-  getDisplayNameForElementID: ReturnType<typeof vi.fn>;
+  // Either name may exist on a real rendererInterface depending on
+  // react-devtools-core version (`Element` in modern, `Fiber` in older
+  // bundles). Both are optional in the mock so individual tests can prove
+  // the scripts handle each surface.
+  getDisplayNameForElementID?: ReturnType<typeof vi.fn>;
+  getDisplayNameForFiberID?: ReturnType<typeof vi.fn>;
 }
 
 function makeRi(
@@ -41,6 +46,11 @@ function makeRi(
     rootID?: number;
     commits?: BackendCommit[];
     names?: Record<number, string>;
+    // 'element' → only getDisplayNameForElementID exists (modern devtools)
+    // 'fiber'   → only getDisplayNameForFiberID exists (RN ≤0.75-ish)
+    // 'both'    → both (defensive)
+    // 'none'    → neither (unrecognized devtools version)
+    nameApi?: "element" | "fiber" | "both" | "none";
   } = {}
 ): MockRi {
   const ri = {
@@ -61,9 +71,15 @@ function makeRi(
   ri.getProfilingData = vi.fn(() => ({
     dataForRoots: opts.commits ? [{ rootID: opts.rootID ?? 1, commitData: opts.commits }] : [],
   }));
-  ri.getDisplayNameForElementID = vi.fn((id: number) =>
-    opts.names && opts.names[id] != null ? opts.names[id] : null
-  );
+  const lookup = (id: number) =>
+    opts.names && opts.names[id] != null ? opts.names[id] : null;
+  const api = opts.nameApi ?? "element";
+  if (api === "element" || api === "both") {
+    ri.getDisplayNameForElementID = vi.fn(lookup);
+  }
+  if (api === "fiber" || api === "both") {
+    ri.getDisplayNameForFiberID = vi.fn(lookup);
+  }
   return ri;
 }
 
@@ -108,6 +124,7 @@ interface StartResult {
 interface StopReadResult {
   live: { dataForRoots: Array<{ rootID: number; commitData: BackendCommit[] }> } | null;
   displayNameById: Record<string, string | null>;
+  displayNameApiAvailable?: boolean;
 }
 
 afterEach(() => {
@@ -287,7 +304,7 @@ describe("STOP_AND_READ_SCRIPT (multi-renderer)", () => {
     expect(r.displayNameById["99"]).toBe("PaperNode");
   });
 
-  it("falls back to the per-renderer cache when getDisplayNameForElementID returns null", () => {
+  it("falls back to the per-renderer cache when the live accessor returns null", () => {
     const fabric = makeRi({ rootID: 10, commits: [commit(42)] }); // returns null for 42
     const ris = new Map<number, MockRi>([[1, fabric]]);
     const out = withHook(ris, () => {
@@ -311,6 +328,78 @@ describe("STOP_AND_READ_SCRIPT (multi-renderer)", () => {
     const r = JSON.parse(out) as StopReadResult;
     expect(r.live).toBeNull();
     expect(r.displayNameById).toEqual({});
+  });
+
+  // Regression: this is the exact bug observed against RN 0.74-era runtimes
+  // whose bundled react-devtools-core exposes getDisplayNameForFiberID
+  // instead of getDisplayNameForElementID. Pre-fix the script blindly called
+  // ElementID, every call threw, the catch dropped every fiber, and the stop
+  // tool reported 0 captured / 18,921 unattributed.
+  it("resolves names via getDisplayNameForFiberID when ElementID is absent (old react-devtools)", () => {
+    const ri = makeRi({
+      rootID: 10,
+      commits: [commit(42)],
+      names: { 42: "FromFiberID" },
+      nameApi: "fiber",
+    });
+    const ris = new Map<number, MockRi>([[1, ri]]);
+    const out = withHook(ris, () => {
+      // Setup wrapper stashes __argent_getDisplayName__ once per ri.
+      evalIIFE(REACT_NATIVE_PROFILER_SETUP_SCRIPT);
+      return evalIIFE<string>(STOP_AND_READ_SCRIPT);
+    });
+    const r = JSON.parse(out) as StopReadResult;
+
+    expect(r.displayNameById["42"]).toBe("FromFiberID");
+    expect(r.displayNameApiAvailable).toBe(true);
+    expect(ri.getDisplayNameForFiberID).toHaveBeenCalled();
+  });
+
+  it("also works when ElementID is present (modern react-devtools)", () => {
+    const ri = makeRi({
+      rootID: 10,
+      commits: [commit(42)],
+      names: { 42: "FromElementID" },
+      nameApi: "element",
+    });
+    const ris = new Map<number, MockRi>([[1, ri]]);
+    const out = withHook(ris, () => {
+      evalIIFE(REACT_NATIVE_PROFILER_SETUP_SCRIPT);
+      return evalIIFE<string>(STOP_AND_READ_SCRIPT);
+    });
+    const r = JSON.parse(out) as StopReadResult;
+
+    expect(r.displayNameById["42"]).toBe("FromElementID");
+    expect(r.displayNameApiAvailable).toBe(true);
+    expect(ri.getDisplayNameForElementID).toHaveBeenCalled();
+  });
+
+  it("prefers ElementID when both names exist (modern-name precedence)", () => {
+    const ri = makeRi({
+      rootID: 10,
+      commits: [commit(42)],
+      names: { 42: "Shared" },
+      nameApi: "both",
+    });
+    const ris = new Map<number, MockRi>([[1, ri]]);
+    withHook(ris, () => {
+      evalIIFE(REACT_NATIVE_PROFILER_SETUP_SCRIPT);
+      return evalIIFE<string>(STOP_AND_READ_SCRIPT);
+    });
+    expect(ri.getDisplayNameForElementID).toHaveBeenCalled();
+    expect(ri.getDisplayNameForFiberID).not.toHaveBeenCalled();
+  });
+
+  it("flags displayNameApiAvailable=false when no accessor exists on any ri", () => {
+    // This is the diagnostic that distinguishes "wrong react-devtools version"
+    // from "transient-unmount race" in the unattributed-fibers report.
+    const ri = makeRi({ rootID: 10, commits: [commit(42)], nameApi: "none" });
+    const ris = new Map<number, MockRi>([[1, ri]]);
+    const out = withHook(ris, () => evalIIFE<string>(STOP_AND_READ_SCRIPT));
+    const r = JSON.parse(out) as StopReadResult;
+
+    expect(r.displayNameApiAvailable).toBe(false);
+    expect(r.displayNameById["42"]).toBeNull();
   });
 });
 

--- a/packages/tool-server/test/react-profiler/scripts-multi-renderer.test.ts
+++ b/packages/tool-server/test/react-profiler/scripts-multi-renderer.test.ts
@@ -71,8 +71,7 @@ function makeRi(
   ri.getProfilingData = vi.fn(() => ({
     dataForRoots: opts.commits ? [{ rootID: opts.rootID ?? 1, commitData: opts.commits }] : [],
   }));
-  const lookup = (id: number) =>
-    opts.names && opts.names[id] != null ? opts.names[id] : null;
+  const lookup = (id: number) => (opts.names && opts.names[id] != null ? opts.names[id] : null);
   const api = opts.nameApi ?? "element";
   if (api === "element" || api === "both") {
     ri.getDisplayNameForElementID = vi.fn(lookup);


### PR DESCRIPTION
## Summary
- Resolve profiler display-name lookup across both `getDisplayNameForElementID` and legacy `getDisplayNameForFiberID` backends.
- Add a fallback diagnostic (`displayNameApiAvailable` / `unattributed_reason`) so fully-unattributed captures are reported as an API-surface mismatch instead of a transient lifecycle race.
- Extend multi-renderer script coverage for modern, legacy, mixed, and missing display-name accessor scenarios.