### PR TITLE
feat: support arm64 Linux simulator-server binary

### DIFF
--- a/.github/workflows/build-package-artifact.yml
+++ b/.github/workflows/build-package-artifact.yml
@@ -54,7 +54,7 @@ jobs:
             p="packages/argent/bin/${plat}/simulator-server"
             if [[ -x "$p" ]]; then
               size=$(wc -c <"$p")
-              echo "  ok ${plat}: ${p} (${size} bytes)"
+              echo "  ok ${plat}: ${p} (${size} bytes; $(file -b "$p"))"
             else
               echo "  missing ${plat}: ${p}"
               if [[ "$plat" == "darwin" ]]; then missing=1; fi

--- a/.github/workflows/build-package-artifact.yml
+++ b/.github/workflows/build-package-artifact.yml
@@ -50,7 +50,7 @@ jobs:
           set -e
           missing=0
           echo "simulator-server inventory:"
-          for plat in darwin linux; do
+          for plat in darwin linux linux-arm64; do
             p="packages/argent/bin/${plat}/simulator-server"
             if [[ -x "$p" ]]; then
               size=$(wc -c <"$p")
@@ -58,7 +58,7 @@ jobs:
             else
               echo "  missing ${plat}: ${p}"
               if [[ "$plat" == "darwin" ]]; then missing=1; fi
-              if [[ "$plat" == "linux" && "${ARGENT_REQUIRE_LINUX_BINARY}" == "1" ]]; then missing=1; fi
+              if [[ "$plat" == linux* && "${ARGENT_REQUIRE_LINUX_BINARY}" == "1" ]]; then missing=1; fi
             fi
           done
           [[ "$missing" == "0" ]] || { echo "::error::required simulator-server binary missing"; exit 1; }

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -79,7 +79,7 @@ jobs:
             p="packages/argent/bin/${plat}/simulator-server"
             if [[ -x "$p" ]]; then
               size=$(wc -c <"$p")
-              echo "  ✓ ${plat}: ${p} (${size} bytes)"
+              echo "  ✓ ${plat}: ${p} (${size} bytes; $(file -b "$p"))"
             else
               echo "  ✗ ${plat}: ${p} — missing"
               if [[ "$plat" == "darwin" ]]; then missing=1; fi

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -63,10 +63,11 @@ jobs:
       - run: npm run build -w @swmansion/argent
 
       # Per-platform bundle layout (commit 80e724a). darwin is always required;
-      # Linux is gated by ARGENT_REQUIRE_LINUX_BINARY so the existing release
-      # pipeline keeps working until radon's Linux artifact is reliably present
-      # — flip the env var to "1" once that lands. The inventory always logs
-      # what shipped so a silently-missing Linux binary shows up in the run.
+      # both Linux keys (x86_64 "linux" and arm64 "linux-arm64") are gated by
+      # ARGENT_REQUIRE_LINUX_BINARY so the existing release pipeline keeps
+      # working until radon's Linux artifacts are reliably present — flip the
+      # env var to "1" once that lands. The inventory always logs what shipped
+      # so a silently-missing Linux binary shows up in the run.
       - name: Verify per-platform simulator-server binaries
         env:
           ARGENT_REQUIRE_LINUX_BINARY: "0"
@@ -74,7 +75,7 @@ jobs:
           set -e
           missing=0
           echo "simulator-server inventory:"
-          for plat in darwin linux; do
+          for plat in darwin linux linux-arm64; do
             p="packages/argent/bin/${plat}/simulator-server"
             if [[ -x "$p" ]]; then
               size=$(wc -c <"$p")
@@ -82,7 +83,7 @@ jobs:
             else
               echo "  ✗ ${plat}: ${p} — missing"
               if [[ "$plat" == "darwin" ]]; then missing=1; fi
-              if [[ "$plat" == "linux" && "${ARGENT_REQUIRE_LINUX_BINARY}" == "1" ]]; then missing=1; fi
+              if [[ "$plat" == linux* && "${ARGENT_REQUIRE_LINUX_BINARY}" == "1" ]]; then missing=1; fi
             fi
           done
           [[ "$missing" == "0" ]] || { echo "::error::required simulator-server binary missing"; exit 1; }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,10 +53,11 @@ jobs:
       - run: npm run build -w @swmansion/argent
 
       # Per-platform bundle layout (commit 80e724a). darwin is always required;
