### PR TITLE
fix(tool-server): persist update-note suppression across restarts

### DIFF
--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -188,7 +188,13 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
         const { updateAvailable, currentVersion, latestVersion } = getUpdateState();
         const shouldNotify = updateAvailable && !isUpdateNoteSuppressed();
         if (shouldNotify) {
-          suppressUpdateNote(AUTO_SUPPRESS_MS);
+          // Best-effort: a persistence failure here must not fail the user's tool call.
+          // Worst case: the note appears again on the next request.
+          try {
+            suppressUpdateNote(AUTO_SUPPRESS_MS);
+          } catch {
+            // ignore
+          }
         }
         res.json({
           data,

--- a/packages/tool-server/src/utils/update-checker.ts
+++ b/packages/tool-server/src/utils/update-checker.ts
@@ -1,10 +1,35 @@
+import fs from "node:fs";
 import https from "node:https";
+import os from "node:os";
+import path from "node:path";
 import semver from "semver";
 import { version as currentVersion } from "../../package.json";
 
 const PACKAGE_NAME = "@swmansion/argent";
 const CHECK_INTERVAL_MS = 60 * 60 * 1000 * 24; // 24 hour
 const REQUEST_TIMEOUT_MS = 10_000;
+
+function getSuppressionFilePath(): string {
+  return path.join(os.homedir(), ".argent", "update-suppression.json");
+}
+
+function loadSuppressUntil(): number {
+  try {
+    const raw = fs.readFileSync(getSuppressionFilePath(), "utf8");
+    const parsed = JSON.parse(raw) as { suppressUntil?: unknown };
+    const value = parsed.suppressUntil;
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  } catch {
+    // Missing file, parse error, or read error — treat as "no suppression".
+    return 0;
+  }
+}
+
+function persistSuppressUntil(value: number): void {
+  const filePath = getSuppressionFilePath();
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify({ suppressUntil: value }));
+}
 
 export interface UpdateState {
   /** Whether a newer version is available on npm. */
@@ -22,7 +47,7 @@ let state: UpdateState = {
 };
 
 let interval: ReturnType<typeof setInterval> | null = null;
-let suppressUntil = 0;
+let suppressUntil = loadSuppressUntil();
 
 /** Returns the current update state (read-only snapshot). */
 export function getUpdateState(): Readonly<UpdateState> {
@@ -34,9 +59,15 @@ export function isUpdateNoteSuppressed(): boolean {
   return Date.now() < suppressUntil;
 }
 
-/** Suppress update notifications for the given duration (milliseconds). */
+/**
+ * Suppress update notifications for the given duration (milliseconds).
+ * Persists across tool-server restarts. Throws if the suppression file
+ * cannot be written.
+ */
 export function suppressUpdateNote(durationMs: number): void {
-  suppressUntil = Date.now() + durationMs;
+  const next = Date.now() + durationMs;
+  persistSuppressUntil(next);
+  suppressUntil = next;
 }
 
 function isNewerVersion(latest: string, current: string): boolean {

--- a/packages/tool-server/test/update-checker.test.ts
+++ b/packages/tool-server/test/update-checker.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import https from "node:https";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { EventEmitter } from "node:events";
 
 // We need to mock https before importing the module under test.
@@ -262,5 +265,101 @@ describe("update-checker", () => {
 
     handle1.dispose();
     handle2.dispose();
+  });
+});
+
+describe("update-checker — suppression persistence", () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "argent-suppress-test-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const suppressionFile = () => path.join(tmpHome, ".argent", "update-suppression.json");
+
+  it("loads no suppression when the file is missing", async () => {
+    const { isUpdateNoteSuppressed } = await import("../src/utils/update-checker");
+    expect(isUpdateNoteSuppressed()).toBe(false);
+  });
+
+  it("loads no suppression when the file is malformed", async () => {
+    fs.mkdirSync(path.dirname(suppressionFile()), { recursive: true });
+    fs.writeFileSync(suppressionFile(), "not json");
+    const { isUpdateNoteSuppressed } = await import("../src/utils/update-checker");
+    expect(isUpdateNoteSuppressed()).toBe(false);
+  });
+
+  it("loads no suppression when suppressUntil is not a number", async () => {
+    fs.mkdirSync(path.dirname(suppressionFile()), { recursive: true });
+    fs.writeFileSync(suppressionFile(), JSON.stringify({ suppressUntil: "soon" }));
+    const { isUpdateNoteSuppressed } = await import("../src/utils/update-checker");
+    expect(isUpdateNoteSuppressed()).toBe(false);
+  });
+
+  it("honors a future suppressUntil read from disk", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    fs.mkdirSync(path.dirname(suppressionFile()), { recursive: true });
+    fs.writeFileSync(
+      suppressionFile(),
+      JSON.stringify({ suppressUntil: Date.now() + 60 * 60 * 1000 })
+    );
+    const { isUpdateNoteSuppressed } = await import("../src/utils/update-checker");
+    expect(isUpdateNoteSuppressed()).toBe(true);
+  });
+
+  it("treats a past suppressUntil as not suppressed", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    fs.mkdirSync(path.dirname(suppressionFile()), { recursive: true });
+    fs.writeFileSync(suppressionFile(), JSON.stringify({ suppressUntil: Date.now() - 1000 }));
+    const { isUpdateNoteSuppressed } = await import("../src/utils/update-checker");
+    expect(isUpdateNoteSuppressed()).toBe(false);
+  });
+
+  it("writes the suppression timestamp to disk on suppressUpdateNote", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const { suppressUpdateNote } = await import("../src/utils/update-checker");
+    suppressUpdateNote(60 * 60 * 1000);
+    const raw = fs.readFileSync(suppressionFile(), "utf8");
+    expect(JSON.parse(raw)).toEqual({ suppressUntil: Date.now() + 60 * 60 * 1000 });
+  });
+
+  it("creates the .argent directory if it does not exist", async () => {
+    expect(fs.existsSync(path.join(tmpHome, ".argent"))).toBe(false);
+    const { suppressUpdateNote } = await import("../src/utils/update-checker");
+    suppressUpdateNote(1000);
+    expect(fs.existsSync(suppressionFile())).toBe(true);
+  });
+
+  it("survives a module reload (simulates tool-server process restart)", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const first = await import("../src/utils/update-checker");
+    first.suppressUpdateNote(60 * 60 * 1000);
+    expect(first.isUpdateNoteSuppressed()).toBe(true);
+
+    // Simulate restart: clear the module cache and re-import. The new module
+    // must read the suppression back from disk.
+    vi.resetModules();
+    const second = await import("../src/utils/update-checker");
+    expect(second.isUpdateNoteSuppressed()).toBe(true);
+  });
+
+  it("throws when the suppression file cannot be written", async () => {
+    // Replace the .argent path with a regular file so mkdir/write fails.
+    fs.writeFileSync(path.join(tmpHome, ".argent"), "");
+    const { suppressUpdateNote } = await import("../src/utils/update-checker");
+    expect(() => suppressUpdateNote(1000)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

`dismiss-update` (and the auto-suppression after delivering an update note) only stored `suppressUntil` in a module-scoped variable, so the dismissal evaporated the moment the tool-server process exited — which the launcher does after 30 min of idleness, on machine reboot, and on `npx @swmansion/argent update`. Users asking to silence the note for 24 h would see it reappear well within the window, contradicting the tool's own description.

This PR persists `suppressUntil` to `~/.argent/update-suppression.json` (alongside the existing `tool-server.json` / `tool-server.log`) and reads it back on module init, so the dismissal survives restarts.

- `suppressUpdateNote` now writes through to disk and throws on write failure (matches `dismiss-update`'s documented "Fails if … the suppression state cannot be persisted").
- The HTTP auto-suppress call (after delivering a note alongside an unrelated tool result) is wrapped in try/catch — a disk-write failure there must not 500 the user's tool call. Worst case: the note repeats next request.
- Missing/malformed/wrong-typed file all degrade to "no suppression" — never crashes the server.

## Test plan

- [x] `npx vitest run test/update-checker.test.ts` — 19/19 pass (10 original + 9 new persistence tests).
- [x] `test/http-update-note.test.ts` + `test/http-tools-meta.test.ts` — 14/14 pass (mock update-checker; persistence is transparent).
- [x] Full `@argent/tool-server` suite — 726/727 pass. The single failure (`test/android-binary.test.ts:73`, `/usr/bin/adb` resolution) is pre-existing on `main` and unrelated.
- [x] `npm run typecheck:tests` clean, `npm run build` clean, `prettier --check` clean.
- [x] Restart simulated via `vi.resetModules()` + re-import → suppression loaded back from disk.