### PR TITLE
fix(native-profiler): attach by PID instead of CFBundleExecutable on iOS (Xcode 26.5)

### DIFF
--- a/packages/tool-server/src/tools/profiler/native-profiler/native-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/native-profiler/native-profiler-start.ts
@@ -18,7 +18,7 @@ const zodSchema = z.object({
     .string()
     .optional()
     .describe(
-      "iOS: the exact CFBundleExecutable of the app to profile. Android: the app's package name. " +
+      "iOS: the CFBundleExecutable or display name of the app to profile. Android: the app's package name. " +
         "If omitted, auto-detects the currently running foreground app. Only provide this if " +
         "auto-detection picks the wrong app."
     ),

--- a/packages/tool-server/src/tools/profiler/native-profiler/platforms/ios.ts
+++ b/packages/tool-server/src/tools/profiler/native-profiler/platforms/ios.ts
@@ -61,7 +61,27 @@ interface AppInfo {
   ApplicationType: string;
 }
 
-function detectRunningApp(udid: string): string {
+interface DetectedApp {
+  /** CFBundleExecutable — used for human-readable messages and api.appProcess. */
+  executable: string;
+  /**
+   * Host PID of the running app, parsed from `launchctl list`. We attach by PID
+   * rather than by name because Xcode 26.5's `xctrace --attach` matches the app
+   * display name (not CFBundleExecutable, as Xcode <= 26.3 did), so passing the
+   * executable name fails with "Cannot find process matching name". A PID is
+   * unambiguous and works across Xcode versions. For simulator apps the launchd
+   * PID is also the host PID xctrace attaches to. Null when the target is not
+   * currently running (then we fall back to attaching by name).
+   */
+  pid: number | null;
+}
+
+/**
+ * Enumerate the user apps currently running on the simulator, each paired with
+ * its host PID. The PID is the leading column of `launchctl list`; apps that are
+ * registered but not running carry `-` there and are skipped.
+ */
+function enumerateRunningUserApps(udid: string): { info: AppInfo; pid: number }[] {
   let launchctlOutput: string;
   try {
     launchctlOutput = execSync(`xcrun simctl spawn ${udid} launchctl list`, {
@@ -76,15 +96,17 @@ function detectRunningApp(udid: string): string {
     );
   }
 
-  const runningBundleIds = new Set<string>();
+  // Lines look like: `19967\t0\tUIKitApplication:com.apple.Preferences[183a][rb-legacy]`
+  // (PID, status, label). Only lines with a numeric PID are actually running.
+  const runningPids = new Map<string, number>();
   for (const line of launchctlOutput.split("\n")) {
-    const match = line.match(/UIKitApplication:([^\[]+)/);
+    const match = line.match(/^\s*(\d+)\s+\S+\s+UIKitApplication:([^\[]+)/);
     if (match) {
-      runningBundleIds.add(match[1]);
+      runningPids.set(match[2], Number(match[1]));
     }
   }
 
-  if (runningBundleIds.size === 0) {
+  if (runningPids.size === 0) {
     throw new Error(
       "No running apps detected on the simulator. Launch the app first using `launch-app`, then retry."
     );
@@ -106,10 +128,11 @@ function detectRunningApp(udid: string): string {
 
   const installedApps: Record<string, AppInfo> = JSON.parse(listAppsOutput);
 
-  const runningUserApps: AppInfo[] = [];
-  for (const [, appInfo] of Object.entries(installedApps)) {
-    if (appInfo.ApplicationType === "User" && runningBundleIds.has(appInfo.CFBundleIdentifier)) {
-      runningUserApps.push(appInfo);
+  const runningUserApps: { info: AppInfo; pid: number }[] = [];
+  for (const [, info] of Object.entries(installedApps)) {
+    const pid = runningPids.get(info.CFBundleIdentifier);
+    if (info.ApplicationType === "User" && pid !== undefined) {
+      runningUserApps.push({ info, pid });
     }
   }
 
@@ -119,19 +142,49 @@ function detectRunningApp(udid: string): string {
     );
   }
 
+  return runningUserApps;
+}
+
+/** Auto-detect the single running user app to profile, with its host PID. */
+function detectRunningApp(udid: string): DetectedApp {
+  const runningUserApps = enumerateRunningUserApps(udid);
+
   if (runningUserApps.length > 1) {
     const appList = runningUserApps
       .map(
-        (a) =>
-          `  - ${a.CFBundleExecutable} (${a.CFBundleIdentifier}${a.CFBundleDisplayName ? `, "${a.CFBundleDisplayName}"` : ""})`
+        ({ info }) =>
+          `  - ${info.CFBundleExecutable} (${info.CFBundleIdentifier}${info.CFBundleDisplayName ? `, "${info.CFBundleDisplayName}"` : ""})`
       )
       .join("\n");
     throw new Error(
-      `Multiple user apps are running on the simulator:\n${appList}\nSpecify \`app_process\` with the CFBundleExecutable of the app you want to profile.`
+      `Multiple user apps are running on the simulator:\n${appList}\nSpecify \`app_process\` with the CFBundleExecutable or display name of the app you want to profile.`
     );
   }
 
-  return runningUserApps[0].CFBundleExecutable;
+  const { info, pid } = runningUserApps[0];
+  return { executable: info.CFBundleExecutable, pid };
+}
+
+/**
+ * Resolve an explicitly-provided `app_process` to a host PID by matching it
+ * against the CFBundleExecutable or CFBundleDisplayName of a running user app.
+ * Falls back to attaching by the given name (pid: null) when nothing matches —
+ * e.g. the app isn't running yet — so the cold-start retry can still kick in.
+ */
+function resolveExplicitApp(udid: string, name: string): DetectedApp {
+  let runningUserApps: { info: AppInfo; pid: number }[];
+  try {
+    runningUserApps = enumerateRunningUserApps(udid);
+  } catch {
+    return { executable: name, pid: null };
+  }
+  const matched = runningUserApps.find(
+    ({ info }) => info.CFBundleExecutable === name || info.CFBundleDisplayName === name
+  );
+  if (matched) {
+    return { executable: matched.info.CFBundleExecutable, pid: matched.pid };
+  }
+  return { executable: name, pid: null };
 }
 
 async function registerStartupNotify(name: string): Promise<NotifyHandle | null> {
@@ -201,7 +254,13 @@ export async function startNativeProfilerIos(
   }
 
   const templatePath = params.template_path ?? resolveDefaultTemplatePath();
-  const appProcess = params.app_process ?? detectRunningApp(params.device_id);
+  const detected = params.app_process
+    ? resolveExplicitApp(params.device_id, params.app_process)
+    : detectRunningApp(params.device_id);
+  const appProcess = detected.executable;
+  // Attach by PID when we know it (immune to Xcode 26.5's display-name `--attach`
+  // matching); fall back to the name when the target isn't running yet.
+  const attachTarget = detected.pid != null ? String(detected.pid) : appProcess;
 
   const debugDir = await getDebugDir();
   const timestamp = new Date()
@@ -228,7 +287,7 @@ export async function startNativeProfilerIos(
       "--device",
       params.device_id,
       "--attach",
-      appProcess,
+      attachTarget,
       "--output",
       outputFile,
       "--no-prompt",
@@ -285,7 +344,7 @@ export async function startNativeProfilerIos(
       `xctrace could not find process "${appProcess}" after ${MAX_START_ATTEMPTS} attempts within ${totalMs} ms. ` +
         `The app appears to be cold-launching — its bundle is registered with launchd, but xctrace's process resolver hasn't seen it yet. ` +
         `Wait 1–2 seconds for the app to finish launching and retry. ` +
-        `If the wrong app is being detected, pass app_process explicitly with the CFBundleExecutable.`
+        `If the wrong app is being detected, pass app_process explicitly with the CFBundleExecutable or display name.`
     );
   };
 


### PR DESCRIPTION
## Problem

On Xcode 26.5 (`xctrace 16.0 (17F42)`), `native-profiler-start` auto-detection fails to attach for many real apps with **"Cannot find process matching name: <App>"**, even though the app is running. A user hit exactly this and found that passing `app_process` with the app's **display name** worked, while auto-detection (which uses `CFBundleExecutable`) did not.

## Root cause — an undocumented `xctrace --attach` semantics change

`xctrace record --device <sim> --attach <name>` changed how it matches the target between Xcode versions. Verified empirically on a 26.5 sim using **Settings** (`CFBundleExecutable=Preferences`, display name `Settings`) and the side-by-side 26.3 toolchain:

| `--attach` argument | Xcode **26.3** (last-good) | Xcode **26.5** |
|---|---|---|
| `Preferences` (CFBundleExecutable — what Argent passed) | ✅ attaches | ❌ "Cannot find process matching name" |
| `Settings` (display name) | ❌ "ambiguous" | ✅ attaches |
| `19967` (numeric PID) | ✅ attaches | ✅ attaches |

So 26.5 matches `--attach` by **app display name**, not by the executable/process name. Argent returned `CFBundleExecutable`, which is now the wrong field. (This was missed earlier because the investigation used Maps, where executable == display name.)

This is **distinct from** the `coreprofilesessiontap` finalize hang on 26.4+ — it breaks *attach*, before recording even starts, and only for apps where `CFBundleExecutable != CFBundleDisplayName`.

## Fix — attach by PID

PID attach works on **both** 26.3 and 26.5 and is immune to the name-semantics flip and to `--attach` ambiguity. The host PID is already present in the `launchctl list` output we parse (leading column) and is also the simulator app's launchd PID — we were simply discarding it.

- `detectRunningApp` now parses the host PID into a `Map<bundleId, pid>` (same command, same loop) and returns `{ executable, pid }`.
- `startNativeProfilerIos` attaches by `--attach <pid>` when known, falling back to name-attach (with the existing cold-start retry) when the target isn't running yet.
- An explicit `app_process` now resolves to a PID by matching **either** `CFBundleExecutable` or `CFBundleDisplayName` of a running app — so users who follow the old "pass CFBundleExecutable" guidance also succeed on 26.5.
- Updated the two now-inaccurate "use CFBundleExecutable" messages and the tool param doc.

## Verification

- `tsc` clean; all 34 iOS profiler unit tests pass (cold-start retry + stop-recovery).
- New PID-parsing regex validated against **live** `launchctl` output on a 26.5 sim (extracts the correct PID).
- `xctrace --attach <pid>` confirmed to attach on 26.5 and 26.3.
- Not yet exercised: a full auto-detect run through the compiled code against a live running **user** app (no user app installed on the test sim; user-app selection logic itself is unchanged).

## Relationship to the finalize hang

This fixes **attach** only. On stock 26.5 the trace still won't *package* (the separate Instruments `coreprofilesessiontap` finalize regression), so a host `--all-processes` fallback is still needed to actually produce data there. The two are complementary: with PID-attach, the device-attach path stops failing on a name that can never resolve and will light up automatically if Apple fixes finalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
