### PR TITLE
fix(tool-server): compare same-aspect screenshots in screenshot-diff instead of failing on a resolution mismatch

### DIFF
--- a/packages/tool-server/src/tools/screenshot-diff/resize.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/resize.ts
@@ -1,0 +1,236 @@
+// Pure (pngjs-free) image resampling helpers for screenshot-diff.
+//
+// This module intentionally has NO dependency on `pngjs`. It operates on a
+// plain decoded-image shape (`{ width, height, data }` with tightly-packed
+// RGBA bytes) so that it can be unit-tested in environments where `pngjs` is
+// not runtime-resolvable. `screenshot-diff.ts` re-uses these helpers and wraps
+// the results back into `pngjs` `PNG` objects where it needs them.
+
+/**
+ * Minimal decoded-image shape shared with `screenshot-diff.ts`'s `DecodedPng`
+ * and `font-diff.ts`'s `FontGeometryImage`. `data` is a tightly-packed RGBA
+ * byte buffer of length `width * height * 4`.
+ */
+export interface DecodedRgbaImage {
+  width: number;
+  height: number;
+  data: Buffer;
+}
+
+// Aspect ratios are treated as equal when they agree within this relative
+// tolerance. Uniform scalings of the same framebuffer (e.g. a 0.3x saved
+// screenshot vs a 1.0x live capture) match exactly in theory but pick up tiny
+// rounding error from integer pixel dimensions, so a small tolerance is needed.
+const ASPECT_RATIO_TOLERANCE = 0.01;
+
+/**
+ * When two decoded images share the same aspect ratio (within
+ * {@link ASPECT_RATIO_TOLERANCE}) but differ in resolution, downscale the
+ * larger one to the smaller one's exact dimensions so they can be compared
+ * pixel-for-pixel. The smaller image is returned untouched; we never upscale.
+ *
+ * Returns `null` when the aspect ratios genuinely differ — callers should keep
+ * treating that as a hard dimension mismatch.
+ */
+export function normalizeToCommonSize(
+  baseline: DecodedRgbaImage,
+  current: DecodedRgbaImage
+): { baseline: DecodedRgbaImage; current: DecodedRgbaImage } | null {
+  if (baseline.width === current.width && baseline.height === current.height) {
+    return { baseline, current };
+  }
+
+  if (!aspectRatiosMatch(baseline, current)) {
+    return null;
+  }
+
+  const baselineArea = baseline.width * baseline.height;
+  const currentArea = current.width * current.height;
+
+  if (baselineArea <= currentArea) {
+    return {
+      baseline,
+      current: resizeDecodedPng(current, baseline.width, baseline.height),
+    };
+  }
+
+  return {
+    baseline: resizeDecodedPng(baseline, current.width, current.height),
+    current,
+  };
+}
+
+function aspectRatiosMatch(a: DecodedRgbaImage, b: DecodedRgbaImage): boolean {
+  if (a.width <= 0 || a.height <= 0 || b.width <= 0 || b.height <= 0) {
+    return false;
+  }
+  const aspectA = a.width / a.height;
+  const aspectB = b.width / b.height;
+  const largest = Math.max(aspectA, aspectB);
+  if (largest === 0) return false;
+  return Math.abs(aspectA - aspectB) / largest <= ASPECT_RATIO_TOLERANCE;
+}
+
+/**
+ * Lanczos3-resample a decoded RGBA image to the target dimensions, returning a
+ * new decoded image backed by a plain `Buffer`. Shared with the diff-artifact
+ * downscaler in `screenshot-diff.ts`.
+ */
+export function resizeDecodedPng(
+  src: DecodedRgbaImage,
+  width: number,
+  height: number
+): DecodedRgbaImage {
+  const targetWidth = Math.max(1, Math.round(width));
+  const targetHeight = Math.max(1, Math.round(height));
+  if (targetWidth === src.width && targetHeight === src.height) {
+    return { width: src.width, height: src.height, data: Buffer.from(src.data) };
+  }
+
+  const horizontal = buildLanczos3AxisWeights(src.width, targetWidth);
+  const vertical = buildLanczos3AxisWeights(src.height, targetHeight);
+
+  const intermediate = new Float32Array(targetWidth * src.height * 4);
+  resampleHorizontalRgba({
+    sourceData: src.data,
+    sourceWidth: src.width,
+    sourceHeight: src.height,
+    targetWidth,
+    weights: horizontal,
+    output: intermediate,
+  });
+
+  const output = Buffer.alloc(targetWidth * targetHeight * 4);
+  resampleVerticalRgba({
+    intermediate,
+    targetWidth,
+    targetHeight,
+    weights: vertical,
+    output,
+  });
+
+  return { width: targetWidth, height: targetHeight, data: output };
+}
+
+export interface ResampleAxisWeights {
+  start: number;
+  weights: Float32Array;
+}
+
+function resampleHorizontalRgba(params: {
+  sourceData: Buffer;
+  sourceWidth: number;
+  sourceHeight: number;
+  targetWidth: number;
+  weights: ResampleAxisWeights[];
+  output: Float32Array;
+}): void {
+  for (let y = 0; y < params.sourceHeight; y++) {
+    const rowOffset = y * params.sourceWidth * 4;
+    const targetRowOffset = y * params.targetWidth * 4;
+    for (let x = 0; x < params.targetWidth; x++) {
+      const { start, weights } = params.weights[x];
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let a = 0;
+      const baseOffset = rowOffset + start * 4;
+      for (let k = 0; k < weights.length; k++) {
+        const sampleOffset = baseOffset + k * 4;
+        const w = weights[k];
+        r += params.sourceData[sampleOffset] * w;
+        g += params.sourceData[sampleOffset + 1] * w;
+        b += params.sourceData[sampleOffset + 2] * w;
+        a += params.sourceData[sampleOffset + 3] * w;
+      }
+      const targetOffset = targetRowOffset + x * 4;
+      params.output[targetOffset] = r;
+      params.output[targetOffset + 1] = g;
+      params.output[targetOffset + 2] = b;
+      params.output[targetOffset + 3] = a;
+    }
+  }
+}
+
+function resampleVerticalRgba(params: {
+  intermediate: Float32Array;
+  targetWidth: number;
+  targetHeight: number;
+  weights: ResampleAxisWeights[];
+  output: Buffer;
+}): void {
+  const rowStride = params.targetWidth * 4;
+  for (let y = 0; y < params.targetHeight; y++) {
+    const { start, weights } = params.weights[y];
+    const targetRowOffset = y * rowStride;
+    for (let x = 0; x < params.targetWidth; x++) {
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let a = 0;
+      const columnOffset = start * rowStride + x * 4;
+      for (let k = 0; k < weights.length; k++) {
+        const sampleOffset = columnOffset + k * rowStride;
+        const w = weights[k];
+        r += params.intermediate[sampleOffset] * w;
+        g += params.intermediate[sampleOffset + 1] * w;
+        b += params.intermediate[sampleOffset + 2] * w;
+        a += params.intermediate[sampleOffset + 3] * w;
+      }
+      const targetOffset = targetRowOffset + x * 4;
+      params.output[targetOffset] = clampToByte(r);
+      params.output[targetOffset + 1] = clampToByte(g);
+      params.output[targetOffset + 2] = clampToByte(b);
+      params.output[targetOffset + 3] = clampToByte(a);
+    }
+  }
+}
+
+function buildLanczos3AxisWeights(sourceSize: number, targetSize: number): ResampleAxisWeights[] {
+  const scale = targetSize / sourceSize;
+  // For downscaling, stretch the kernel by `scale` to act as a low-pass
+  // anti-aliasing filter. For upscaling, evaluate the kernel at its native
+  // width so we interpolate rather than blur.
+  const filterScale = scale < 1 ? scale : 1;
+  const supportInSource = LANCZOS3_RADIUS / filterScale;
+  const axis: ResampleAxisWeights[] = new Array(targetSize);
+
+  for (let i = 0; i < targetSize; i++) {
+    const center = (i + 0.5) / scale - 0.5;
+    const start = Math.max(0, Math.ceil(center - supportInSource - LANCZOS3_EPSILON));
+    const end = Math.min(sourceSize - 1, Math.floor(center + supportInSource + LANCZOS3_EPSILON));
+    const length = Math.max(1, end - start + 1);
+    const weights = new Float32Array(length);
+    let sum = 0;
+    for (let k = 0; k < length; k++) {
+      const sampleIndex = start + k;
+      const w = lanczos3Kernel((sampleIndex - center) * filterScale);
+      weights[k] = w;
+      sum += w;
+    }
+    if (sum !== 0) {
+      const inverseSum = 1 / sum;
+      for (let k = 0; k < length; k++) {
+        weights[k] *= inverseSum;
+      }
+    }
+    axis[i] = { start, weights };
+  }
+  return axis;
+}
+
+const LANCZOS3_RADIUS = 3;
+const LANCZOS3_EPSILON = 1e-9;
+
+function lanczos3Kernel(x: number): number {
+  if (x === 0) return 1;
+  if (x <= -LANCZOS3_RADIUS || x >= LANCZOS3_RADIUS) return 0;
+  const piX = Math.PI * x;
+  return (LANCZOS3_RADIUS * Math.sin(piX) * Math.sin(piX / LANCZOS3_RADIUS)) / (piX * piX);
+}
+
+function clampToByte(value: number): number {
+  if (value <= 0) return 0;
+  if (value >= 255) return 255;
+  return Math.round(value);
+}

