### PR TITLE
refactor(tool-server): remove ARGENT_DISABLE_UPDATE_NOTIFICATIONS opt-out

### DIFF
--- a/packages/tool-server/src/update-utils.ts
+++ b/packages/tool-server/src/update-utils.ts
@@ -7,7 +7,6 @@ How to update:
   - Manual (user-initiated): run \`npx @swmansion/argent update\` in the terminal
   - Agent-assisted (requires explicit user consent): call the \`update-argent\` tool — only after the user has explicitly asked you to update Argent in this conversation
   - To postpone this reminder: call the \`dismiss-update\` tool with the number of hours to suppress it
-  - To turn this reminder off permanently: the user can set \`ARGENT_DISABLE_UPDATE_NOTIFICATIONS=1\` in the tools-server environment
 
 ACTION REQUIRED: Save a note (via TODO, task list) that an Argent update to v${latestVersion} is available so you can remind the user about it later. This notification will not repeat for the next 30 minutes. 
 

--- a/packages/tool-server/src/utils/update-checker.ts
+++ b/packages/tool-server/src/utils/update-checker.ts
@@ -13,9 +13,6 @@ const PACKAGE_NAME = "@swmansion/argent";
 const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}`;
 const CHECK_INTERVAL_MS = 60 * 60 * 1000 * 24; // 24 hour
 
-/** Set truthy to silence the update reminder entirely (no check, no note). */
-const DISABLE_ENV = "ARGENT_DISABLE_UPDATE_NOTIFICATIONS";
-
 function getSuppressionFilePath(): string {
   return path.join(os.homedir(), ".argent", "update-suppression.json");
 }
@@ -75,12 +72,6 @@ let state: UpdateState = {
 
 let interval: ReturnType<typeof setInterval> | null = null;
 let suppressUntil = loadSuppressUntil();
-
-/** True when update reminders are disabled via the environment. */
-export function areUpdateNotificationsDisabled(): boolean {
-  const v = process.env[DISABLE_ENV];
-  return v === "1" || v === "true";
-}
 
 /** Returns the current update state (read-only snapshot). */
 export function getUpdateState(): Readonly<UpdateState> {
@@ -145,13 +136,9 @@ async function check(): Promise<void> {
 
 /**
  * Run an immediate check, then recheck every 24h. Returns a dispose fn for the
- * timer. No-op when reminders are disabled (no request, state stays default).
+ * timer.
  */
 export function startUpdateChecker(): { dispose(): void } {
-  if (areUpdateNotificationsDisabled()) {
-    return { dispose() {} };
-  }
-
   // Clear any leaked interval from a prior call.
   if (interval) {
     clearInterval(interval);

--- a/packages/tool-server/test/update-checker.test.ts
+++ b/packages/tool-server/test/update-checker.test.ts
@@ -43,7 +43,6 @@ describe("update-checker", () => {
     vi.setSystemTime(NOW);
     vi.resetModules();
     vi.clearAllMocks();
-    delete process.env.ARGENT_DISABLE_UPDATE_NOTIFICATIONS;
     mockFetchRegistryInfo.mockReset();
     mockDetectMinReleaseAgeMs.mockReset();
     mockDetectMinReleaseAgeMs.mockResolvedValue(0); // no policy by default
@@ -57,7 +56,6 @@ describe("update-checker", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
-    delete process.env.ARGENT_DISABLE_UPDATE_NOTIFICATIONS;
   });
 
   it("detects an available, installable update on startup", async () => {
@@ -234,25 +232,6 @@ describe("update-checker", () => {
     expect(state.updateInstallable).toBe(false);
     expect(state.installableVersion).toBeNull();
     expect(state.latestPublishedAt).toBeNull();
-
-    handle.dispose();
-  });
-
-  // ── Disable flag ───────────────────────────────────────────────────
-
-  it("does not check or notify when notifications are disabled", async () => {
-    process.env.ARGENT_DISABLE_UPDATE_NOTIFICATIONS = "1";
-    vi.resetModules();
-    const mod = await import("../src/utils/update-checker");
-
-    mockFetchRegistryInfo.mockResolvedValue(singleVersion("99.0.0", "2020-01-01T00:00:00Z"));
-
-    const handle = mod.startUpdateChecker();
-    await vi.advanceTimersByTimeAsync(60 * 60 * 1000 * 24);
-
-    expect(mockFetchRegistryInfo).not.toHaveBeenCalled();
-    expect(mod.getUpdateState().updateInstallable).toBe(false);
-    expect(mod.areUpdateNotificationsDisabled()).toBe(true);
 
     handle.dispose();
   });


### PR DESCRIPTION
## What

Removes the `ARGENT_DISABLE_UPDATE_NOTIFICATIONS` environment variable and everything tied to it: the `DISABLE_ENV` constant, the exported `areUpdateNotificationsDisabled()` predicate, the early-return gate in `startUpdateChecker()`, the reminder-note bullet that advertised it, and the corresponding test.

## Why

The env var made `startUpdateChecker()` a no-op, which left `getUpdateState()` stuck at its defaults (`updateAvailable: false`, `installableVersion: null`). Because the `update-argent` tool reads that shared state, **silencing the periodic reminder also blinded the explicit, user-consented update path** — `update-argent` would report *"Argent is already up to date"* even when a newer version existed on npm. A user who'd quietened the nags but then explicitly asked the agent to update was wrongly told there was nothing to do (only the CLI `npx @swmansion/argent update` still worked).

Postponing/suppressing reminders is already handled by the time-based `dismiss-update` tool, whose suppression persists in `~/.argent/update-suppression.json` and does **not** disable the underlying check — so the update state stays accurate. That makes the env var both redundant and a footgun, so it's removed rather than worked around.

## Behavior after this change

- The 24h update checker always runs; `getUpdateState()` reflects real registry state.
- Reminders are still gated by `dismiss-update` (and the 30-minute auto-suppress after each surfaced note).
- `update-argent` now sees accurate state regardless of reminder suppression.

## Tests

- Removed the now-obsolete "does not check or notify when notifications are disabled" test.
- `vitest run` for `update-checker`, `http-update-note`, and `update-argent-tool` passes (42 tests); `tsc --noEmit` clean for `tool-server`.