### PR TITLE
feat(boot-device): Linux boot diagnostics for KVM access and AVD sizing

### DIFF
--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -24,6 +24,7 @@ import {
   waitForBootCompleted,
 } from "../../utils/adb";
 import { ensureDep } from "../../utils/check-deps";
+import { linuxBootDiagnostics } from "../../utils/linux-preflight";
 import { listIosSimulators } from "../../utils/ios-devices";
 
 const execFileAsync = promisify(execFile);
@@ -659,6 +660,10 @@ async function bootAndroidImpl(params: {
   // resolver, which honors `$ANDROID_HOME` in addition to PATH.
   await ensureDep("adb");
   await ensureDep("emulator");
+
+  for (const msg of linuxBootDiagnostics(params.avdName) ?? []) {
+    console.warn(`[boot-device:linux] ${msg}`);
+  }
   const emulatorBinary = await resolveEmulatorOrThrow();
   const overallDeadline = Date.now() + params.bootTimeoutMs;
 

--- a/packages/tool-server/src/utils/linux-preflight.ts
+++ b/packages/tool-server/src/utils/linux-preflight.ts
@@ -1,0 +1,107 @@
+import * as fs from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Linux-host preflight for boot-device. Two checks, both deterministic:
+//
+//   1. /dev/kvm usable by this user — without it qemu falls back to TCG
+//      software emulation (10–50× slower).
+//   2. Target AVD's hw.ramSize / vm.heapSize meet the floor the README
+//      documents — undersized AVDs Watchdog-kill system_server under
+//      real-world RN dev-mode load and the user sees cryptic "Activity
+//      not started" / "Status: timeout" errors during the restart window.
+//
+// Both warnings name the exact fix. Logged at boot; never throws, never
+// blocks. Returns null on non-Linux so the call site can be one-lined.
+//
+// We deliberately do NOT probe /proc/cpuinfo, host Vulkan ICDs, OpenGL, or
+// any other env heuristic — those are flaky enough on Linux (containers,
+// exotic kernels, hypervisors that hide vmx/svm) to produce false positives.
+export function linuxBootDiagnostics(avdName?: string): string[] | null {
+  if (process.platform !== "linux") return null;
+  const diags: string[] = [];
+  const kvm = checkKvm();
+  if (kvm) diags.push(kvm);
+  if (avdName) {
+    const sizing = checkAvdSizing(avdName);
+    if (sizing) diags.push(sizing);
+  }
+  return diags;
+}
+
+function checkKvm(): string | null {
+  try {
+    fs.accessSync("/dev/kvm", fs.constants.R_OK | fs.constants.W_OK);
+    return null;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return "/dev/kvm is missing — KVM module is not loaded or virtualization is disabled in BIOS/UEFI. The emulator will fall back to TCG software emulation (10–50× slower). Enable VT-x/AMD-V in BIOS and load the kvm module (`modprobe kvm_intel` or `modprobe kvm_amd`).";
+    }
+    // EACCES is the typical case: /dev/kvm is mode 660 root:kvm and the user
+    // isn't in the `kvm` group. usermod is the standard fix.
+    return `/dev/kvm exists but is not readable/writable by this user (code=${code ?? "unknown"}). KVM acceleration unavailable; emulator will fall back to TCG software emulation (10–50× slower). Add your user to the \`kvm\` group: \`sudo usermod -aG kvm $USER\` and re-login.`;
+  }
+}
+
+const MIN_RAM_MB = 4096;
+const MIN_HEAP_MB = 512;
+
+function checkAvdSizing(avdName: string): string | null {
+  // Default `avdmanager create avd` ships hw.ramSize=2G, vm.heapSize=228M —
+  // enough for hello-world but not for Hermes+Metro+swiftshader. Read the
+  // config we know the emulator binary will load and delegate the verdict to
+  // the pure parser so the test path doesn't need fs mocking.
+  const configPath = join(homedir(), ".android", "avd", `${avdName}.avd`, "config.ini");
+  let content: string;
+  try {
+    content = fs.readFileSync(configPath, "utf8");
+  } catch {
+    return null;
+  }
+  return diagnoseAvdSizing(avdName, content, configPath);
+}
+
+/**
+ * Pure: parse hw.ramSize / vm.heapSize out of an AVD config.ini and return a
+ * single combined warning string when either is below the README floor.
+ * Exported so tests can drive it without filesystem setup.
+ */
+export function diagnoseAvdSizing(
+  avdName: string,
+  configContent: string,
+  configPath: string
+): string | null {
+  const ramMb = readMb(configContent, "hw.ramSize");
+  const heapMb = readMb(configContent, "vm.heapSize");
+  const issues: string[] = [];
+  if (ramMb !== null && ramMb < MIN_RAM_MB) {
+    issues.push(`hw.ramSize=${ramMb} MB (recommended ≥ ${MIN_RAM_MB})`);
+  }
+  if (heapMb !== null && heapMb < MIN_HEAP_MB) {
+    issues.push(`vm.heapSize=${heapMb} MB (recommended ≥ ${MIN_HEAP_MB})`);
+  }
+  if (issues.length === 0) return null;
+  return (
+    `AVD "${avdName}" is undersized: ${issues.join(", ")}. ` +
+    `Under load (Hermes JIT, Metro bundling, swiftshader rendering) Android's ` +
+    `Watchdog can suicide-restart system_server, leaving the device transiently ` +
+    `unresponsive. Edit ${configPath} to raise hw.ramSize to ${MIN_RAM_MB} and ` +
+    `vm.heapSize to ${MIN_HEAP_MB} (see README "Linux host: extra prerequisites").`
+  );
+}
+
+// Read a `key = NNNN[M|MB|G|GB]` line and normalize to MB. The emulator
+// accepts both no-suffix integers (interpreted as MB) and `G` suffixes; we
+// match the same convention so the recommendation matches reality.
+function readMb(content: string, key: string): number | null {
+  const re = new RegExp(
+    `^\\s*${key.replace(/\./g, "\\.")}\\s*=\\s*(\\d+)\\s*([MmGg][Bb]?)?\\s*$`,
+    "m"
+  );
+  const m = content.match(re);
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n)) return null;
+  return (m[2] || "M").toLowerCase().startsWith("g") ? n * 1024 : n;
+}

