### PR TITLE
fix(tool-server): select the correct renderer in debugger-inspect-element

### DIFF
--- a/packages/tool-server/src/utils/debugger/scripts/inspect-at-point.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/inspect-at-point.ts
@@ -21,9 +21,37 @@
 export function makeInspectScript(x: number, y: number, requestId: string): string {
   return `(function() {
   var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-  var renderer = Array.from(hook.renderers.values())[0];
-  var roots = hook.getFiberRoots(1);
-  var root = Array.from(roots)[0];
+
+  // Pick the renderer + root that hosts the real app UI. Secondary reconcilers
+  // (react-native-skia, react-native-svg, ...) register their own renderer and
+  // often take id 1, whose roots contain only that library's nodes. Walk every
+  // renderer's roots and keep the (renderer, root) pair with the largest fiber
+  // subtree, then run getInspectorDataForViewAtPoint against that renderer.
+  var renderer = null, root = null, _best = -1;
+  if (hook.renderers && typeof hook.renderers.forEach === 'function') {
+    hook.renderers.forEach(function(_r, _id) {
+      var _rs;
+      try { _rs = hook.getFiberRoots(_id); } catch (e) { return; }
+      if (!_rs) return;
+      _rs.forEach(function(_rt) {
+        var _sz = 0, _stk = [_rt.current];
+        while (_stk.length > 0 && _sz < 20000) {
+          var _nd = _stk.pop();
+          if (!_nd) continue;
+          _sz++;
+          if (_nd.child) _stk.push(_nd.child);
+          if (_nd.sibling) _stk.push(_nd.sibling);
+        }
+        if (_sz > _best) { _best = _sz; renderer = _r; root = _rt; }
+      });
+    });
+  }
+  if (!renderer || !root) {
+    renderer = Array.from(hook.renderers.values())[0];
+    var _legacy = hook.getFiberRoots(1);
+    root = _legacy ? Array.from(_legacy)[0] : null;
+  }
+  if (!renderer || !root) { __argent_callback(JSON.stringify({requestId:'${requestId}',type:'inspect_result',error:'no fiber roots'})); return; }
 
   var useFabric = typeof nativeFabricUIManager !== 'undefined';
 

--- a/packages/tool-server/test/debugger/inspect-at-point-script.test.ts
+++ b/packages/tool-server/test/debugger/inspect-at-point-script.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeInspectScript } from "../../src/utils/debugger/scripts/inspect-at-point";
+
+/**
+ * `makeInspectScript` returns a self-contained IIFE injected via Runtime.evaluate.
+ * Eval it against a mock `window.__REACT_DEVTOOLS_GLOBAL_HOOK__` to verify it runs
+ * getInspectorDataForViewAtPoint against the renderer that hosts the real UI rather
+ * than assuming the first-registered renderer / id 1 — apps with a secondary
+ * reconciler (react-native-skia, react-native-svg, …) register their own renderer,
+ * often at id 1, whose roots contain only that library's nodes.
+ *
+ * Regression harness for software-mansion/argent#317. Style mirrors
+ * test/react-profiler/scripts-multi-renderer.test.ts.
+ */
+
+function hostFiber(publicInstance: unknown) {
+  return { type: "RCTView", stateNode: { node: {}, canonical: { nativeTag: 1, publicInstance } }, child: null, sibling: null };
+}
+
+function comp(displayName: string, child: unknown, sibling: unknown = null) {
+  return { type: { displayName }, child, sibling };
+}
+
+function rootOf(childFiber: unknown) {
+  return { current: { type: null, stateNode: null, child: childFiber, sibling: null } };
+}
+
+/** A renderer interface whose getInspectorDataForViewAtPoint is a spy. */
+function makeRenderer(closestInstance: unknown) {
+  const fn = vi.fn((_ref: unknown, _x: number, _y: number, cb: (data: unknown) => void) =>
+    cb({ closestInstance })
+  );
+  return { renderer: { rendererConfig: { getInspectorDataForViewAtPoint: fn } }, fn };
+}
+
+function makeHook(entries: Array<[number, unknown, unknown[]]>) {
+  const renderers = new Map<number, unknown>();
+  const rootsById = new Map<number, unknown[]>();
+  for (const [id, ri, roots] of entries) {
+    renderers.set(id, ri);
+    rootsById.set(id, roots);
+  }
+  return { renderers, getFiberRoots: (id: number) => new Set(rootsById.get(id) ?? []) };
+}
+
+function runInspect(hook: unknown): { type: string; items?: Array<{ name: string }>; error?: string } | null {
+  const g = globalThis as Record<string, unknown>;
+  const saved = {
+    window: g.window,
+    hook: g.__REACT_DEVTOOLS_GLOBAL_HOOK__,
+    nf: g.nativeFabricUIManager,
+    cb: g.__argent_callback,
+  };
+  let captured: { type: string } | null = null;
+  g.window = g;
+  g.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook;
+  g.nativeFabricUIManager = {}; // useFabric true → findHostFiber uses stateNode.node
+  g.__argent_callback = (payload: string) => { captured = JSON.parse(payload); };
+  try {
+    (0, eval)(makeInspectScript(50, 90, "t"));
+    return captured;
+  } finally {
+    g.window = saved.window;
+    g.__REACT_DEVTOOLS_GLOBAL_HOOK__ = saved.hook;
+    g.nativeFabricUIManager = saved.nf;
+    g.__argent_callback = saved.cb;
+  }
+}
+
+afterEach(() => {
+  const g = globalThis as Record<string, unknown>;
+  delete g.window;
+  delete g.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  delete g.nativeFabricUIManager;
+  delete g.__argent_callback;
+});
+
+describe("makeInspectScript — multi-renderer renderer selection (argent#317)", () => {
+  it("inspects against the renderer hosting the real UI, not a secondary reconciler at id 1", async () => {
+    const rnPI = { __marker: "rn" };
+    const rnRoot = rootOf(comp("MyButton", hostFiber(rnPI), comp("MyLabel", null)));
+    const skiaRoot = rootOf(hostFiber({ __marker: "skia" }));
+
+    const rn = makeRenderer(comp("MyButton", null)); // closestInstance fiber chain
+    const skia = makeRenderer(comp("SkiaCircle", null));
+
+    // skia registered at id 1 (the old hardcoded pick); real UI under id 3 with a bigger subtree
+    const hook = makeHook([
+      [1, skia.renderer, [skiaRoot]],
+      [3, rn.renderer, [rnRoot]],
+    ]);
+
+    const out = runInspect(hook);
+
+    expect(rn.fn).toHaveBeenCalledTimes(1);
+    expect(skia.fn).not.toHaveBeenCalled();
+    // inspectRef must be the RN host's public instance
+    expect(rn.fn.mock.calls[0][0]).toBe(rnPI);
+    expect(out?.type).toBe("inspect_result");
+    expect(out?.items?.map((i) => i.name)).toContain("MyButton");
+  });
+
+  it("smoke: single-renderer app still inspects", async () => {
+    const pi = { __marker: "only" };
+    const rnRoot = rootOf(comp("Solo", hostFiber(pi)));
+    const rn = makeRenderer(comp("Solo", null));
+    const out = runInspect(makeHook([[1, rn.renderer, [rnRoot]]]));
+    expect(rn.fn).toHaveBeenCalledTimes(1);
+    expect(rn.fn.mock.calls[0][0]).toBe(pi);
+    expect(out?.items?.map((i) => i.name)).toContain("Solo");
+  });
+});


### PR DESCRIPTION
## Summary

Companion to #316. `debugger-inspect-element` has the same hardcoded-renderer assumption as the component-tree script, so it inspects the wrong React renderer on multi-renderer apps.

## Root cause

`makeInspectScript` (`packages/tool-server/src/utils/debugger/scripts/inspect-at-point.ts`) picks:

```js
var renderer = Array.from(hook.renderers.values())[0];
var roots = hook.getFiberRoots(1);
var root = Array.from(roots)[0];
```

On React Native **New Architecture** apps that also use a secondary React reconciler (`react-native-skia`, `react-native-svg`, `react-three-fiber`, …), that library registers its own renderer and frequently takes id `1`. `renderer` then points at the Skia/SVG reconciler and `getFiberRoots(1)` returns only its roots, so `renderer.rendererConfig.getInspectorDataForViewAtPoint(...)` runs against the wrong tree and returns no app component at the touch point.

## Fix

Enumerate `hook.renderers`, walk each renderer's roots, and select the **(renderer, root)** pair with the largest fiber subtree (the real app UI) before inspecting — then call `getInspectorDataForViewAtPoint` on that renderer. Falls back to the previous first-renderer behavior if enumeration yields nothing.

Unlike the component-tree script, the Fabric layout path here was already correct (it uses `hostFiber.stateNode.canonical.publicInstance`), so no measurement change is needed — this PR is purely the renderer/root selection.

## Testing

- Full `npm run build` (`tsc --build`) passes; the modified file typechecks under `strict`.
- Same environment as #316: a React 19.2 / Fabric (bridgeless) app whose DevTools hook exposes a `react-native-skia` renderer at id 1 alongside the real `react-native` UI renderer. With the fix, inspection resolves against the app renderer instead of the Skia one.

No change to the output schema or the Paper path.
