### PR TITLE
fix(installer): suppress npm stderr in getLatestVersion

### DIFF
--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -384,9 +384,16 @@ export function getGloballyInstalledVersion(): string | null {
 const PROBE_TIMEOUT_MS = 3_000;
 
 export function getLatestVersion(): string {
+  // stdio: ["ignore", "pipe", "ignore"] — matches `getGlobalBinaryPath` above.
+  // Without it, npm warnings (notably EBADDEVENGINES when the user's cwd
+  // package.json pins a different package-manager or node version) print
+  // straight to the user's terminal, even though argent catches the thrown
+  // exception silently. Bluesky's package.json triggers this on every host
+  // that doesn't match its `devEngines.runtime` / `devEngines.packageManager`.
   const result = execSync(`npm view ${PACKAGE_NAME} version --registry ${NPM_REGISTRY}`, {
     encoding: "utf8",
     timeout: PROBE_TIMEOUT_MS,
+    stdio: ["ignore", "pipe", "ignore"],
   });
   return result.trim();
 }


### PR DESCRIPTION
## Summary

- Adds `stdio: ["ignore", "pipe", "ignore"]` to the `execSync` call in `getLatestVersion()`, matching the pattern already used in `getGlobalBinaryPath`
- Prevents npm warnings (notably `EBADDEVENGINES`) from printing to the user's terminal when argent checks for updates inside a project whose `package.json` triggers engine mismatch warnings — e.g. Bluesky's repo

## Stacking

Stacked on `feat/linux-host-support`. Base will be retargeted to `main` after that PR merges.

## Test plan

- [ ] `npm run test -w packages/argent-installer` passes