### PR TITLE
fix(tool-server): make debugger-component-tree work on New Arch / multi-renderer apps

### DIFF
--- a/packages/tool-server/src/utils/debugger/scripts/component-tree.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/component-tree.ts
@@ -5,8 +5,14 @@
  * (testID, accessibilityLabel, visible text).
  *
  * Supports both Fabric (new architecture) and Paper (old architecture).
- * On Fabric, uses nativeFabricUIManager.measure with the shadow node.
- * On Paper, falls back to UIManager.measureInWindow with native tags.
+ * On Fabric, measures via the public host instance (ReactNativeElement)
+ * measureInWindow, falling back to nativeFabricUIManager.measure with the
+ * shadow node. On Paper, falls back to UIManager.measureInWindow with native tags.
+ *
+ * Renderer selection is renderer-agnostic: apps that use a secondary reconciler
+ * (react-native-skia, react-native-svg, etc.) register their own renderer, so we
+ * enumerate every renderer and walk the mounted root with the largest fiber
+ * subtree rather than assuming the React Native renderer is id 1.
  *
  * Measurement is async-safe: on Paper (where measureInWindow is async),
  * the script collects all candidates first, then batch-measures them via
@@ -26,9 +32,38 @@ export function makeComponentTreeScript(opts: {
   var TRACK_SKIPPED = ${trackSkipped};
   var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
   if (!hook) return JSON.stringify({ error: 'No DevTools hook' });
-  var roots = hook.getFiberRoots(1);
-  if (!roots || roots.size === 0) return JSON.stringify({ error: 'No fiber roots' });
-  var root = Array.from(roots)[0];
+  // Collect fiber roots across ALL renderers. A single React renderer id is not
+  // safe to assume: secondary reconcilers (e.g. react-native-skia) frequently
+  // register first and own renderer id 1, whose roots contain only that library's
+  // nodes (Skia shapes, etc.) and none of the tappable app UI.
+  var _allRoots = [];
+  if (hook.renderers && typeof hook.renderers.forEach === 'function') {
+    hook.renderers.forEach(function(_r, _rendererId) {
+      try {
+        var _rs = hook.getFiberRoots(_rendererId);
+        if (_rs) _rs.forEach(function(_rt) { _allRoots.push(_rt); });
+      } catch (e) {}
+    });
+  }
+  if (_allRoots.length === 0) {
+    var _legacy = hook.getFiberRoots(1);
+    if (_legacy) _legacy.forEach(function(_rt) { _allRoots.push(_rt); });
+  }
+  if (_allRoots.length === 0) return JSON.stringify({ error: 'No fiber roots' });
+  // Pick the mounted root with the largest fiber subtree — i.e. the real app UI.
+  var root = _allRoots[0];
+  var _bestSize = -1;
+  for (var _ri = 0; _ri < _allRoots.length; _ri++) {
+    var _sz = 0, _stk = [_allRoots[_ri].current];
+    while (_stk.length > 0 && _sz < 20000) {
+      var _nd = _stk.pop();
+      if (!_nd) continue;
+      _sz++;
+      if (_nd.child) _stk.push(_nd.child);
+      if (_nd.sibling) _stk.push(_nd.sibling);
+    }
+    if (_sz > _bestSize) { _bestSize = _sz; root = _allRoots[_ri]; }
+  }
 
   var useFabric = typeof nativeFabricUIManager !== 'undefined';
   var UIManagerMod;
@@ -124,7 +159,20 @@ export function makeComponentTreeScript(opts: {
 
   function getHostInfo(fiber) {
     if (typeof fiber.type !== 'string' || !fiber.stateNode) return null;
-    if (useFabric && fiber.stateNode.node) return { f: true, n: fiber.stateNode.node };
+    if (useFabric && fiber.stateNode.canonical) {
+      // New-arch Fabric host instance: stateNode = { node, canonical }. Carry the
+      // public instance (ReactNativeElement, exposes measureInWindow), the shadow
+      // node for the legacy nativeFabricUIManager.measure fallback, and use the
+      // numeric nativeTag as a stable per-host cache key.
+      var _canon = fiber.stateNode.canonical;
+      return {
+        f: true,
+        n: typeof _canon.nativeTag === 'number' ? _canon.nativeTag : fiber.stateNode.node,
+        pi: _canon.publicInstance || null,
+        sn: fiber.stateNode.node || null
+      };
+    }
+    if (useFabric && fiber.stateNode.node) return { f: true, n: fiber.stateNode.node, sn: fiber.stateNode.node };
     if (!useFabric) {
       if (fiber.stateNode.canonical && typeof fiber.stateNode.canonical.nativeTag === 'number')
         return { f: false, n: fiber.stateNode.canonical.nativeTag };
@@ -257,13 +305,29 @@ export function makeComponentTreeScript(opts: {
   }
 
   function measureOne(info) {
-    return new Promise(function(resolve) {
+    return new Promise(function(_resolve) {
+      // Guard against measure callbacks that never fire (detached / off-screen
+      // shadow nodes) so the Promise.all below cannot hang indefinitely.
+      var _settled = false;
+      function resolve(v) { if (_settled) return; _settled = true; _resolve(v); }
+      setTimeout(function() { resolve(null); }, 1200);
       try {
         if (info.f) {
-          nativeFabricUIManager.measure(info.n, function(x, y, w, h, px, py) {
-            if (w > 0 && h > 0) resolve({ x: Math.round(px), y: Math.round(py), w: Math.round(w), h: Math.round(h) });
-            else resolve(null);
-          });
+          if (info.pi && typeof info.pi.measureInWindow === 'function') {
+            // Preferred path: works on bridgeless, where the global
+            // nativeFabricUIManager is an empty object with no measure().
+            info.pi.measureInWindow(function(x, y, w, h) {
+              if (w > 0 && h > 0) resolve({ x: Math.round(x), y: Math.round(y), w: Math.round(w), h: Math.round(h) });
+              else resolve(null);
+            });
+          } else if (typeof nativeFabricUIManager !== 'undefined' && typeof nativeFabricUIManager.measure === 'function') {
+            nativeFabricUIManager.measure(info.sn || info.n, function(x, y, w, h, px, py) {
+              if (w > 0 && h > 0) resolve({ x: Math.round(px), y: Math.round(py), w: Math.round(w), h: Math.round(h) });
+              else resolve(null);
+            });
+          } else {
+            resolve(null);
+          }
         } else {
           UIManagerMod.measureInWindow(info.n, function(x, y, w, h) {
             if (w > 0 && h > 0) resolve({ x: Math.round(x), y: Math.round(y), w: Math.round(w), h: Math.round(h) });

--- a/packages/tool-server/test/debugger/component-tree-script.test.ts
+++ b/packages/tool-server/test/debugger/component-tree-script.test.ts
@@ -23,7 +23,13 @@ function hostFiber(nativeTag: number, rect: Rect, opts: { withPublicInstance?: b
     cb(rect.x, rect.y, rect.w, rect.h);
   const canonical: Record<string, unknown> = { nativeTag };
   if (opts.withPublicInstance !== false) canonical.publicInstance = { measureInWindow };
-  return { type: "RCTView", stateNode: { node: {}, canonical }, memoizedProps: {}, child: null, sibling: null };
+  return {
+    type: "RCTView",
+    stateNode: { node: {}, canonical },
+    memoizedProps: {},
+    child: null,
+    sibling: null,
+  };
 }
 
 function comp(displayName: string, testID: string, child: unknown, sibling: unknown = null) {
@@ -31,7 +37,9 @@ function comp(displayName: string, testID: string, child: unknown, sibling: unkn
 }
 
 function rootOf(childFiber: unknown) {
-  return { current: { type: null, stateNode: null, memoizedProps: null, child: childFiber, sibling: null } };
+  return {
+    current: { type: null, stateNode: null, memoizedProps: null, child: childFiber, sibling: null },
+  };
 }
 
 function makeHook(rootsByRenderer: Record<number, unknown[]>) {
@@ -40,7 +48,10 @@ function makeHook(rootsByRenderer: Record<number, unknown[]>) {
   return { renderers, getFiberRoots: (id: number) => new Set(rootsByRenderer[id] ?? []) };
 }
 
-async function runScript(hook: unknown, nativeFabricUIManager: unknown): Promise<{ result: string } | null> {
+async function runScript(
+  hook: unknown,
+  nativeFabricUIManager: unknown
+): Promise<{ result: string } | null> {
   const g = globalThis as Record<string, unknown>;
   const saved = {
     window: g.window,
@@ -54,7 +65,9 @@ async function runScript(hook: unknown, nativeFabricUIManager: unknown): Promise
   g.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook;
   g.nativeFabricUIManager = nativeFabricUIManager;
   g.__r = function () {}; // metro require stub; the Dimensions block is try/caught
-  g.__argent_callback = (payload: string) => { captured = JSON.parse(payload); };
+  g.__argent_callback = (payload: string) => {
+    captured = JSON.parse(payload);
+  };
   try {
     // indirect eval keeps access to the globalThis the script reads
     await (0, eval)(makeComponentTreeScript({ requestId: "t" }));
@@ -70,7 +83,11 @@ async function runScript(hook: unknown, nativeFabricUIManager: unknown): Promise
 
 function components(captured: { result: string } | null) {
   expect(captured).toBeTruthy();
-  return JSON.parse(captured!.result).components as Array<{ name: string; testID?: string; rect: Rect | null }>;
+  return JSON.parse(captured!.result).components as Array<{
+    name: string;
+    testID?: string;
+    rect: Rect | null;
+  }>;
 }
 
 afterEach(() => {
@@ -121,10 +138,18 @@ describe("makeComponentTreeScript — Fabric layout (argent#316)", () => {
   });
 
   it("falls back to nativeFabricUIManager.measure when there is no publicInstance", async () => {
-    const rn = rootOf(comp("MyButton", "button", hostFiber(1, { x: 0, y: 0, w: 0, h: 0 }, { withPublicInstance: false })));
+    const rn = rootOf(
+      comp(
+        "MyButton",
+        "button",
+        hostFiber(1, { x: 0, y: 0, w: 0, h: 0 }, { withPublicInstance: false })
+      )
+    );
     const nf = {
-      measure: (_node: unknown, cb: (x: number, y: number, w: number, h: number, px: number, py: number) => void) =>
-        cb(0, 0, 100, 40, 11, 22),
+      measure: (
+        _node: unknown,
+        cb: (x: number, y: number, w: number, h: number, px: number, py: number) => void
+      ) => cb(0, 0, 100, 40, 11, 22),
     };
     const comps = components(await runScript(makeHook({ 3: [rn] }), nf));
     const btn = comps.find((c) => c.testID === "button");

--- a/packages/tool-server/test/debugger/component-tree-script.test.ts
+++ b/packages/tool-server/test/debugger/component-tree-script.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { makeComponentTreeScript } from "../../src/utils/debugger/scripts/component-tree";
+
+/**
+ * `makeComponentTreeScript` returns a self-contained async IIFE injected via
+ * Runtime.evaluate. Eval it against a mock `window.__REACT_DEVTOOLS_GLOBAL_HOOK__`
+ * to verify it:
+ *   1. selects the renderer that hosts the real UI rather than assuming
+ *      DevTools renderer id 1 (apps with a secondary reconciler such as
+ *      react-native-skia register their own renderer, often at id 1), and
+ *   2. measures layout via the public host instance (`measureInWindow`) when the
+ *      global `nativeFabricUIManager` is an empty object — the bridgeless case
+ *      where `nativeFabricUIManager.measure` does not exist.
+ *
+ * Regression harness for software-mansion/argent#316. Style mirrors
+ * test/react-profiler/scripts-multi-renderer.test.ts.
+ */
+
+type Rect = { x: number; y: number; w: number; h: number };
+
+function hostFiber(nativeTag: number, rect: Rect, opts: { withPublicInstance?: boolean } = {}) {
+  const measureInWindow = (cb: (x: number, y: number, w: number, h: number) => void) =>
+    cb(rect.x, rect.y, rect.w, rect.h);
+  const canonical: Record<string, unknown> = { nativeTag };
+  if (opts.withPublicInstance !== false) canonical.publicInstance = { measureInWindow };
+  return { type: "RCTView", stateNode: { node: {}, canonical }, memoizedProps: {}, child: null, sibling: null };
+}
+
+function comp(displayName: string, testID: string, child: unknown, sibling: unknown = null) {
+  return { type: { displayName }, memoizedProps: { testID }, child, sibling };
+}
+
+function rootOf(childFiber: unknown) {
+  return { current: { type: null, stateNode: null, memoizedProps: null, child: childFiber, sibling: null } };
+}
+
+function makeHook(rootsByRenderer: Record<number, unknown[]>) {
+  const renderers = new Map<number, unknown>();
+  for (const id of Object.keys(rootsByRenderer)) renderers.set(Number(id), {});
+  return { renderers, getFiberRoots: (id: number) => new Set(rootsByRenderer[id] ?? []) };
+}
+
+async function runScript(hook: unknown, nativeFabricUIManager: unknown): Promise<{ result: string } | null> {
+  const g = globalThis as Record<string, unknown>;
+  const saved = {
+    window: g.window,
+    hook: g.__REACT_DEVTOOLS_GLOBAL_HOOK__,
+    nf: g.nativeFabricUIManager,
+    cb: g.__argent_callback,
+    r: g.__r,
+  };
+  let captured: { result: string } | null = null;
+  g.window = g;
+  g.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook;
+  g.nativeFabricUIManager = nativeFabricUIManager;
+  g.__r = function () {}; // metro require stub; the Dimensions block is try/caught
+  g.__argent_callback = (payload: string) => { captured = JSON.parse(payload); };
+  try {
+    // indirect eval keeps access to the globalThis the script reads
+    await (0, eval)(makeComponentTreeScript({ requestId: "t" }));
+    return captured;
+  } finally {
+    g.window = saved.window;
+    g.__REACT_DEVTOOLS_GLOBAL_HOOK__ = saved.hook;
+    g.nativeFabricUIManager = saved.nf;
+    g.__argent_callback = saved.cb;
+    g.__r = saved.r;
+  }
+}
+
+function components(captured: { result: string } | null) {
+  expect(captured).toBeTruthy();
+  return JSON.parse(captured!.result).components as Array<{ name: string; testID?: string; rect: Rect | null }>;
+}
+
+afterEach(() => {
+  const g = globalThis as Record<string, unknown>;
+  delete g.window;
+  delete g.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  delete g.nativeFabricUIManager;
+  delete g.__argent_callback;
+  delete g.__r;
+});
+
+describe("makeComponentTreeScript — multi-renderer renderer selection (argent#316)", () => {
+  it("walks the renderer with the real UI, not a secondary reconciler at id 1", async () => {
+    // Secondary reconciler (skia-like) registered at id 1 with a small subtree;
+    // the real react-native UI lives in a larger root under id 3.
+    const rn = rootOf(
+      comp(
+        "MyButton",
+        "button",
+        hostFiber(1, { x: 10, y: 20, w: 100, h: 40 }),
+        comp("MyLabel", "label", hostFiber(2, { x: 10, y: 70, w: 100, h: 30 }))
+      )
+    );
+    const skia = rootOf(comp("SkiaCircle", "skia-only", hostFiber(9, { x: 0, y: 0, w: 5, h: 5 })));
+    const hook = makeHook({ 1: [skia], 3: [rn] });
+
+    const comps = components(await runScript(hook, {}));
+    const ids = comps.map((c) => c.testID);
+    expect(ids).toContain("button");
+    expect(ids).toContain("label");
+    expect(ids).not.toContain("skia-only");
+  });
+
+  it("smoke: single-renderer app still works", async () => {
+    const rn = rootOf(comp("MyButton", "button", hostFiber(1, { x: 1, y: 2, w: 3, h: 4 })));
+    const comps = components(await runScript(makeHook({ 1: [rn] }), {}));
+    expect(comps.map((c) => c.testID)).toContain("button");
+  });
+});
+
+describe("makeComponentTreeScript — Fabric layout (argent#316)", () => {
+  it("measures via publicInstance.measureInWindow when nativeFabricUIManager is empty (bridgeless)", async () => {
+    const rn = rootOf(comp("MyButton", "button", hostFiber(1, { x: 10, y: 20, w: 100, h: 40 })));
+    // {} → useFabric is true but there is no .measure; the public instance path must be used.
+    const comps = components(await runScript(makeHook({ 3: [rn] }), {}));
+    const btn = comps.find((c) => c.testID === "button");
+    expect(btn?.rect).toEqual({ x: 10, y: 20, w: 100, h: 40 });
+  });
+
+  it("falls back to nativeFabricUIManager.measure when there is no publicInstance", async () => {
+    const rn = rootOf(comp("MyButton", "button", hostFiber(1, { x: 0, y: 0, w: 0, h: 0 }, { withPublicInstance: false })));
+    const nf = {
+      measure: (_node: unknown, cb: (x: number, y: number, w: number, h: number, px: number, py: number) => void) =>
+        cb(0, 0, 100, 40, 11, 22),
+    };
+    const comps = components(await runScript(makeHook({ 3: [rn] }), nf));
+    const btn = comps.find((c) => c.testID === "button");
+    expect(btn?.rect).toEqual({ x: 11, y: 22, w: 100, h: 40 });
+  });
+});


### PR DESCRIPTION
## Summary

`debugger-component-tree` returns **"No visible components found on screen"** on React Native **New Architecture (Fabric / bridgeless)** apps that also use a secondary React reconciler such as `react-native-skia` — even when the app is fully rendered and CDP is connected. This PR fixes the two root causes so the tool returns the real component tree with names, testIDs, and accurate tap coordinates.

## Root cause

The injected fiber-walk script (`packages/tool-server/src/utils/debugger/scripts/component-tree.ts`) made two assumptions that don't hold on modern RN:

1. **Hardcoded renderer id.** `hook.getFiberRoots(1)` assumes the React Native renderer is DevTools renderer id `1`. Libraries that ship their own React reconciler (`react-native-skia`, `react-native-svg`, `react-three-fiber`, …) register a renderer too and frequently take id `1`. On such apps `getFiberRoots(1)` returns only that library's roots (e.g. Skia shapes), so the walk never reaches the app UI → `No visible components`.

2. **`nativeFabricUIManager.measure` under bridgeless.** Layout was read via `nativeFabricUIManager.measure(stateNode.node, …)`. Under bridgeless, `globalThis.nativeFabricUIManager` is an **empty object** (no `.measure`), so every measure threw and all rects became `null` — components were then filtered out (and the few kept by testID reported no usable rect).

## Fix

- **Renderer-agnostic root selection:** enumerate `hook.renderers`, collect roots from every renderer, and walk the mounted root with the largest fiber subtree (the real app UI) instead of hardcoding id 1.
- **Fabric layout via the public host instance:** measure through `stateNode.canonical.publicInstance.measureInWindow()` (a `ReactNativeElement`) — the **same approach this repo's `inspect-at-point.ts` already uses** — falling back to `nativeFabricUIManager.measure(shadowNode, …)` when that global is functional (non-bridgeless).
- **Hang guard:** a per-measure 1200 ms timeout so `Promise.all` can't stall on a measure callback that never fires (detached / off-screen nodes).

No change to the output schema or the Paper (old-architecture) path.

## How to reproduce

On a Fabric + bridgeless RN app that also renders `react-native-skia`:

```
argent run debugger-connect       --device_id <udid> --port <metro>
argent run debugger-component-tree --device_id <udid> --port <metro>
# before: "No visible components found on screen."
```

The DevTools hook reports multiple renderers — e.g. `getFiberRoots(1)` is the Skia reconciler (only canvas nodes), while the real app UI lives in a different react-native renderer that the hardcoded id never reaches.

## Testing

- Full `npm run build` (`tsc --build`, project references) passes; the modified file typechecks under `strict`.
- Verified live against a **React 19.2.0 / Fabric (bridgeless)** app whose DevTools hook exposes 3 renderers (id 1 = `react-native-skia` `0.0.1`; id 3 = `react-native` `19.2.0` holding the real ~2,900-fiber UI tree).

Before (unpatched): `No visible components found on screen.` — even with `--includeSkipped` and after forcing a fresh commit.

After (this change) — names + testIDs + accurate coords (example genericized):

```
Screen: 440x956
OnboardingQuestion "<question text>"            (tap: 0.50,0.17)
  SelectableCard [testID=onboarding.option.yes]  (tap: 0.50,0.84)
    Text "Yes"                                    (tap: 0.50,0.84)
  SelectableCard [testID=onboarding.option.no]    (tap: 0.50,0.93)
Pressable [testID=screen.back-button]             (tap: 0.09,0.09)   ← top-left ✓
TouchableOpacity [testID=dev-settings.trigger]    (tap: 0.06,0.97)   ← bottom-left ✓
```

Coordinates were spot-checked against the visible layout (back button top-left, an off-screen/hidden trigger bottom-left).

## Notes

`inspect-at-point.ts` has the same hardcoded `getFiberRoots(1)` / `renderers[0]` renderer assumption (its Fabric layout path already uses `publicInstance`, which is what motivated this fix). I scoped this PR to `component-tree`; happy to follow up on the inspect path separately.
