### PR TITLE
feat(android-binary): probe OS-default SDK install locations when env vars are absent

### DIFF
--- a/packages/tool-server/src/utils/android-binary.ts
+++ b/packages/tool-server/src/utils/android-binary.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { access } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
@@ -101,9 +102,43 @@ function androidRoots(): string[] {
   // alias Android still honors. Some environments set only one. We try both
   // in declared order so a user who set ANDROID_HOME explicitly always wins
   // over a stale ANDROID_SDK_ROOT inherited from elsewhere.
-  return [process.env.ANDROID_HOME, process.env.ANDROID_SDK_ROOT].filter((v): v is string =>
-    Boolean(v && v.trim())
+  const envRoots = [process.env.ANDROID_HOME, process.env.ANDROID_SDK_ROOT].filter(
+    (v): v is string => Boolean(v && v.trim())
   );
+  // OS-default install locations. Important: an MCP server (or any process
+  // spawned by a GUI app like Claude Code's desktop client) inherits the GUI's
+  // env, which on Linux+Wayland and macOS Finder-launched apps lacks the
+  // shell-rc-exported ANDROID_HOME. Probing the canonical install paths lets
+  // a user who installed via Android Studio (or apt) have argent "just work"
+  // without hand-editing .mcp.json or exporting env vars in shell rc files
+  // they don't realize the GUI doesn't read.
+  return [...envRoots, ...defaultAndroidRoots()];
+}
+
+/**
+ * Canonical SDK install locations argent probes after env vars come up empty.
+ *
+ * Picked to match what Android Studio installs by default and what the
+ * upstream Android docs / common Linux package managers ship. Order matters
+ * only when the *same* SDK is reachable through two of these — first match
+ * wins via `androidRoots()`'s linear scan.
+ */
+function defaultAndroidRoots(): string[] {
+  const home = homedir();
+  const roots = [
+    // Android Studio defaults (the two big ones — covers the majority of
+    // user installs that arrive without any env-var setup).
+    join(home, "Library", "Android", "sdk"), // macOS Android Studio default
+    join(home, "Android", "Sdk"), // Linux Android Studio default
+    // Common manual install convention. Not picked by any installer but used
+    // often enough in tutorials and Dockerfiles that probing it costs little.
+    join(home, "android-sdk"),
+    // System-wide locations (Linux package managers, Homebrew on macOS).
+    "/opt/android-sdk",
+    "/usr/lib/android-sdk", // Debian/Ubuntu `android-sdk` apt package
+    "/usr/local/share/android-sdk", // Homebrew cask
+  ];
+  return roots;
 }
 
 /** Test-only: clear the resolver cache between tests. */

--- a/packages/tool-server/test/android-binary.test.ts
+++ b/packages/tool-server/test/android-binary.test.ts
@@ -15,7 +15,11 @@ import {
 // Snapshot the env vars we mutate so a failing assertion can't leak state into
 // the next test (or the surrounding process: vitest reuses the worker for
 // other suites and a stale ANDROID_HOME would silently flip their behavior).
-const ENV_KEYS = ["PATH", "ANDROID_HOME", "ANDROID_SDK_ROOT"] as const;
+// HOME is included because `androidRoots()` derives Android Studio's default
+// install path from `os.homedir()`, which on Linux/macOS honors $HOME. Pinning
+// HOME to a tmpdir keeps the resolver from accidentally finding the dev's real
+// SDK during tests that assert "not resolvable".
+const ENV_KEYS = ["PATH", "ANDROID_HOME", "ANDROID_SDK_ROOT", "HOME"] as const;
 const originalEnv: Record<string, string | undefined> = {};
 
 async function fakeSdk(root: string, name: "adb" | "emulator"): Promise<string> {
@@ -54,7 +58,7 @@ describe("resolveAndroidBinary", () => {
     // Strip PATH down to OS basics so the test doesn't accidentally find a
     // real `emulator` binary on the host running the suite (CI shouldn't have
     // one but a developer's macOS easily can).
-    process.env.PATH = "/usr/bin:/bin";
+    process.env.PATH = tmpRoot; // empty: keep PATH-installed adb/emulator on dev boxes from short-circuiting the probe
     process.env.ANDROID_HOME = sdk;
     delete process.env.ANDROID_SDK_ROOT;
 
@@ -65,7 +69,7 @@ describe("resolveAndroidBinary", () => {
   it("finds adb under $ANDROID_HOME/platform-tools when not on PATH", async () => {
     const sdk = join(tmpRoot, "sdk");
     const expected = await fakeSdk(sdk, "adb");
-    process.env.PATH = "/usr/bin:/bin";
+    process.env.PATH = tmpRoot; // empty: keep PATH-installed adb/emulator on dev boxes from short-circuiting the probe
     process.env.ANDROID_HOME = sdk;
     delete process.env.ANDROID_SDK_ROOT;
 
@@ -76,7 +80,7 @@ describe("resolveAndroidBinary", () => {
   it("falls back to $ANDROID_SDK_ROOT when $ANDROID_HOME is unset", async () => {
     const sdk = join(tmpRoot, "sdk-root");
     const expected = await fakeSdk(sdk, "emulator");
-    process.env.PATH = "/usr/bin:/bin";
+    process.env.PATH = tmpRoot; // empty: keep PATH-installed adb/emulator on dev boxes from short-circuiting the probe
     delete process.env.ANDROID_HOME;
     process.env.ANDROID_SDK_ROOT = sdk;
 
@@ -104,12 +108,62 @@ describe("resolveAndroidBinary", () => {
   });
 
   it("returns null when neither PATH nor SDK roots resolve", async () => {
-    process.env.PATH = "/usr/bin:/bin";
+    process.env.PATH = tmpRoot; // empty: keep PATH-installed adb/emulator on dev boxes from short-circuiting the probe
     delete process.env.ANDROID_HOME;
     delete process.env.ANDROID_SDK_ROOT;
+    // Pin HOME to an empty tmpdir so the default-install probe can't
+    // accidentally pick up a real Android Studio install at
+    // `~/Android/Sdk` or `~/Library/Android/sdk` on the dev's box.
+    process.env.HOME = tmpRoot;
 
     const path = await resolveAndroidBinary("emulator");
     expect(path).toBeNull();
+  });
+
+  it("finds emulator under ~/Android/Sdk (Linux Android Studio default) without env vars", async () => {
+    const sdk = join(tmpRoot, "Android", "Sdk");
+    const expected = await fakeSdk(sdk, "emulator");
+    // PATH points at an empty dir so a dev with `emulator` installed via apt
+    // (in /usr/bin) can still run this suite without it short-circuiting on
+    // PATH before we exercise the default-install probe.
+    process.env.PATH = tmpRoot;
+    delete process.env.ANDROID_HOME;
+    delete process.env.ANDROID_SDK_ROOT;
+    process.env.HOME = tmpRoot;
+
+    const path = await resolveAndroidBinary("emulator");
+    expect(path).toBe(expected);
+  });
+
+  it("finds adb under ~/Library/Android/sdk (macOS Android Studio default) without env vars", async () => {
+    const sdk = join(tmpRoot, "Library", "Android", "sdk");
+    const expected = await fakeSdk(sdk, "adb");
+    process.env.PATH = tmpRoot;
+    delete process.env.ANDROID_HOME;
+    delete process.env.ANDROID_SDK_ROOT;
+    process.env.HOME = tmpRoot;
+
+    const path = await resolveAndroidBinary("adb");
+    expect(path).toBe(expected);
+  });
+
+  it("prefers $ANDROID_HOME over default install locations", async () => {
+    // SDK at $ANDROID_HOME
+    const envSdk = join(tmpRoot, "env-sdk");
+    const envBinary = await fakeSdk(envSdk, "emulator");
+    // Decoy SDK at the Linux Android Studio default — should be ignored when
+    // ANDROID_HOME is set, so a user with two installs gets the one they
+    // explicitly picked, not the one Studio happened to drop.
+    const studioSdk = join(tmpRoot, "Android", "Sdk");
+    await fakeSdk(studioSdk, "emulator");
+
+    process.env.PATH = tmpRoot;
+    process.env.ANDROID_HOME = envSdk;
+    delete process.env.ANDROID_SDK_ROOT;
+    process.env.HOME = tmpRoot;
+
+    const path = await resolveAndroidBinary("emulator");
+    expect(path).toBe(envBinary);
   });
 
   it("ignores a non-executable file at the canonical SDK path", async () => {
@@ -120,9 +174,13 @@ describe("resolveAndroidBinary", () => {
     await writeFile(join(dir, "emulator"), "stub", { mode: 0o644 });
     await chmod(join(dir, "emulator"), 0o644);
 
-    process.env.PATH = "/usr/bin:/bin";
+    process.env.PATH = tmpRoot; // empty: keep PATH-installed adb/emulator on dev boxes from short-circuiting the probe
     process.env.ANDROID_HOME = sdk;
     delete process.env.ANDROID_SDK_ROOT;
+    // Pin HOME so the default-install probe can't fall back to a real SDK on
+    // the dev's box (~/android-sdk, ~/Android/Sdk, etc.) and turn this into
+    // a "found something else, test passes for the wrong reason" pass.
+    process.env.HOME = tmpRoot;
 
     const path = await resolveAndroidBinary("emulator");
     // Resolver should refuse the non-executable candidate. With no other
@@ -152,7 +210,7 @@ describe("ensureDep('emulator')", () => {
   it("passes when emulator is resolvable via $ANDROID_HOME alone", async () => {
     const sdk = join(tmpRoot, "sdk");
     await fakeSdk(sdk, "emulator");
-    process.env.PATH = "/usr/bin:/bin";
+    process.env.PATH = tmpRoot; // empty: keep PATH-installed adb/emulator on dev boxes from short-circuiting the probe
     process.env.ANDROID_HOME = sdk;
     delete process.env.ANDROID_SDK_ROOT;
 
@@ -160,9 +218,12 @@ describe("ensureDep('emulator')", () => {
   });
 
   it("throws DependencyMissingError with install hint when neither resolves", async () => {
-    process.env.PATH = "/usr/bin:/bin";
+    process.env.PATH = tmpRoot; // empty: keep PATH-installed adb/emulator on dev boxes from short-circuiting the probe
     delete process.env.ANDROID_HOME;
     delete process.env.ANDROID_SDK_ROOT;
+    // Same reason as the resolver test: keep the default-install probe from
+    // finding a real SDK on the dev box and turning this into a flaky pass.
+    process.env.HOME = tmpRoot;
 
     await expect(ensureDep("emulator")).rejects.toBeInstanceOf(DependencyMissingError);
     try {


### PR DESCRIPTION
## Summary

- Extends `androidRoots()` to fall back to OS-default Android SDK install paths after `ANDROID_HOME` / `ANDROID_SDK_ROOT` come up empty
- Covers Android Studio defaults (`~/Library/Android/sdk` on macOS, `~/Android/Sdk` on Linux) and common system-wide paths (`/opt/android-sdk`, `/usr/lib/android-sdk`, etc.)
- Fixes the case where an MCP server spawned by a GUI process (Claude Code desktop, VS Code) doesn't inherit the shell-exported `ANDROID_HOME`, causing argent to silently fail to find `adb`/`emulator` even on a correctly configured machine

## Stacking

Stacked on `feat/linux-host-support`. Base will be retargeted to `main` after that PR merges.

## Test plan

- [ ] New tests in `android-binary.test.ts` cover the Studio-default paths and the `ANDROID_HOME` priority invariant
- [ ] `npm run test -w packages/tool-server` passes