### PR TITLE
feat(link): accept a full http(s):// URL target (reverse proxy / tunnel)

### DIFF
--- a/packages/argent-cli/src/link.ts
+++ b/packages/argent-cli/src/link.ts
@@ -5,7 +5,7 @@ import {
   writeLinkConfig,
   clearLinkConfig,
   formatToolsServerUrl,
-  parseLinkUrl,
+  parseLinkTarget,
   type LinkConfig,
 } from "@argent/tools-client";
 import { parsePort, StartFlagError } from "./server.js";
@@ -14,6 +14,8 @@ interface LinkFlags {
   host: string | null;
   port: number | null;
   token: string | null;
+  /** Canonical URL when a full http(s):// or argent:// target was given. */
+  url: string | null;
   yes: boolean;
   noVerify: boolean;
   help: boolean;
@@ -55,6 +57,7 @@ export function parseLinkFlags(argv: string[]): LinkFlags {
     host: null,
     port: null,
     token: null,
+    url: null,
     yes: false,
     noVerify: false,
     help: false,
@@ -104,18 +107,20 @@ export function parseLinkFlags(argv: string[]): LinkFlags {
       flags.token = tok.slice("--token=".length);
       continue;
     }
-    // Positional argent://[<token>@]<host>:<port> connection string. parseLinkUrl
-    // throws on a malformed argent:// URL and returns null for anything else.
+    // Positional target: an argent://[<token>@]<host>:<port> pairing string or a
+    // full http(s):// URL (for a reverse proxy / tunnel). parseLinkTarget throws
+    // on a malformed recognized URL and returns null for anything else.
     if (!tok.startsWith("-")) {
-      const parsed = parseLinkUrl(tok);
+      const parsed = parseLinkTarget(tok);
       if (!parsed) {
         throw new StartFlagError(
-          `Unrecognized argument "${tok}". Expected an argent://[<token>@]<host>:<port> ` +
-            `connection string or flags (see --help).`
+          `Unrecognized argument "${tok}". Expected an argent://… pairing string, ` +
+            `an http(s):// URL, or flags (see --help).`
         );
       }
       flags.host = validateHost(parsed.host);
       flags.port = validateConnectPort(String(parsed.port));
+      flags.url = parsed.url;
       if (parsed.token) flags.token = parsed.token;
       continue;
     }
@@ -142,15 +147,23 @@ export function parseUnlinkFlags(argv: string[]): UnlinkFlags {
 }
 
 export function printLinkHelp(): void {
-  console.log(`Usage: argent link [argent://[<token>@]<host>:<port>] [flags]
+  console.log(`Usage: argent link [<target>] [flags]
 
 Route argent client requests (argent tools / run / mcp) to a remote tool-server
 instead of auto-spawning a local one. The target is persisted to ~/.argent/link.json
 and survives shell restarts.
 
-The easiest path is to paste the connection string that \`argent server start\`
-prints (it carries host, port, and auth token):
+<target> may be:
+  - argent://[<token>@]<host>:<port>   the string \`argent server start\` prints
+  - http(s)://<host>[:<port>][/path]   a full URL — use this for a reverse proxy
+                                       or tunnel (ngrok, cloudflared, nginx). The
+                                       scheme and any path prefix are preserved;
+                                       requests go to <url>/tools.
+
+The easiest LAN path is to paste the connection string from \`argent server start\`:
   argent link argent://<token>@10.0.0.42:3001
+For a tunnel, point at its public URL and pass the server's token:
+  argent link https://argent.example.com --token <token>
 
 Resolution order for the tool-server URL:
   1. ARGENT_TOOLS_URL environment variable (highest precedence)
@@ -172,6 +185,8 @@ Flags:
 
 Examples:
   argent link argent://ab12…c2@10.0.0.42:3001   Pair from a server-start string.
+  argent link https://argent.example.com --token ab12…c2
+                                             Link through an HTTPS tunnel/proxy.
   argent link                                Interactive prompts for host and port.
   argent link --host 10.0.0.42 --port 3001   Confirms interactively, then saves.
   argent link --host 10.0.0.42 --token ab12…c2 --yes
@@ -180,9 +195,9 @@ Examples:
                                              Saves immediately, no health check.
 
 Security:
-  The token (if any) is stored 0600 and sent as a bearer header. Traffic is
-  still plain HTTP with no TLS — treat any non-loopback link as
-  trusted-network-only.
+  The token (if any) is stored 0600 and sent as a bearer header. An http:// link
+  has no TLS — treat any non-loopback http link as trusted-network-only. Prefer
+  an https:// tunnel/proxy when crossing untrusted networks.
 
 Notes:
   - If ARGENT_TOOLS_URL is also set in your environment, it overrides the link.
@@ -297,13 +312,27 @@ function printRestartHint(): void {
   );
 }
 
-function printSecurityCaveat(host: string, token: string | undefined): void {
+function printSecurityCaveat(host: string, token: string | undefined, url: string): void {
   if (isLoopback(host)) return;
+  const tls = url.startsWith("https://");
+  if (tls) {
+    // TLS handles transport security; nothing alarming to add beyond the
+    // (already required) token for a public endpoint.
+    if (!token) {
+      process.stderr.write(
+        pc.yellow(
+          `WARNING: ${host} is reached over HTTPS but with NO token — anyone who can ` +
+            `reach the URL can drive the server. Pair with a token.\n`
+        )
+      );
+    }
+    return;
+  }
   if (token) {
     process.stderr.write(
       pc.dim(
         `Note: ${host} is reached over plain HTTP (bearer-token auth, no TLS). ` +
-          `Keep this link to a trusted network or VPN.\n`
+          `Keep this link to a trusted network or VPN, or front it with an https:// tunnel.\n`
       )
     );
     return;
@@ -373,7 +402,9 @@ export async function link(argv: string[]): Promise<void> {
     flags.token ??
     (existing && existing.host === host && existing.port === port ? existing.token : undefined);
 
-  let url = formatToolsServerUrl(host, port);
+  // A full http(s):// / argent:// target carries its own canonical URL (scheme,
+  // optional path); the --host/--port path builds a plain http://host:port.
+  let url = flags.url ?? formatToolsServerUrl(host, port);
 
   // Overwrite confirmation (interactive only)
   if (!flags.yes && existing) {
@@ -462,7 +493,7 @@ export async function link(argv: string[]): Promise<void> {
     console.log(`${pc.green("✓")} Linked: ${pc.cyan(url)}`);
   }
   if (token) console.log(pc.dim("  auth: token stored in ~/.argent/link.json (0600)"));
-  printSecurityCaveat(host, token);
+  printSecurityCaveat(host, token, url);
   if (process.env.ARGENT_TOOLS_URL) {
     console.log(
       pc.yellow(

--- a/packages/argent-cli/test/parse-link-flags.test.ts
+++ b/packages/argent-cli/test/parse-link-flags.test.ts
@@ -8,6 +8,7 @@ describe("parseLinkFlags — defaults", () => {
       host: null,
       port: null,
       token: null,
+      url: null,
       yes: false,
       noVerify: false,
       help: false,
@@ -41,6 +42,7 @@ describe("parseLinkFlags — flag forms", () => {
       host: "10.0.0.42",
       port: 4567,
       token: null,
+      url: null,
       yes: true,
       noVerify: true,
       help: false,
@@ -52,11 +54,27 @@ describe("parseLinkFlags — flag forms", () => {
     expect(parseLinkFlags(["--token=ab12cd"]).token).toBe("ab12cd");
   });
 
-  it("parses an argent:// connection string into host, port, and token", () => {
+  it("parses an argent:// connection string into host, port, token, and url", () => {
     const flags = parseLinkFlags(["argent://tok_abc@10.0.0.42:3001"]);
     expect(flags.host).toBe("10.0.0.42");
     expect(flags.port).toBe(3001);
     expect(flags.token).toBe("tok_abc");
+    expect(flags.url).toBe("http://10.0.0.42:3001");
+  });
+
+  it("parses a full https:// URL into url + derived host/port", () => {
+    const flags = parseLinkFlags(["https://argent.example.com"]);
+    expect(flags.url).toBe("https://argent.example.com");
+    expect(flags.host).toBe("argent.example.com");
+    expect(flags.port).toBe(443);
+  });
+
+  it("preserves an explicit port and path on a full URL, and reads a userinfo token", () => {
+    const flags = parseLinkFlags(["https://tok_xyz@proxy.example.com:8443/argent"]);
+    expect(flags.url).toBe("https://proxy.example.com:8443/argent");
+    expect(flags.host).toBe("proxy.example.com");
+    expect(flags.port).toBe(8443);
+    expect(flags.token).toBe("tok_xyz");
   });
 
   it("parses an argent:// connection string without a token", () => {

--- a/packages/argent-tools-client/src/index.ts
+++ b/packages/argent-tools-client/src/index.ts
@@ -37,10 +37,12 @@ export {
   isRemoteRouted,
   formatLinkUrl,
   parseLinkUrl,
+  parseLinkTarget,
   LINK_PATHS,
   LINK_URL_SCHEME,
   type LinkConfig,
   type ResolvedToolsUrl,
   type ToolsUrlSource,
   type ParsedLinkUrl,
+  type ParsedLinkTarget,
 } from "./link-config.js";

--- a/packages/argent-tools-client/src/link-config.ts
+++ b/packages/argent-tools-client/src/link-config.ts
@@ -171,3 +171,61 @@ export function parseLinkUrl(input: string): ParsedLinkUrl | null {
   const token = u.username ? decodeURIComponent(u.username) : undefined;
   return { host, port, ...(token ? { token } : {}) };
 }
+
+// ── Full-URL targets ────────────────────────────────────────────────────
+// `argent link` also accepts a full http(s) URL so it can point at a reverse
+// proxy / tunnel (ngrok, cloudflared, nginx) rather than only a bare host:port.
+
+export interface ParsedLinkTarget {
+  /** Canonical URL to persist and hit verbatim (no trailing slash). */
+  url: string;
+  /** Hostname (for display, the loopback check, and re-prompt defaults). */
+  host: string;
+  /** Port — explicit, or the scheme default (443 for https, 80 for http). */
+  port: number;
+  token?: string;
+}
+
+function httpFromHostPort(host: string, port: number): string {
+  const h = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return `http://${h}:${port}`;
+}
+
+/**
+ * Parse a `link` target. Accepts:
+ *   - argent://[<token>@]<host>:<port>  — the server-start pairing string (→ http)
+ *   - http://… / https://…              — a full URL (scheme, host, optional port + path)
+ *
+ * Returns null for anything else (e.g. a bare host, so the caller can fall back
+ * to --host/--port). Throws on a recognized-but-malformed URL.
+ */
+export function parseLinkTarget(input: string): ParsedLinkTarget | null {
+  // argent:// → http://host:port (parseLinkUrl throws on a malformed argent URL).
+  const argent = parseLinkUrl(input);
+  if (argent) {
+    return {
+      url: httpFromHostPort(argent.host, argent.port),
+      host: argent.host,
+      port: argent.port,
+      ...(argent.token ? { token: argent.token } : {}),
+    };
+  }
+
+  if (!/^https?:\/\//i.test(input)) return null;
+  let u: URL;
+  try {
+    u = new URL(input);
+  } catch {
+    throw new Error(`Invalid URL "${input}" — expected http(s)://<host>[:<port>][/path].`);
+  }
+  const host = u.hostname.startsWith("[") ? u.hostname.slice(1, -1) : u.hostname;
+  if (!host) throw new Error(`URL "${input}" is missing a host.`);
+  const port = u.port ? Number(u.port) : u.protocol === "https:" ? 443 : 80;
+  // Canonical: scheme + host (keeps an explicit non-default port) + path,
+  // dropping a bare trailing slash and any query/fragment. `${url}/tools` then
+  // composes cleanly even when the proxy mounts the server under a path prefix.
+  const path = u.pathname === "/" ? "" : u.pathname.replace(/\/+$/, "");
+  const url = `${u.protocol}//${u.host}${path}`;
+  const token = u.username ? decodeURIComponent(u.username) : undefined;
+  return { url, host, port, ...(token ? { token } : {}) };
+}

--- a/packages/argent-tools-client/test/link-config.test.ts
+++ b/packages/argent-tools-client/test/link-config.test.ts
@@ -274,3 +274,56 @@ describe("connection string (argent://)", () => {
     expect(() => linkConfig.parseLinkUrl("argent://10.0.0.42")).toThrow();
   });
 });
+
+describe("parseLinkTarget (full URL)", () => {
+  it("maps argent:// to an http URL", () => {
+    expect(linkConfig.parseLinkTarget("argent://tok@10.0.0.42:3001")).toEqual({
+      url: "http://10.0.0.42:3001",
+      host: "10.0.0.42",
+      port: 3001,
+      token: "tok",
+    });
+  });
+
+  it("parses an https URL with default port", () => {
+    expect(linkConfig.parseLinkTarget("https://argent.example.com")).toEqual({
+      url: "https://argent.example.com",
+      host: "argent.example.com",
+      port: 443,
+    });
+  });
+
+  it("preserves explicit port + path and strips a trailing slash", () => {
+    expect(linkConfig.parseLinkTarget("https://proxy.example.com:8443/argent/")).toEqual({
+      url: "https://proxy.example.com:8443/argent",
+      host: "proxy.example.com",
+      port: 8443,
+    });
+  });
+
+  it("reads a userinfo token on an http(s) URL", () => {
+    expect(linkConfig.parseLinkTarget("https://tok_xyz@proxy.example.com")).toEqual({
+      url: "https://proxy.example.com",
+      host: "proxy.example.com",
+      port: 443,
+      token: "tok_xyz",
+    });
+  });
+
+  it("brackets/keeps IPv6 hosts", () => {
+    expect(linkConfig.parseLinkTarget("http://[::1]:3001")).toEqual({
+      url: "http://[::1]:3001",
+      host: "::1",
+      port: 3001,
+    });
+  });
+
+  it("returns null for a bare host or unknown scheme", () => {
+    expect(linkConfig.parseLinkTarget("10.0.0.42")).toBeNull();
+    expect(linkConfig.parseLinkTarget("ftp://example.com")).toBeNull();
+  });
+
+  it("throws on a malformed argent:// target (delegates to parseLinkUrl)", () => {
+    expect(() => linkConfig.parseLinkTarget("argent://10.0.0.42")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on **#182** (`feat/argent-server-start`). Lets `argent link` point at a tool-server behind a reverse proxy or tunnel (ngrok, cloudflared, nginx, Tailscale Funnel), not only a bare LAN `host:port`.

Today the link model only encodes `http://<host>:<port>`, so an HTTPS tunnel like `https://argent.example.com` can't be persisted by `argent link` — you have to fall back to `ARGENT_TOOLS_URL` + `ARGENT_AUTH_TOKEN` env vars. This makes the full-URL case first-class.

## What changed

- **`parseLinkTarget(input)`** (`@argent/tools-client`) accepts:
  - `argent://[<token>@]<host>:<port>` — the `server start` pairing string (→ `http`)
  - `http(s)://<host>[:<port>][/path]` — a full URL
  It preserves the scheme, an explicit non-default port, and a path prefix (requests compose as `<url>/tools`), strips a bare trailing slash, and reads an optional userinfo token.
- **`argent link <url>`** persists the canonical URL to `~/.argent/link.json` and hits it verbatim on the pre-flight; `tools-client` / `mcp-server` already consume `link.url` verbatim, so remote routing + bearer auth flow through unchanged.
- **Security note is scheme-aware**: no "no TLS" nag for `https://`; still warns on a tokenless public endpoint.

## Usage

```
# HTTPS tunnel / proxy:
argent link https://argent.example.com --token <token>
# argent:// pairing string (unchanged):
argent link argent://<token>@10.0.0.42:3001
```

For a reverse proxy, the proxy must present a Host the tool-server's DNS-rebinding guard accepts — rewrite the upstream Host to loopback (`nginx: proxy_set_header Host 127.0.0.1:3001;`, `ngrok --host-header=rewrite`) or bind `--host 0.0.0.0` (guard disabled) behind a firewall.

## Test plan

- [x] `parseLinkTarget` unit tests: argent://, https default port, explicit port + path + trailing-slash strip, userinfo token, IPv6, bare-host/unknown-scheme → null, malformed argent:// throws
- [x] `parseLinkFlags` accepts a full https URL (derives host/port, reads token)
- [x] tools-client (77), cli (112), mcp (65), tool-server suites pass; `tsc --build` + prettier clean

> Note: traffic security for the `http://` case is unchanged (plain HTTP) — the win here is that `https://` tunnels are now expressible and the token rides along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)