-      # Linux is gated by ARGENT_REQUIRE_LINUX_BINARY so the existing release
-      # pipeline keeps working until radon's Linux artifact is reliably present
-      # — flip the env var to "1" once that lands. The inventory always logs
-      # what shipped so a silently-missing Linux binary shows up in the run.
+      # both Linux keys (x86_64 "linux" and arm64 "linux-arm64") are gated by
+      # ARGENT_REQUIRE_LINUX_BINARY so the existing release pipeline keeps
+      # working until radon's Linux artifacts are reliably present — flip the
+      # env var to "1" once that lands. The inventory always logs what shipped
+      # so a silently-missing Linux binary shows up in the run.
       - name: Verify per-platform simulator-server binaries
         env:
           ARGENT_REQUIRE_LINUX_BINARY: "0"
@@ -64,7 +65,7 @@ jobs:
           set -e
           missing=0
           echo "simulator-server inventory:"
-          for plat in darwin linux; do
+          for plat in darwin linux linux-arm64; do
             p="packages/argent/bin/${plat}/simulator-server"
             if [[ -x "$p" ]]; then
               size=$(wc -c <"$p")
@@ -72,7 +73,7 @@ jobs:
             else
               echo "  ✗ ${plat}: ${p} — missing"
               if [[ "$plat" == "darwin" ]]; then missing=1; fi
-              if [[ "$plat" == "linux" && "${ARGENT_REQUIRE_LINUX_BINARY}" == "1" ]]; then missing=1; fi
+              if [[ "$plat" == linux* && "${ARGENT_REQUIRE_LINUX_BINARY}" == "1" ]]; then missing=1; fi
             fi
           done
           [[ "$missing" == "0" ]] || { echo "::error::required simulator-server binary missing"; exit 1; }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
             p="packages/argent/bin/${plat}/simulator-server"
             if [[ -x "$p" ]]; then
               size=$(wc -c <"$p")
-              echo "  ✓ ${plat}: ${p} (${size} bytes)"
+              echo "  ✓ ${plat}: ${p} (${size} bytes; $(file -b "$p"))"
             else
               echo "  ✗ ${plat}: ${p} — missing"
               if [[ "$plat" == "darwin" ]]; then missing=1; fi

--- a/packages/argent/scripts/argent-simulator-server.cjs
+++ b/packages/argent/scripts/argent-simulator-server.cjs
@@ -13,11 +13,19 @@ const { spawn } = require("node:child_process");
 const path = require("node:path");
 const fs = require("node:fs");
 
-const binary = path.join(__dirname, process.platform, "simulator-server");
+// Mirrors hostPlatformKey() in @argent/native-devtools-ios: darwin ships a
+// universal (lipo) binary, but Linux binaries are single-arch ELFs, so arm64
+// Linux resolves to its own "linux-arm64" directory next to the x86_64 one
+// ("linux"). Duplicated here because the dispatcher must stay a standalone
+// file — it ships verbatim as the npm `bin` entry.
+const platformKey =
+  process.platform === "linux" && process.arch === "arm64" ? "linux-arm64" : process.platform;
+
+const binary = path.join(__dirname, platformKey, "simulator-server");
 if (!fs.existsSync(binary)) {
   console.error(
-    `argent-simulator-server: no binary for platform "${process.platform}" at ${binary}.\n` +
-      `Supported hosts today: darwin, linux.`
+    `argent-simulator-server: no binary for platform "${platformKey}" at ${binary}.\n` +
+      `Supported hosts today: darwin, linux (x86_64 and arm64).`
   );
   process.exit(1);
 }

--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -73,7 +73,9 @@ const AX_TCP_BIN_SRC = path.resolve(BIN_SRC_ROOT, "darwin/tcp/ax-service");
 const BIN_DIR = path.resolve(__dirname, "../bin");
 const AX_BIN_DEST = path.resolve(BIN_DIR, "darwin/ax-service");
 const AX_TCP_BIN_DEST = path.resolve(BIN_DIR, "darwin/tcp/ax-service");
-const SUPPORTED_HOST_PLATFORMS = ["darwin", "linux"];
+// Host platform keys (see hostPlatformKey() in @argent/native-devtools-ios):
+// darwin is a universal binary; Linux ships one single-arch ELF per key.
+const SUPPORTED_HOST_PLATFORMS = ["darwin", "linux", "linux-arm64"];
 // Generated module pinning the Perfetto version that stamps the bundled
 // trace_processor.wasm. esbuild inlines it into every bundle via the
 // @argent/native-devtools-android alias.

