### PR TITLE
fix(mcp): report the real installed version in the MCP handshake

### DIFF
--- a/packages/argent-mcp/src/installed-version.ts
+++ b/packages/argent-mcp/src/installed-version.ts
@@ -1,0 +1,24 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Version reported in the MCP `initialize` handshake (`serverInfo.version`).
+ *
+ * Resolved from the package.json one directory above the executing file —
+ * the same pattern as `getInstalledVersion()` in packages/argent/src/cli.ts:
+ * in the published package the bundled `dist/mcp-server.mjs` sits next to
+ * `dist/cli.js`, so two-up is @swmansion/argent's shipped package.json; in
+ * the dev workspace the compiled file resolves @argent/mcp's own package.json.
+ * Both are version-bumped in lockstep, so either source is correct — unlike
+ * the hardcoded literal this replaces, which had drifted several releases
+ * behind the actual install.
+ */
+export function getInstalledVersion(): string {
+  try {
+    const pkgPath = path.resolve(import.meta.dirname, "..", "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -28,6 +28,7 @@ import {
   getAutoScreenshotDelayMs,
 } from "./auto-screenshot.js";
 import { toMcpTool } from "./tool-mapping.js";
+import { getInstalledVersion } from "./installed-version.js";
 
 const MAX_RETRIES = 4;
 const EXP_BACKOFF_BASE = 250;
@@ -182,7 +183,7 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
   }
 
   const server = new Server(
-    { name: "argent", version: "0.5.3" },
+    { name: "argent", version: getInstalledVersion() },
     {
       capabilities: { tools: {} },
       instructions:

--- a/packages/argent-mcp/test/installed-version.test.ts
+++ b/packages/argent-mcp/test/installed-version.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getInstalledVersion } from "../src/installed-version.js";
+
+describe("getInstalledVersion", () => {
+  it("matches the workspace package.json version (no more hardcoded drift)", () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")
+    ) as { version: string };
+    expect(getInstalledVersion()).toBe(pkg.version);
+  });
+
+  it("never returns the stale literal this replaced", () => {
+    expect(getInstalledVersion()).not.toBe("0.5.3");
+  });
+});


### PR DESCRIPTION
## Summary

`serverInfo.version` in the MCP `initialize` response was hardcoded to `"0.5.3"` in `mcp-server.ts` and had drifted several releases behind the actual install (currently 0.11.0). Spotted while driving the MCP server over stdio:

```
server: {"name":"argent","version":"0.5.3"}   # argent --version says 0.11.0
```

## Fix

New `getInstalledVersion()` in `packages/argent-mcp/src/installed-version.ts` resolves the version at runtime from the package.json one directory above the executing file — the same pattern `packages/argent/src/cli.ts` already uses for the `argent --version` banner:

- published bundle: `dist/mcp-server.mjs` → two-up is **@swmansion/argent**'s shipped package.json
- dev workspace: compiled `@argent/mcp` output → its own package.json

Both are version-bumped in lockstep. Falls back to `"unknown"` instead of another literal that can drift.

## Test plan

- [x] Unit tests: helper matches the workspace package.json version and never returns the stale literal
- [x] `npm run build`, `typecheck:tests`, prettier clean
- [x] 66 argent-mcp tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)