### PR TITLE
fix(argent): declare + ship tree-sitter so react-profiler-component-source finds components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3680,7 +3680,9 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.20.0"
+        "@modelcontextprotocol/sdk": "^1.20.0",
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-typescript": "^0.23.2"
       },
       "bin": {
         "argent": "dist/cli.js",

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -41,7 +41,9 @@
     "scripts/postinstall.cjs"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.20.0"
+    "@modelcontextprotocol/sdk": "^1.20.0",
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-typescript": "^0.23.2"
   },
   "devDependencies": {
     "@argent/cli": "file:../argent-cli",

--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -294,9 +294,9 @@ const ASSETS = [
 
 /**
  * Bundle a single entry point with esbuild and log the result.
- * @param {{ entry: string, out: string, format: "cjs" | "esm", label: string }} opts
+ * @param {{ entry: string, out: string, format: "cjs" | "esm", label: string, external?: string[] }} opts
  */
-function buildBundle({ entry, out, format, label }) {
+function buildBundle({ entry, out, format, label, external = [] }) {
   esbuild.buildSync({
     entryPoints: [entry],
     bundle: true,
@@ -307,8 +307,13 @@ function buildBundle({ entry, out, format, label }) {
     alias: ALIASES,
     mainFields: MAIN_FIELDS,
     // ESM bundles need the require() shim (for inlined CJS deps) and must keep
-    // node: builtins external; the CJS bundle needs neither.
-    ...(format === "esm" ? { banner: ESM_REQUIRE_BANNER, external: ["node:*"] } : {}),
+    // node: builtins external; the CJS bundle needs neither. Any caller-supplied
+    // externals (e.g. tree-sitter native addons) are merged on top.
+    ...(format === "esm"
+      ? { banner: ESM_REQUIRE_BANNER, external: ["node:*", ...external] }
+      : external.length
+        ? { external }
+        : {}),
   });
   console.log(`✓ Bundled ${label} → ${path.relative(process.cwd(), out)}`);
 }
@@ -438,7 +443,16 @@ fs.rmSync(ANDROID_MANIFEST_DEST, { force: true });
 fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
 
 // Bundle the tools server (CJS — the dispatcher loads it via require()).
-buildBundle({ entry: TOOLS_ENTRY, out: OUT_FILE, format: "cjs", label: "tools server" });
+// tree-sitter / tree-sitter-typescript are native addons (.node) that esbuild
+// cannot inline; keep them external so the bundle `require()`s them at runtime
+// from the published package's own dependencies (see package.json).
+buildBundle({
+  entry: TOOLS_ENTRY,
+  out: OUT_FILE,
+  format: "cjs",
+  label: "tools server",
+  external: ["tree-sitter", "tree-sitter-typescript"],
+});
 
 // The remaining bundles are ESM so that:
 //   - installer: import.meta.dirname works at runtime (the dispatcher

--- a/packages/tool-server/src/tools/profiler/react/react-profiler-component-source.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-component-source.ts
@@ -42,10 +42,20 @@ Returns found: false if the component is not found in user-owned code (e.g. live
     const entry = astIndex.index.get(params.component_name);
 
     if (!entry) {
+      if (!astIndex.treeSitterAvailable) {
+        return {
+          found: false,
+          component: params.component_name,
+          message:
+            `Component source lookup is unavailable: the tree-sitter parser could not be loaded, ` +
+            `so no source files were indexed. Ensure @swmansion/argent's "tree-sitter" and ` +
+            `"tree-sitter-typescript" dependencies are installed.`,
+        };
+      }
       return {
         found: false,
         component: params.component_name,
-        message: `Component "${params.component_name}" not found in ${params.project_root}`,
+        message: `Component "${params.component_name}" not found in ${params.project_root} (searched ${astIndex.indexedFiles} files).`,
       };
     }
 

--- a/packages/tool-server/src/utils/react-profiler/pipeline/06-resolve/ast-index.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/06-resolve/ast-index.ts
@@ -141,6 +141,29 @@ function nodeContainsCall(node: TreeSitterNode, callName: string): boolean {
   return false;
 }
 
+/**
+ * Detect a React component wrapper call: memo(...) / forwardRef(...) /
+ * React.memo(...) / React.forwardRef(...) (also nested, e.g. memo(forwardRef(...)),
+ * since the outer callee is what we match). Components declared as
+ * `const X = memo(...)` / `const X = forwardRef(...)` have a call_expression
+ * value node, so without recognising these they would be missed entirely --
+ * and profiler-flagged components are disproportionately memo-wrapped.
+ */
+function reactWrapperCall(node: TreeSitterNode | undefined): {
+  isWrapper: boolean;
+  isMemo: boolean;
+} {
+  if (!node || node.type !== "call_expression") return { isWrapper: false, isMemo: false };
+  const callee = node.children[0];
+  let name: string | undefined;
+  if (callee?.type === "identifier") name = callee.text;
+  else if (callee?.type === "member_expression")
+    name = callee.children[callee.children.length - 1]?.text;
+  if (name === "memo") return { isWrapper: true, isMemo: true };
+  if (name === "forwardRef") return { isWrapper: true, isMemo: false };
+  return { isWrapper: false, isMemo: false };
+}
+
 function isWrappedInMemo(source: string, componentName: string): boolean {
   const memoPattern = /\b(React\.memo|memo)\s*\(\s*(\w+)/g;
   let match;
@@ -204,12 +227,15 @@ export async function buildAstIndexWithDiagnostics(projectRoot: string): Promise
       } else if (node.type === "variable_declarator") {
         const nameNode = node.children[0];
         const valueNode = node.children[node.children.length - 1];
+        const wrapper = reactWrapperCall(valueNode);
         if (
           nameNode &&
           nameNode.type === "identifier" &&
           isCapitalized(nameNode.text) &&
           valueNode &&
-          (valueNode.type === "arrow_function" || valueNode.type === "function_expression")
+          (valueNode.type === "arrow_function" ||
+            valueNode.type === "function_expression" ||
+            wrapper.isWrapper)
         ) {
           const componentName = nameNode.text;
           if (!index.has(componentName)) {
@@ -217,7 +243,7 @@ export async function buildAstIndexWithDiagnostics(projectRoot: string): Promise
               file,
               line: nameNode.startPosition.row + 1,
               col: nameNode.startPosition.column,
-              isMemoized: isWrappedInMemo(source, componentName),
+              isMemoized: isWrappedInMemo(source, componentName) || wrapper.isMemo,
               hasUseCallback: nodeContainsCall(node, "useCallback"),
               hasUseMemo: nodeContainsCall(node, "useMemo"),
             });

--- a/packages/tool-server/test/react-profiler/ast-index.test.ts
+++ b/packages/tool-server/test/react-profiler/ast-index.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { buildAstIndexWithDiagnostics } from "../../src/utils/react-profiler/pipeline/06-resolve/ast-index";
+
+/**
+ * react-profiler-component-source returned found:false for every component in a
+ * standard TS/TSX Expo project because @swmansion/argent never declared (or
+ * shipped) tree-sitter / tree-sitter-typescript, so the parser require() threw,
+ * was swallowed, and the index was always empty. The grammar/match logic itself
+ * is correct — this test guards it for the idiomatic declaration forms and, via
+ * treeSitterAvailable, fails loudly if the parser dependency goes missing again.
+ */
+describe("buildAstIndexWithDiagnostics", () => {
+  it("indexes export-default-function, plain-function, and arrow TSX components", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ast-index-"));
+    mkdirSync(join(dir, "components"), { recursive: true });
+    writeFileSync(
+      join(dir, "components", "foo.tsx"),
+      [
+        `import React from "react";`,
+        `type P = { x: number };`,
+        `export default function Foo({ x }: P) { return <View>{x}</View>; }`,
+        `function Bar({ y }: { y: number }) { return <View>{y}</View>; }`,
+        `const Baz = ({ z }: { z: number }) => <View>{z}</View>;`,
+        ``,
+      ].join("\n")
+    );
+
+    const res = await buildAstIndexWithDiagnostics(dir);
+
+    expect(res.treeSitterAvailable).toBe(true);
+    expect(res.index.get("Foo")?.line).toBe(3);
+    expect(res.index.get("Bar")?.line).toBe(4);
+    expect(res.index.get("Baz")?.line).toBe(5);
+  });
+});

--- a/packages/tool-server/test/react-profiler/ast-index.test.ts
+++ b/packages/tool-server/test/react-profiler/ast-index.test.ts
@@ -8,9 +8,10 @@ import { buildAstIndexWithDiagnostics } from "../../src/utils/react-profiler/pip
  * react-profiler-component-source returned found:false for every component in a
  * standard TS/TSX Expo project because @swmansion/argent never declared (or
  * shipped) tree-sitter / tree-sitter-typescript, so the parser require() threw,
- * was swallowed, and the index was always empty. The grammar/match logic itself
- * is correct — this test guards it for the idiomatic declaration forms and, via
- * treeSitterAvailable, fails loudly if the parser dependency goes missing again.
+ * was swallowed, and the index was always empty. These tests guard the matcher
+ * for the idiomatic declaration forms (plain/default/arrow AND memo/forwardRef
+ * wrappers) and, via treeSitterAvailable, fail loudly if the parser dependency
+ * goes missing again.
  */
 describe("buildAstIndexWithDiagnostics", () => {
   it("indexes export-default-function, plain-function, and arrow TSX components", async () => {
@@ -34,5 +35,36 @@ describe("buildAstIndexWithDiagnostics", () => {
     expect(res.index.get("Foo")?.line).toBe(3);
     expect(res.index.get("Bar")?.line).toBe(4);
     expect(res.index.get("Baz")?.line).toBe(5);
+  });
+
+  it("indexes memo()/forwardRef()/React.memo()/nested-wrapped components", async () => {
+    // Regression: wrapped components are declared `const X = memo(...)`, whose
+    // value node is a call_expression (not arrow/function), so they were missed
+    // entirely and returned found:false — and profiler findings are
+    // disproportionately memo-wrapped. memo => isMemoized true; forwardRef alone
+    // => false.
+    const dir = mkdtempSync(join(tmpdir(), "ast-index-wrap-"));
+    mkdirSync(join(dir, "components"), { recursive: true });
+    writeFileSync(
+      join(dir, "components", "wrapped.tsx"),
+      [
+        `import React, { memo, forwardRef } from "react";`,
+        `export const MemoFn = memo(function MemoFn() { return <View />; });`,
+        `export const MemoArrow = memo(({ a }: { a: number }) => <View>{a}</View>);`,
+        `export const Fwd = forwardRef(function FwdImpl(p, ref) { return <View />; });`,
+        `export const Dotted = React.memo(function Dotted() { return <View />; });`,
+        `export const Nested = memo(forwardRef(function NestedImpl(p, ref) { return <View />; }));`,
+        ``,
+      ].join("\n")
+    );
+
+    const res = await buildAstIndexWithDiagnostics(dir);
+
+    expect(res.treeSitterAvailable).toBe(true);
+    expect(res.index.get("MemoFn")).toMatchObject({ line: 2, isMemoized: true });
+    expect(res.index.get("MemoArrow")).toMatchObject({ line: 3, isMemoized: true });
+    expect(res.index.get("Fwd")).toMatchObject({ line: 4, isMemoized: false });
+    expect(res.index.get("Dotted")).toMatchObject({ line: 5, isMemoized: true });
+    expect(res.index.get("Nested")).toMatchObject({ line: 6, isMemoized: true });
   });
 });


### PR DESCRIPTION
## Problem

`react-profiler-component-source` returned `found:false` for **every** component in a standard TS/TSX Expo project.

## Two root causes (both verified live against the Bluesky app)

1. **tree-sitter never declared/shipped.** `@swmansion/argent` didn't depend on `tree-sitter`/`tree-sitter-typescript`, so the parser `require()` threw, was swallowed, and the AST index was always empty. Fixed by adding them as runtime deps and keeping them `external` in the CJS tools bundle so the native addons are `require()`d at runtime (not inlined). Verified: `HostingProvider`, `LoggedOutLayout`, `Login` now resolve with correct file:line.

2. **memo()/forwardRef() components were skipped.** The AST matcher's `variable_declarator` branch only indexed `arrow_function`/`function_expression` value nodes; a wrapped component (`const X = memo(...)` / `forwardRef(...)` / `React.memo(...)`) has a `call_expression` value node, so it was never indexed — and profiler findings are disproportionately memo-wrapped, i.e. exactly the components users look up. Now recognises memo/forwardRef wrapper calls (incl. `React.`-prefixed and nested `memo(forwardRef(...))`) and indexes the declared name; `memo` sets `isMemoized`. Verified live: `ThreadItemReadMore`, `CenteredView`, `ScrollView`, `BookmarkButton`, `Logo` now resolve.

## Tests
`ast-index.test.ts` covers the idiomatic forms (default-export/plain/arrow) and the memo/forwardRef/React.memo/nested wrappers; the wrapped-form test fails on pre-fix code. Rebased onto latest main (re-merged the `bundle-tools.cjs` helper refactor; bundle still externalizes tree-sitter). CI green.