--- a/packages/argent/test/dispatcher.test.ts
+++ b/packages/argent/test/dispatcher.test.ts
@@ -32,17 +32,26 @@ beforeEach(() => {
   }
 });
 
+// Mirrors the dispatcher's host platform key: process.platform, except
+// "linux-arm64" on arm64 Linux. Keeps the suite green on every host the
+// dispatcher itself supports.
+const HOST_PLATFORM_KEY =
+  process.platform === "linux" && process.arch === "arm64" ? "linux-arm64" : process.platform;
+
 /**
  * Stage a tmp dispatcher dir. Returns the path to the copied dispatcher .cjs
  * (suitable to pass to `node`) and the per-platform bin dir where the caller
  * should drop a fake simulator-server.
  */
-function stageDispatcher(): { dispatcher: string; platformDir: string } {
+function stageDispatcher(platformKey: string = HOST_PLATFORM_KEY): {
+  dispatcher: string;
+  platformDir: string;
+} {
   const dir = fs.mkdtempSync(path.join(tmpRoot, "case-"));
   sessionTmpDirs.push(dir);
   const dispatcher = path.join(dir, "argent-simulator-server.cjs");
   fs.copyFileSync(DISPATCHER_SRC, dispatcher);
-  const platformDir = path.join(dir, process.platform);
+  const platformDir = path.join(dir, platformKey);
   fs.mkdirSync(platformDir, { recursive: true });
   return { dispatcher, platformDir };
 }
@@ -105,6 +114,34 @@ describe("argent-simulator-server dispatcher", () => {
     expect(result.stderr).toContain("argent-simulator-server: no binary");
     expect(result.stderr).toContain(process.platform);
     expect(result.stderr).toContain("Supported hosts today: darwin, linux");
+  });
+
+  it("resolves the linux-arm64 binary when running on arm64 Linux", async () => {
+    // The dispatcher reads process.platform / process.arch at require time,
+    // so the test fakes both inside a child process (via `node -e`) before
+    // requiring the dispatcher — exercising the real resolution logic on any
+    // host. The fake binary is a bash script, so executing it works even
+    // though the staged directory is named for a different platform.
+    const { dispatcher, platformDir } = stageDispatcher("linux-arm64");
+    writeFakeBinary(platformDir, "#!/usr/bin/env bash\necho arm64-ok\nexit 0\n");
+    const stub =
+      'Object.defineProperty(process, "platform", { value: "linux" });' +
+      'Object.defineProperty(process, "arch", { value: "arm64" });' +
+      "require(process.argv[1]);";
+    const result = await new Promise<RunResult>((resolve, reject) => {
+      const child = spawn(process.execPath, ["-e", stub, dispatcher], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (c) => (stdout += c.toString()));
+      child.stderr.on("data", (c) => (stderr += c.toString()));
+      child.on("error", reject);
+      child.on("exit", (code, signal) => resolve({ exitCode: code, signal, stdout, stderr }));
+    });
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("arm64-ok");
+    expect(result.exitCode).toBe(0);
   });
 
   it("propagates the child's exit code on a clean exit", async () => {

--- a/packages/native-devtools-ios/src/index.ts
+++ b/packages/native-devtools-ios/src/index.ts
@@ -54,10 +54,23 @@ export const nativeDevtoolsDylibPathTcp = () => {
 
 // simulator-server is a host-side binary that talks to both iOS Simulators
 // (macOS) and Android emulators (any host with `adb`). Each platform's
-// binary lives in its own subdirectory of bin/ — keyed by `process.platform`
-// — so a single npm package can ship both without colliding filenames.
+// binary lives in its own subdirectory of bin/ — keyed by the host platform
+// key below — so a single npm package can ship all of them without colliding
+// filenames.
+//
+// The key is `process.platform`, except on arm64 Linux where it is
+// "linux-arm64": darwin ships a universal (lipo) binary so one "darwin" dir
+// serves both arches, but Linux binaries are single-arch ELFs, so arm64 gets
+// its own directory next to the x86_64 one ("linux", the pre-arm64 name kept
+// for backward compatibility).
+export function hostPlatformKey(): string {
+  if (process.platform === "linux" && process.arch === "arm64") {
+    return "linux-arm64";
+  }
+  return process.platform;
+}
 function platformBinDir(): string {
-  return path.join(BIN_DIR, process.platform);
+  return path.join(BIN_DIR, hostPlatformKey());
 }
 // TCP dir: <platform>/tcp by default; ARGENT_SIMULATOR_SERVER_TCP_DIR overrides the whole path.
 function platformTcpBinDir(): string {
@@ -74,8 +87,8 @@ export function simulatorServerBinaryPath(): string {
       ? ` Found a binary at the old flat path ${flat}; move it to ${p} or update ARGENT_SIMULATOR_SERVER_DIR to point at the parent of the platform subdirectory.`
       : "";
     throw new Error(
-      `simulator-server binary not found for platform "${process.platform}" at ${p}. ` +
-        `Supported hosts today: darwin, linux.${migrationHint}`
+      `simulator-server binary not found for platform "${hostPlatformKey()}" at ${p}. ` +
+        `Supported hosts today: darwin, linux (x86_64 and arm64).${migrationHint}`
     );
   }
   return p;

--- a/packages/native-devtools-ios/test/index.test.ts
+++ b/packages/native-devtools-ios/test/index.test.ts
@@ -17,11 +17,16 @@ import type * as ResolverModule from "../src/index";
 
 let tmpRoot = "";
 const originalPlatform = process.platform;
+const originalArch = process.arch;
 const originalDevtoolsDir = process.env.ARGENT_NATIVE_DEVTOOLS_DIR;
 const originalSimulatorDir = process.env.ARGENT_SIMULATOR_SERVER_DIR;
 
 function setPlatform(value: NodeJS.Platform) {
   Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+function setArch(value: NodeJS.Architecture) {
+  Object.defineProperty(process, "arch", { value, configurable: true });
 }
 
 beforeAll(() => {
@@ -31,6 +36,7 @@ beforeAll(() => {
 afterAll(() => {
   if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
   setPlatform(originalPlatform);
+  setArch(originalArch);
   if (originalDevtoolsDir === undefined) delete process.env.ARGENT_NATIVE_DEVTOOLS_DIR;
   else process.env.ARGENT_NATIVE_DEVTOOLS_DIR = originalDevtoolsDir;
   if (originalSimulatorDir === undefined) delete process.env.ARGENT_SIMULATOR_SERVER_DIR;
@@ -39,6 +45,7 @@ afterAll(() => {
 
 afterEach(() => {
   setPlatform(originalPlatform);
+  setArch(originalArch);
 });
 
 /**
@@ -135,6 +142,68 @@ describe("simulator-server path resolution", () => {
     const r = await loadResolver();
     expect(() => r.simulatorServerBinaryPath()).toThrow(/old flat path/);
     expect(() => r.simulatorServerBinaryPath()).toThrow(new RegExp(process.platform));
+  });
+});
+
+describe("host platform key (arch-aware Linux bin dirs)", () => {
+  // Linux binaries are single-arch ELFs (unlike the universal macOS binary),
+  // so arm64 Linux resolves to its own "linux-arm64" directory while x86_64
+  // keeps the pre-arm64 "linux" name. Without this split, an arm64 host would
+  // silently pick up the x86_64 ELF and fail with ENOEXEC at spawn time.
+  it("resolves bin/linux-arm64 on arm64 Linux", async () => {
+    setPlatform("linux");
+    setArch("arm64");
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "linux-arm64-"));
+    const platDir = path.join(dir, "linux-arm64");
+    fs.mkdirSync(platDir, { recursive: true });
+    const binPath = path.join(platDir, "simulator-server");
+    fs.writeFileSync(binPath, "", { mode: 0o755 });
+    process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
+    const r = await loadResolver();
+    expect(r.hostPlatformKey()).toBe("linux-arm64");
+    expect(r.simulatorServerBinaryPath()).toBe(binPath);
+    expect(r.simulatorServerBinaryDir()).toBe(platDir);
+  });
+
+  it("keeps resolving bin/linux on x86_64 Linux", async () => {
+    setPlatform("linux");
+    setArch("x64");
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "linux-x64-"));
+    const platDir = path.join(dir, "linux");
+    fs.mkdirSync(platDir, { recursive: true });
+    const binPath = path.join(platDir, "simulator-server");
+    fs.writeFileSync(binPath, "", { mode: 0o755 });
+    process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
+    const r = await loadResolver();
+    expect(r.hostPlatformKey()).toBe("linux");
+    expect(r.simulatorServerBinaryPath()).toBe(binPath);
+  });
+
+  it("keeps resolving bin/darwin on arm64 macOS (universal binary)", async () => {
+    setPlatform("darwin");
+    setArch("arm64");
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "darwin-arm64-"));
+    const platDir = path.join(dir, "darwin");
+    fs.mkdirSync(platDir, { recursive: true });
+    const binPath = path.join(platDir, "simulator-server");
+    fs.writeFileSync(binPath, "", { mode: 0o755 });
+    process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
+    const r = await loadResolver();
+    expect(r.hostPlatformKey()).toBe("darwin");
+    expect(r.simulatorServerBinaryPath()).toBe(binPath);
+  });
+
+  it("names the linux-arm64 key in the missing-binary error", async () => {
+    // The error must name the directory actually searched ("linux-arm64"),
+    // not bare process.platform, so an arm64 user re-running the download
+    // script can tell which asset is absent.
+    setPlatform("linux");
+    setArch("arm64");
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "linux-arm64-missing-"));
+    fs.mkdirSync(path.join(dir, "linux-arm64"), { recursive: true });
+    process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
+    const r = await loadResolver();
+    expect(() => r.simulatorServerBinaryPath()).toThrow(/linux-arm64/);
   });
 });
 

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -137,16 +137,20 @@ console.log("✓ Dispatcher TypeScript built\n");
 
 // Copy the simulator-server binary for the current host platform into the
 // platform-keyed subdir the runtime resolver looks at. Mirrors bundle-tools.cjs
-// but only for `process.platform` — dev iterations don't need every host's
-// binary alongside.
-const BIN_DIR = path.join(ARGENT_PKG, "bin", process.platform);
-const BIN_SRC = path.join(NATIVE_DEVTOOLS_PKG, "bin", process.platform, "simulator-server");
+// but only for the current host's key — dev iterations don't need every
+// host's binary alongside. The key mirrors hostPlatformKey() in
+// @argent/native-devtools-ios (process.platform, except "linux-arm64" on
+// arm64 Linux).
+const HOST_PLATFORM_KEY =
+  process.platform === "linux" && process.arch === "arm64" ? "linux-arm64" : process.platform;
+const BIN_DIR = path.join(ARGENT_PKG, "bin", HOST_PLATFORM_KEY);
+const BIN_SRC = path.join(NATIVE_DEVTOOLS_PKG, "bin", HOST_PLATFORM_KEY, "simulator-server");
 const BIN_DEST = path.join(BIN_DIR, "simulator-server");
 fs.mkdirSync(BIN_DIR, { recursive: true });
 if (fs.existsSync(BIN_SRC)) {
   fs.copyFileSync(BIN_SRC, BIN_DEST);
   fs.chmodSync(BIN_DEST, 0o755);
-  console.log(`✓ Copied simulator-server binary (${process.platform})`);
+  console.log(`✓ Copied simulator-server binary (${HOST_PLATFORM_KEY})`);
 } else {
   console.warn(
     `⚠ simulator-server binary not found at ${BIN_SRC} — gestures won't work. ` +

--- a/scripts/download-simulator-server.sh
+++ b/scripts/download-simulator-server.sh
@@ -68,6 +68,28 @@ for entry in "${TARGETS[@]}"; do
 
   mv "${PLATFORM_DIR}/${ASSET_NAME}" "${PLATFORM_DIR}/simulator-server"
   chmod +x "${PLATFORM_DIR}/simulator-server"
+
+  # Architecture sanity check: a wrong-arch binary in a platform dir is worse
+  # than a missing one — the resolver would happily pick it and the user gets
+  # an ENOEXEC at spawn time with no hint of the root cause. Fail hard here
+  # (unlike the missing-asset case above) because a present-but-mislabeled
+  # asset is an upstream packaging bug that must not ship.
+  if command -v file >/dev/null 2>&1; then
+    DESC="$(file -b "${PLATFORM_DIR}/simulator-server")"
+    case "${PLATFORM}" in
+      darwin) EXPECT="Mach-O universal" ;;
+      linux) EXPECT="ELF 64-bit.*x86-64" ;;
+      linux-arm64) EXPECT="ELF 64-bit.*aarch64" ;;
+      *) EXPECT="" ;;
+    esac
+    if [[ -n "${EXPECT}" ]] && ! [[ "${DESC}" =~ ${EXPECT} ]]; then
+      echo "✗ ${ASSET_NAME} has the wrong architecture for ${PLATFORM}:" >&2
+      echo "    got:      ${DESC}" >&2
+      echo "    expected: ${EXPECT}" >&2
+      exit 1
+    fi
+    echo "  ✓ arch ok: ${DESC}"
+  fi
 done
 
 echo ""

--- a/scripts/download-simulator-server.sh
+++ b/scripts/download-simulator-server.sh
@@ -18,12 +18,14 @@ REPO="software-mansion-labs/simulator-server-releases"
 TAG="${1:-radon-main}"
 DEST_DIR="packages/native-devtools-ios/bin"
 
-# release-asset-name → process.platform key. Asset names follow the upstream
-# build matrix (`simulator-server-argent-{macos,linux}`); the keys mirror
-# Node's process.platform so the resolver can lookup by host platform.
+# release-asset-name → host platform key. Asset names follow the upstream
+# build matrix (`simulator-server-argent-{macos,linux,linux-arm64}`); the keys
+# mirror hostPlatformKey() in @argent/native-devtools-ios (process.platform,
+# except "linux-arm64" on arm64 Linux) so the resolver can lookup by host.
 declare -a TARGETS=(
   "simulator-server-argent-macos:darwin"
   "simulator-server-argent-linux:linux"
+  "simulator-server-argent-linux-arm64:linux-arm64"
 )
 
 mkdir -p "${DEST_DIR}"


### PR DESCRIPTION
## Summary

The only Linux simulator-server binary argent ships today is x86_64 (`simulator-server-argent-linux` — verified: `ELF 64-bit … x86-64`). On arm64 Linux hosts (Lima/UTM VMs on Apple Silicon, arm cloud instances, Raspberry Pi-class devices) the package has no usable binary — the x86_64 ELF would only fail with `ENOEXEC` at spawn time.

This PR teaches the whole binary pipeline about a **host platform key**: `process.platform` everywhere, except arm64 Linux which maps to `linux-arm64`. macOS keeps a single `darwin/` dir because its binary is universal (lipo); Linux binaries are single-arch ELFs, so each arch gets its own platform-keyed directory. x86_64 Linux keeps the existing `linux` key for backward compatibility.

## Changes

- **`@argent/native-devtools-ios` resolver** — new exported `hostPlatformKey()`; `simulatorServerBinaryPath()` resolves `bin/linux-arm64/` on arm64 Linux and names the searched key in its error message.
- **`argent-simulator-server.cjs` dispatcher** (npm `bin` entry) — mirrors the same key (duplicated deliberately; the dispatcher ships as a standalone file).
- **`bundle-tools.cjs`** — `linux-arm64` added to the supported host platform dirs; copied into the package when staged, warn-and-skip otherwise (same as x86_64 Linux).
- **`scripts/download-simulator-server.sh`** — downloads `simulator-server-argent-linux-arm64` into `bin/linux-arm64/`; tolerates the asset being absent (warn + skip) until the upstream release ships it, so publishing keeps working in the meantime.
- **`scripts/dev.cjs`** — copies the current host's binary by key.
- **publish / publish-next / build-package-artifact workflows** — `linux-arm64` added to the binary inventory; gated by the existing `ARGENT_REQUIRE_LINUX_BINARY` flag (now covering both Linux keys via a `linux*` glob).

## Tests

- Resolver: new arch-aware suite — `linux`+`arm64` → `bin/linux-arm64`, `linux`+`x64` → `bin/linux`, `darwin`+`arm64` → `bin/darwin`, and the missing-binary error names `linux-arm64`.
- Dispatcher: end-to-end test faking `process.platform`/`process.arch` in a child process to exercise the real resolution path on any host.
- Full suite: 146 files / 1651 tests pass. `tsc --build` clean.
- `download-simulator-server.sh` exercised against the live `radon-main` release: downloads darwin + linux, warn-and-skips the not-yet-published arm64 asset.

## Dependencies

Companion PR software-mansion/radon#126 adds the `ubuntu-24.04-arm` build leg that publishes `simulator-server-argent-linux-arm64` to `simulator-server-releases`. This PR is safe to merge first (the download script and verify steps tolerate the missing asset); arm64 hosts start working once a release containing the new asset is cut.