### PR TITLE
fix(release): ship ax-service in bin/darwin/ so describe works in published packages

### DIFF
--- a/packages/argent/test/package-manifest.test.ts
+++ b/packages/argent/test/package-manifest.test.ts
@@ -13,3 +13,61 @@ describe("package manifest", () => {
     expect(pkg.files).toContain("skills/");
   });
 });
+
+// Regression guard for the ax-service-missing-from-release bug (first shipped
+// in 0.9.0). The Linux-support layout migration (#249) moved the ax-service
+// lookup to the per-platform `bin/<platform>/` directory — `axServiceBinaryPath()`
+// resolves `bin/darwin/ax-service` and `bundle-tools.cjs` copies the published
+// binary FROM `bin/darwin/ax-service` — but `download-native-binaries.sh` (the
+// path the standard `pack`/CI release uses) kept writing the downloaded binary
+// to the flat `bin/` root. The producer and consumer disagreed, so the bundler
+// found nothing under darwin/, skipped the copy with only a warning, and every
+// release silently shipped without ax-service. `describe`'s primary path then
+// failed and fell back to native-devtools (or an empty tree), with a misleading
+// "not booted through argent" hint. This test pins the producer→consumer path
+// agreement so the two can never drift apart again.
+describe("ax-service native-binary placement (producer/consumer path agreement)", () => {
+  const workspaceRoot = path.resolve(import.meta.dirname, "..", "..", "..");
+  const downloadScript = fs.readFileSync(
+    path.join(workspaceRoot, "scripts/download-native-binaries.sh"),
+    "utf8"
+  );
+  const bundleTools = fs.readFileSync(
+    path.join(workspaceRoot, "packages/argent/scripts/bundle-tools.cjs"),
+    "utf8"
+  );
+
+  // Resolve a `FOO="..."` shell assignment, expanding any ${VARS} already known.
+  function shVar(src: string, name: string, known: Record<string, string>): string {
+    const m = src.match(new RegExp(`^${name}="([^"]*)"`, "m"));
+    if (!m) throw new Error(`assignment ${name}=... not found`);
+    return m[1].replace(/\$\{(\w+)\}/g, (_, v) => {
+      if (!(v in known)) throw new Error(`unknown var ${v} while expanding ${name}`);
+      return known[v];
+    });
+  }
+
+  it("download-native-binaries.sh writes ax-service into bin/darwin/, matching bundle-tools.cjs", () => {
+    // Producer: where the release-download script puts ax-service.
+    const BIN_DIR = shVar(downloadScript, "BIN_DIR", {});
+    const IOS_BIN_DIR = shVar(downloadScript, "IOS_BIN_DIR", { BIN_DIR });
+    // The ax-service download block must target IOS_BIN_DIR, not the flat root.
+    const axBlock = downloadScript.slice(downloadScript.indexOf('--pattern "ax-service"'));
+    const dirMatch = axBlock.match(/--dir "\$\{(\w+)\}"/);
+    expect(dirMatch?.[1]).toBe("IOS_BIN_DIR");
+    const producerDir = IOS_BIN_DIR; // packages/native-devtools-ios/bin/darwin
+
+    // Consumer: where bundle-tools copies the published binary FROM.
+    const binSrcRoot = bundleTools.match(/BIN_SRC_ROOT = path\.resolve\([^,]+,\s*"([^"]+)"\)/)?.[1];
+    const axSrcRel = bundleTools.match(
+      /AX_BIN_SRC = path\.resolve\(BIN_SRC_ROOT,\s*"([^"]+)"\)/
+    )?.[1];
+    expect(binSrcRoot).toBe("packages/native-devtools-ios/bin");
+    expect(axSrcRel).toBe("darwin/ax-service");
+    const consumerFile = path.posix.join(binSrcRoot!, axSrcRel!);
+
+    // The two MUST agree: producer dir + ax-service === consumer source file.
+    expect(path.posix.join(producerDir, "ax-service")).toBe(consumerFile);
+    expect(producerDir.endsWith("/darwin")).toBe(true);
+  });
+});

--- a/scripts/download-native-binaries.sh
+++ b/scripts/download-native-binaries.sh
@@ -25,12 +25,21 @@ fi
 
 DYLIBS_DIR="packages/native-devtools-ios/dylibs"
 BIN_DIR="packages/native-devtools-ios/bin"
+# ax-service is macOS-only (it spawns inside an iOS Simulator), so it lives
+# under the darwin/ host-platform subdirectory — matching what
+# axServiceBinaryPath() resolves (bin/<platform>/ax-service) and what
+# packages/argent/scripts/bundle-tools.cjs copies into the published package
+# (bin/darwin/ax-service). Writing it to the flat bin/ root instead silently
+# drops it from every release: bundle-tools looks under darwin/, finds nothing,
+# and skips the copy, so describe's ax-service path is unusable (regressed in
+# the Linux-support layout migration, #249).
+IOS_BIN_DIR="${BIN_DIR}/darwin"
 ANDROID_DIST_DIR="packages/native-devtools-android/dist"
 ANDROID_MANIFEST_FILE="packages/native-devtools-android/manifest.json"
 
 echo "Downloading native binaries from ${REPO} (tag: ${TAG})..."
 