--- a/packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts
@@ -7,6 +7,7 @@ import {
   type TextAnalysis,
 } from "./text-diff";
 import { formatScreenshotDiffSummary } from "./screenshot-diff-summary";
+import { normalizeToCommonSize, resizeDecodedPng } from "./resize";
 
 export interface Size {
   width: number;
@@ -117,19 +118,26 @@ export async function diffPngFiles(options: {
 }): Promise<PngDiffResult> {
   const settings = resolveDiffSettings();
 
-  const [baseline, current] = await Promise.all([
+  const [decodedBaseline, decodedCurrent] = await Promise.all([
     decodePngFile(options.baselinePath),
     decodePngFile(options.currentPath),
   ]);
 
-  if (baseline.width !== current.width || baseline.height !== current.height) {
+  // Same-aspect screenshots saved at different scales (e.g. a 0.3x baseline vs
+  // a 1.0x live capture) are uniform scalings of one framebuffer, so normalize
+  // them to a common size and compare instead of failing on the resolution
+  // mismatch. Genuinely different aspect ratios still hard-fail below.
+  const normalized = normalizeToCommonSize(decodedBaseline, decodedCurrent);
+  if (!normalized) {
     return summarizeResult(
       buildDimensionMismatchResult({
-        baseline,
-        current,
+        baseline: decodedBaseline,
+        current: decodedCurrent,
       })
     );
   }
+  const baseline = normalized.baseline;
+  const current = normalized.current;
 
   const totalPixels = baseline.width * baseline.height;
   const pixelDiff = markChangedPixels({
@@ -158,13 +166,17 @@ export async function diffPngFiles(options: {
   const mismatchPercentage =
     totalPixels === 0 ? 0 : (pixelDiff.differentPixels / totalPixels) * 100;
 
+  // The OCR/font-geometry pass re-reads the original files from disk, so it
+  // must receive the originally-decoded images (whose dimensions match those
+  // files) rather than the normalized copies. Derive its top cutoff from the
+  // original baseline height for the same reason.
   const textAnalysis = await analyzeScreenshotTextChangesSafely({
     baselinePath: options.baselinePath,
     currentPath: options.currentPath,
     hasPixelDiff: pixelDiff.differentPixels > 0,
-    baselineImage: baseline,
-    currentImage: current,
-    ignoreTopPixels: pixelDiff.ignoredTopRows,
+    baselineImage: decodedBaseline,
+    currentImage: decodedCurrent,
+    ignoreTopPixels: ignoredTopRowsFor(decodedBaseline.height, settings.ignoreTopNormalizedY),
     textChangeMinConfidence: DEFAULT_TEXT_CHANGE_MIN_CONFIDENCE,
   });
 
@@ -224,10 +236,7 @@ function markChangedPixels(params: {
   const baselineData = params.baseline.data;
   const currentData = params.current.data;
   const mask = new Uint8Array(totalPixels);
-  const ignoredTopRows = Math.min(
-    params.baseline.height,
-    Math.ceil(params.baseline.height * params.ignoreTopNormalizedY)
-  );
+  const ignoredTopRows = ignoredTopRowsFor(params.baseline.height, params.ignoreTopNormalizedY);
   let differentPixels = 0;
 
   for (let y = ignoredTopRows; y < params.baseline.height; y++) {
@@ -246,6 +255,10 @@ function markChangedPixels(params: {
   }
 
   return { mask, differentPixels, ignoredTopRows };
+}
+
+function ignoredTopRowsFor(height: number, ignoreTopNormalizedY: number): number {
+  return Math.min(height, Math.ceil(height * ignoreTopNormalizedY));
 }
 
 function getChangedRegions(params: {
@@ -378,179 +391,13 @@ async function writePngFile(filePath: string, png: PNG): Promise<void> {
 }
 
 function downscalePng(source: PNG, scale: number): PNG {
-  const targetWidth = Math.max(1, Math.round(source.width * scale));
-  const targetHeight = Math.max(1, Math.round(source.height * scale));
-  if (targetWidth === source.width && targetHeight === source.height) {
-    return clonePng(source);
-  }
-
-  return lanczos3ResizeRgba({
-    sourceData: source.data,
-    sourceWidth: source.width,
-    sourceHeight: source.height,
-    targetWidth,
-    targetHeight,
-  });
-}
-
-interface ResampleAxisWeights {
-  start: number;
-  weights: Float32Array;
-}
-
-function lanczos3ResizeRgba(params: {
-  sourceData: Buffer;
-  sourceWidth: number;
-  sourceHeight: number;
-  targetWidth: number;
-  targetHeight: number;
-}): PNG {
-  const horizontal = buildLanczos3AxisWeights(params.sourceWidth, params.targetWidth);
-  const vertical = buildLanczos3AxisWeights(params.sourceHeight, params.targetHeight);
-
-  const intermediate = new Float32Array(params.targetWidth * params.sourceHeight * 4);
-  resampleHorizontalRgba({
-    sourceData: params.sourceData,
-    sourceWidth: params.sourceWidth,
-    sourceHeight: params.sourceHeight,
-    targetWidth: params.targetWidth,
-    weights: horizontal,
-    output: intermediate,
-  });
-
-  const target = new PNG({ width: params.targetWidth, height: params.targetHeight });
-  resampleVerticalRgba({
-    intermediate,
-    targetWidth: params.targetWidth,
-    targetHeight: params.targetHeight,
-    weights: vertical,
-    output: target.data,
-  });
-
-  return target;
-}
-
-function resampleHorizontalRgba(params: {
-  sourceData: Buffer;
-  sourceWidth: number;
-  sourceHeight: number;
-  targetWidth: number;
-  weights: ResampleAxisWeights[];
-  output: Float32Array;
-}): void {
-  for (let y = 0; y < params.sourceHeight; y++) {
-    const rowOffset = y * params.sourceWidth * 4;
-    const targetRowOffset = y * params.targetWidth * 4;
-    for (let x = 0; x < params.targetWidth; x++) {
-      const { start, weights } = params.weights[x];
-      let r = 0;
-      let g = 0;
-      let b = 0;
-      let a = 0;
-      const baseOffset = rowOffset + start * 4;
-      for (let k = 0; k < weights.length; k++) {
-        const sampleOffset = baseOffset + k * 4;
-        const w = weights[k];
-        r += params.sourceData[sampleOffset] * w;
-        g += params.sourceData[sampleOffset + 1] * w;
-        b += params.sourceData[sampleOffset + 2] * w;
-        a += params.sourceData[sampleOffset + 3] * w;
-      }
-      const targetOffset = targetRowOffset + x * 4;
-      params.output[targetOffset] = r;
-      params.output[targetOffset + 1] = g;
-      params.output[targetOffset + 2] = b;
-      params.output[targetOffset + 3] = a;
-    }
-  }
-}
-
-function resampleVerticalRgba(params: {
-  intermediate: Float32Array;
-  targetWidth: number;
-  targetHeight: number;
-  weights: ResampleAxisWeights[];
-  output: Buffer;
-}): void {
-  const rowStride = params.targetWidth * 4;
-  for (let y = 0; y < params.targetHeight; y++) {
-    const { start, weights } = params.weights[y];
-    const targetRowOffset = y * rowStride;
-    for (let x = 0; x < params.targetWidth; x++) {
-      let r = 0;
-      let g = 0;
-      let b = 0;
-      let a = 0;
-      const columnOffset = start * rowStride + x * 4;
-      for (let k = 0; k < weights.length; k++) {
-        const sampleOffset = columnOffset + k * rowStride;
-        const w = weights[k];
-        r += params.intermediate[sampleOffset] * w;
-        g += params.intermediate[sampleOffset + 1] * w;
-        b += params.intermediate[sampleOffset + 2] * w;
-        a += params.intermediate[sampleOffset + 3] * w;
-      }
-      const targetOffset = targetRowOffset + x * 4;
-      params.output[targetOffset] = clampToByte(r);
-      params.output[targetOffset + 1] = clampToByte(g);
-      params.output[targetOffset + 2] = clampToByte(b);
-      params.output[targetOffset + 3] = clampToByte(a);
-    }
-  }
-}
-
-function buildLanczos3AxisWeights(sourceSize: number, targetSize: number): ResampleAxisWeights[] {
-  const scale = targetSize / sourceSize;
-  // For downscaling, stretch the kernel by `scale` to act as a low-pass
-  // anti-aliasing filter. For upscaling, evaluate the kernel at its native
-  // width so we interpolate rather than blur.
-  const filterScale = scale < 1 ? scale : 1;
-  const supportInSource = LANCZOS3_RADIUS / filterScale;
-  const axis: ResampleAxisWeights[] = new Array(targetSize);
-
-  for (let i = 0; i < targetSize; i++) {
-    const center = (i + 0.5) / scale - 0.5;
-    const start = Math.max(0, Math.ceil(center - supportInSource - LANCZOS3_EPSILON));
-    const end = Math.min(sourceSize - 1, Math.floor(center + supportInSource + LANCZOS3_EPSILON));
-    const length = Math.max(1, end - start + 1);
-    const weights = new Float32Array(length);
-    let sum = 0;
-    for (let k = 0; k < length; k++) {
-      const sampleIndex = start + k;
-      const w = lanczos3Kernel((sampleIndex - center) * filterScale);
-      weights[k] = w;
-      sum += w;
-    }
-    if (sum !== 0) {
-      const inverseSum = 1 / sum;
-      for (let k = 0; k < length; k++) {
-        weights[k] *= inverseSum;
-      }
-    }
-    axis[i] = { start, weights };
-  }
-  return axis;
-}
-
-const LANCZOS3_RADIUS = 3;
-const LANCZOS3_EPSILON = 1e-9;
-
-function lanczos3Kernel(x: number): number {
-  if (x === 0) return 1;
-  if (x <= -LANCZOS3_RADIUS || x >= LANCZOS3_RADIUS) return 0;
-  const piX = Math.PI * x;
-  return (LANCZOS3_RADIUS * Math.sin(piX) * Math.sin(piX / LANCZOS3_RADIUS)) / (piX * piX);
-}
-
-function clampToByte(value: number): number {
-  if (value <= 0) return 0;
-  if (value >= 255) return 255;
-  return Math.round(value);
-}
-
-function clonePng(source: PNG): PNG {
-  const target = new PNG({ width: source.width, height: source.height });
-  source.data.copy(target.data);
+  const resized = resizeDecodedPng(
+    { width: source.width, height: source.height, data: source.data },
+    source.width * scale,
+    source.height * scale
+  );
+  const target = new PNG({ width: resized.width, height: resized.height });
+  resized.data.copy(target.data);
   return target;
 }
 

--- a/packages/tool-server/test/screenshot-diff-resize.test.ts
+++ b/packages/tool-server/test/screenshot-diff-resize.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeToCommonSize,
+  resizeDecodedPng,
+  type DecodedRgbaImage,
+} from "../src/tools/screenshot-diff/resize";
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function solidImage(width: number, height: number, color: Rgb): DecodedRgbaImage {
+  const data = Buffer.alloc(width * height * 4);
+  for (let i = 0; i < width * height; i++) {
+    const offset = i * 4;
+    data[offset] = color.r;
+    data[offset + 1] = color.g;
+    data[offset + 2] = color.b;
+    data[offset + 3] = 255;
+  }
+  return { width, height, data };
+}
+
+// A deterministic gradient so resampling has real signal to work with.
+function gradientImage(width: number, height: number): DecodedRgbaImage {
+  const data = Buffer.alloc(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const offset = (y * width + x) * 4;
+      data[offset] = Math.round((x / Math.max(1, width - 1)) * 255);
+      data[offset + 1] = Math.round((y / Math.max(1, height - 1)) * 255);
+      data[offset + 2] = 128;
+      data[offset + 3] = 255;
+    }
+  }
+  return { width, height, data };
+}
+
+function pixelAt(image: DecodedRgbaImage, x: number, y: number): Rgb {
+  const offset = (y * image.width + x) * 4;
+  return {
+    r: image.data[offset],
+    g: image.data[offset + 1],
+    b: image.data[offset + 2],
+  };
+}
+
+describe("resizeDecodedPng", () => {
+  it("downscales to the requested dimensions with a correctly-sized RGBA buffer", () => {
+    const resized = resizeDecodedPng(gradientImage(30, 60), 10, 20);
+    expect(resized.width).toBe(10);
+    expect(resized.height).toBe(20);
+    expect(resized.data.length).toBe(10 * 20 * 4);
+  });
+
+  it("returns a detached copy when the size is unchanged", () => {
+    const source = solidImage(8, 8, { r: 10, g: 20, b: 30 });
+    const resized = resizeDecodedPng(source, 8, 8);
+    expect(resized.width).toBe(8);
+    expect(resized.height).toBe(8);
+    expect(resized.data).not.toBe(source.data);
+    expect(Buffer.compare(resized.data, source.data)).toBe(0);
+  });
+
+  it("preserves a uniform color when downscaling", () => {
+    const resized = resizeDecodedPng(solidImage(30, 60, { r: 200, g: 100, b: 50 }), 10, 20);
+    // Resampling a flat field must reproduce the same color everywhere.
+    expect(pixelAt(resized, 0, 0)).toEqual({ r: 200, g: 100, b: 50 });
+    expect(pixelAt(resized, 5, 10)).toEqual({ r: 200, g: 100, b: 50 });
+    expect(pixelAt(resized, 9, 19)).toEqual({ r: 200, g: 100, b: 50 });
+  });
+});
+
+describe("normalizeToCommonSize", () => {
+  it("returns both images untouched when dimensions already match", () => {
+    const baseline = gradientImage(10, 20);
+    const current = gradientImage(10, 20);
+    const result = normalizeToCommonSize(baseline, current);
+    expect(result).not.toBeNull();
+    expect(result!.baseline).toBe(baseline);
+    expect(result!.current).toBe(current);
+  });
+
+  it("downscales the larger same-aspect image to the smaller common size", () => {
+    // Case 1: same aspect (0.5), different size -> both end up at 10x20.
+    const baseline = gradientImage(30, 60);
+    const current = gradientImage(10, 20);
+    const result = normalizeToCommonSize(baseline, current);
+
+    expect(result).not.toBeNull();
+    expect(result!.baseline.width).toBe(10);
+    expect(result!.baseline.height).toBe(20);
+    expect(result!.current.width).toBe(10);
+    expect(result!.current.height).toBe(20);
+    // Baseline was the larger image, so it must have been resampled to a new buffer.
+    expect(result!.baseline.data.length).toBe(10 * 20 * 4);
+    expect(result!.baseline.data).not.toBe(baseline.data);
+    // The smaller image is passed through untouched.
+    expect(result!.current).toBe(current);
+  });
+
+  it("downscales the larger side regardless of which argument it is", () => {
+    // Larger image supplied as `current` this time -> it is the one resized.
+    const baseline = gradientImage(10, 20);
+    const current = gradientImage(30, 60);
+    const result = normalizeToCommonSize(baseline, current);
+
+    expect(result).not.toBeNull();
+    expect(result!.baseline).toBe(baseline);
+    expect(result!.current.width).toBe(10);
+    expect(result!.current.height).toBe(20);
+    expect(result!.current.data.length).toBe(10 * 20 * 4);
+  });
+
+  it("keeps identical scaled content consistent without crashing", () => {
+    // Case 2: same content at two scales -> normalized outputs share dims and
+    // the uniform color survives the resample.
+    const baseline = solidImage(30, 60, { r: 12, g: 34, b: 56 });
+    const current = solidImage(10, 20, { r: 12, g: 34, b: 56 });
+    const result = normalizeToCommonSize(baseline, current);
+
+    expect(result).not.toBeNull();
+    expect(result!.baseline.width).toBe(result!.current.width);
+    expect(result!.baseline.height).toBe(result!.current.height);
+    expect(result!.baseline.width).toBe(10);
+    expect(result!.baseline.height).toBe(20);
+    expect(pixelAt(result!.baseline, 4, 9)).toEqual({ r: 12, g: 34, b: 56 });
+    expect(pixelAt(result!.current, 4, 9)).toEqual({ r: 12, g: 34, b: 56 });
+  });
+
+  it("normalizes when aspect ratios differ within the 1% tolerance", () => {
+    // 0.5 vs 0.4995 aspect (~0.1% difference) -> treated as the same framebuffer.
+    const baseline = gradientImage(1000, 2000);
+    const current = gradientImage(999, 2000);
+    const result = normalizeToCommonSize(baseline, current);
+
+    expect(result).not.toBeNull();
+    expect(result!.baseline.width).toBe(result!.current.width);
+    expect(result!.baseline.height).toBe(result!.current.height);
+  });
+
+  it("returns null for a transposed aspect ratio", () => {
+    // Case 3a: 20x10 (2.0) vs 10x20 (0.5).
+    const result = normalizeToCommonSize(gradientImage(20, 10), gradientImage(10, 20));
+    expect(result).toBeNull();
+  });
+
+  it("returns null when aspect ratios differ beyond the tolerance", () => {
+    // Case 3b: 0.5 vs ~0.476 aspect (~4.8% difference) exceeds the 1% tolerance.
+    const result = normalizeToCommonSize(gradientImage(100, 200), gradientImage(100, 210));
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a degenerate zero-dimension image", () => {
+    const result = normalizeToCommonSize(
+      { width: 0, height: 0, data: Buffer.alloc(0) },
+      gradientImage(10, 20)
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/packages/tool-server/test/screenshot-diff.test.ts
+++ b/packages/tool-server/test/screenshot-diff.test.ts
@@ -113,6 +113,26 @@ describe("diffPngFiles", () => {
     expect(result.contextDiffPath).toBeUndefined();
   });
 
+  it("compares same-aspect screenshots of different resolutions instead of failing", async () => {
+    const dir = await makeTempDir();
+    const baselinePath = path.join(dir, "baseline.png");
+    const currentPath = path.join(dir, "current.png");
+    // Same aspect ratio (0.5), different scale: a 0.3x-style saved baseline vs a
+    // full-res live capture. These must be normalized and compared, not rejected.
+    await writePng(baselinePath, 10, 20, { r: 30, g: 60, b: 90 });
+    await writePng(currentPath, 20, 40, { r: 30, g: 60, b: 90 });
+
+    const result = await diffPngFiles({ baselinePath, currentPath, outputDir: dir });
+
+    expect(result.dimensionMismatch).toBeUndefined();
+    expect(result.summary).not.toContain("dimension_mismatch");
+    expect(result.imageSize).toEqual({ width: 10, height: 20 });
+    expect(result.diffPath).toBe(path.join(dir, "current-diff.png"));
+    const diff = PNG.sync.read(await fs.readFile(result.diffPath!));
+    expect(diff.width).toBe(10);
+    expect(diff.height).toBe(20);
+  });
+
   it("merges same-line fragments but keeps separate rows distinct", async () => {
     const dir = await makeTempDir();
     const baselinePath = path.join(dir, "baseline.png");


### PR DESCRIPTION
## Problem

`screenshot-diff` rejects the workflow its own docs call "the common visual-regression flow" — `baselinePath` + `captureCurrent: true`.

The `screenshot` tool saves PNGs at a default scale of `0.3` (e.g. `396x860`), while `screenshot-diff`'s live capture is hardcoded to full resolution `1.0` (e.g. `1320x2868`). Feeding a saved `0.3x` baseline together with a `1.0x` live capture returns `status: dimension_mismatch` and refuses to compare — even though both images are uniform scalings of the same framebuffer and share an identical aspect ratio. The advertised default workflow is therefore broken out of the box.

## Root cause

`diffPngFiles` (in `packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts`) treated **any** difference in pixel dimensions as a hard failure:

```ts
if (baseline.width !== current.width || baseline.height !== current.height) {
  return summarizeResult(buildDimensionMismatchResult({ baseline, current }));
}
```

There was no allowance for two images that depict the same content at different scales.

## Fix

Before the hard dimension-equality check, normalize the two decoded images to a common size when their aspect ratios match (within a 1% tolerance, to absorb integer-rounding of pixel dimensions). The **larger** image is downscaled to the **smaller** one's exact dimensions using the existing Lanczos3 resampler — we never upscale, so we never invent detail. When the aspect ratios genuinely differ, the existing `dimension_mismatch` hard-fail is preserved unchanged.

- New pngjs-free module `packages/tool-server/src/tools/screenshot-diff/resize.ts` exports `normalizeToCommonSize(baseline, current)` (returns same-sized images, or `null` when aspects differ) and `resizeDecodedPng(src, width, height)`. The pure Lanczos3 resampling math (which has no `pngjs` dependency) was moved here; `screenshot-diff.ts` now imports it, and its `downscalePng` delegates to `resizeDecodedPng`, so there is a single resampler implementation.
- The OCR / font-geometry pass (`analyzeScreenshotTextChangesSafely` → `detectFontGeometryChange`) re-reads the original files from disk and samples in-memory pixels using OCR-derived bounds in those files' coordinate space. It therefore keeps receiving the **originally decoded** images (not the normalized copies), and its top cutoff is derived from the original baseline height. Only the pixel-diff path operates on the normalized, same-sized images. This keeps the text pass byte-for-byte consistent with prior behavior.

## Testing

- **`packages/tool-server/test/screenshot-diff-resize.test.ts`** (new, pngjs-free, runs locally): unit tests for the new pure helpers — same-aspect different-size pairs normalize to the smaller common size; uniform color survives the resample; transposed and out-of-tolerance aspect ratios return `null`; an in-tolerance (~0.1%) aspect difference still normalizes. **11/11 passing locally.**
- **`packages/tool-server/test/screenshot-diff.test.ts`** (existing): added an integration case asserting that a same-aspect, different-resolution baseline/current pair is **not** reported as `dimension_mismatch` and produces a diff at the smaller common size. This is the true before/after for the bug.

### CI caveat

`screenshot-diff.ts` imports `pngjs` at module load, so `screenshot-diff.test.ts` (and the integration case above) can only run in an environment where `pngjs` is installed — i.e. **CI**. The new `resize.ts` and `screenshot-diff-resize.test.ts` are intentionally `pngjs`-free so the core normalization logic is verifiable without that dependency. Typecheck (`tsc --noEmit -p tsconfig.test.json`) is clean for the changed files.
