### PR TITLE
fix(boot-device): five correctness fixes from post-merge Linux review

### DIFF
--- a/packages/native-devtools-ios/src/index.ts
+++ b/packages/native-devtools-ios/src/index.ts
@@ -2,8 +2,10 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 
 // When bundled by esbuild, __dirname points into dist/.
-// ARGENT_NATIVE_DEVTOOLS_DIR lets the launcher override the dylib directory,
-// matching the same pattern used by ARGENT_SIMULATOR_SERVER_DIR.
+// ARGENT_NATIVE_DEVTOOLS_DIR overrides the dylib base directory.
+// ARGENT_SIMULATOR_SERVER_DIR overrides the binary base directory; it must
+// point at the *root* of the per-platform tree (i.e. the parent of
+// bin/<platform>/), not directly at the directory containing the binary.
 const DYLIB_DIR = process.env.ARGENT_NATIVE_DEVTOOLS_DIR ?? path.join(__dirname, "..", "dylibs");
 const BIN_DIR = process.env.ARGENT_SIMULATOR_SERVER_DIR ?? path.join(__dirname, "..", "bin");
 const DYLIB_TCP_DIR = process.env.ARGENT_NATIVE_DEVTOOLS_TCP_DIR ?? path.join(DYLIB_DIR, "tcp");
@@ -41,10 +43,14 @@ export const keyboardPatchDylibPath = () => {
   return requireDylibIn(DYLIB_DIR, "libKeyboardPatch.dylib");
 };
 
-export const bootstrapDylibPathTcp = () =>
-  requireDylibIn(DYLIB_TCP_DIR, "libArgentInjectionBootstrap.dylib");
-export const nativeDevtoolsDylibPathTcp = () =>
-  requireDylibIn(DYLIB_TCP_DIR, "libNativeDevtoolsIos.dylib");
+export const bootstrapDylibPathTcp = () => {
+  requireDarwin("bootstrapDylibPathTcp");
+  return requireDylibIn(DYLIB_TCP_DIR, "libArgentInjectionBootstrap.dylib");
+};
+export const nativeDevtoolsDylibPathTcp = () => {
+  requireDarwin("nativeDevtoolsDylibPathTcp");
+  return requireDylibIn(DYLIB_TCP_DIR, "libNativeDevtoolsIos.dylib");
+};
 
 // simulator-server is a host-side binary that talks to both iOS Simulators
 // (macOS) and Android emulators (any host with `adb`). Each platform's