-mkdir -p "${DYLIBS_DIR}" "${BIN_DIR}" "${ANDROID_DIST_DIR}"
+mkdir -p "${DYLIBS_DIR}" "${BIN_DIR}" "${IOS_BIN_DIR}" "${ANDROID_DIST_DIR}"
 
 for DYLIB in libNativeDevtoolsIos.dylib libKeyboardPatch.dylib libArgentInjectionBootstrap.dylib; do
   echo "  Downloading ${DYLIB}..."
@@ -45,9 +54,9 @@ echo "  Downloading ax-service..."
 gh release download "${TAG}" \
   --repo "${REPO}" \
   --pattern "ax-service" \
-  --dir "${BIN_DIR}" \
+  --dir "${IOS_BIN_DIR}" \
   --clobber
-chmod +x "${BIN_DIR}/ax-service"
+chmod +x "${IOS_BIN_DIR}/ax-service"
 
 echo "  Downloading argent-android-devtools.apk..."
 # The release publishes the APK under a stable name (no versioning in the
@@ -68,10 +77,10 @@ ANDROID_TARGET="${ANDROID_DIST_DIR}/argent-android-devtools-${ANDROID_VERSION_NA
 mv -f "${TMP_APK}" "${ANDROID_TARGET}"
 trap - EXIT
 
-echo "Downloaded native binaries to ${DYLIBS_DIR}/, ${BIN_DIR}/, and ${ANDROID_DIST_DIR}/"
+echo "Downloaded native binaries to ${DYLIBS_DIR}/, ${IOS_BIN_DIR}/, and ${ANDROID_DIST_DIR}/"
 
 if command -v codesign &>/dev/null; then
-  for f in "${DYLIBS_DIR}"/*.dylib "${BIN_DIR}/ax-service"; do
+  for f in "${DYLIBS_DIR}"/*.dylib "${IOS_BIN_DIR}/ax-service"; do
     codesign -dvv "$f" 2>&1 || echo "Warning: signature verification failed for $f"
   done
 fi


### PR DESCRIPTION
## Summary

`describe` is broken in every published package since **0.9.0**: on a normally-booted simulator it returns only a bare `ROOT AXGroup` (empty tree) or silently falls back to native-devtools, always accompanied by the misleading hint *"this simulator was not booted through argent … call boot-device with force=true"* — even right after a forced argent boot, so there is no recovery.

**Root cause:** the published npm package is **missing the `ax-service` binary** entirely.

## Bisect

| Release | `ax-service` in tarball | `describe` |
|---|---|---|
| 0.7.1 | `bin/ax-service` (flat) ✅ | works |
| 0.8.1 | `bin/ax-service` (flat) ✅ | works |
| **0.9.0** | **absent** ❌ | **broken** |
| 0.10.0 | **absent** ❌ | **broken** |

- **Last good release:** 0.8.1
- **First broken release:** 0.9.0
- **Breaking commit:** `80661fad` — *feat: Linux support (#249)*

## Why it broke

#249 migrated native binaries to a per-platform `bin/<platform>/` layout and updated **two of the three** places that touch the ax-service path:

- `packages/native-devtools-ios/src/index.ts` — `axServiceBinaryPath()` now resolves `bin/darwin/ax-service` (was flat `bin/ax-service`).
- `packages/argent/scripts/bundle-tools.cjs` — copies the published binary **from** `bin/darwin/ax-service`.

…but it **did not** update `scripts/download-native-binaries.sh` — the script the standard `pack` / CI release path runs — which kept downloading ax-service to the **flat `bin/` root**.

Producer (download script) and consumer (bundler/resolver) disagreed. During `pack`, the bundler looked under `bin/darwin/`, found nothing, **warned and skipped the copy**, and the tarball shipped with no ax-service. At runtime the ax-service factory throws *(binary not found)* → `describe` catches it → empty tree + degraded hint → native-devtools fallback (which itself fails on plain screens like SpringBoard).

`pack:mcp:local` (which runs `build:ios-binaries` → `build.sh`, already writing to `bin/darwin/`) was unaffected — only released/downloaded builds were broken, which is why it wasn't caught locally.

## Fix

`download-native-binaries.sh` now downloads ax-service into `bin/darwin/`, matching the resolver and the bundler. Plus a regression test (`package-manifest.test.ts`) that pins the producer→consumer path agreement so the two scripts can't silently drift again (verified it fails on the pre-fix path and passes after).

## Verification

Rebuilt via **`npm run pack:mcp`** → tarball now contains `package/bin/darwin/ax-service` (byte-identical, signed Mach-O). Drove the **packaged** binary's `describe` RPC directly and via the full MCP `describe` tool:

- iPhone 17 Pro — iOS 26.4 → `source: ax-service`, full tree (32 elements), no degraded hint ✅
- iPhone Air — iOS 26.4 → `source: ax-service`, full tree ✅
- iPhone 16 Pro — iOS 18.5 → `source: ax-service`, full tree (33 elements) ✅

Before the fix all three returned a bare `ROOT AXGroup` (or native-devtools fallback) + the degraded hint.

Tests: `packages/tool-server` ax-service/describe suites (40) green; `packages/argent` suite (12, incl. new guard) green.

## Notes
- Script-only change to release tooling + one test; no runtime TS changes. The bundled `bin/` artifacts are gitignored (produced by `pack`), so the diff is just the script and the test.
- Independent of `fix/boot-device-refresh-stale-services` (stale-service eviction after reboot) — that fix can't help while the binary is absent from the package; both are needed for fully healthy `describe`.