### PR TITLE
chore: bump versions to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3676,7 +3676,7 @@
     },
     "packages/argent": {
       "name": "@swmansion/argent",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3705,7 +3705,7 @@
     },
     "packages/argent-cli": {
       "name": "@argent/cli",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/tools-client": "file:../argent-tools-client",
@@ -3720,7 +3720,7 @@
     },
     "packages/argent-installer": {
       "name": "@argent/installer",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client",
         "@argent/update-core": "file:../update-core",
@@ -3740,7 +3740,7 @@
     },
     "packages/argent-mcp": {
       "name": "@argent/mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/tools-client": "file:../argent-tools-client",
@@ -3754,7 +3754,7 @@
     },
     "packages/argent-tools-client": {
       "name": "@argent/tools-client",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "devDependencies": {
         "@types/node": "^25.9.0",
         "typescript": "^6.0.3",
@@ -3836,7 +3836,7 @@
     },
     "packages/configuration-core": {
       "name": "@argent/configuration-core",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "devDependencies": {
         "@types/node": "^25.9.0",
         "typescript": "^6.0.3",
@@ -3876,7 +3876,7 @@
     },
     "packages/native-devtools-android": {
       "name": "@argent/native-devtools-android",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "devDependencies": {
         "@types/node": "^25.9.0",
         "typescript": "^6.0.3",
@@ -3885,7 +3885,7 @@
     },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "devDependencies": {
         "@types/node": "^25.9.0",
         "typescript": "^6.0.3",
@@ -3894,7 +3894,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "zod": "^4.0.0"
       },
@@ -3905,14 +3905,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@argent/native-devtools-android": "file:../native-devtools-android",
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
@@ -3948,7 +3948,7 @@
     },
     "packages/update-core": {
       "name": "@argent/update-core",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "semver": "^7.7.4"
       },

--- a/packages/argent-cli/package.json
+++ b/packages/argent-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Shell CLI commands for argent: tools, run, server, enable, disable, flags",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/installer",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Workspace setup logic for argent: init, update, uninstall",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-mcp/package.json
+++ b/packages/argent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MCP stdio protocol adapter — talks to the argent tool-server and forwards calls",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-tools-client/package.json
+++ b/packages/argent-tools-client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tools-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Spawn-and-talk client for the argent tool-server (used by MCP and CLI)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MCP server for iOS Simulator and Android Emulator control",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/configuration-core/package.json
+++ b/packages/configuration-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/configuration-core",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "description": "Source of truth for argent feature flags: registry, JSON storage, and isFlagEnabled",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/native-devtools-android/package.json
+++ b/packages/native-devtools-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-android",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/native-devtools-ios/package.json
+++ b/packages/native-devtools-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-ios",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Claude Code skills for iOS simulator and Android emulator interaction via argent",
   "scripts": {

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Framework-agnostic tool registry for iOS simulator and Android emulator control",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/update-core/package.json
+++ b/packages/update-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/update-core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Shared npm release-age detection and installable-target resolution for argent updates",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps the package suite from `0.10.0` to **`0.11.0`**.

## Changed
- All release packages `0.10.0 → 0.11.0`: `@swmansion/argent`, `@argent/cli`, `@argent/installer`, `@argent/mcp`, `@argent/tools-client`, `@argent/native-devtools-android`, `@argent/native-devtools-ios`, `@argent/registry`, `@argent/skills`, `@argent/tool-server`, `@argent/update-core`.
- `@argent/configuration-core` `0.9.0 → 0.11.0` — was lagging a release behind (extracted in #295); aligned to the suite. (It's `private`/unpublished, so this is internal-only.)
- Regenerated `package-lock.json` to reflect the new workspace versions.

## Not changed
- `@argent/ui` stays at `0.0.1` (separate pre-release track).
- The private workspace root has no version.
- Internal deps use `file:../` specifiers, so no dependency ranges needed updating.

No source/runtime changes — `argent --version` reads from `package.json` at runtime.