### PR TITLE
chore: bump all package versions to 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3643,7 +3643,7 @@
     },
     "packages/argent": {
       "name": "@swmansion/argent",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3672,7 +3672,7 @@
     },
     "packages/argent-cli": {
       "name": "@argent/cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client"
       },
@@ -3715,7 +3715,7 @@
     },
     "packages/argent-installer": {
       "name": "@argent/installer",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client",
         "@clack/prompts": "^1.4.0",
@@ -3765,7 +3765,7 @@
     },
     "packages/argent-mcp": {
       "name": "@argent/mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client",
         "@modelcontextprotocol/sdk": "^1.29.0"
@@ -3809,7 +3809,7 @@
     },
     "packages/argent-tools-client": {
       "name": "@argent/tools-client",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "devDependencies": {
         "@types/node": "^25.9.0",
         "typescript": "^6.0.3",
@@ -3939,7 +3939,7 @@
     },
     "packages/native-devtools-android": {
       "name": "@argent/native-devtools-android",
-      "version": "0.7.1",
+      "version": "0.8.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.5.0"
@@ -3947,7 +3947,7 @@
     },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "devDependencies": {
         "@types/node": "^25.9.0",
         "typescript": "^6.0.3"
@@ -3986,7 +3986,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "zod": "^4.0.0"
       },
@@ -4011,14 +4011,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@argent/native-devtools-android": "file:../native-devtools-android",
         "@argent/native-devtools-ios": "file:../native-devtools-ios",

--- a/packages/argent-cli/package.json
+++ b/packages/argent-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Shell CLI commands for argent: tools, run, server",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/installer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Workspace setup logic for argent: init, update, uninstall",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-mcp/package.json
+++ b/packages/argent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP stdio protocol adapter — talks to the argent tool-server and forwards calls",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-tools-client/package.json
+++ b/packages/argent-tools-client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tools-client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Spawn-and-talk client for the argent tool-server (used by MCP and CLI)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP server for iOS Simulator and Android Emulator control",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/native-devtools-android/package.json
+++ b/packages/native-devtools-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-android",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/native-devtools-ios/package.json
+++ b/packages/native-devtools-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-ios",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "Claude Code skills for iOS simulator and Android emulator interaction via argent",
   "scripts": {

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Framework-agnostic tool registry for iOS simulator and Android emulator control",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump all 10 workspace packages to version `0.8.1` (`package.json` + `package-lock.json`)
- Includes `native-devtools-android` (`0.7.1` → `0.8.1`), all others from `0.8.0` → `0.8.1`
- `ui` package left at `0.0.1` (independent versioning)

## Test plan
- [ ] Verify `npm install` resolves cleanly
- [ ] Verify `argent --version` reports `0.8.1`