### PR TITLE
chore(bundle): purge stale Android assets and alias the Android source

### DIFF
--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -12,6 +12,10 @@ const NATIVE_DEVTOOLS_ENTRY = path.resolve(
   WORKSPACE_ROOT,
   "packages/native-devtools-ios/src/index.ts"
 );
+const NATIVE_DEVTOOLS_ANDROID_ENTRY = path.resolve(
+  WORKSPACE_ROOT,
+  "packages/native-devtools-android/src/index.ts"
+);
 const TOOLS_CLIENT_ENTRY = path.resolve(
   WORKSPACE_ROOT,
   "packages/argent-tools-client/src/index.ts"
@@ -28,6 +32,7 @@ const CLI_OUT_FILE = path.resolve(__dirname, "../dist/cli-cmds.mjs");
 const ALIASES = {
   "@argent/registry": REGISTRY_ENTRY,
   "@argent/native-devtools-ios": NATIVE_DEVTOOLS_ENTRY,
+  "@argent/native-devtools-android": NATIVE_DEVTOOLS_ANDROID_ENTRY,
   "@argent/tools-client": TOOLS_CLIENT_ENTRY,
   "@argent/installer": INSTALLER_ENTRY,
   "@argent/mcp": MCP_ENTRY,
@@ -70,6 +75,20 @@ const ANDROID_APK_DEST_DIR = path.resolve(__dirname, "../dist");
 for (const dir of [BIN_DIR, DYLIBS_DEST, SKILLS_DEST, RULES_DEST, AGENTS_DEST]) {
   fs.rmSync(dir, { recursive: true, force: true });
   fs.mkdirSync(dir, { recursive: true });
+}
+
+// The Android helper artifacts live alongside the bundles (manifest at the
+// package root, APK inside the shared dist/ folder) so they aren't covered
+// by the per-directory purge above. Removing them explicitly keeps a
+// missing-APK rebuild from leaving a stale manifest behind that would later
+// fool helperManifest() into pointing at an APK that's no longer present.
+fs.rmSync(ANDROID_MANIFEST_DEST, { force: true });
+if (fs.existsSync(ANDROID_APK_DEST_DIR)) {
+  for (const entry of fs.readdirSync(ANDROID_APK_DEST_DIR)) {
+    if (/^argent-android-devtools-.*\.apk$/.test(entry)) {
+      fs.rmSync(path.join(ANDROID_APK_DEST_DIR, entry), { force: true });
+    }
+  }
 }
 
 // Ensure dist/ exists


### PR DESCRIPTION
## Summary

Two small follow-ups to #237's Android helper bundling.

1. **Stale-artifact purge.** `bundle-tools.cjs` purges `bin/`, `dylibs/`, `skills/`, `rules/`, `agents/` at the top of every run, but the two Android assets live elsewhere — `manifest.json` at the package root and the APK inside the shared `dist/` folder — so they fall through the cracks. A rebuild where the source APK is missing leaves the previous manifest behind, and at runtime `helperManifest()` happily reads it while `bundledHelperApkPath()` points at an APK that no longer exists. Adds an explicit purge of both at startup so a clean tarball either ships both files or neither.

2. **Android source alias.** Adds `@argent/native-devtools-android` to the esbuild alias map so the tool-server bundle resolves from `src/index.ts` directly, mirroring the iOS sibling. Removes the implicit dependency on `tsc --build` having produced `dist/index.js` before `bundle-tools.cjs` runs.

## Context

<details>

This came out of an E2E review of #237. Of the six findings flagged there:

- H1 (missing keystore in the argent-private submodule) — **resolved on main** by `software-mansion/argent-private@9770740` ("chore: update .gitignore to remove Android signing keys and add debug.keystore").
- H2 (no APK in `argent-private-releases`) — **resolved on main**: `argent-android-devtools.apk` is now present in `argent-main` and `argent-v0.8.1`. `bash scripts/download-native-binaries.sh` succeeds end-to-end.
- M1 (silent stale-manifest survival across builds) — **fixed by this PR**.
- L3 (Android alias missing from esbuild map) — **fixed by this PR**.
- L2 (only `console.debug` surfaces the legacy-uiautomator fallback) — the original author intentionally chose debug-level "without leaking into the per-call result"; leaving as-is.
- L1 (no Java-side tests for `SnapshotInstrumentation`) — needs a test harness in `argent-private`; out of scope here.

## Test plan
- [x] `npx prettier --check packages/argent/scripts/bundle-tools.cjs` — clean
- [x] `npm run build` from the workspace root — `tsc --build` succeeds
- [x] `npx vitest run` in `packages/tool-server` — 718/718 pass
- [x] Repro before/after: built once with APK present, deleted source APK, re-ran `bundle-tools.cjs` standalone — confirmed `packages/argent/manifest.json` (210 B) and stale `packages/argent/dist/argent-android-devtools-0.1.0.apk` are both purged; resulting `npm pack` ships 44 files with no Android stragglers (vs 46 with both present).
- [x] Alias check: deleted `packages/native-devtools-android/dist/index.js` and re-ran `bundle-tools.cjs` — bundling still succeeded (esbuild resolved from `src/index.ts` via the new alias). With the alias removed, the same delete causes `Failed to resolve entry for package "@argent/native-devtools-android"` at bundle time.

</details>