--- a/packages/tool-server/test/linux-preflight.test.ts
+++ b/packages/tool-server/test/linux-preflight.test.ts
@@ -1,0 +1,77 @@
+// Unit tests for linuxBootDiagnostics. The KVM branch is small enough that
+// we test the two deterministic shapes (null on non-linux, array on linux)
+// and trust the try/catch from reading the code. AVD sizing is exercised
+// via the pure `diagnoseAvdSizing` helper so we don't need fs mocking.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { diagnoseAvdSizing, linuxBootDiagnostics } from "../src/utils/linux-preflight";
+
+const originalPlatform = process.platform;
+function setPlatform(p: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+
+afterEach(() => setPlatform(originalPlatform));
+
+describe("linuxBootDiagnostics", () => {
+  it("returns null on non-linux", () => {
+    setPlatform("darwin");
+    expect(linuxBootDiagnostics()).toBeNull();
+  });
+
+  it("returns an array on linux", () => {
+    setPlatform("linux");
+    const result = linuxBootDiagnostics();
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    // On a host where /dev/kvm is RW, the array is empty; where it isn't,
+    // it contains a single string with `/dev/kvm` somewhere in it. We
+    // accept either to make this test independent of the host's KVM
+    // state — the actual fs branches are simple enough that reading the
+    // code is more reliable than mocking node:fs in vitest.
+    for (const msg of result!) {
+      expect(msg).toMatch(/\/dev\/kvm/);
+    }
+  });
+});
+
+describe("diagnoseAvdSizing", () => {
+  const PATH = "/home/test/.android/avd/argent-test.avd/config.ini";
+
+  it("flags hw.ramSize below 4096 MB (the 2G avdmanager default)", () => {
+    // 2G is the avdmanager default; covers the "fresh avdmanager AVD wedges
+    // under real load" case that motivates the diagnostic. The path is
+    // echoed back so the user knows exactly which file to edit.
+    const out = diagnoseAvdSizing("argent-test", "hw.ramSize = 2G\nvm.heapSize = 512\n", PATH);
+    expect(out).toMatch(/undersized.*hw\.ramSize=2048 MB/);
+    expect(out).not.toMatch(/vm\.heapSize=/);
+    expect(out).toContain(PATH);
+  });
+
+  it("flags vm.heapSize below 512 MB (the 228 avdmanager default)", () => {
+    // 228 is the avdmanager default; isolates the heap-only branch so a
+    // regression that conflates ram vs heap parsing surfaces here.
+    const out = diagnoseAvdSizing("argent-test", "hw.ramSize = 4096\nvm.heapSize = 228M\n", PATH);
+    expect(out).toMatch(/undersized.*vm\.heapSize=228 MB/);
+    expect(out).not.toMatch(/hw\.ramSize=/);
+  });
+
+  it("emits a single combined warning when BOTH ram and heap are low", () => {
+    const out = diagnoseAvdSizing("argent-test", "hw.ramSize = 2G\nvm.heapSize = 228M\n", PATH);
+    expect(out).toMatch(/hw\.ramSize=2048 MB/);
+    expect(out).toMatch(/vm\.heapSize=228 MB/);
+  });
+
+  it("returns null when both ram and heap meet the floor", () => {
+    expect(
+      diagnoseAvdSizing("argent-test", "hw.ramSize = 4096\nvm.heapSize = 512\n", PATH)
+    ).toBeNull();
+  });
+
+  it("returns null when the keys are absent — partial configs aren't a fail signal", () => {
+    // A config.ini that omits hw.ramSize / vm.heapSize means the emulator
+    // will use its own defaults; we can't know the value without invoking
+    // the emulator, so we stay silent rather than guess.
+    expect(diagnoseAvdSizing("argent-test", "hw.cpu.ncore = 4\n", PATH)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `linux-preflight.ts` with two non-blocking diagnostics run at boot time on Linux hosts:
  - `/dev/kvm` readability check — warns when KVM is missing or inaccessible, which causes 10–50× TCG software-emulation slowdown
  - AVD `hw.ramSize` / `vm.heapSize` floor check — warns when values are below the threshold where Android's Watchdog kills `system_server` under Hermes+Metro+swiftshader load
- Both warnings name the exact fix command; neither throws nor blocks
- Wired into `boot-device.ts` via `linuxBootDiagnostics(avdName)` immediately after `ensureDep` succeeds

## Stacking

Stacked on `feat/linux-host-support`. Base will be retargeted to `main` after that PR merges.

## Test plan

- [ ] `linux-preflight.test.ts` covers the pure `diagnoseAvdSizing` helper for all four sizing combinations
- [ ] `npm run test -w packages/tool-server` passes