### PR TITLE
fix(wayland-e2e): use ARGENT_PORT instead of PORT to start tool-server

### DIFF
--- a/.github/workflows/wayland-e2e.yml
+++ b/.github/workflows/wayland-e2e.yml
@@ -181,7 +181,7 @@ jobs:
           mkdir -p ~/.argent
           : > ~/.argent/tool-server.log
           cd packages/tool-server
-          nohup env PORT=3033 npx ts-node src/index.ts start \
+          nohup env ARGENT_PORT=3033 npx ts-node src/index.ts start \
             > ~/.argent/tool-server.log 2>&1 &
           echo "tool-server pid=$!"
           # Wait for /tools to respond.


### PR DESCRIPTION
## Summary
- The tool-server reads its port from `ARGENT_PORT` (index.ts:72), not the generic `PORT` env var
- The CI step was setting `PORT=3033` which the process silently ignored, causing it to bind on the default 3001
- The health-poll loop and every downstream curl targeted 3033, so startup always timed out