### PR TITLE
fix(screenshot-diff): make live capture work on Android + surface real capture errors

### DIFF
--- a/packages/tool-server/src/tools/screenshot-diff/index.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/index.ts
@@ -176,7 +176,19 @@ async function captureLiveInput(params: {
     throw new Error("Live screenshot capture requires a simulatorServer service.");
   }
 
-  const capture = await params.captureScreenshot(params.api, params.rotation, params.signal, 1.0);
+  // Prefer a full-resolution capture for maximum diff fidelity. Some Android
+  // emulator configurations cannot stream a full-res frame — the simulator-server
+  // rejects it with a "wrong data size" framebuffer mismatch — which previously
+  // made the entire baselinePath + captureCurrent flow unusable on Android. Fall
+  // back to the server's default scale, which captures reliably; same-aspect
+  // normalization in diffPngFiles keeps a scaled capture diff-compatible with a
+  // baseline saved at any scale. Full-res is preserved wherever it works (iOS).
+  let capture: Awaited<ReturnType<CaptureScreenshot>>;
+  try {
+    capture = await params.captureScreenshot(params.api, params.rotation, params.signal, 1.0);
+  } catch {
+    capture = await params.captureScreenshot(params.api, params.rotation, params.signal);
+  }
   const suffix = crypto.randomBytes(4).toString("hex");
   const destination = path.join(params.outputDir, `${params.name}-${suffix}.live.png`);
   await fs.mkdir(params.outputDir, { recursive: true });

--- a/packages/tool-server/src/utils/simulator-client.ts
+++ b/packages/tool-server/src/utils/simulator-client.ts
@@ -112,6 +112,15 @@ export async function httpScreenshot(
     );
   }
   if (resBody.url == null || resBody.path == null) {
+    // Some capture failures come back as HTTP 200 with an `error` field rather
+    // than a non-2xx status (e.g. Android full-resolution requests that exceed
+    // what the emulator framebuffer can stream: "wrong data size, expected X
+    // got Y"). Surface that message instead of the misleading generic hint so
+    // the real cause is visible rather than sending callers to restart a
+    // perfectly healthy server.
+    if (resBody.error) {
+      throw new Error(`Screenshot failed: ${resBody.error}.`);
+    }
     throw new Error(
       "Screenshot failed: server response missing url or path. " +
         "The simulator-server may be misconfigured. Try restarting it."

--- a/packages/tool-server/test/screenshot-diff-tool.test.ts
+++ b/packages/tool-server/test/screenshot-diff-tool.test.ts
@@ -119,6 +119,62 @@ describe("screenshotDiffTool", () => {
     expect(result.diffPath).toBe(path.join(dir, `${liveBaseName}-diff.png`));
   });
 
+  it("falls back to the default scale when the full-resolution capture fails (Android framebuffer mismatch)", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-fallback-"));
+    const baselinePath = path.join(dir, "baseline.png");
+    const capturedPath = path.join(dir, "captured.png");
+    await writePng(baselinePath, 2, 2, { r: 0, g: 0, b: 0 });
+    await writePng(capturedPath, 2, 2, { r: 0, g: 0, b: 0 });
+    // Full-res (scale 1.0) fails the way the Android simulator-server does;
+    // the default-scale retry (no scale arg) succeeds.
+    const captureScreenshot = vi.fn(
+      async (_api: unknown, _rotation: unknown, _signal: unknown, scale?: number) => {
+        if (scale === 1.0) {
+          throw new Error("Screenshot failed: wrong data size, expected 7853760 got 17627328.");
+        }
+        return { url: "http://localhost/current.png", path: capturedPath };
+      }
+    );
+
+    const result = await executeScreenshotDiffTool(
+      { simulatorServer: { apiUrl: "http://localhost:4949" } },
+      { baselinePath, captureCurrent: true, udid: "ABC", outputDir: dir },
+      {},
+      captureScreenshot as never
+    );
+
+    // Full-res attempted first, then a default-scale retry without an explicit scale.
+    expect(captureScreenshot).toHaveBeenCalledTimes(2);
+    expect(captureScreenshot.mock.calls[0]![3]).toBe(1.0);
+    expect(captureScreenshot.mock.calls[1]![3]).toBeUndefined();
+    const liveCaptures = (await fs.readdir(dir)).filter((name) =>
+      /^current-[a-f0-9]{8}\.live\.png$/.test(name)
+    );
+    expect(liveCaptures).toHaveLength(1);
+    expect(result.diffPath).toBeTruthy();
+  });
+
+  it("propagates the error when both the full-res capture and the fallback fail", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-bothfail-"));
+    const baselinePath = path.join(dir, "baseline.png");
+    await writePng(baselinePath, 2, 2, { r: 0, g: 0, b: 0 });
+    const captureScreenshot = vi.fn(
+      async (_api: unknown, _rotation: unknown, _signal: unknown, scale?: number) => {
+        throw new Error(scale === 1.0 ? "full-res failed" : "device offline");
+      }
+    );
+
+    await expect(
+      executeScreenshotDiffTool(
+        { simulatorServer: { apiUrl: "http://localhost:4949" } },
+        { baselinePath, captureCurrent: true, udid: "ABC", outputDir: dir },
+        {},
+        captureScreenshot as never
+      )
+    ).rejects.toThrow("device offline");
+    expect(captureScreenshot).toHaveBeenCalledTimes(2);
+  });
+
   it("uses a fresh hashed filename for each live capture so concurrent diffs do not collide", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-unique-"));
     const baselinePath = path.join(dir, "baseline.png");

--- a/packages/tool-server/test/simulator-client.test.ts
+++ b/packages/tool-server/test/simulator-client.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { httpScreenshot } from "../src/utils/simulator-client";
+
+function fakeFetch(status: number, json: unknown) {
+  return vi.fn(
+    async () =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => json,
+      }) as unknown as Response
+  );
+}
+
+const api = { apiUrl: "http://127.0.0.1:4949" } as never;
+
+describe("httpScreenshot", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("surfaces the server's error message when a 200 response carries { error } and no url/path", async () => {
+    // The Android simulator-server reports a full-resolution framebuffer
+    // mismatch as HTTP 200 + { error }, not a non-2xx status. The real cause
+    // must reach the caller, not the misleading "restart the server" hint.
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch(200, { error: "wrong data size, expected 7853760 got 17627328" })
+    );
+    await expect(httpScreenshot(api)).rejects.toThrow(
+      "Screenshot failed: wrong data size, expected 7853760 got 17627328."
+    );
+  });
+
+  it("uses the generic hint only when url/path are missing AND there is no error field", async () => {
+    vi.stubGlobal("fetch", fakeFetch(200, {}));
+    await expect(httpScreenshot(api)).rejects.toThrow("server response missing url or path");
+  });
+
+  it("returns url and path on a successful capture", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch(200, { url: "http://127.0.0.1:4949/media/x.png", path: "/tmp/x.png" })
+    );
+    await expect(httpScreenshot(api)).resolves.toEqual({
+      url: "http://127.0.0.1:4949/media/x.png",
+      path: "/tmp/x.png",
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`screenshot-diff` with `baselinePath` + `captureCurrent: true` — the tool's own
documented *"common visual-regression flow"* — fails reproducibly on Android with:

> Screenshot failed: server response missing url or path. The simulator-server may be misconfigured. Try restarting it.

That message is misleading (the server is healthy), and the flow is 100% broken on Android.

## Root cause (verified against a live emulator)

`captureLiveInput` requests a **full-resolution** capture (`scale: 1.0`). The Android
simulator-server can't stream some framebuffers at full res and returns **HTTP 200**
with an `error` field. Confirmed directly against the running simulator-server:

| request | response |
|---|---|
| `{"scale":0.5}` | `{"path":…,"url":…}` ✅ |
| `{}` (full res) | `{"error":"wrong data size, expected 7853760 got 17627328"}` ❌ |
| `{"scale":1.0}` | `{"error":"wrong data size, expected 7853760 got 17627328"}` ❌ |

(`7853760 = 1080×2424×3`; the emulator returns ~2.24× that.)

Two compounding bugs:
1. **`httpScreenshot`** only reads `error` on a non-2xx status. On the `200 + {error}` path it falls through to the generic *"missing url or path … restart it"*, hiding the real cause.
2. **`captureLiveInput`** hard-codes `scale: 1.0` with no fallback, so the whole diff fails on Android.

## Fix (TS-only)

- **`httpScreenshot`**: when `url`/`path` are missing, surface `resBody.error` if present (so *"wrong data size …"* reaches the caller) before the generic hint.
- **`captureLiveInput`**: attempt full-res, and on any failure **retry at the server's default scale**, which captures reliably. #285's same-aspect normalization already makes a scaled capture diff-compatible with a baseline saved at any scale, and full-res is preserved wherever it works (iOS). If the fallback also fails, its error propagates.

## Tests

`screenshot-diff-tool.test.ts` — full-res→default-scale fallback (asserts the `1.0` call then a default-scale retry), and error propagation when both fail.
`simulator-client.test.ts` (new) — `httpScreenshot` surfaces the server `error` on a `200+{error}` response, still uses the generic hint when there's genuinely no info, and returns `url`/`path` on success.

All 21 screenshot-diff/simulator-client tests pass; `tsc` clean on the changed files.

## Scope note

The underlying inability to capture a full-resolution Android frame is a **simulator-server (native)** issue — the *"wrong data size"* framebuffer mismatch. This PR makes the tool **degrade gracefully** (works at the default scale) and **diagnose clearly** instead of failing outright; a proper native fix for full-res Android capture is a separate follow-up.