### PR TITLE
feat: record AI client metadata for telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,15 @@ argent init
 
 ## Privacy
 
-Argent does not collect or transmit any user data.
-No telemetry, no analytics, no crash reporting.
+Argent collects anonymous, opt-out usage and diagnostic telemetry to help us prioritise features and fix what breaks. It is minimal by design.
 
-- Argent integrates with your agent locally over MCP stdio.
-- Its internal tools are not reachable from outside your machine.
-- The only outbound network call we make is the version check against our public npm package, which sends no user data and fails gracefully if blocked.
+You can opt out at any time:
+
+```bash
+argent telemetry disable   # check status with: argent telemetry status
+```
+
+For the full details — see the [Argent Privacy Notice (Telemetry)](https://github.com/software-mansion/argent/blob/main/TELEMETRY.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You can opt out at any time:
 argent telemetry disable   # check status with: argent telemetry status
 ```
 
-For the full details — see the [Argent Privacy Notice (Telemetry)](https://github.com/software-mansion/argent/blob/main/TELEMETRY.md).
+For the full details — see the [Argent Privacy Notice (Telemetry)](https://github.com/software-mansion/argent/blob/main/Telemetry.md).
 
 ## License
 

--- a/Telemetry.md
+++ b/Telemetry.md
@@ -1,0 +1,111 @@
+# Argent Privacy Notice (Telemetry)
+
+Effective date: 16 June 2026 · Version: 1.0
+
+This notice is a product-specific supplement to the Software Mansion Privacy Policy (the "Policy") and applies to telemetry collected by Argent, a Software Mansion Software Product. Capitalised terms used but not defined here (including Personal Data, Usage Data, Legitimate Interest, EEA and Software Mansion Software Product) have the meaning given to them in the Policy. Where this notice and the Policy differ in respect of Argent telemetry, this notice prevails.
+
+Argent collects a small amount of usage and diagnostic data ("telemetry") to help us understand how the tool is used and to make it more reliable. We have designed it to be minimal by default: we do not collect the content of your work - no source code, no file paths, no tool inputs, no application data, no error messages, and no device identifiers.
+
+## How to opt out
+
+Telemetry is enabled by default. You can disable it at any time, and the change takes effect immediately and permanently for that installation. This is also how you exercise your right to object (see Your rights below).
+
+```bash
+argent telemetry disable
+```
+
+To check the current status:
+
+```bash
+argent telemetry status
+```
+
+Disabling telemetry does not affect any functionality of Argent.
+
+## Why we collect telemetry
+
+We use telemetry, in our Legitimate Interest, only to:
+
+- understand which features are used, so we can prioritise development;
+- detect where installation, updates, or tools fail, so we can fix them;
+- measure reliability and performance (e.g. how long operations run, error rates);
+- understand the environments Argent runs in (operating system, runtime versions, terminal vs CI).
+
+We do not use telemetry for advertising, marketing, profiling, automated decision-making, or sale of data, and we never combine it with any account or with Personal Data collected through other Services.
+
+## What we collect
+
+### Installation, update and uninstallation
+
+- the progress of an installation: which options were selected; whether it started, completed, failed, or was cancelled; and at which step it was cancelled;
+- the progress of an update to a newer version;
+- the progress of an uninstallation of Argent.
+
+### Tool and process usage
+
+- which Argent tools are invoked, and whether they succeeded or returned an error;
+- which AI coding tool is driving Argent;
+- how long a process ran in the terminal or in CI, and which Argent component emitted the event;
+- start and stop of the Argent tool-server, its uptime, the number of tools used, and the reason it stopped.
+
+### Environment
+
+- Argent version, Node.js version, operating system, processor architecture;
+- whether the process runs in an interactive terminal and whether it runs in a CI environment;
+- whether Argent is used in connection with Android or iOS.
+
+### Diagnostics
+
+- the fact that an error occurred (event type and code only — never the error content or message).
+
+### Identifiers
+
+- a randomly generated identifier that persists for an installation, used only to distinguish unique installations and to de-duplicate events. It does not contain, and is not derived from, your name, username, account, or any device identifier;
+- a random session identifier generated for each usage session.
+
+## What we never collect
+
+To be explicit, Argent telemetry never includes:
+
+- tool inputs or arguments;
+- file paths or file names;
+- source code or its contents;
+- application data;
+- device identifiers (e.g. hardware IDs, MAC addresses, serial numbers);
+- the content or text of error messages.
+
+## Who we disclose the data to
+
+We use PostHog (provided by PostHog, Inc., San Francisco, USA) as our product analytics provider, acting as our processor under a Data Processing Agreement.
+
+Telemetry data is hosted in the European Union (Frankfurt, Germany) on PostHog's EU Cloud. PostHog engages its own sub-processors (cloud hosting and operational monitoring) located in the EU for the EU Cloud and keeps this list to a strict minimum. You can find the current list of PostHog sub-processors on PostHog's website, and a set of useful links is available from us on request.
+
+## Legal basis for processing
+
+The controller is Software Mansion S.A. (details below). To the extent that the telemetry described here constitutes Personal Data, we process it on the basis of our Legitimate Interest (Article 6(1)(f) GDPR) in maintaining, securing, and improving Argent, consistent with the legitimate-interest grounds set out in the Policy. We have carried out a balancing assessment, taking into account the minimal and non-content nature of the data and the simple opt-out above, and concluded that this interest is not overridden by your interests or fundamental rights and freedoms. You may object to this processing at any time by opting out.
+
+## How long we keep the data
+
+Telemetry events are retained for up to 72 months, after which they are deleted or aggregated into non-identifiable statistics.
+
+## International data transfers
+
+Telemetry data is stored within the EEA (Germany). As PostHog, Inc. is established in the United States, access from outside the EEA (e.g. for support) may occur and is governed by the European Commission's Standard Contractual Clauses.
+
+## Your rights
+
+Subject to the conditions in the GDPR, you have the right of access, rectification, erasure, restriction of processing, data portability, and the right to object, as described in the Data Subject Rights section of the Policy. Because the data is not linked to a named individual or account, we may be unable to identify your specific records without additional information from you (Article 11 GDPR); the most effective way to stop processing is to opt out as described above.
+
+To exercise these rights, contact us at legal@swmansion.com.
+
+You also have the right to lodge a complaint with a competent supervisory authority. In Poland this is the Personal Data Protection Office (UODO), ul. Stawki 2, 00-193 Warszawa.
+
+## Controller and contact
+
+The controller of your Personal Data is Software Mansion S.A., a joint stock company with its principal place of business at ul. Zabłocie 43b, 30-701 Kraków, Poland, entered in the register of businesses conducted by the District Court in Kraków for Kraków-Śródmieście, XI Commercial Division of the National Court Register with KRS number 0000961952, NIP 6793131302, REGON 364909814.
+
+For any questions or requests regarding this notice, contact us at legal@swmansion.com.
+
+## Changes to this notice
+
+We may update this notice as Argent evolves. The most current version will be available with the effective date and version shown at the top, and material changes will be announced through the usual Argent release channels.

--- a/Telemetry.md
+++ b/Telemetry.md
@@ -2,7 +2,7 @@
 
 Effective date: 16 June 2026 · Version: 1.0
 
-This notice is a product-specific supplement to the Software Mansion Privacy Policy (the "Policy") and applies to telemetry collected by Argent, a Software Mansion Software Product. Capitalised terms used but not defined here (including Personal Data, Usage Data, Legitimate Interest, EEA and Software Mansion Software Product) have the meaning given to them in the Policy. Where this notice and the Policy differ in respect of Argent telemetry, this notice prevails.
+This notice is a product-specific supplement to the [Software Mansion Privacy Policy](https://swmansion.com/) (the "Policy") and applies to telemetry collected by Argent, a Software Mansion Software Product. Capitalised terms used but not defined here (including Personal Data, Usage Data, Legitimate Interest, EEA and Software Mansion Software Product) have the meaning given to them in the Policy. Where this notice and the Policy differ in respect of Argent telemetry, this notice prevails.
 
 Argent collects a small amount of usage and diagnostic data ("telemetry") to help us understand how the tool is used and to make it more reliable. We have designed it to be minimal by default: we do not collect the content of your work - no source code, no file paths, no tool inputs, no application data, no error messages, and no device identifiers.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4907,6 +4907,7 @@
       "version": "0.12.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
+        "@argent/telemetry": "file:../telemetry",
         "@argent/tools-client": "file:../argent-tools-client",
         "@modelcontextprotocol/sdk": "^1.29.0"
       },

--- a/packages/argent-installer/src/first-run-notice.ts
+++ b/packages/argent-installer/src/first-run-notice.ts
@@ -1,0 +1,29 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import {
+  shouldShowFirstRunNotice,
+  markFirstRunNoticeShown,
+  FIRST_RUN_NOTICE_BODY_LINES,
+  TELEMETRY_OPT_OUT_COMMAND,
+  TELEMETRY_DETAILS_URL,
+} from "@argent/telemetry";
+
+/**
+ * Print the anonymous-telemetry notice, once per installation. Shared by
+ * `argent init` and `argent update` so both surfaces render the same message;
+ * the marker is cleared on uninstall so reinstalls show it again. The opt-out
+ * command is highlighted in cyan to match how commands are styled elsewhere in
+ * the flow. No-op when telemetry is disabled or already shown this installation.
+ */
+export function printFirstRunNotice(): void {
+  if (!shouldShowFirstRunNotice()) return;
+  p.log.info(
+    [
+      pc.bold("Telemetry"),
+      ...FIRST_RUN_NOTICE_BODY_LINES.map((line) => pc.dim(line)),
+      `${pc.dim("Opt out anytime:")} ${pc.cyan(TELEMETRY_OPT_OUT_COMMAND)}`,
+      `${pc.dim("Details:")} ${pc.dim(TELEMETRY_DETAILS_URL)}`,
+    ].join("\n")
+  );
+  markFirstRunNoticeShown();
+}

--- a/packages/argent-installer/src/first-run-notice.ts
+++ b/packages/argent-installer/src/first-run-notice.ts
@@ -2,18 +2,26 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import {
   shouldShowFirstRunNotice,
+  hasShownFirstRunNotice,
   markFirstRunNoticeShown,
+  getConsentState,
+  writeConsentFlag,
+  setSessionConsentOverride,
   FIRST_RUN_NOTICE_BODY_LINES,
   TELEMETRY_OPT_OUT_COMMAND,
   TELEMETRY_DETAILS_URL,
 } from "@argent/telemetry";
 
+/** The command users run to turn telemetry back on after disabling it. */
+const TELEMETRY_OPT_IN_COMMAND = "argent telemetry enable";
+
 /**
  * Print the anonymous-telemetry notice, once per installation. Shared by
- * `argent init` and `argent update` so both surfaces render the same message;
- * the marker is cleared on uninstall so reinstalls show it again. The opt-out
- * command is highlighted in cyan to match how commands are styled elsewhere in
- * the flow. No-op when telemetry is disabled or already shown this installation.
+ * `argent update` and the non-interactive `argent init` path so both surfaces
+ * render the same informational message; the marker is cleared on uninstall so
+ * reinstalls show it again. The opt-out command is highlighted in cyan to match
+ * how commands are styled elsewhere in the flow. No-op when telemetry is
+ * disabled or already shown this installation.
  */
 export function printFirstRunNotice(): void {
   if (!shouldShowFirstRunNotice()) return;
@@ -26,4 +34,104 @@ export function printFirstRunNotice(): void {
     ].join("\n")
   );
   markFirstRunNoticeShown();
+}
+
+export type TelemetryConsentOutcome =
+  | { kind: "enabled"; commit: () => void }
+  | { kind: "disabled"; reason: "flag" }
+  | { kind: "disabled"; reason: "choice"; commit: () => void }
+  | { kind: "skipped" }
+  | { kind: "cancelled" };
+
+/**
+ * Resolve telemetry consent for `argent init`, BEFORE the first track() call so
+ * the user's choice governs whether this session's installation events are
+ * collected at all.
+ *
+ * Precedence:
+ *  1. `--no-telemetry` — always disables, prompt or not.
+ *  2. Non-interactive (`--yes`) — keep the default-on (opt-out) model and just
+ *     surface the informational notice; there is no TTY to prompt on.
+ *  3. An env override (DO_NOT_TRACK / ARGENT_TELEMETRY) already owns the
+ *     decision and config can't override it, so don't prompt.
+ *  4. Already decided on a previous install — honor it, don't re-ask.
+ *  5. Interactive first run — ask, defaulting the selection to Enabled.
+ *
+ * An interactive choice (case 5) takes effect for THIS session immediately via
+ * an in-process override, but is only persisted — and the notice only marked
+ * shown — when the caller invokes the returned `commit()`. init defers that to
+ * a completed install, so a user who picks a value then aborts setup is
+ * re-prompted next run instead of silently inheriting the abandoned choice. The
+ * `--no-telemetry` flag (case 1) is an explicit, durable opt-out and persists
+ * right away.
+ */
+export async function resolveTelemetryConsent(opts: {
+  nonInteractive: boolean;
+  disableFlag: boolean;
+}): Promise<TelemetryConsentOutcome> {
+  // 1. Explicit --no-telemetry wins in every mode.
+  if (opts.disableFlag) {
+    writeConsentFlag(false);
+    markFirstRunNoticeShown();
+    p.log.info(`${pc.bold("Telemetry")} ${pc.dim("disabled (--no-telemetry).")}`);
+    return { kind: "disabled", reason: "flag" };
+  }
+
+  // 2. Non-interactive: keep the default, surface the notice only.
+  if (opts.nonInteractive) {
+    printFirstRunNotice();
+    return { kind: "skipped" };
+  }
+
+  // 3/4. Don't prompt when an env override owns the decision, or when the user
+  // already chose on a previous install.
+  const source = getConsentState().source.source;
+  const envOwnsDecision = source === "env_do_not_track" || source === "env_argent_telemetry";
+  if (envOwnsDecision || hasShownFirstRunNotice()) {
+    return { kind: "skipped" };
+  }
+
+  // 5. Interactive first run: explain what we collect, then ask.
+  p.log.info(
+    [
+      pc.bold("Telemetry"),
+      ...FIRST_RUN_NOTICE_BODY_LINES.map((line) => pc.dim(line)),
+      `${pc.dim("Opt out anytime:")} ${pc.cyan(TELEMETRY_OPT_OUT_COMMAND)}`,
+      `${pc.dim("Details:")} ${pc.dim(TELEMETRY_DETAILS_URL)}`,
+    ].join("\n")
+  );
+
+  const choice = await p.select({
+    message: "Enable anonymous telemetry?",
+    options: [
+      { value: "enabled" as const, label: "Enabled", hint: "recommended" },
+      { value: "disabled" as const, label: "Disabled" },
+    ],
+    initialValue: "enabled" as const,
+  });
+
+  if (p.isCancel(choice)) {
+    // Caller cancels init without tracking — the user agreed to nothing.
+    return { kind: "cancelled" };
+  }
+
+  const enabled = choice === "enabled";
+  // Make the pick effective for this session right away, but defer the durable
+  // write: committing only on a completed install means an aborted init re-asks
+  // next run rather than remembering a choice the user backed out of.
+  setSessionConsentOverride(enabled);
+  const commit = (): void => {
+    writeConsentFlag(enabled);
+    markFirstRunNoticeShown();
+  };
+
+  if (enabled) {
+    p.log.info(`${pc.bold("Telemetry")} ${pc.green("enabled")}.`);
+    return { kind: "enabled", commit };
+  }
+
+  p.log.info(
+    `${pc.bold("Telemetry")} ${pc.dim(`disabled. Enable anytime: ${TELEMETRY_OPT_IN_COMMAND}`)}`
+  );
+  return { kind: "disabled", reason: "choice", commit };
 }

--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -121,11 +121,6 @@ export async function init(args: string[]): Promise<void> {
 
   telemetryInit("installer");
 
-  track("installation:cli_init_start", {
-    package_manager: detectPackageManager(),
-    is_non_interactive: nonInteractive,
-  });
-
   let editorsConfiguredCount = 0;
   let initSucceeded = false;
   let telemetryFinalized = false;
@@ -172,6 +167,11 @@ export async function init(args: string[]): Promise<void> {
     p.log.info(`${pc.dim("Package:")} ${PACKAGE_NAME}@${version}`);
 
     printFirstRunNotice();
+
+    track("installation:cli_init_start", {
+      package_manager: detectPackageManager(),
+      is_non_interactive: nonInteractive,
+    });
 
     // ── Step 0: Install / Update Check ──────────────────────────────────────────
 

--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -3,7 +3,7 @@ import pc from "picocolors";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { spawn } from "node:child_process";
-import { init as telemetryInit, track, isEnabled as telemetryIsEnabled } from "@argent/telemetry";
+import { init as telemetryInit, track } from "@argent/telemetry";
 import { FAILURE_CODES, type FailureSignal } from "@argent/registry";
 import {
   detectAdapters,
@@ -37,6 +37,7 @@ import {
 } from "./skills.js";
 import { PACKAGE_NAME } from "./constants.js";
 import { finalizeTelemetry } from "./telemetry-finalize.js";
+import { printFirstRunNotice } from "./first-run-notice.js";
 
 type InstallerFailureSignal = FailureSignal & { failure_area: "installer" };
 
@@ -119,7 +120,6 @@ export async function init(args: string[]): Promise<void> {
   const initStartTime = performance.now();
 
   telemetryInit("installer");
-  printTelemetryNotice();
 
   track("installation:cli_init_start", {
     package_manager: detectPackageManager(),
@@ -170,6 +170,8 @@ export async function init(args: string[]): Promise<void> {
 
     let version = getInstalledVersion() ?? "unknown";
     p.log.info(`${pc.dim("Package:")} ${PACKAGE_NAME}@${version}`);
+
+    printFirstRunNotice();
 
     // ── Step 0: Install / Update Check ──────────────────────────────────────────
 
@@ -772,25 +774,6 @@ export async function init(args: string[]): Promise<void> {
     await finalizeInitTelemetry(INSTALL_UNCLASSIFIED_FAILED);
     throw err;
   }
-}
-
-// Print the notice only when this run may send telemetry.
-function printTelemetryNotice(): void {
-  if (!telemetryIsEnabled()) return;
-  p.log.info(
-    [
-      pc.bold("Telemetry"),
-      pc.dim("Argent collects anonymous, opt-out usage telemetry (PostHog EU) so we can"),
-      pc.dim("prioritise the features and bugs that matter most. No raw arguments, paths,"),
-      pc.dim("error messages, or environment values are ever sent — only event names and"),
-      pc.dim("a small set of typed, validator-enforced properties."),
-      pc.dim(""),
-      pc.dim("A lifetime-stable anonymous UUID is generated on first run. To opt out,"),
-      pc.dim("run `argent telemetry disable` or set `DO_NOT_TRACK=1` /"),
-      pc.dim("`ARGENT_TELEMETRY=0`. To audit what is sent,"),
-      pc.dim("set `ARGENT_TELEMETRY_DEBUG=1` and inspect `~/.argent/telemetry-debug.log`."),
-    ].join("\n")
-  );
 }
 
 function sanitizeEditorName(raw: string): string {

--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -37,7 +37,7 @@ import {
 } from "./skills.js";
 import { PACKAGE_NAME } from "./constants.js";
 import { finalizeTelemetry } from "./telemetry-finalize.js";
-import { printFirstRunNotice } from "./first-run-notice.js";
+import { resolveTelemetryConsent } from "./first-run-notice.js";
 
 type InstallerFailureSignal = FailureSignal & { failure_area: "installer" };
 
@@ -116,6 +116,7 @@ function extractFlag(args: string[], flag: string): string | null {
 
 export async function init(args: string[]): Promise<void> {
   const nonInteractive = args.includes("--yes") || args.includes("-y");
+  const noTelemetry = args.includes("--no-telemetry");
   const fromTar = extractFlag(args, "--from");
   const initStartTime = performance.now();
 
@@ -166,7 +167,14 @@ export async function init(args: string[]): Promise<void> {
     let version = getInstalledVersion() ?? "unknown";
     p.log.info(`${pc.dim("Package:")} ${PACKAGE_NAME}@${version}`);
 
-    printFirstRunNotice();
+    // Resolve telemetry consent before the first track() so the user's choice
+    // governs whether this session's installation events are collected at all.
+    const consent = await resolveTelemetryConsent({ nonInteractive, disableFlag: noTelemetry });
+    if (consent.kind === "cancelled") {
+      // No tracking on a consent-prompt cancel — the user agreed to nothing.
+      p.cancel("Initialization cancelled.");
+      process.exit(0);
+    }
 
     track("installation:cli_init_start", {
       package_manager: detectPackageManager(),
@@ -766,6 +774,11 @@ export async function init(args: string[]): Promise<void> {
     p.outro("Done.");
 
     initSucceeded = true;
+    // Persist an interactive first-run telemetry choice only now that init has
+    // completed. Until this point the pick governs the session via an in-process
+    // override but isn't written to disk, so aborting setup leaves nothing behind
+    // and the next run re-prompts instead of inheriting the abandoned choice.
+    if ("commit" in consent) consent.commit();
     await finalizeInitTelemetry();
   } catch (err) {
     // Any unclassified throw (file I/O, copyRulesAndAgents, the online check, a

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -31,6 +31,7 @@ import { PACKAGE_NAME } from "./constants.js";
 import { resolveInstallableUpdateTarget } from "./update-target.js";
 import { killToolServer } from "@argent/tools-client";
 import { finalizeTelemetry } from "./telemetry-finalize.js";
+import { printFirstRunNotice } from "./first-run-notice.js";
 
 function getRequestedVersion(args: string[]): string | null {
   for (let i = 0; i < args.length; i += 1) {
@@ -158,6 +159,8 @@ export async function update(args: string[]): Promise<void> {
 
   try {
     p.intro(pc.bgCyan(pc.black(" argent update ")));
+
+    printFirstRunNotice();
 
     // When invoked via `npx @swmansion/argent update`, the running package is
     // the npx cache and will always be at the latest published version. Reading the

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -118,7 +118,6 @@ export async function update(args: string[]): Promise<void> {
   const trigger = getUpdateTriggerFromEnv();
   telemetryInit("installer");
   const updateStartTime = performance.now();
-  track("installation:cli_update_start", {});
   let telemetryFinalized = false;
 
   const trackPackageAction = async (
@@ -161,6 +160,8 @@ export async function update(args: string[]): Promise<void> {
     p.intro(pc.bgCyan(pc.black(" argent update ")));
 
     printFirstRunNotice();
+
+    track("installation:cli_update_start", {});
 
     // When invoked via `npx @swmansion/argent update`, the running package is
     // the npx cache and will always be at the latest published version. Reading the

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -31,7 +31,7 @@ import { PACKAGE_NAME } from "./constants.js";
 import { resolveInstallableUpdateTarget } from "./update-target.js";
 import { killToolServer } from "@argent/tools-client";
 import { finalizeTelemetry } from "./telemetry-finalize.js";
-import { printFirstRunNotice } from "./first-run-notice.js";
+import { resolveTelemetryConsent } from "./first-run-notice.js";
 
 function getRequestedVersion(args: string[]): string | null {
   for (let i = 0; i < args.length; i += 1) {
@@ -114,6 +114,7 @@ export function resolveUpdatePackageAction(
 
 export async function update(args: string[]): Promise<void> {
   const nonInteractive = args.includes("--yes") || args.includes("-y");
+  const noTelemetry = args.includes("--no-telemetry");
   const requestedVersion = getRequestedVersion(args);
   const trigger = getUpdateTriggerFromEnv();
   telemetryInit("installer");
@@ -159,7 +160,10 @@ export async function update(args: string[]): Promise<void> {
   try {
     p.intro(pc.bgCyan(pc.black(" argent update ")));
 
-    printFirstRunNotice();
+    // `--no-telemetry` force-disables before the first track(); otherwise just
+    // surface the notice. update never prompts — it often runs from the old
+    // binary or non-TTY contexts where the init consent step can't apply.
+    await resolveTelemetryConsent({ nonInteractive: true, disableFlag: noTelemetry });
 
     track("installation:cli_update_start", {});
 

--- a/packages/argent-installer/test/init.test.ts
+++ b/packages/argent-installer/test/init.test.ts
@@ -9,8 +9,21 @@ import {
   ARGENT_SKILLS_REPO,
   buildArgentSkillsSource,
 } from "../src/utils.js";
-import { printFirstRunNotice } from "../src/first-run-notice.js";
-import { hasShownFirstRunNotice, _resetConsentCacheForTest } from "@argent/telemetry";
+import * as p from "@clack/prompts";
+import { printFirstRunNotice, resolveTelemetryConsent } from "../src/first-run-notice.js";
+import {
+  hasShownFirstRunNotice,
+  markFirstRunNoticeShown,
+  isEnabled,
+  _resetConsentCacheForTest,
+} from "@argent/telemetry";
+
+// Real clack `select` reads stdin and can't run headless; stub it (and isCancel)
+// while keeping the rest of the module (log.* writes to the mocked stdout).
+vi.mock("@clack/prompts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@clack/prompts")>();
+  return { ...actual, select: vi.fn(), isCancel: vi.fn(() => false) };
+});
 
 // These tests verify the logic used by init.ts without running the full TUI.
 // The actual init flow is interactive and tested via the integration harness.
@@ -86,6 +99,152 @@ describe("printFirstRunNotice", () => {
     process.env.ARGENT_TELEMETRY = "0";
     _resetConsentCacheForTest();
     printFirstRunNotice();
+    expect(hasShownFirstRunNotice()).toBe(false);
+  });
+});
+
+describe("resolveTelemetryConsent", () => {
+  let tmp: string;
+  let savedHome: string | undefined;
+  let savedUserProfile: string | undefined;
+  let savedArgentTelemetry: string | undefined;
+  let savedDoNotTrack: string | undefined;
+
+  const readConfig = (): Record<string, any> => {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(tmp, ".argent", "config.json"), "utf8"));
+    } catch {
+      return {};
+    }
+  };
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "argent-installer-consent-"));
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+    savedArgentTelemetry = process.env.ARGENT_TELEMETRY;
+    savedDoNotTrack = process.env.DO_NOT_TRACK;
+    process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
+    delete process.env.ARGENT_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+    _resetConsentCacheForTest();
+    vi.mocked(p.select).mockReset();
+    vi.mocked(p.isCancel).mockReset();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    const restore = (
+      key: "HOME" | "USERPROFILE" | "ARGENT_TELEMETRY" | "DO_NOT_TRACK",
+      value: string | undefined
+    ) => {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    };
+    restore("HOME", savedHome);
+    restore("USERPROFILE", savedUserProfile);
+    restore("ARGENT_TELEMETRY", savedArgentTelemetry);
+    restore("DO_NOT_TRACK", savedDoNotTrack);
+    _resetConsentCacheForTest();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("--no-telemetry disables and marks shown without prompting (any mode)", async () => {
+    const result = await resolveTelemetryConsent({ nonInteractive: false, disableFlag: true });
+    expect(result).toEqual({ kind: "disabled", reason: "flag" });
+    expect(p.select).not.toHaveBeenCalled();
+    expect(readConfig().telemetry?.enabled).toBe(false);
+    expect(isEnabled()).toBe(false);
+    expect(hasShownFirstRunNotice()).toBe(true);
+  });
+
+  it("non-interactive keeps the default and only surfaces the notice", async () => {
+    const result = await resolveTelemetryConsent({ nonInteractive: true, disableFlag: false });
+    expect(result).toEqual({ kind: "skipped" });
+    expect(p.select).not.toHaveBeenCalled();
+    // No persisted override — still default-on.
+    expect(readConfig().telemetry?.enabled).toBeUndefined();
+    expect(isEnabled()).toBe(true);
+    expect(hasShownFirstRunNotice()).toBe(true);
+  });
+
+  it("does not prompt when an env override owns the decision", async () => {
+    process.env.ARGENT_TELEMETRY = "0";
+    _resetConsentCacheForTest();
+    const result = await resolveTelemetryConsent({ nonInteractive: false, disableFlag: false });
+    expect(result).toEqual({ kind: "skipped" });
+    expect(p.select).not.toHaveBeenCalled();
+    expect(hasShownFirstRunNotice()).toBe(false);
+  });
+
+  it("does not re-prompt once a choice was made on a previous install", async () => {
+    markFirstRunNoticeShown();
+    const result = await resolveTelemetryConsent({ nonInteractive: false, disableFlag: false });
+    expect(result).toEqual({ kind: "skipped" });
+    expect(p.select).not.toHaveBeenCalled();
+  });
+
+  it("an interactive Enabled choice is effective immediately but only persists on commit", async () => {
+    vi.mocked(p.select).mockResolvedValue("enabled");
+    const result = await resolveTelemetryConsent({ nonInteractive: false, disableFlag: false });
+    expect(result.kind).toBe("enabled");
+    // Effective for the session via the in-process override...
+    expect(isEnabled()).toBe(true);
+    // ...but nothing is on disk until the install commits.
+    expect(readConfig().telemetry?.enabled).toBeUndefined();
+    expect(hasShownFirstRunNotice()).toBe(false);
+
+    if (result.kind === "enabled") result.commit();
+    expect(readConfig().telemetry?.enabled).toBe(true);
+    expect(isEnabled()).toBe(true);
+    expect(hasShownFirstRunNotice()).toBe(true);
+  });
+
+  it("an interactive Disabled choice suppresses the session immediately but only persists on commit", async () => {
+    vi.mocked(p.select).mockResolvedValue("disabled");
+    const result = await resolveTelemetryConsent({ nonInteractive: false, disableFlag: false });
+    expect(result).toMatchObject({ kind: "disabled", reason: "choice" });
+    // Session is already opted out even though nothing is on disk yet.
+    expect(isEnabled()).toBe(false);
+    expect(readConfig().telemetry?.enabled).toBeUndefined();
+    expect(hasShownFirstRunNotice()).toBe(false);
+
+    if (result.kind === "disabled" && result.reason === "choice") result.commit();
+    expect(readConfig().telemetry?.enabled).toBe(false);
+    expect(isEnabled()).toBe(false);
+    expect(hasShownFirstRunNotice()).toBe(true);
+  });
+
+  it("re-prompts on the next run when a prior choice was never committed (aborted init)", async () => {
+    // First run: the user picks Enabled but aborts before init commits.
+    vi.mocked(p.select).mockResolvedValue("enabled");
+    const first = await resolveTelemetryConsent({ nonInteractive: false, disableFlag: false });
+    expect(first.kind).toBe("enabled");
+    // No commit() — the install was abandoned.
+
+    // A fresh process clears the in-process override and re-reads disk, which
+    // still carries no decision. _resetConsentCacheForTest models that restart.
+    _resetConsentCacheForTest();
+    expect(hasShownFirstRunNotice()).toBe(false);
+    expect(readConfig().telemetry?.enabled).toBeUndefined();
+
+    // Second run: must ask again rather than inherit the abandoned "enabled".
+    vi.mocked(p.select).mockResolvedValue("disabled");
+    const second = await resolveTelemetryConsent({ nonInteractive: false, disableFlag: false });
+    expect(p.select).toHaveBeenCalledTimes(2);
+    expect(second).toMatchObject({ kind: "disabled", reason: "choice" });
+  });
+
+  it("cancelling the prompt persists nothing and reports cancelled", async () => {
+    const cancelSymbol = Symbol("clack:cancel");
+    vi.mocked(p.select).mockResolvedValue(cancelSymbol as never);
+    vi.mocked(p.isCancel).mockReturnValue(true);
+    const result = await resolveTelemetryConsent({ nonInteractive: false, disableFlag: false });
+    expect(result).toEqual({ kind: "cancelled" });
+    expect(readConfig().telemetry?.enabled).toBeUndefined();
     expect(hasShownFirstRunNotice()).toBe(false);
   });
 });

--- a/packages/argent-installer/test/init.test.ts
+++ b/packages/argent-installer/test/init.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import {
   SKILLS_DIR,
@@ -7,6 +9,8 @@ import {
   ARGENT_SKILLS_REPO,
   buildArgentSkillsSource,
 } from "../src/utils.js";
+import { printFirstRunNotice } from "../src/first-run-notice.js";
+import { hasShownFirstRunNotice, _resetConsentCacheForTest } from "@argent/telemetry";
 
 // These tests verify the logic used by init.ts without running the full TUI.
 // The actual init flow is interactive and tested via the integration harness.
@@ -27,6 +31,62 @@ describe("init — skills path resolution", () => {
   it("AGENTS_DIR resolves relative to dist/", () => {
     expect(AGENTS_DIR).toContain("agents");
     expect(path.isAbsolute(AGENTS_DIR)).toBe(true);
+  });
+});
+
+describe("printFirstRunNotice", () => {
+  let tmp: string;
+  let savedHome: string | undefined;
+  let savedUserProfile: string | undefined;
+  let savedArgentTelemetry: string | undefined;
+  let savedDoNotTrack: string | undefined;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "argent-installer-notice-"));
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+    savedArgentTelemetry = process.env.ARGENT_TELEMETRY;
+    savedDoNotTrack = process.env.DO_NOT_TRACK;
+    process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
+    delete process.env.ARGENT_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+    _resetConsentCacheForTest();
+    // Keep clack output from polluting the test reporter.
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    const restore = (
+      key: "HOME" | "USERPROFILE" | "ARGENT_TELEMETRY" | "DO_NOT_TRACK",
+      value: string | undefined
+    ) => {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    };
+    restore("HOME", savedHome);
+    restore("USERPROFILE", savedUserProfile);
+    restore("ARGENT_TELEMETRY", savedArgentTelemetry);
+    restore("DO_NOT_TRACK", savedDoNotTrack);
+    _resetConsentCacheForTest();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("marks the notice shown on first run and is a no-op afterwards", () => {
+    expect(hasShownFirstRunNotice()).toBe(false);
+    printFirstRunNotice();
+    expect(hasShownFirstRunNotice()).toBe(true);
+    // Second call must not throw and the marker stays set.
+    printFirstRunNotice();
+    expect(hasShownFirstRunNotice()).toBe(true);
+  });
+
+  it("does not mark the notice shown when telemetry is opted out", () => {
+    process.env.ARGENT_TELEMETRY = "0";
+    _resetConsentCacheForTest();
+    printFirstRunNotice();
+    expect(hasShownFirstRunNotice()).toBe(false);
   });
 });
 

--- a/packages/argent-mcp/package.json
+++ b/packages/argent-mcp/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@argent/configuration-core": "file:../configuration-core",
+    "@argent/telemetry": "file:../telemetry",
     "@argent/tools-client": "file:../argent-tools-client",
     "@modelcontextprotocol/sdk": "^1.29.0"
   },

--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -14,6 +14,7 @@ import {
   type ToolMeta,
   type ToolsServerPaths,
 } from "@argent/tools-client";
+import { canonicalizeAiClient, AI_CLIENT_NAME_PATTERN } from "@argent/telemetry";
 import {
   toMcpContent,
   flowRunToMcpContent,
@@ -115,6 +116,24 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
     return AUTH_TOKEN ? { Authorization: `Bearer ${AUTH_TOKEN}` } : {};
   }
 
+  // Coarse identity of the AI tool driving this MCP server, forwarded to the
+  // tool-server (a separate process that owns tool telemetry) as request headers.
+  // The signal is the MCP handshake clientInfo.name; unrecognized tools are
+  // reported as `other` with a bounded free-form name. Never carries prompts,
+  // model output, or tool args.
+  function aiClientHeaders(): Record<string, string> {
+    const rawName = server.getClientVersion()?.name?.trim() || undefined;
+    const aiClient = canonicalizeAiClient(rawName);
+    if (aiClient) return { "X-Argent-AI-Client": aiClient };
+    if (rawName) {
+      return {
+        "X-Argent-AI-Client": "other",
+        ...(AI_CLIENT_NAME_PATTERN.test(rawName) ? { "X-Argent-AI-Client-Name": rawName } : {}),
+      };
+    }
+    return {};
+  }
+
   let reconnectPromise: Promise<void> | null = null;
 
   async function reconnect(): Promise<void> {
@@ -186,7 +205,7 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
     const res = await fetchWithReconnect(() => `${TOOLS_URL}/tools/${name}`, reconnect, {
       init: {
         method: "POST",
-        headers: { "Content-Type": "application/json", ...authHeader() },
+        headers: { "Content-Type": "application/json", ...authHeader(), ...aiClientHeaders() },
         body: JSON.stringify(finalArgs ?? {}),
       },
       fetchTimeoutMs: meta?.longRunning ? null : FETCH_TIMEOUT_MS,

--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -14,7 +14,13 @@ import {
   type ToolMeta,
   type ToolsServerPaths,
 } from "@argent/tools-client";
-import { canonicalizeAiClient, AI_CLIENT_NAME_PATTERN } from "@argent/telemetry";
+import {
+  canonicalizeAiClient,
+  AI_CLIENT_NAME_PATTERN,
+  FIRST_RUN_NOTICE,
+  markFirstRunNoticeShown,
+  shouldShowFirstRunNotice,
+} from "@argent/telemetry";
 import {
   toMcpContent,
   flowRunToMcpContent,
@@ -88,6 +94,16 @@ export interface StartMcpServerOptions {
 }
 
 export async function startMcpServer(options: StartMcpServerOptions): Promise<void> {
+  // First-run telemetry notice, once per installation, for users who reach a
+  // telemetry-enabled build via an update: `argent update` runs the OLD binary
+  // (postinstall skipped), so the editor relaunching `argent mcp` is often the
+  // first time the new code runs. stdout is the JSON-RPC channel — the notice
+  // MUST go to stderr to avoid corrupting it.
+  if (shouldShowFirstRunNotice()) {
+    process.stderr.write(`[argent] ${FIRST_RUN_NOTICE}\n`);
+    markFirstRunNoticeShown();
+  }
+
   // isFlagEnabled hits disk, so resolve it once at startup rather than on every
   // tool call. A flag change therefore needs an MCP restart to take effect.
   const autoScreenshotOn = autoScreenshotEnabled();

--- a/packages/telemetry/src/ai-identity.ts
+++ b/packages/telemetry/src/ai-identity.ts
@@ -1,0 +1,74 @@
+// Coarse identity of the AI coding tool driving the MCP server. We record only
+// a canonical client slug (which tool) — never prompts, model output, or args.
+//
+// The single signal is the MCP `initialize` handshake `clientInfo.name` (ground
+// truth of what is actually connecting), read at runtime via
+// `Server.getClientVersion()`. Anything we can't map is reported as `other` with
+// a sanitized free-form name.
+
+export const AI_CLIENTS = [
+  "codex",
+  "claude_code",
+  "cursor",
+  "gemini",
+  "vscode",
+  "windsurf",
+  "zed",
+  "opencode",
+  "copilot",
+  "other",
+] as const;
+
+export type AiClient = (typeof AI_CLIENTS)[number];
+
+/** Bounded free-form client name, used for the long tail of unrecognized tools. */
+export const AI_CLIENT_NAME_PATTERN = /^[A-Za-z0-9 ._-]{1,80}$/;
+
+export type AiTelemetryProps = {
+  ai_client?: AiClient;
+  /** Raw, sanitized clientInfo.name — only carried when `ai_client` is `other`. */
+  ai_client_name?: string;
+};
+
+// Runtime MCP `clientInfo.name` → canonical slug. Patterns are tested against the
+// trimmed, lower-cased name. Each is verified against the tool's source; we match
+// the CLIENT identity precisely so decoys are excluded
+const RUNTIME_CLIENT_PATTERNS: ReadonlyArray<readonly [RegExp, AiClient]> = [
+  [/^codex-mcp-client\b/, "codex"],
+  [/^claude-code\b/, "claude_code"],
+  [/^cursor\b/, "cursor"],
+  [/^gemini-cli-mcp-client\b/, "gemini"],
+  [/^visual studio code\b/, "vscode"],
+  [/^code - oss\b/, "vscode"],
+  [/^windsurf\b/, "windsurf"],
+  [/^zed\b/, "zed"],
+  [/^opencode\b/, "opencode"],
+  [/^github-copilot-developer\b/, "copilot"],
+];
+
+/**
+ * Pick out only the AI-client telemetry keys from a wider metadata object,
+ * omitting any that are absent so events never carry `undefined` values. Shared
+ * by every emitter so the spread shape stays identical across call sites.
+ */
+export function aiTelemetryFromMeta(meta: AiTelemetryProps): AiTelemetryProps {
+  return {
+    ...(meta.ai_client ? { ai_client: meta.ai_client } : {}),
+    ...(meta.ai_client_name ? { ai_client_name: meta.ai_client_name } : {}),
+  };
+}
+
+/**
+ * Normalize a runtime MCP `clientInfo.name` to an {@link AiClient}. Returns
+ * `undefined` for anything unrecognized (callers may then fall back to `other` +
+ * a sanitized free-form name).
+ */
+export function canonicalizeAiClient(value: string | undefined | null): AiClient | undefined {
+  if (typeof value !== "string") return undefined;
+  const lower = value.trim().toLowerCase();
+  if (!lower) return undefined;
+  for (const [pattern, slug] of RUNTIME_CLIENT_PATTERNS) {
+    if (pattern.test(lower)) return slug;
+  }
+  return undefined;
+}

--- a/packages/telemetry/src/config-file.ts
+++ b/packages/telemetry/src/config-file.ts
@@ -22,36 +22,115 @@ export function readConfigObject(): Record<string, unknown> {
   return {};
 }
 
+// A read → mutate → publish cycle completes in well under a second; a lock held
+// longer than this is treated as orphaned by a crashed/`kill -9`'d writer and
+// stolen, so a dead process can't wedge consent writes forever.
+const LOCK_STALE_MS = 10_000;
+// Total time to wait for the lock before giving up and proceeding unlocked.
+// Degrading to the old (lock-free) behavior is strictly no worse than before
+// this lock existed and keeps a stuck peer from blocking the user's command.
+const LOCK_MAX_WAIT_MS = 2_000;
+const LOCK_RETRY_MS = 25;
+
+// Block the (single-threaded) script for `ms` without busy-spinning. Only ever
+// reached under real cross-process contention, never in the common case.
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+interface ConfigLock {
+  fd: number;
+  lockPath: string;
+}
+
+// Acquire an exclusive on-disk lock for config.json, or return null if it
+// couldn't be taken within the budget (caller then proceeds best-effort). A
+// non-null result must be released. Stale-lock recovery is best-effort: in the
+// pathological case of two writers observing the same orphaned lock at once the
+// steal can race, but that is vastly rarer than the lost-update it replaces.
+function acquireConfigLock(): ConfigLock | null {
+  const lockPath = configFilePath() + ".lock";
+  const deadline = Date.now() + LOCK_MAX_WAIT_MS;
+  for (;;) {
+    try {
+      const fd = fs.openSync(lockPath, "wx", 0o600);
+      try {
+        fs.writeSync(fd, `${process.pid}\n`);
+      } catch {
+        /* recording the holder pid is advisory only */
+      }
+      return { fd, lockPath };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") return null;
+      // Held by another process. Steal it if it looks orphaned.
+      try {
+        if (Date.now() - fs.statSync(lockPath).mtimeMs > LOCK_STALE_MS) {
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+      } catch {
+        continue; // vanished between open and stat — retry immediately
+      }
+      if (Date.now() >= deadline) return null;
+      sleepSync(LOCK_RETRY_MS);
+    }
+  }
+}
+
+function releaseConfigLock(lock: ConfigLock): void {
+  try {
+    fs.closeSync(lock.fd);
+  } catch {
+    /* already closed */
+  }
+  try {
+    fs.unlinkSync(lock.lockPath);
+  } catch {
+    /* already removed (e.g. stolen as stale by a peer) */
+  }
+}
+
 /**
  * Apply `mutate` to the current config and persist the result atomically.
  *
  * Reads the existing document (preserving keys this caller does not touch),
  * lets `mutate` patch it in place, then writes to a temp file and renames so a
  * crash mid-write leaves the previous config intact.
+ *
+ * The whole read → mutate → publish cycle runs under a cross-process lock so a
+ * concurrent writer touching a *different* key can't clobber ours: without it
+ * two processes both read the old document, each patches only its own key, and
+ * the last `rename` wins — silently dropping the other's change (e.g. a
+ * telemetry opt-out lost behind a first-run-notice write).
  */
 export function updateConfig(mutate: (config: Record<string, unknown>) => void): void {
   fs.mkdirSync(argentHomeDir(), { recursive: true });
 
-  const next = readConfigObject();
-  mutate(next);
+  const lock = acquireConfigLock();
+  try {
+    const next = readConfigObject();
+    mutate(next);
 
-  const finalPath = configFilePath();
-  const tmpPath = path.join(argentHomeDir(), `.config.tmp.${process.pid}.${crypto.randomUUID()}`);
-  const fd = fs.openSync(tmpPath, "wx", 0o600);
-  try {
-    fs.writeSync(fd, JSON.stringify(next, null, 2) + "\n");
-    fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
-  }
-  try {
-    fs.renameSync(tmpPath, finalPath);
-  } catch (err) {
+    const finalPath = configFilePath();
+    const tmpPath = path.join(argentHomeDir(), `.config.tmp.${process.pid}.${crypto.randomUUID()}`);
+    const fd = fs.openSync(tmpPath, "wx", 0o600);
     try {
-      fs.unlinkSync(tmpPath);
-    } catch {
-      /* nothing to clean up */
+      fs.writeSync(fd, JSON.stringify(next, null, 2) + "\n");
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
     }
-    throw err;
+    try {
+      fs.renameSync(tmpPath, finalPath);
+    } catch (err) {
+      try {
+        fs.unlinkSync(tmpPath);
+      } catch {
+        /* nothing to clean up */
+      }
+      throw err;
+    }
+  } finally {
+    if (lock) releaseConfigLock(lock);
   }
 }

--- a/packages/telemetry/src/config-file.ts
+++ b/packages/telemetry/src/config-file.ts
@@ -1,0 +1,57 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { argentHomeDir, configFilePath } from "./paths.js";
+
+// Shared read/write for ~/.argent/config.json. The config holds several
+// independent keys (telemetry consent, first-run notices, ...), so every writer
+// must merge rather than overwrite, and publish atomically so an interrupted
+// write can never truncate keys it does not own.
+
+/** Parse the config document, returning an empty object when missing/malformed. */
+export function readConfigObject(): Record<string, unknown> {
+  try {
+    const raw = fs.readFileSync(configFilePath(), "utf8");
+    const json = JSON.parse(raw) as unknown;
+    if (json && typeof json === "object") {
+      return json as Record<string, unknown>;
+    }
+  } catch {
+    /* missing or malformed — treat as a fresh document */
+  }
+  return {};
+}
+
+/**
+ * Apply `mutate` to the current config and persist the result atomically.
+ *
+ * Reads the existing document (preserving keys this caller does not touch),
+ * lets `mutate` patch it in place, then writes to a temp file and renames so a
+ * crash mid-write leaves the previous config intact.
+ */
+export function updateConfig(mutate: (config: Record<string, unknown>) => void): void {
+  fs.mkdirSync(argentHomeDir(), { recursive: true });
+
+  const next = readConfigObject();
+  mutate(next);
+
+  const finalPath = configFilePath();
+  const tmpPath = path.join(argentHomeDir(), `.config.tmp.${process.pid}.${crypto.randomUUID()}`);
+  const fd = fs.openSync(tmpPath, "wx", 0o600);
+  try {
+    fs.writeSync(fd, JSON.stringify(next, null, 2) + "\n");
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  try {
+    fs.renameSync(tmpPath, finalPath);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      /* nothing to clean up */
+    }
+    throw err;
+  }
+}

--- a/packages/telemetry/src/consent.ts
+++ b/packages/telemetry/src/consent.ts
@@ -5,7 +5,12 @@ import { updateConfig } from "./config-file.js";
 // Consent is evaluated on every track() so a running tool server sees opt-outs.
 // The config file is re-parsed only when its mtime or inode changes.
 export interface ConsentSource {
-  source: "env_do_not_track" | "env_argent_telemetry" | "config_file" | "default";
+  source:
+    | "env_do_not_track"
+    | "env_argent_telemetry"
+    | "session_override"
+    | "config_file"
+    | "default";
   /** Detailed override identifier for `argent telemetry status` output. */
   detail?: string;
 }
@@ -22,6 +27,12 @@ interface CachedConfig {
 }
 
 const cache: { current: CachedConfig | null } = { current: null };
+
+// Non-persisted, in-process consent decision for the current run. Set while a
+// first-run consent choice is pending commit so the pick governs THIS session's
+// events immediately, without writing to config.json. null means "no in-process
+// override — fall through to the env / config / default precedence below".
+let sessionOverride: boolean | null = null;
 
 function readConfigOverride(): boolean | null {
   let stats: fs.Stats;
@@ -104,6 +115,15 @@ export function getConsentState(env: NodeJS.ProcessEnv = process.env): ConsentSt
     };
   }
 
+  // An in-process first-run choice that hasn't been committed to disk yet. It
+  // loses to an explicit environment opt-out (handled above) but beats the
+  // config file and the default, so a pending "Disabled" pick suppresses this
+  // session's events even though the choice isn't persisted until the install
+  // completes.
+  if (sessionOverride !== null) {
+    return { enabled: sessionOverride, source: { source: "session_override" } };
+  }
+
   const persisted = readConfigOverride();
   if (persisted === false) {
     return { enabled: false, source: { source: "config_file", detail: "config.json" } };
@@ -132,7 +152,20 @@ export function writeConsentFlag(enabled: boolean): void {
   cache.current = null;
 }
 
-/** Test seam: blow away the in-memory mtime cache. */
+/**
+ * Apply (or clear) an in-process consent decision for the current run without
+ * touching config.json. `argent init` uses this so a first-run "Enable/Disable"
+ * pick governs the session immediately, while the durable record is only written
+ * once the install actually completes — an aborted init leaves nothing behind
+ * (the override dies with the process) and the next run re-prompts. Pass null to
+ * clear it. See `writeConsentFlag` for the persisted counterpart.
+ */
+export function setSessionConsentOverride(enabled: boolean | null): void {
+  sessionOverride = enabled;
+}
+
+/** Test seam: blow away the in-memory mtime cache and any session override. */
 export function _resetConsentCacheForTest(): void {
   cache.current = null;
+  sessionOverride = null;
 }

--- a/packages/telemetry/src/consent.ts
+++ b/packages/telemetry/src/consent.ts
@@ -1,7 +1,6 @@
-import * as crypto from "node:crypto";
 import * as fs from "node:fs";
-import * as path from "node:path";
-import { argentHomeDir, configFilePath } from "./paths.js";
+import { configFilePath } from "./paths.js";
+import { updateConfig } from "./config-file.js";
 
 // Consent is evaluated on every track() so a running tool server sees opt-outs.
 // The config file is re-parsed only when its mtime or inode changes.
@@ -123,53 +122,13 @@ export function isEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
 
 /** Persist the telemetry flag without discarding other config keys. */
 export function writeConsentFlag(enabled: boolean): void {
-  fs.mkdirSync(argentHomeDir(), { recursive: true });
-
-  let existing: Record<string, unknown> = {};
-  try {
-    const raw = fs.readFileSync(configFilePath(), "utf8");
-    const json = JSON.parse(raw) as unknown;
-    if (json && typeof json === "object") {
-      existing = json as Record<string, unknown>;
-    }
-  } catch {
-    /* missing or malformed — write a fresh document */
-  }
-
-  const telemetryBlock =
-    typeof existing.telemetry === "object" && existing.telemetry
-      ? (existing.telemetry as Record<string, unknown>)
-      : {};
-
-  const next: Record<string, unknown> = {
-    ...existing,
-    telemetry: {
-      ...telemetryBlock,
-      enabled,
-    },
-  };
-
-  // Atomic publish: write to a temp file then rename so an interrupted write
-  // can never truncate the shared config (which holds non-telemetry keys too).
-  const finalPath = configFilePath();
-  const tmpPath = path.join(argentHomeDir(), `.config.tmp.${process.pid}.${crypto.randomUUID()}`);
-  const fd = fs.openSync(tmpPath, "wx", 0o600);
-  try {
-    fs.writeSync(fd, JSON.stringify(next, null, 2) + "\n");
-    fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
-  }
-  try {
-    fs.renameSync(tmpPath, finalPath);
-  } catch (err) {
-    try {
-      fs.unlinkSync(tmpPath);
-    } catch {
-      /* nothing to clean up */
-    }
-    throw err;
-  }
+  updateConfig((config) => {
+    const telemetryBlock =
+      typeof config.telemetry === "object" && config.telemetry
+        ? (config.telemetry as Record<string, unknown>)
+        : {};
+    config.telemetry = { ...telemetryBlock, enabled };
+  });
   cache.current = null;
 }
 

--- a/packages/telemetry/src/erasure.ts
+++ b/packages/telemetry/src/erasure.ts
@@ -1,5 +1,6 @@
 import { deleteAnonId } from "./identity.js";
 import { writeConsentFlag } from "./consent.js";
+import { resetFirstRunNotice } from "./notice.js";
 import { emitDebugError } from "./debug.js";
 
 export interface ForgetOptions {
@@ -35,6 +36,14 @@ export async function forget(options: ForgetOptions = {}): Promise<ForgetResult>
     localIdRemoved = true;
   } catch (err) {
     emitDebugError("forget: deleting telemetry-id failed", err);
+  }
+
+  // Clear the first-run-notice marker so a later reinstall surfaces the notice
+  // again. Consent is handled above; this only resets the "already shown" state.
+  try {
+    resetFirstRunNotice();
+  } catch (err) {
+    emitDebugError("forget: resetting first-run notice failed", err);
   }
 
   return { localIdRemoved, consentDisabled };

--- a/packages/telemetry/src/events.ts
+++ b/packages/telemetry/src/events.ts
@@ -2,6 +2,7 @@
 // same surface at runtime.
 
 import type { FailureSignal } from "@argent/registry";
+import type { AiTelemetryProps } from "./ai-identity.js";
 
 // Single source of truth for the device platform enum: the TS union below and
 // sanitize.ts's runtime allowlist both derive from this tuple, so adding a
@@ -104,20 +105,20 @@ export interface InstallationCliUninstallCompleteProps extends FailureTelemetryP
 
 // Tool usage events
 
-export interface ToolInvokeProps {
+export interface ToolInvokeProps extends AiTelemetryProps {
   tool: string;
   tool_invocation_id: string;
   platform?: Platform;
 }
 
-export interface ToolCompleteProps {
+export interface ToolCompleteProps extends AiTelemetryProps {
   tool: string;
   tool_invocation_id: string;
   platform?: Platform;
   duration_ms: number;
 }
 
-export interface ToolFailProps extends FailureTelemetryProps {
+export interface ToolFailProps extends FailureTelemetryProps, AiTelemetryProps {
   tool: string;
   tool_invocation_id?: string;
   platform?: Platform;

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -26,6 +26,14 @@ export { _resetConsentCacheForTest } from "./consent.js";
 export { EVENT_NAMES } from "./events.js";
 export { isDebugEnabled } from "./debug.js";
 export { getConsentState } from "./consent.js";
+// Persists the consent flag without emitting a transition event — for recording
+// an initial first-run choice. Use markDisabled() (not this) for a live opt-out
+// that should send a final telemetry:opt_out before the pipe closes.
+export { writeConsentFlag } from "./consent.js";
+// Applies a first-run choice to the current session only (in-process, not on
+// disk), so an interactive consent prompt can govern this run's events before
+// the decision is committed at install completion.
+export { setSessionConsentOverride } from "./consent.js";
 export {
   FIRST_RUN_NOTICE,
   FIRST_RUN_NOTICE_BODY_LINES,

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -26,6 +26,16 @@ export { _resetConsentCacheForTest } from "./consent.js";
 export { EVENT_NAMES } from "./events.js";
 export { isDebugEnabled } from "./debug.js";
 export { getConsentState } from "./consent.js";
+export {
+  FIRST_RUN_NOTICE,
+  FIRST_RUN_NOTICE_BODY_LINES,
+  TELEMETRY_OPT_OUT_COMMAND,
+  TELEMETRY_DETAILS_URL,
+  hasShownFirstRunNotice,
+  markFirstRunNoticeShown,
+  resetFirstRunNotice,
+  shouldShowFirstRunNotice,
+} from "./notice.js";
 export { getSessionId } from "./base-props.js";
 export {
   AI_CLIENTS,

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -27,6 +27,14 @@ export { EVENT_NAMES } from "./events.js";
 export { isDebugEnabled } from "./debug.js";
 export { getConsentState } from "./consent.js";
 export { getSessionId } from "./base-props.js";
+export {
+  AI_CLIENTS,
+  AI_CLIENT_NAME_PATTERN,
+  canonicalizeAiClient,
+  aiTelemetryFromMeta,
+  type AiClient,
+  type AiTelemetryProps,
+} from "./ai-identity.js";
 
 const SHORT_FLUSH_TIMEOUT_MS = 1_500;
 

--- a/packages/telemetry/src/notice.ts
+++ b/packages/telemetry/src/notice.ts
@@ -12,7 +12,7 @@ import { isEnabled } from "./consent.js";
 export const TELEMETRY_OPT_OUT_COMMAND = "argent telemetry disable";
 
 /** Link to the full privacy notice. */
-export const TELEMETRY_DETAILS_URL = "https://swmansion.com/privacy/argent-telemetry";
+export const TELEMETRY_DETAILS_URL = "https://swmansion.com/legal/argent/privacy-notice/";
 
 /**
  * The descriptive body, one entry per rendered line. The opt-out command and

--- a/packages/telemetry/src/notice.ts
+++ b/packages/telemetry/src/notice.ts
@@ -1,0 +1,78 @@
+// First-run telemetry notice. Shown once per installation — to fresh installs
+// (via `argent init`) and to users who update into a telemetry-enabled version
+// (via the next `argent init` / `argent update` / `argent mcp` the new binary
+// runs). The "already shown" marker lives in ~/.argent/config.json and is
+// cleared on uninstall (see resetFirstRunNotice), so a later reinstall shows it
+// again rather than staying silently suppressed.
+
+import { readConfigObject, updateConfig } from "./config-file.js";
+import { isEnabled } from "./consent.js";
+
+/** The command users run to opt out — callers may highlight it on their surface. */
+export const TELEMETRY_OPT_OUT_COMMAND = "argent telemetry disable";
+
+/** Link to the full privacy notice. */
+export const TELEMETRY_DETAILS_URL = "https://swmansion.com/privacy/argent-telemetry";
+
+/**
+ * The descriptive body, one entry per rendered line. The opt-out command and
+ * details URL are kept separate so each surface can style the command/link to
+ * match its own conventions (e.g. cyan in the installer TUI).
+ */
+export const FIRST_RUN_NOTICE_BODY_LINES: readonly string[] = [
+  "Argent collects anonymous usage data to help us improve the tool. We never",
+  "collect your source code, file paths, tool inputs, or error contents.",
+];
+
+/** The whole notice as a plain string, for surfaces without a renderer (mcp stderr). */
+export const FIRST_RUN_NOTICE = [
+  ...FIRST_RUN_NOTICE_BODY_LINES,
+  `Opt out anytime: ${TELEMETRY_OPT_OUT_COMMAND}`,
+  `Details: ${TELEMETRY_DETAILS_URL}`,
+].join("\n");
+
+/** Whether the first-run notice has already been shown for this installation. */
+export function hasShownFirstRunNotice(): boolean {
+  const notices = readConfigObject().notices;
+  if (notices && typeof notices === "object") {
+    return (notices as Record<string, unknown>).first_run_shown === true;
+  }
+  return false;
+}
+
+/** Persist the "notice shown" marker, preserving other config keys. */
+export function markFirstRunNoticeShown(): void {
+  updateConfig((config) => {
+    const noticesBlock =
+      typeof config.notices === "object" && config.notices
+        ? (config.notices as Record<string, unknown>)
+        : {};
+    config.notices = { ...noticesBlock, first_run_shown: true };
+  });
+}
+
+/**
+ * Clear the "notice shown" marker so the next install surfaces the notice again.
+ * Called from the uninstall reset path. No-op when nothing is recorded, so it
+ * never creates an empty config file just to delete a key. Telemetry consent is
+ * intentionally left untouched — a persisted opt-out must survive a reinstall.
+ */
+export function resetFirstRunNotice(): void {
+  if (!hasShownFirstRunNotice()) return;
+  updateConfig((config) => {
+    const notices = config.notices;
+    if (notices && typeof notices === "object") {
+      delete (notices as Record<string, unknown>).first_run_shown;
+    }
+  });
+}
+
+/**
+ * True when the notice should be rendered now: telemetry is active and the
+ * notice has not been shown yet for this installation. When telemetry is
+ * disabled (env or config) we skip the notice and do NOT mark it shown, so it
+ * still appears once if the user later opts back in.
+ */
+export function shouldShowFirstRunNotice(): boolean {
+  return isEnabled() && !hasShownFirstRunNotice();
+}

--- a/packages/telemetry/src/registry-listener.ts
+++ b/packages/telemetry/src/registry-listener.ts
@@ -1,10 +1,11 @@
 import { FAILURE_CODES, getFailureSignalOrFallback, type Registry } from "@argent/registry";
 import { track } from "./index.js";
 import type { Platform } from "./events.js";
+import { aiTelemetryFromMeta, type AiTelemetryProps } from "./ai-identity.js";
 
 // HTTP captures request-only metadata here so registry lifecycle events can
-// include platform context without carrying raw params.
-export interface InvocationMeta {
+// include platform context (and the coarse AI client) without carrying raw params.
+export interface InvocationMeta extends AiTelemetryProps {
   platform?: Platform;
 }
 
@@ -34,6 +35,7 @@ export function attachRegistryTelemetry(registry: Registry): AttachHandle {
       tool: toolId,
       tool_invocation_id: toolInvocationId,
       ...(meta.platform ? { platform: meta.platform } : {}),
+      ...aiTelemetryFromMeta(meta),
     });
   };
 
@@ -44,6 +46,7 @@ export function attachRegistryTelemetry(registry: Registry): AttachHandle {
       tool_invocation_id: toolInvocationId,
       ...(meta.platform ? { platform: meta.platform } : {}),
       duration_ms: durationMs,
+      ...aiTelemetryFromMeta(meta),
     });
   };
 
@@ -66,6 +69,7 @@ export function attachRegistryTelemetry(registry: Registry): AttachHandle {
       ...(meta.platform ? { platform: meta.platform } : {}),
       duration_ms: durationMs,
       ...signal,
+      ...aiTelemetryFromMeta(meta),
     });
   };
 

--- a/packages/telemetry/src/sanitize.ts
+++ b/packages/telemetry/src/sanitize.ts
@@ -8,6 +8,7 @@ import {
   NETWORK_FAILURES,
 } from "@argent/registry";
 import { PLATFORMS, type EventName, type EventPropertyMap } from "./events.js";
+import { AI_CLIENTS, AI_CLIENT_NAME_PATTERN } from "./ai-identity.js";
 
 // Per-event property allowlist and validators. Unknown keys and invalid values
 // are dropped before anything reaches PostHog.
@@ -81,6 +82,14 @@ const FAILURE_EXIT_CODE = finiteNonNeg(255);
 const FAILURE_SIGNAL_NAME = oneOf(FAILURE_SIGNAL_NAMES);
 const FAILURE_SPAWN_CODE = oneOf(FAILURE_SPAWN_CODES);
 const NETWORK_FAILURE = oneOf(NETWORK_FAILURES);
+
+const AI_CLIENT = oneOf(AI_CLIENTS);
+const AI_CLIENT_NAME = matches(AI_CLIENT_NAME_PATTERN, 80);
+
+const AI_TELEMETRY = {
+  ai_client: AI_CLIENT,
+  ai_client_name: AI_CLIENT_NAME,
+};
 
 const FAILURE_SIGNAL = {
   error_code: ERROR_CODE,
@@ -175,12 +184,14 @@ export const ALLOWED: ValidatorMap = {
     tool: TOOL_NAME,
     tool_invocation_id: UUID,
     platform: PLATFORM,
+    ...AI_TELEMETRY,
   },
   "tool:complete": {
     tool: TOOL_NAME,
     tool_invocation_id: UUID,
     platform: PLATFORM,
     duration_ms: DURATION_MS,
+    ...AI_TELEMETRY,
   },
   "tool:fail": {
     tool: TOOL_NAME,
@@ -188,6 +199,7 @@ export const ALLOWED: ValidatorMap = {
     platform: PLATFORM,
     duration_ms: DURATION_MS,
     ...FAILURE_SIGNAL,
+    ...AI_TELEMETRY,
   },
   "cli:run_fail": {
     tool: TOOL_NAME,

--- a/packages/telemetry/test/ai-identity.test.ts
+++ b/packages/telemetry/test/ai-identity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { AI_CLIENT_NAME_PATTERN, canonicalizeAiClient } from "../src/ai-identity.js";
+
+describe("canonicalizeAiClient", () => {
+  describe("runtime MCP clientInfo.name (verified from each tool's source)", () => {
+    const RUNTIME_NAMES: Array<[string, string]> = [
+      ["codex-mcp-client", "codex"],
+      ["claude-code", "claude_code"],
+      ["cursor-vscode", "cursor"],
+      ["gemini-cli-mcp-client", "gemini"],
+      ["gemini-cli-mcp-client-myserver", "gemini"], // older suffixed form
+      ["Visual Studio Code", "vscode"],
+      ["Visual Studio Code - Insiders", "vscode"],
+      ["Code - OSS", "vscode"],
+      ["windsurf", "windsurf"],
+      ["Zed", "zed"],
+      ["opencode", "opencode"],
+      ["github-copilot-developer", "copilot"], // observed in real Copilot MCP logs
+    ];
+
+    it.each(RUNTIME_NAMES)("maps %s → %s", (name, slug) => {
+      expect(canonicalizeAiClient(name)).toBe(slug);
+    });
+
+    it("does not mistake Codex's server-mode identity for the client", () => {
+      // We are always the server; we only ever receive `codex-mcp-client`. The
+      // server-mode string must not be matched by the client patterns.
+      expect(canonicalizeAiClient("codex-mcp-server")).toBeUndefined();
+    });
+  });
+
+  it("returns undefined for unrecognized clients (caller decides on `other`)", () => {
+    // `other` is a caller decision (raw clientInfo.name we couldn't map), not a
+    // value canonicalize should ever produce from an unknown string.
+    expect(canonicalizeAiClient("other")).toBeUndefined();
+    expect(canonicalizeAiClient("some-unknown-mcp-client")).toBeUndefined();
+    // Hermes sends a generic name and is no longer specially attributed.
+    expect(canonicalizeAiClient("mcp")).toBeUndefined();
+  });
+
+  it("returns undefined for empty / non-string input", () => {
+    expect(canonicalizeAiClient(undefined)).toBeUndefined();
+    expect(canonicalizeAiClient(null)).toBeUndefined();
+    expect(canonicalizeAiClient("")).toBeUndefined();
+    expect(canonicalizeAiClient("   ")).toBeUndefined();
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(canonicalizeAiClient("  codex-mcp-client  ")).toBe("codex");
+  });
+});
+
+describe("AI_CLIENT_NAME_PATTERN", () => {
+  it("accepts real clientInfo.name values", () => {
+    for (const name of ["codex-mcp-client", "Visual Studio Code - Insiders", "Zed", "opencode"]) {
+      expect(AI_CLIENT_NAME_PATTERN.test(name)).toBe(true);
+    }
+  });
+
+  it("rejects path-like or oversized values", () => {
+    expect(AI_CLIENT_NAME_PATTERN.test("/Users/alice/secret-client")).toBe(false);
+    expect(AI_CLIENT_NAME_PATTERN.test("x".repeat(81))).toBe(false);
+  });
+});

--- a/packages/telemetry/test/notice.test.ts
+++ b/packages/telemetry/test/notice.test.ts
@@ -1,0 +1,104 @@
+import * as fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import { scopeHome, snapshotEnv } from "./helpers.js";
+import { writeConsentFlag, _resetConsentCacheForTest } from "../src/consent.js";
+import {
+  FIRST_RUN_NOTICE,
+  TELEMETRY_OPT_OUT_COMMAND,
+  TELEMETRY_DETAILS_URL,
+  hasShownFirstRunNotice,
+  markFirstRunNoticeShown,
+  resetFirstRunNotice,
+  shouldShowFirstRunNotice,
+} from "../src/notice.js";
+import { forget } from "../src/erasure.js";
+import { configFilePath } from "../src/paths.js";
+
+describe("first-run notice", () => {
+  scopeHome();
+  const restoreEnv = () => snapshotEnv(["DO_NOT_TRACK", "ARGENT_TELEMETRY"]);
+
+  function readConfig(): {
+    telemetry?: { enabled?: boolean };
+    notices?: { first_run_shown?: boolean };
+  } {
+    return JSON.parse(fs.readFileSync(configFilePath(), "utf8"));
+  }
+
+  it("has not been shown on a fresh install (no config file)", () => {
+    expect(hasShownFirstRunNotice()).toBe(false);
+  });
+
+  it("reads true once the marker is persisted", () => {
+    markFirstRunNoticeShown();
+    expect(hasShownFirstRunNotice()).toBe(true);
+  });
+
+  it("preserves the telemetry consent flag when marking the notice shown", () => {
+    writeConsentFlag(false);
+    markFirstRunNoticeShown();
+    const config = readConfig();
+    expect(config.telemetry?.enabled).toBe(false);
+    expect(config.notices?.first_run_shown).toBe(true);
+  });
+
+  it("should show when telemetry is enabled and the notice is unseen", () => {
+    const restore = restoreEnv();
+    try {
+      delete process.env.DO_NOT_TRACK;
+      delete process.env.ARGENT_TELEMETRY;
+      _resetConsentCacheForTest();
+      expect(shouldShowFirstRunNotice()).toBe(true);
+      markFirstRunNoticeShown();
+      expect(shouldShowFirstRunNotice()).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("should not show when telemetry is disabled, and does not mark it shown", () => {
+    const restore = restoreEnv();
+    try {
+      process.env.ARGENT_TELEMETRY = "0";
+      _resetConsentCacheForTest();
+      expect(shouldShowFirstRunNotice()).toBe(false);
+      expect(hasShownFirstRunNotice()).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  describe("resetFirstRunNotice", () => {
+    it("clears the marker so the notice shows again on reinstall", () => {
+      markFirstRunNoticeShown();
+      expect(hasShownFirstRunNotice()).toBe(true);
+      resetFirstRunNotice();
+      expect(hasShownFirstRunNotice()).toBe(false);
+    });
+
+    it("leaves a persisted opt-out untouched so it survives a reinstall", () => {
+      writeConsentFlag(false);
+      markFirstRunNoticeShown();
+      resetFirstRunNotice();
+      const config = readConfig();
+      expect(config.notices?.first_run_shown).toBeUndefined();
+      expect(config.telemetry?.enabled).toBe(false);
+    });
+
+    it("is a no-op when nothing was recorded (creates no config file)", () => {
+      resetFirstRunNotice();
+      expect(fs.existsSync(configFilePath())).toBe(false);
+    });
+
+    it("is run by forget() so uninstall resets the marker", async () => {
+      markFirstRunNoticeShown();
+      await forget({ disableConsent: false });
+      expect(hasShownFirstRunNotice()).toBe(false);
+    });
+  });
+
+  it("exposes the notice copy with the opt-out command and details URL", () => {
+    expect(FIRST_RUN_NOTICE).toContain(TELEMETRY_OPT_OUT_COMMAND);
+    expect(FIRST_RUN_NOTICE).toContain(TELEMETRY_DETAILS_URL);
+  });
+});

--- a/packages/telemetry/test/registry-listener.test.ts
+++ b/packages/telemetry/test/registry-listener.test.ts
@@ -50,6 +50,46 @@ describe("attachRegistryTelemetry", () => {
     handle.detach();
   });
 
+  it("threads the AI client through invoke / complete / fail events", () => {
+    const trackSpy = vi.spyOn(telemetry, "track");
+    const registry = new Registry();
+    const handle = attachRegistryTelemetry(registry);
+
+    handle.recordInvocation(INVOCATION_ID_1, { platform: "ios", ai_client: "codex" });
+    registry.events.emit("toolInvoked", "gesture-tap", INVOCATION_ID_1);
+    registry.events.emit("toolCompleted", "gesture-tap", INVOCATION_ID_1, 10);
+
+    handle.recordInvocation(INVOCATION_ID_2, {
+      ai_client: "other",
+      ai_client_name: "some-new-tool",
+    });
+    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_2);
+    registry.events.emit("toolFailed", "screenshot", INVOCATION_ID_2, new Error("boom"), 5);
+
+    expect(trackSpy.mock.calls[0]![1]).toMatchObject({ ai_client: "codex" });
+    expect(trackSpy.mock.calls[1]![1]).toMatchObject({ ai_client: "codex" });
+    expect(trackSpy.mock.calls[3]![1]).toMatchObject({
+      ai_client: "other",
+      ai_client_name: "some-new-tool",
+    });
+
+    handle.detach();
+  });
+
+  it("omits AI keys entirely when no client metadata was recorded", () => {
+    const trackSpy = vi.spyOn(telemetry, "track");
+    const registry = new Registry();
+    const handle = attachRegistryTelemetry(registry);
+
+    handle.recordInvocation(INVOCATION_ID_1, { platform: "ios" });
+    registry.events.emit("toolInvoked", "gesture-tap", INVOCATION_ID_1);
+
+    expect(trackSpy.mock.calls[0]![1]).not.toHaveProperty("ai_client");
+    expect(trackSpy.mock.calls[0]![1]).not.toHaveProperty("ai_client_name");
+
+    handle.detach();
+  });
+
   it("emits tool:fail with tool metadata and real duration", () => {
     const trackSpy = vi.spyOn(telemetry, "track");
     const registry = new Registry();

--- a/packages/telemetry/test/sanitize.test.ts
+++ b/packages/telemetry/test/sanitize.test.ts
@@ -59,6 +59,53 @@ describe("sanitize", () => {
         });
       }
     });
+
+    it("accepts coarse AI client metadata on tool events", () => {
+      expect(
+        sanitize("tool:invoke", {
+          tool: "gesture-tap",
+          tool_invocation_id: "11111111-1111-4111-8111-111111111111",
+          ai_client: "codex",
+          ai_client_name: "codex-mcp-client",
+        })
+      ).toEqual({
+        tool: "gesture-tap",
+        tool_invocation_id: "11111111-1111-4111-8111-111111111111",
+        ai_client: "codex",
+        ai_client_name: "codex-mcp-client",
+      });
+    });
+
+    it("drops unregistered AI client slugs and path-leaking client names", () => {
+      expect(
+        sanitize("tool:invoke", {
+          tool: "gesture-tap",
+          tool_invocation_id: "11111111-1111-4111-8111-111111111111",
+          ai_client: "my-private-client",
+          ai_client_name: "/Users/alice/secret-client",
+        })
+      ).toEqual({
+        tool: "gesture-tap",
+        tool_invocation_id: "11111111-1111-4111-8111-111111111111",
+      });
+    });
+
+    it("carries AI client metadata on tool:fail alongside the failure signal", () => {
+      expect(
+        sanitize("tool:fail", {
+          tool: "screenshot",
+          tool_invocation_id: "11111111-1111-4111-8111-111111111111",
+          duration_ms: 12,
+          error_code: FAILURE_CODES.REGISTRY_TOOL_FAILURE_UNCLASSIFIED,
+          ai_client: "other",
+          ai_client_name: "some-new-tool",
+        })
+      ).toMatchObject({
+        ai_client: "other",
+        ai_client_name: "some-new-tool",
+        error_code: FAILURE_CODES.REGISTRY_TOOL_FAILURE_UNCLASSIFIED,
+      });
+    });
   });
 
   describe("matches validator", () => {

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -9,6 +9,7 @@ import {
   type Registry,
   type ResolvedFileInput,
 } from "@argent/registry";
+import { AI_CLIENTS, AI_CLIENT_NAME_PATTERN, type AiTelemetryProps } from "@argent/telemetry";
 import { ToolNotFoundError } from "@argent/registry";
 import { createIdleTimer, IDLE_CHECK_INTERVAL_MS } from "./utils/idle-timer";
 import { DependencyMissingError, ensureDeps } from "./utils/check-deps";
@@ -95,11 +96,11 @@ function extractDeviceArg(data: unknown): string | null {
   return null;
 }
 
-type InvocationMeta = { platform?: Platform };
+type InvocationMeta = { platform?: Platform } & AiTelemetryProps;
 // Only coarse platform context is retained for failure telemetry. The raw
 // device id (UDID / serial) is used transiently to infer platform and never
 // stored or forwarded.
-type HttpFailureMeta = { platform?: Platform };
+type HttpFailureMeta = { platform?: Platform } & AiTelemetryProps;
 
 function inferPlatform(deviceId: string | null): HttpFailureMeta["platform"] | null {
   if (!deviceId) return null;
@@ -110,17 +111,45 @@ function inferPlatform(deviceId: string | null): HttpFailureMeta["platform"] | n
   }
 }
 
-function extractInvocationMeta(hasCapability: boolean, data: unknown): InvocationMeta | null {
-  if (!hasCapability || !data || typeof data !== "object") return null;
-  const record = data as Record<string, unknown>;
-  const deviceArg = extractDeviceArg(record);
-  if (deviceArg) {
-    return { platform: resolveDevice(deviceArg).platform };
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+// The MCP server forwards the coarse AI-client identity as request headers (it
+// lives in a different process). We re-validate here against the same allowlist /
+// pattern the sanitizer enforces, so a misbehaving client can't inject arbitrary
+// values into telemetry. The free-form name is only retained when the client is
+// `other` — mirroring the producer and the documented `AiTelemetryProps` contract,
+// so a recognized (or absent) client can never carry a stray name.
+function extractAiTelemetryMeta(req: Request): AiTelemetryProps {
+  const meta: AiTelemetryProps = {};
+  const client = firstHeader(req.headers["x-argent-ai-client"]);
+  if (client && (AI_CLIENTS as readonly string[]).includes(client)) {
+    meta.ai_client = client as AiTelemetryProps["ai_client"];
   }
-  if (typeof record.avdName === "string") {
-    return { platform: "android" };
+  const clientName = firstHeader(req.headers["x-argent-ai-client-name"]);
+  if (meta.ai_client === "other" && clientName && AI_CLIENT_NAME_PATTERN.test(clientName)) {
+    meta.ai_client_name = clientName;
   }
-  return null;
+  return meta;
+}
+
+function extractInvocationMeta(
+  hasCapability: boolean,
+  data: unknown,
+  aiMeta: AiTelemetryProps
+): InvocationMeta | null {
+  const meta: InvocationMeta = { ...aiMeta };
+  if (hasCapability && data && typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    const deviceArg = extractDeviceArg(record);
+    if (deviceArg) {
+      meta.platform = resolveDevice(deviceArg).platform;
+    } else if (typeof record.avdName === "string") {
+      meta.platform = "android";
+    }
+  }
+  return Object.keys(meta).length > 0 ? meta : null;
 }
 
 // ── HTTP app ────────────────────────────────────────────────────────
@@ -385,6 +414,7 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
     async (req: Request, res: Response) => {
       const name = req.params.name as string;
       const requestStartedAt = performance.now();
+      const aiMeta = extractAiTelemetryMeta(req);
 
       const emitHttpFailure = (
         signal: FailureSignal,
@@ -397,6 +427,7 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
           name,
           {
             ...(platform ? { platform } : {}),
+            ...aiMeta,
           },
           signal,
           performance.now() - requestStartedAt
@@ -562,7 +593,7 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
       const toolInvocationId = randomUUID();
       let releaseInvocationMeta: (() => void) | undefined;
       if (options?.recordInvocation) {
-        const invocationMeta = extractInvocationMeta(Boolean(def.capability), parsedData);
+        const invocationMeta = extractInvocationMeta(Boolean(def.capability), parsedData, aiMeta);
         if (invocationMeta) {
           releaseInvocationMeta = options.recordInvocation(toolInvocationId, invocationMeta);
         }

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -205,7 +205,22 @@ export function start(): void {
     stopWatcher();
     httpHandle.dispose();
 
-    // Emit toolserver:stop before tearing the registry down.
+    // Tear the registry down BEFORE recording toolserver:stop. A crash that
+    // escalates mid-shutdown (crashShutdown sets shutdownReason="crash" plus a
+    // failure signal, then re-enters here and the guard short-circuits it) would
+    // otherwise be lost behind an already-sent reason:"signal" stop event — the
+    // exit code escalates via finalExitCode but the telemetry didn't. Recording
+    // the stop event last means it reflects everything up to this point.
+    // Guarded so a dispose failure can't skip the stop event itself.
+    try {
+      await registry.dispose();
+    } catch (err) {
+      process.stderr.write(`[tool-server] registry dispose failed: ${String(err)}\n`);
+    }
+
+    // Capture toolserver:stop, then drain — the final telemetry action, so the
+    // reason/signal are as fresh as possible. (A crash during the drain below is
+    // inherently unobservable: the queue is already closing.)
     try {
       telemetryTrack("toolserver:stop", {
         reason: shutdownReason,
@@ -219,7 +234,6 @@ export function start(): void {
       // Telemetry must never block process exit.
     }
 
-    await registry.dispose();
     if (server) {
       const forceExit = setTimeout(() => process.exit(finalExitCode), PROCESS_TIMEOUT_MS);
       await new Promise<void>((resolve) => server!.close(() => resolve()));

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -4,6 +4,7 @@ import {
   attachRegistryTelemetry,
   track as telemetryTrack,
   shutdown as telemetryShutdown,
+  aiTelemetryFromMeta,
 } from "@argent/telemetry";
 import { createHttpApp } from "./http";
 import { createRegistry } from "./utils/setup-registry";
@@ -242,6 +243,7 @@ export function start(): void {
         ...(meta.platform ? { platform: meta.platform } : {}),
         duration_ms: durationMs,
         ...signal,
+        ...aiTelemetryFromMeta(meta),
       });
     },
   });

--- a/packages/tool-server/test/http-tools-meta.test.ts
+++ b/packages/tool-server/test/http-tools-meta.test.ts
@@ -168,4 +168,98 @@ describe("GET /tools progressive-loading metadata", () => {
 
     expect(recordInvocation).toHaveBeenCalledWith(expect.any(String), { platform: "android" });
   });
+
+  it("records the AI client from request headers alongside platform", async () => {
+    let seenMeta: Record<string, unknown> | undefined;
+    const recordInvocation = vi.fn((_id: string, meta: Record<string, unknown>) => {
+      seenMeta = meta;
+      return vi.fn();
+    });
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .set("X-Argent-AI-Client", "codex")
+      .send({ udid: "11111111-1111-1111-1111-111111111111" })
+      .expect(200);
+
+    expect(seenMeta).toEqual({ platform: "ios", ai_client: "codex" });
+  });
+
+  it("captures an unknown tool by name when ai_client is `other`", async () => {
+    let seenMeta: Record<string, unknown> | undefined;
+    const recordInvocation = vi.fn((_id: string, meta: Record<string, unknown>) => {
+      seenMeta = meta;
+      return vi.fn();
+    });
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    // A non-device tool with no platform context still records because AI
+    // metadata is present on the request.
+    await request(handle.app)
+      .post("/tools/plain-tool")
+      .set("X-Argent-AI-Client", "other")
+      .set("X-Argent-AI-Client-Name", "some-new-tool")
+      .send({})
+      .expect(200);
+
+    expect(seenMeta).toEqual({ ai_client: "other", ai_client_name: "some-new-tool" });
+  });
+
+  it("drops unregistered AI client slugs and path-leaking client names", async () => {
+    const recordInvocation = vi.fn(() => vi.fn());
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    // Unknown slug + unsafe name → nothing usable → no metadata → not recorded
+    // for a non-device tool.
+    await request(handle.app)
+      .post("/tools/plain-tool")
+      .set("X-Argent-AI-Client", "evil-client")
+      .set("X-Argent-AI-Client-Name", "/Users/alice/secret")
+      .send({})
+      .expect(200);
+
+    expect(recordInvocation).not.toHaveBeenCalled();
+  });
+
+  it("drops the free-form client name unless ai_client is `other`", async () => {
+    let seenMeta: Record<string, unknown> | undefined;
+    const recordInvocation = vi.fn((_id: string, meta: Record<string, unknown>) => {
+      seenMeta = meta;
+      return vi.fn();
+    });
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    // A recognized client must never carry a free-form name (the invariant is
+    // that the name is only meaningful for the `other` long tail). The name is
+    // a perfectly valid pattern here — it is dropped purely on the coupling.
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .set("X-Argent-AI-Client", "codex")
+      .set("X-Argent-AI-Client-Name", "claude-code")
+      .send({ udid: "11111111-1111-1111-1111-111111111111" })
+      .expect(200);
+
+    expect(seenMeta).toEqual({ platform: "ios", ai_client: "codex" });
+  });
+
+  it("drops a client name sent with no ai_client header", async () => {
+    const recordInvocation = vi.fn(() => vi.fn());
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    // Name-only, no slug → nothing usable → no metadata → not recorded for a
+    // non-device tool.
+    await request(handle.app)
+      .post("/tools/plain-tool")
+      .set("X-Argent-AI-Client-Name", "some-new-tool")
+      .send({})
+      .expect(200);
+
+    expect(recordInvocation).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Adds a coarse, anonymous signal to tool telemetry: which AI coding tool is driving the MCP server (Claude Code, Codex, Cursor, Gemini, VS Code, Windsurf, Zed, opencode, Copilot, or other).

## How it works

1. Source of truth — the MCP `initialize` handshake clientInfo.name, read at runtime via `Server.getClientVersion()`. New `ai-identity.ts` in `@argent/telemetry` canonicalizes that raw name to a known slug. Unrecognized tools become `other` plus a bounded, sanitized free-form name.
2. Cross-process hop — telemetry lives in the tool-server, but `clientInfo` lives in the MCP server process. The MCP server forwards the identity as `X-Argent-AI-Client` / `X-Argent-AI-Client-Name` request headers.
3. Re-validation at the boundary — the tool-server re-checks both headers against the same allowlist/pattern the sanitizer enforces, so a misbehaving client can't inject arbitrary telemetry values. The free-form name is retained only when ai_client === "other".
4. Threading through events — `AiTelemetryProps` is mixed into the tool event types and merged in the registry listener and tool-server stop handler via the shared aiTelemetryFromMeta helper, so keys are omitted entirely when absent.

## Privacy

It records only which tool is connected. It is validated at the `mcp-server`, re-validated at the `tool-server`, and enforced a third time by the `sanitizer` allowlist before anything reaches PostHog. Path-like or oversized names are dropped.