### PR TITLE
fix(tool-server): reject platform-absent hardware buttons in the button tool

### DIFF
--- a/packages/tool-server/src/tools/button/index.ts
+++ b/packages/tool-server/src/tools/button/index.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
-import type { ToolCapability, ToolDefinition } from "@argent/registry";
+import type { Platform, ToolCapability, ToolDefinition } from "@argent/registry";
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
+import { UnsupportedOperationError } from "../../utils/capability";
 import { sendCommand } from "../../utils/simulator-client";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -19,6 +20,21 @@ interface Result {
   pressed: string;
 }
 
+/**
+ * Hardware buttons that physically exist per platform. The zod enum is the
+ * union of both platforms' buttons (a flat enum can't express the dependency),
+ * so we refine here: iOS has no `back`, Android has no `actionButton`.
+ *
+ * Rejecting at the tool layer is required because the simulator-server
+ * transport is fire-and-forget (see `sendCommand`) and cannot report a backend
+ * rejection — an unsupported button would otherwise be a silent no-op that the
+ * tool still reports as a successful `{ pressed }`.
+ */
+const BUTTONS_BY_PLATFORM: Record<Platform, ReadonlySet<Params["button"]>> = {
+  ios: new Set(["home", "power", "volumeUp", "volumeDown", "appSwitch", "actionButton"]),
+  android: new Set(["home", "back", "power", "volumeUp", "volumeDown", "appSwitch"]),
+};
+
 const capability: ToolCapability = {
   apple: { simulator: true, device: true },
   android: { emulator: true, device: true, unknown: true },
@@ -27,7 +43,7 @@ const capability: ToolCapability = {
 export const buttonTool: ToolDefinition<Params, Result> = {
   id: "button",
   description: `Press a device hardware button (iOS simulator or Android emulator). Sends Down then Up events automatically.
-Supported buttons depend on the platform: home, back, power, volumeUp, volumeDown, appSwitch, actionButton — buttons not present on the target platform are rejected with a clear error from the backend.
+Supported buttons depend on the platform: home, back, power, volumeUp, volumeDown, appSwitch, actionButton — buttons not present on the target platform (e.g. \`back\` on iOS, \`actionButton\` on Android) are rejected with a clear error.
 Use when you need to trigger hardware button events.
 Returns { pressed: buttonName }.
 Fails if the simulator-server / emulator backend is not reachable for the given device.`,
@@ -37,6 +53,14 @@ Fails if the simulator-server / emulator backend is not reachable for the given 
     simulatorServer: simulatorServerRef(resolveDevice(params.udid)),
   }),
   async execute(services, params) {
+    const device = resolveDevice(params.udid);
+    if (!BUTTONS_BY_PLATFORM[device.platform].has(params.button)) {
+      throw new UnsupportedOperationError(
+        "button",
+        device,
+        `button '${params.button}' is not available on ${device.platform}`
+      );
+    }
     const api = services.simulatorServer as SimulatorServerApi;
     sendCommand(api, {
       cmd: "button",

--- a/packages/tool-server/src/tools/button/index.ts
+++ b/packages/tool-server/src/tools/button/index.ts
@@ -43,7 +43,7 @@ const capability: ToolCapability = {
 export const buttonTool: ToolDefinition<Params, Result> = {
   id: "button",
   description: `Press a device hardware button (iOS simulator or Android emulator). Sends Down then Up events automatically.
-Supported buttons depend on the platform: home, back, power, volumeUp, volumeDown, appSwitch, actionButton — buttons not present on the target platform (e.g. \`back\` on iOS, \`actionButton\` on Android) are rejected with a clear error.
+Supported buttons depend on the platform: home, back, power, volumeUp, volumeDown, appSwitch, actionButton — buttons not present on the target platform (e.g. 'back' on iOS, 'actionButton' on Android) are rejected with a clear error.
 Use when you need to trigger hardware button events.
 Returns { pressed: buttonName }.
 Fails if the simulator-server / emulator backend is not reachable for the given device.`,

--- a/packages/tool-server/test/button.test.ts
+++ b/packages/tool-server/test/button.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Keep the real module (blueprints import from it too) but neutralise the
+// fire-and-forget WebSocket send so no real socket is opened during the test.
+vi.mock("../src/utils/simulator-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/utils/simulator-client")>()),
+  sendCommand: vi.fn(),
+}));
+
+import { buttonTool } from "../src/tools/button";
+import { UnsupportedOperationError } from "../src/utils/capability";
+
+const iosUdid = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA";
+const androidUdid = "emulator-5554";
+const services = { simulatorServer: {} } as never;
+
+describe("button tool — per-platform validation", () => {
+  it("rejects `back` on iOS (no hardware back button) instead of a silent no-op", async () => {
+    await expect(
+      buttonTool.execute(services, { udid: iosUdid, button: "back" })
+    ).rejects.toBeInstanceOf(UnsupportedOperationError);
+  });
+
+  it("rejects `actionButton` on Android", async () => {
+    await expect(
+      buttonTool.execute(services, { udid: androidUdid, button: "actionButton" })
+    ).rejects.toBeInstanceOf(UnsupportedOperationError);
+  });
+
+  it("accepts `back` on Android (it is a real hardware key there)", async () => {
+    await expect(
+      buttonTool.execute(services, { udid: androidUdid, button: "back" })
+    ).resolves.toEqual({ pressed: "back" });
+  });
+
+  it("accepts every iOS-valid button", async () => {
+    for (const button of ["home", "power", "volumeUp", "volumeDown", "appSwitch", "actionButton"] as const) {
+      await expect(
+        buttonTool.execute(services, { udid: iosUdid, button })
+      ).resolves.toEqual({ pressed: button });
+    }
+  });
+});

--- a/packages/tool-server/test/button.test.ts
+++ b/packages/tool-server/test/button.test.ts
@@ -34,10 +34,17 @@ describe("button tool — per-platform validation", () => {
   });
 
   it("accepts every iOS-valid button", async () => {
-    for (const button of ["home", "power", "volumeUp", "volumeDown", "appSwitch", "actionButton"] as const) {
-      await expect(
-        buttonTool.execute(services, { udid: iosUdid, button })
-      ).resolves.toEqual({ pressed: button });
+    for (const button of [
+      "home",
+      "power",
+      "volumeUp",
+      "volumeDown",
+      "appSwitch",
+      "actionButton",
+    ] as const) {
+      await expect(buttonTool.execute(services, { udid: iosUdid, button })).resolves.toEqual({
+        pressed: button,
+      });
     }
   });
 });


### PR DESCRIPTION
## Problem

The `button` tool's description states that buttons not present on the target platform "are rejected with a clear error", but the implementation accepts any button in the enum on any device. On iOS, `button: "back"` (there is no hardware back key) returns `{ pressed: "back" }` — a **silent no-op reported as success**, so an automated caller believes a back-navigation happened when nothing did. Reproduced live on an iOS 18.5 simulator.

## Root cause

`execute` (`tools/button/index.ts`) calls `sendCommand` and returns `{ pressed }` unconditionally, with no per-platform validation. The "rejected … from the backend" promise is also architecturally impossible: `sendCommand` (`utils/simulator-client.ts`) is fire-and-forget — it pushes a WebSocket frame and never reads a reply, so a backend rejection cannot surface to the caller.

## Fix

Validate the requested button against a per-platform set in the tool layer (the platform is known synchronously from the UDID via `resolveDevice`), throwing the existing `UnsupportedOperationError` (→ HTTP 400) for buttons that don't exist on the device:

- **iOS:** `home`, `power`, `volumeUp`, `volumeDown`, `appSwitch`, `actionButton` (no `back`)
- **Android:** `home`, `back`, `power`, `volumeUp`, `volumeDown`, `appSwitch` (no `actionButton`)

Cross-platform correctness is preserved — `back` still works on Android. The zod enum stays the union of both platforms' buttons (a flat enum can't express the dependency); the per-platform `Set` enforces the refinement. The description is reworded to match (validation lives in the tool, not "the backend").

## Testing

Adds `test/button.test.ts` — the tool previously had no test.

```
vitest run test/button.test.ts  →  4 passed
```

Verified fail-before/pass-after: with `src/tools/button/index.ts` reverted to `main`, the two rejection tests fail (old code resolves `{ pressed: "back" }` / `{ pressed: "actionButton" }`); with the fix, all four pass.