@@ -61,9 +67,15 @@ function platformTcpBinDir(): string {
 export function simulatorServerBinaryPath(): string {
   const p = path.join(platformBinDir(), "simulator-server");
   if (!fs.existsSync(p)) {
+    // Help callers who set ARGENT_SIMULATOR_SERVER_DIR to a flat dir (the old
+    // pre-Linux-support layout where simulator-server lived at the root).
+    const flat = path.join(BIN_DIR, "simulator-server");
+    const migrationHint = fs.existsSync(flat)
+      ? ` Found a binary at the old flat path ${flat}; move it to ${p} or update ARGENT_SIMULATOR_SERVER_DIR to point at the parent of the platform subdirectory.`
+      : "";
     throw new Error(
       `simulator-server binary not found for platform "${process.platform}" at ${p}. ` +
-        `Supported hosts today: darwin, linux.`
+        `Supported hosts today: darwin, linux.${migrationHint}`
     );
   }
   return p;

--- a/packages/native-devtools-ios/test/index.test.ts
+++ b/packages/native-devtools-ios/test/index.test.ts
@@ -66,6 +66,16 @@ describe("requireDarwin gating", () => {
     expect(() => r.keyboardPatchDylibPath()).toThrow(/requires a macOS host/);
   });
 
+  it("throws with a root-cause message on linux for TCP iOS-only dylibs", async () => {
+    // TCP variants are equally iOS-Simulator-only; the guard must fire before
+    // the file-existence check so Linux callers get the platform error, not
+    // a misleading "dylib not found" for the tcp/ subdirectory.
+    setPlatform("linux");
+    const r = await loadResolver();
+    expect(() => r.bootstrapDylibPathTcp()).toThrow(/requires a macOS host/);
+    expect(() => r.nativeDevtoolsDylibPathTcp()).toThrow(/requires a macOS host/);
+  });
+
   it("throws with a root-cause message on linux for ax-service", async () => {
     // ax-service is darwin-only (runs INSIDE the iOS Simulator), so the
     // resolver must throw the platform error BEFORE the file-existence check.
@@ -108,6 +118,22 @@ describe("simulator-server path resolution", () => {
     process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
     const r = await loadResolver();
     expect(() => r.simulatorServerBinaryPath()).toThrow(/simulator-server binary not found/);
+    expect(() => r.simulatorServerBinaryPath()).toThrow(new RegExp(process.platform));
+  });
+
+  it("includes a migration hint when ARGENT_SIMULATOR_SERVER_DIR points at the old flat layout", async () => {
+    // Prior to the Linux per-platform layout, ARGENT_SIMULATOR_SERVER_DIR
+    // was the directory that contained simulator-server directly. A user
+    // with that setup now gets a "not found" error; the migration hint in
+    // the message tells them exactly what changed and how to fix it.
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "flat-layout-"));
+    fs.mkdirSync(path.join(dir, process.platform), { recursive: true });
+    // Place the binary at the flat (old) path.
+    const flatBin = path.join(dir, "simulator-server");
+    fs.writeFileSync(flatBin, "", { mode: 0o755 });
+    process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
+    const r = await loadResolver();
+    expect(() => r.simulatorServerBinaryPath()).toThrow(/old flat path/);
     expect(() => r.simulatorServerBinaryPath()).toThrow(new RegExp(process.platform));
   });
 });

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -162,12 +162,11 @@ function selectGpuMode(): string {
 // Opt-in `-no-window` for CI/containers/Wayland sessions where the emulator's
 // bundled Qt has no wayland plugin (would SIGABRT). `-no-window` selects
 // qemu-system-x86_64-headless which skips Qt entirely; screencap still works.
+// Accepted truthy values: "1", "true", "yes" (case-insensitive). Anything else
+// — including "false", "no", "0", or empty — is treated as disabled.
 function selectExtraEmulatorArgs(): string[] {
-  const noWindow = process.env.ARGENT_EMULATOR_NO_WINDOW;
-  if (noWindow && noWindow.trim() && noWindow.trim() !== "0") {
-    return ["-no-window"];
-  }
-  return [];
+  const trimmed = (process.env.ARGENT_EMULATOR_NO_WINDOW ?? "").trim().toLowerCase();
+  return ["1", "true", "yes"].includes(trimmed) ? ["-no-window"] : [];
 }
 
 // Poll cadences for the boot state machine. These intervals only pace how
@@ -659,6 +658,12 @@ async function bootAndroidImpl(params: {
   // resolver, which honors `$ANDROID_HOME` in addition to PATH.
   await ensureDep("adb");
   await ensureDep("emulator");
+  // Validate and capture boot-configuration env vars upfront so a typo in
+  // ARGENT_EMULATOR_GPU_MODE surfaces before any slow I/O (snapshot probe,
+  // AVD list, emulator spawn) rather than mid-function with a misleading
+  // "emulator has been terminated" suffix.
+  const gpuMode = selectGpuMode();
+  const extraEmulatorArgs = selectExtraEmulatorArgs();
   const emulatorBinary = await resolveEmulatorOrThrow();
   const overallDeadline = Date.now() + params.bootTimeoutMs;
 
@@ -756,8 +761,8 @@ async function bootAndroidImpl(params: {
     // the probe resolves a different renderer than the boot and rejects every
     // valid snapshot with "different renderer configured". RENDERER_ARGS
     // keeps the two in lockstep. `-gpu` value and the optional `-no-window`
-    // come from `selectGpuMode` / `selectExtraEmulatorArgs`.
-    const RENDERER_ARGS = ["-gpu", selectGpuMode(), ...selectExtraEmulatorArgs()];
+    // come from `selectGpuMode` / `selectExtraEmulatorArgs` (resolved upfront).
+    const RENDERER_ARGS = ["-gpu", gpuMode, ...extraEmulatorArgs];
     const probe = await checkSnapshotLoadable(params.avdName, "default_boot", {
       extraArgs: [...RENDERER_ARGS, ...LAUNCH_HARDENING_ARGS],
     });
@@ -826,8 +831,8 @@ async function bootAndroidImpl(params: {
     params.avdName,
     "-no-snapshot-load",
     "-gpu",
-    selectGpuMode(),
-    ...selectExtraEmulatorArgs(),
+    gpuMode,
+    ...extraEmulatorArgs,
     ...LAUNCH_HARDENING_ARGS,
   ];
   let coldResult: { serial: string };
@@ -856,7 +861,19 @@ async function bootAndroidImpl(params: {
   // Cold-boot post-condition: under SwiftShader the lockscreen composite lags
   // boot_completed by 5–60 s. Without this, a caller chaining boot-device →
   // screenshot gets a silent all-black PNG. See `awaitFirstRealFrame`.
-  await awaitFirstRealFrame(coldResult.serial, STAGE_BUDGET.firstRealFrame);
+  // Clamp against the remaining overallDeadline so the frame-wait stage cannot
+  // push total elapsed time past bootTimeoutMs. Kill and throw on timeout so
+  // the emulator doesn't linger until the next boot-device call.
+  const frameWaitBudget = Math.min(
+    STAGE_BUDGET.firstRealFrame,
+    Math.max(0, overallDeadline - Date.now())
+  );
+  try {
+    await awaitFirstRealFrame(coldResult.serial, frameWaitBudget);
+  } catch (err) {
+    await killEmulatorQuietly(coldResult.serial);
+    throw err;
+  }
 
   return {
     platform: "android",

--- a/packages/tool-server/test/boot-device-hotboot.test.ts
+++ b/packages/tool-server/test/boot-device-hotboot.test.ts
@@ -310,8 +310,11 @@ describe("boot-device Android — hot-boot with cold-boot fallback", () => {
     ["empty", ""],
     ["whitespace", "   "],
     ["zero", "0"],
+    ["false", "false"],
+    ["no", "no"],
   ])("treats ARGENT_EMULATOR_NO_WINDOW=%s as off", async (_label, value) => {
-    // `export FOO=` is a common shell mis-setting; `0` reads as "disable".
+    // `export FOO=` is a common shell mis-setting; `0`/`false`/`no` all
+    // read as "disable" — only `1`, `true`, `yes` activate -no-window.
     hasSnapshotMock.mockResolvedValue(false);
     mockHappyBootChain();
 


### PR DESCRIPTION
## Summary

Five issues found in the post-merge code review of #249 (Linux support). All confirmed present on main; none fixed by #194.

### H1 — `awaitFirstRealFrame` timeout leaves emulator running

`awaitFirstRealFrame` is called after the cold-boot `try/catch` closes. On a SurfaceFlinger timeout the emulator process stayed alive: `inFlightBoots.finally` cleared the map entry, so the next `boot-device` call found the stale serial via the `alreadyRunning` fast path, had to run `assertScreencapAlive`, killed it there, and then fell through to another full cold boot — doubling latency and surfacing a confusing "wedged framebuffer" error instead of the original timeout.

**Fix:** wrap the `awaitFirstRealFrame` call in a try/catch that calls `killEmulatorQuietly` before re-throwing.

### H2 — `awaitFirstRealFrame` budget not clamped against `overallDeadline`

Every `attemptBoot` stage clamps via `Math.min(params.attemptDeadline, …)`. `awaitFirstRealFrame` received the fixed `STAGE_BUDGET.firstRealFrame` (90 s) with no knowledge of `overallDeadline`, allowing total wall time to silently exceed `bootTimeoutMs` by up to 90 s — violating the documented contract and the Zod schema's `max(900_000)`.

**Fix:** pass `Math.min(STAGE_BUDGET.firstRealFrame, Math.max(0, overallDeadline - Date.now()))`.

### H3 — `ARGENT_SIMULATOR_SERVER_DIR` semantic changed without migration hint

The env var previously pointed directly at the directory containing `simulator-server`; it now points at the root of the per-platform tree. A user with the old flat layout gets a bare "binary not found" with no explanation of what changed.

**Fix:** detect the old flat layout and include a migration hint in the error message; update the env var's doc comment.

### M4 — `ARGENT_EMULATOR_NO_WINDOW=false` silently enables headless mode

`selectExtraEmulatorArgs` used a deny-list (`!== "0"`) so `"false"` and `"no"` — natural shell idioms for "disabled" — both mapped to `-no-window`. Test suite covered `""`, `"   "`, `"0"` but not `"false"`.

**Fix:** switch to an allowlist `["1", "true", "yes"]`; add `"false"` and `"no"` to the parameterized off-test.

### M5 — `bootstrapDylibPathTcp` / `nativeDevtoolsDylibPathTcp` missing `requireDarwin`

All six non-TCP dylib/binary exports gained explicit `requireDarwin()` guards in #249. The two TCP dylib exports did not. A Linux caller gets "dylib not found" instead of "requires macOS host".

**Fix:** add `requireDarwin()` as the first statement in both TCP dylib functions; add a test.

### S7 (bonus) — `selectGpuMode` validation fires mid-function after slow I/O

`selectGpuMode()` and `selectExtraEmulatorArgs()` were called inside deep nested code after several seconds of I/O. A typo in `ARGENT_EMULATOR_GPU_MODE` surfaced late with a spurious "emulator has been terminated" suffix appended.

**Fix:** call both once at the top of `bootAndroidImpl`, just after `ensureDep`, and reuse the captured values — eliminates the late error and the redundant double-call.

## Test plan

- `npm run test -w @argent/tool-server` — **847 passed** (was 845; +2 for `false`/`no` NO_WINDOW cases)
- `npm run test -w @argent/native-devtools-ios` — **10 passed** (was 8; +2 for TCP dylib darwin gate and migration hint)