### PR TITLE
fix(boot-device): don't tear down a healthy-but-slow emulator on the final boot attempt

### DIFF
--- a/packages/skills/skills/argent-android-emulator-setup/SKILL.md
+++ b/packages/skills/skills/argent-android-emulator-setup/SKILL.md
@@ -26,4 +26,4 @@ Pass the Android serial as `udid` to the unified interaction tools — `gesture-
 - Serials are the adb device id. iOS UDIDs and Android serials are not interchangeable, but you do NOT need to tell the tools which platform — dispatch is automatic.
 - `describe` on Android returns a shallower tree than iOS (no accessibility-service equivalent), but covers most tap-target discovery.
 - `reinstall-app` on Android always installs with `-g` so first-launch runtime permissions are pre-granted.
-- To kill the emulator when you're done, run `adb -s <serial> emu kill` from a shell.
+- To stop the emulator, run `adb -s <serial> emu kill` from a shell (clean shutdown). Never `pkill -9`/`kill -9` qemu — a hard kill leaves the userdata image dirty, after which cold boots can hang for many minutes doing recovery (runaway writes, `boot_completed` never flips). If an image gets into that state, boot once with `-wipe-data` to reset it.

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -111,6 +111,7 @@ const STAGE_BUDGET = {
   adbRegister: 60_000, // adb devices sees the serial for this AVD
   deviceReady: 180_000, // adb -s wait-for-device returns (state === "device")
   bootCompleted: 300_000, // sys.boot_completed = 1
+  pmReady: 45_000, // pm path android answers (retried; non-fatal on the final attempt)
   firstRealFrame: 90_000, // screencap returns ≥1 non-zero pixel after cold boot
   firstRealFrameHot: 8_000, // tighter budget for snapshot-restore composite —
   // the broken state is sticky (per assertScreencapAlive's docstring), so a
@@ -461,6 +462,13 @@ async function attemptBoot(params: {
   adbRegisterBudgetMs: number;
   deviceReadyBudgetMs: number;
   bootCompletedBudgetMs: number;
+  // How long to keep retrying the PackageManager sanity probe before giving up.
+  pmProbeBudgetMs: number;
+  // Whether a PM probe that never succeeds should tear the emulator down and
+  // throw. True on the hot-boot attempt (so the caller can fall back to a cold
+  // boot); false on the final cold attempt, where a slow-but-alive guest is
+  // returned as booted rather than destroyed.
+  tearDownIfUnready: boolean;
 }): Promise<{ serial: string }> {
   const child = spawn(params.emulatorBinary, params.emulatorArgs, {
     detached: true,
@@ -574,25 +582,64 @@ async function attemptBoot(params: {
 
   // Stage 5: PackageManager sanity — a snapshot restore preserves
   // sys.boot_completed=1 so this is the first real proof the guest is live.
-  // Race against earlyExitError so a crash here surfaces with the actual
-  // signal/exit-code error, not a misleading "PackageManager did not respond".
-  const stage5Racer = createEarlyExitRacer(() => earlyExitError);
-  try {
-    await Promise.race([
-      adbShell(serial, "pm path android", { timeoutMs: 10_000 }),
-      stage5Racer.promise,
-    ]);
-  } catch (err) {
-    await killEmulatorQuietly(serial, child);
-    if (err instanceof Error && /^emulator binary (exited|terminated)/.test(err.message)) {
-      throw err;
+  // `pm` can take tens of seconds to answer on a loaded host or a freshly
+  // wiped image still finishing its first-boot package scan, even though the
+  // device is healthy and already registered with adb — so retry within a
+  // budget instead of failing on a single 10 s window. Each attempt races
+  // earlyExitError so a real crash surfaces with the actual signal/exit-code
+  // error rather than a misleading "PackageManager did not respond".
+  const pmBudgetMs = Math.max(10_000, params.pmProbeBudgetMs);
+  const pmDeadline = Math.min(params.attemptDeadline, Date.now() + pmBudgetMs);
+  let pmReady = false;
+  let pmCrash: Error | null = null;
+  while (Date.now() < pmDeadline && !earlyExitError) {
+    const stage5Racer = createEarlyExitRacer(() => earlyExitError);
+    try {
+      await Promise.race([
+        adbShell(serial, "pm path android", {
+          timeoutMs: Math.max(2_000, Math.min(10_000, pmDeadline - Date.now())),
+        }),
+        stage5Racer.promise,
+      ]);
+      pmReady = true;
+      break;
+    } catch (err) {
+      // A QEMU crash mid-probe is terminal — stop retrying and surface it below.
+      if (err instanceof Error && /^emulator binary (exited|terminated)/.test(err.message)) {
+        pmCrash = err;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 1_000));
+    } finally {
+      stage5Racer.cancel();
     }
-    throw new Error(
-      `PackageManager did not respond on ${serial} after boot_completed. ` +
-        `Emulator has been terminated.`
+  }
+
+  if (!pmReady) {
+    // A confirmed crash (mid-probe or via the exit racer) always tears down and
+    // rethrows the real cause.
+    const crash = pmCrash ?? earlyExitError;
+    if (crash) {
+      await killEmulatorQuietly(serial, child);
+      throw crash;
+    }
+    // Tear down only when there is still a fallback left to try (hot boot ->
+    // cold boot). On the final attempt a slow-but-alive guest is NOT a reason
+    // to destroy it: it reached boot_completed and registered with adb, gRPC
+    // screenshots/gestures work without PM, and killing it guarantees failure
+    // with nothing to fall back to.
+    if (params.tearDownIfUnready) {
+      await killEmulatorQuietly(serial, child);
+      throw new Error(
+        `PackageManager did not respond on ${serial} within ${Math.round(pmBudgetMs / 1000)}s ` +
+          `after boot_completed. Emulator has been terminated.`
+      );
+    }
+    process.stderr.write(
+      `[boot-device] ${serial} reached boot_completed and registered with adb, but PackageManager ` +
+        `stayed slow for ${Math.round(pmBudgetMs / 1000)}s; returning it as booted rather than ` +
+        `tearing it down. Give it a few seconds to settle if taps or screenshots misbehave.\n`
     );
-  } finally {
-    stage5Racer.cancel();
   }
 
   return { serial };
@@ -802,6 +849,10 @@ async function bootAndroidImpl(params: {
           adbRegisterBudgetMs: 30_000,
           deviceReadyBudgetMs: 30_000,
           bootCompletedBudgetMs: 30_000,
+          // Keep the hot path tight: a single ~10 s PM window, and tear down on
+          // failure so we fall through to the cold boot below.
+          pmProbeBudgetMs: 10_000,
+          tearDownIfUnready: true,
         });
         await assertScreencapAlive(result.serial);
         return {
@@ -851,6 +902,11 @@ async function bootAndroidImpl(params: {
       adbRegisterBudgetMs: STAGE_BUDGET.adbRegister,
       deviceReadyBudgetMs: STAGE_BUDGET.deviceReady,
       bootCompletedBudgetMs: STAGE_BUDGET.bootCompleted,
+      // Final attempt: retry PM for longer, and do NOT tear the emulator down
+      // if it stays slow — a guest that reached boot_completed is usable, and
+      // there is no further fallback to justify destroying it.
+      pmProbeBudgetMs: STAGE_BUDGET.pmReady,
+      tearDownIfUnready: false,
     });
   } catch (err) {
     const base = err instanceof Error ? err.message : String(err);

--- a/packages/tool-server/test/boot-device-hotboot.test.ts
+++ b/packages/tool-server/test/boot-device-hotboot.test.ts
@@ -711,4 +711,70 @@ describe("boot-device Android — hot-boot with cold-boot fallback", () => {
       vi.useRealTimers();
     }
   });
+
+  it("returns the cold-booted emulator as booted when PackageManager stays slow on the final attempt (does not tear it down)", async () => {
+    // Regression: a slow-but-alive guest (pm never answers within the probe
+    // window even though sys.boot_completed=1 and adb registered the serial)
+    // must NOT be torn down on the final cold attempt — there is no fallback
+    // left and the device is usable via gRPC. Previously a single 10 s pm
+    // probe failure killed the emulator and failed the whole boot.
+    hasSnapshotMock.mockResolvedValue(false); // skip hot boot -> straight to cold
+    let killed = false;
+    let devicesCalls = 0;
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "emulator" && args[0] === "-list-avds")
+        return { stdout: "Pixel_7_API_34\n", stderr: "" };
+      if (cmd === "adb" && args[0] === "version")
+        return { stdout: "Android Debug Bridge\n", stderr: "" };
+      if (cmd === "adb" && args[0] === "start-server") return { stdout: "", stderr: "" };
+      if (cmd === "adb" && args[0] === "devices") {
+        devicesCalls += 1;
+        const emuLine = devicesCalls >= 2 ? "emulator-5554\tdevice\n" : "";
+        return { stdout: `List of devices attached\n${emuLine}`, stderr: "" };
+      }
+      if (cmd === "adb" && args[0] === "-s" && args[2] === "wait-for-device")
+        return { stdout: "", stderr: "" };
+      if (cmd === "adb" && args[0] === "-s" && args.includes("emu") && args.includes("kill")) {
+        killed = true;
+        return { stdout: "OK\n", stderr: "" };
+      }
+      if (cmd === "adb" && args[0] === "-s" && args[2] === "shell") {
+        const shellCmd = args[3] ?? "";
+        if (shellCmd.startsWith("getprop sys.boot_completed")) return { stdout: "1\n", stderr: "" };
+        if (shellCmd.startsWith("getprop")) return { stdout: "unknown\n", stderr: "" };
+        // pm never answers — simulate the adb call being SIGKILLed on timeout.
+        if (shellCmd === "pm path android")
+          return new Error(
+            "Command failed: adb -s emulator-5554 shell pm path (killed=true signal=SIGKILL)"
+          );
+        // screencap returns a real (non-zero) frame so awaitFirstRealFrame passes.
+        if (shellCmd.startsWith("screencap")) return { stdout: "1\n", stderr: "" };
+        return { stdout: "\n", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    vi.useFakeTimers();
+    try {
+      const tool = createBootDeviceTool(registry);
+      const resultP = tool.execute!({}, { avdName: "Pixel_7_API_34" });
+      // Drive past the ~45 s PM-probe retry budget instantly. The guest is
+      // alive (screencap returns a real frame, so awaitFirstRealFrame passes),
+      // so the final cold attempt returns it as booted instead of killing it.
+      await vi.advanceTimersByTimeAsync(50_000);
+      const result = await resultP;
+
+      expect(result).toMatchObject({
+        platform: "android",
+        serial: "emulator-5554",
+        booted: true,
+      });
+      // The healthy-but-slow guest must be left running, not killed.
+      expect(killed).toBe(false);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      expect(spawnMock.mock.calls[0]![1]).toContain("-no-snapshot-load");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Problem

On Linux (headless, software-GPU) I hit `boot-device` repeatedly failing with
`PackageManager did not respond ... Emulator has been terminated`, even though
the emulator had booted fine. Root cause: **Stage 5** of `attemptBoot` ran a
single `pm path android` probe with a 10 s timeout and, on failure, killed the
emulator and threw.

On a loaded host (or a freshly `-wipe-data`'d image still finishing its
first-boot package scan), `pm` can take well over 10 s to answer while the guest
is perfectly healthy — it already reached `sys.boot_completed` and registered
with adb. On the **final cold attempt** there is no fallback, so a momentarily
slow PackageManager turned a usable emulator into a hard boot failure (and
destroyed it, so the next try started from a cold boot again).

## Fix

- Stage 5 now **retries** `pm path android` within a budget instead of a single
  10 s window.
- Threads a `tearDownIfUnready` flag through `attemptBoot`:
  - **hot-boot attempt** — tight ~10 s budget, tear down on failure so we still
    fall through to the cold boot.
  - **final cold attempt** — retry up to 45 s and, if PM is still slow, **return
    the emulator as booted rather than destroying it**. gRPC screenshots/gestures
    work without PM, and killing it just guarantees failure with nothing to fall
    back to. A confirmed QEMU crash (mid-probe or via the early-exit racer) still
    tears down and rethrows the real cause.

Also adds a note to the `argent-android-emulator-setup` skill: hard-killing qemu
(`pkill -9`) leaves the userdata image dirty — the usual cause of a cold boot
that hangs for minutes with runaway writes — and `-wipe-data` resets it.

## Tests

`packages/tool-server/test/boot-device-hotboot.test.ts` — added a regression
test asserting the final cold attempt returns the emulator as `booted` (and does
**not** issue `adb emu kill`) when PM stays slow. All 28 boot-device tests pass.

## Out of scope / follow-ups (found during the same Linux session)

- `simulator-server` (Rust) **panics** (`android_emulator.rs:104 "should be
  running"`) when asked to attach to a pre-existing emulator launched with
  `-read-only` that never registered gRPC discovery. Better to return a clear
  "can't attach, reboot via Argent" error. Separate (cross-language) change.
- `screenshot-diff` with `captureCurrent: true` fails reproducibly with
  `"server response missing url or path"` while plain `screenshot` and
  file-vs-file diff both work.
- `react-profiler-component-source` returns `found: false` for valid top-level
  `export function` components.