### PR TITLE
fix(boot-device): refresh stale native-devtools/ax-service after a reboot

### DIFF
--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -1,7 +1,7 @@
 import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { z } from "zod";
-import type { Registry, ToolCapability, ToolDefinition } from "@argent/registry";
+import type { DeviceInfo, Registry, ToolCapability, ToolDefinition } from "@argent/registry";
 import {
   buildInitFailedResult,
   nativeDevtoolsRef,
@@ -9,6 +9,7 @@ import {
   type NativeDevtoolsInitFailedResult,
 } from "../../blueprints/native-devtools";
 import {
+  axServiceRef,
   ensureAutomationEnabled,
   isEntitlementBypassActive,
   setAccessibilityPrefsPreBoot,
@@ -420,6 +421,33 @@ async function bootIos(
   // prefs via `defaults write` — SB won't pick them up until next restart,
   // but describe surfaces a hint about it.
   await ensureAutomationEnabled(udid).catch(() => undefined);
+
+  // A real (re)boot resets the simulator's launchd environment and restarts
+  // SpringBoard/cfprefsd, which invalidates any per-device service cached from
+  // a previous boot of this udid:
+  //   - native-devtools latches `envSetup=true` after its first successful
+  //     setup and never re-runs `ensureEnv`, so the DYLD_INSERT_LIBRARIES the
+  //     reboot just cleared is never restored — injection silently breaks while
+  //     `native-devtools-status` keeps reporting `envSetup: true`.
+  //   - ax-service computes `degraded` once at factory time and holds a daemon
+  //     socket bound to the now-dead boot, so `describe` returns an empty tree
+  //     and a stale "was not booted through argent" hint.
+  // Dispose both (every transport variant) so the next resolve rebuilds them
+  // against the fresh boot. The native-devtools resolve immediately below then
+  // re-runs `ensureEnv` and re-establishes injection. Guarded because a service
+  // that was never resolved this session isn't in the registry.
+  if (needsPreBoot) {
+    const rebootedDevice: DeviceInfo = { id: udid, platform: "ios", kind: "simulator" };
+    const staleRefs = [
+      nativeDevtoolsRef(rebootedDevice),
+      nativeDevtoolsRef(rebootedDevice, { transport: "tcp" }),
+      axServiceRef(rebootedDevice),
+      axServiceRef(rebootedDevice, { transport: "tcp" }),
+    ];
+    for (const ref of staleRefs) {
+      await registry.disposeService(ref.urn).catch(() => undefined);
+    }
+  }
 
   const ndRef = nativeDevtoolsRef({ id: udid, platform: "ios", kind: "simulator" });
   const ndApi = await registry.resolveService<NativeDevtoolsApi>(ndRef.urn, ndRef.options);

--- a/packages/tool-server/test/boot-device.test.ts
+++ b/packages/tool-server/test/boot-device.test.ts
@@ -38,7 +38,22 @@ vi.mock("../src/blueprints/ax-service", () => ({
   setAccessibilityPrefsPreBoot: (...args: unknown[]) => setAccessibilityPrefsPreBootMock(...args),
   ensureAutomationEnabled: (...args: unknown[]) => ensureAutomationEnabledMock(...args),
   isEntitlementBypassActive: (...args: unknown[]) => isEntitlementBypassActiveMock(...args),
+  axServiceRef: (device: { id: string }, opts?: { transport?: string }) => ({
+    urn: `AXService:${device.id}${opts?.transport === "tcp" ? ":tcp" : ""}`,
+    options: { device, transport: opts?.transport ?? "unix" },
+  }),
 }));
+
+// boot-device disposes stale per-device services before re-resolving them, so
+// the registry mock needs a disposeService. A shared helper keeps every iOS
+// test's registry consistent and lets a test reach into the dispose calls.
+function makeRegistry(resolveService: ReturnType<typeof vi.fn>): {
+  registry: Registry;
+  disposeService: ReturnType<typeof vi.fn>;
+} {
+  const disposeService = vi.fn().mockResolvedValue(undefined);
+  return { registry: { resolveService, disposeService } as unknown as Registry, disposeService };
+}
 
 import { createBootDeviceTool } from "../src/tools/devices/boot-device";
 import { __primeDepCacheForTests, __resetDepCacheForTests } from "../src/utils/check-deps";
@@ -83,6 +98,7 @@ describe("boot-device — iOS path", () => {
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
     const registry = {
       resolveService,
+      disposeService: vi.fn().mockResolvedValue(undefined),
     } as unknown as Registry;
 
     const tool = createBootDeviceTool(registry);
@@ -144,7 +160,10 @@ describe("boot-device — iOS path", () => {
 
   it("skips pre-boot plist write when the sim is already Booted and falls back to ensureAutomationEnabled", async () => {
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
-    const registry = { resolveService } as unknown as Registry;
+    const registry = {
+      resolveService,
+      disposeService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
     await tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222" });
@@ -164,7 +183,10 @@ describe("boot-device — iOS path", () => {
     listIosSimulatorsMock.mockResolvedValueOnce([]);
 
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
-    const registry = { resolveService } as unknown as Registry;
+    const registry = {
+      resolveService,
+      disposeService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
     await tool.execute!({}, { udid: "44444444-4444-4444-4444-444444444444" });
@@ -181,7 +203,10 @@ describe("boot-device — iOS path", () => {
     setAccessibilityPrefsPreBootMock.mockRejectedValueOnce(new Error("plutil missing"));
 
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
-    const registry = { resolveService } as unknown as Registry;
+    const registry = {
+      resolveService,
+      disposeService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
     await expect(
@@ -203,7 +228,10 @@ describe("boot-device — iOS path", () => {
         givenUp: true,
       }),
     }));
-    const registry = { resolveService } as unknown as Registry;
+    const registry = {
+      resolveService,
+      disposeService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Registry;
 
     const tool = createBootDeviceTool(registry);
 
@@ -230,7 +258,10 @@ describe("boot-device — iOS path", () => {
       });
 
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
-    const registry = { resolveService } as unknown as Registry;
+    const registry = {
+      resolveService,
+      disposeService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Registry;
 
     const tool = createBootDeviceTool(registry);
 
@@ -257,7 +288,10 @@ describe("boot-device — iOS path", () => {
 
   it("force=true on a Booted sim triggers shutdown → pre-boot write → boot", async () => {
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
-    const registry = { resolveService } as unknown as Registry;
+    const registry = {
+      resolveService,
+      disposeService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
     await expect(
@@ -284,7 +318,10 @@ describe("boot-device — iOS path", () => {
 
   it("force not set on a Booted sim does not shut down", async () => {
     const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
-    const registry = { resolveService } as unknown as Registry;
+    const registry = {
+      resolveService,
+      disposeService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
     await tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222" });
@@ -295,6 +332,59 @@ describe("boot-device — iOS path", () => {
       (args: unknown[]) => Array.isArray(args) && args[1] === "shutdown"
     );
     expect(hasShutdown).toBe(false);
+  });
+
+  // Regression: a sim reboot resets launchd (clearing DYLD_INSERT_LIBRARIES)
+  // and restarts SpringBoard, but native-devtools latches `envSetup=true` and
+  // ax-service freezes `degraded` at factory time — so a cached instance from
+  // the previous boot keeps injection broken and `describe` empty with no
+  // self-recovery. boot-device must evict those services on a real (re)boot so
+  // the next resolve rebuilds them against the fresh boot.
+  it("force=true disposes the stale native-devtools and ax-service before re-resolving them", async () => {
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const { registry, disposeService } = makeRegistry(resolveService);
+    const tool = createBootDeviceTool(registry);
+
+    await tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222", force: true });
+
+    const disposed = disposeService.mock.calls.map(([urn]) => urn);
+    expect(disposed).toEqual(
+      expect.arrayContaining([
+        "NativeDevtools:22222222-2222-2222-2222-222222222222",
+        "NativeDevtools:22222222-2222-2222-2222-222222222222:tcp",
+        "AXService:22222222-2222-2222-2222-222222222222",
+        "AXService:22222222-2222-2222-2222-222222222222:tcp",
+      ])
+    );
+    // The unix native-devtools must be torn down BEFORE it is re-resolved,
+    // otherwise the rebuilt instance would re-use the latched (stale) state.
+    const disposeOrder = disposeService.mock.invocationCallOrder[0]!;
+    const resolveOrder = resolveService.mock.invocationCallOrder[0]!;
+    expect(disposeOrder).toBeLessThan(resolveOrder);
+  });
+
+  it("disposes stale services when booting a Shutdown sim", async () => {
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const { registry, disposeService } = makeRegistry(resolveService);
+    const tool = createBootDeviceTool(registry);
+
+    await tool.execute!({}, { udid: "11111111-1111-1111-1111-111111111111" });
+
+    const disposed = disposeService.mock.calls.map(([urn]) => urn);
+    expect(disposed).toContain("NativeDevtools:11111111-1111-1111-1111-111111111111");
+    expect(disposed).toContain("AXService:11111111-1111-1111-1111-111111111111");
+  });
+
+  it("does NOT dispose services when an already-Booted sim is booted without force", async () => {
+    // No reboot happened (needsPreBoot is false), so the running services are
+    // still valid — tearing them down would needlessly drop a live injection.
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const { registry, disposeService } = makeRegistry(resolveService);
+    const tool = createBootDeviceTool(registry);
+
+    await tool.execute!({}, { udid: "22222222-2222-2222-2222-222222222222" });
+
+    expect(disposeService).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Found while regression-testing Argent **0.10.0** on an iOS 26.4 sim. A simulator reboot leaves the cached per-device services stale, which silently breaks **all native-devtools tools** (`describe` app-scope, `native-describe-screen`, `native-full-hierarchy`, `native-network-logs`) and the injection path, with **no automatic recovery**.

This started as the "ax-service problem" (empty `describe` tree + a misleading hint) but the root cause is shared by `native-devtools`, so the fix lives in `boot-device`.

## Root cause

A reboot resets the simulator's launchd environment (clearing `DYLD_INSERT_LIBRARIES`) and restarts SpringBoard/cfprefsd. The services cached in the Registry from the previous boot are never refreshed:

- **native-devtools** latches `envSetup = true` after its first successful setup (`ensureEnvReady()` early-returns on the latch). After a reboot wipes `DYLD_INSERT_LIBRARIES`, it is never re-written → injection silently breaks, while `native-devtools-status` keeps reporting `envSetup: true` (it returns the stale latch, not a live check). `restart-app` can never re-inject.
- **ax-service** computes `degraded = !entitlementBypassActive` **once at factory time** and holds a daemon socket bound to the now-dead boot → `describe` gets an empty AX tree, falls back to native-devtools, and attaches the stale hint: *"This simulator was not booted through argent … call boot-device with force=true"* — even when it **was** just booted through argent. The advised remedy (`force=true`) hits the very same bug, so the user is stuck.

`boot-device force=true` reproduces it every time: it reboots inside the tool but reuses the cached services. A full `shutdown → boot` happens to recover only because the daemon process exits, fires `terminated`, and the registry tears the service down — so the next resolve rebuilds fresh.

### Reproduction (live, Argent 0.10.0, iPhone 17 Pro / iOS 26.4)
1. `boot-device { force: true }` on a booted sim.
2. ``xcrun simctl spawn <udid> launchctl getenv DYLD_INSERT_LIBRARIES`` → **empty**.
3. `native-devtools-status` → `{ envSetup: true, connected: false, requiresRestart: true }` (false positive).
4. `restart-app` → still `connected: false`.
5. `describe` → full native-devtools tree **plus** the "not booted through argent / force=true" hint.

A clean `shutdown` + `boot-device` (no force) restores `DYLD_INSERT_LIBRARIES` and `connected: true` — confirming the cached-service staleness is the cause.

## Fix

On the real (re)boot paths (`needsPreBoot`: Shutdown, or `force` + Booted), `bootIos` disposes the cached `native-devtools` and `ax-service` services (every transport variant) **before** re-resolving, so the next resolve rebuilds them against the fresh boot. The native-devtools resolve immediately after re-runs `ensureEnv` and re-establishes injection. The already-Booted-without-force path does not reboot, so it leaves the live services untouched.

Uses the existing `Registry.disposeService(urn)` (returns the service to IDLE for re-resolution); guarded so a never-resolved service is a no-op.

## Tests

`packages/tool-server/test/boot-device.test.ts` (+3):
- `force=true` disposes both services (unix + tcp) and disposes **before** re-resolving native-devtools.
- booting a Shutdown sim disposes the stale services.
- already-Booted-without-force does **not** dispose (live injection preserved).

All boot-device / describe / ax-service suites pass; `tsc` + test typecheck clean.

## Status — DRAFT

⚠️ Verified via root-cause analysis (OS-level `DYLD` inspection), the contrasting working `shutdown→boot` path, and unit tests. **Not yet verified end-to-end through the live MCP server**, since that runs the published 0.10.0 package rather than this build. Needs a from-source MCP run (`force` reboot → confirm `DYLD` repopulated + `describe` clean) before un-drafting.

Follow-ups worth considering separately:
- Make `native-devtools-status.envSetup` a live probe rather than the cached latch.
- Make ax-service `degraded` reflect current pref state instead of factory-time only.