### PR TITLE
feat(chromium): multi-tab / window support

### DIFF
--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -9,6 +9,8 @@ All interaction tools below accept a `udid` parameter and auto-dispatch iOS vs A
 
 **Chromium (CDP) app** = any Chromium runtime exposing a Chrome DevTools Protocol endpoint: an Electron app (boot it with `boot-device` + `electronAppPath`), or any Chromium-family browser (Chrome/Brave/Edge) launched with `--remote-debugging-port`. The latter is auto-discovered by `list-devices` on port `9222` plus anything in `ARGENT_CHROMIUM_PORTS`. The same describe/tap/swipe/keyboard/screenshot surface drives all of them.
 
+**Multi-tab / windows (Chromium only):** a Chromium device may have several tabs / BrowserWindows. Use `chromium-tabs` to `list` them (stable ids `t1`, `t2`, …, optional labels), open a `new` one, `select` which is active, or `close` one. Every other tool (`describe`, `gesture-tap`, `screenshot`, `debugger-evaluate`, `open-url`, …) acts on the **active** tab, so `chromium-tabs action=select` before driving a different tab. Note: a cross-process navigation (some redirects) can swap a tab's underlying CDP target — re-run `chromium-tabs action=list` to pick it up under a fresh id.
+
 For platform-specific caveats (Metro `adb reverse`, locked-screen describe errors, etc.), see § 9 Platform-specific notes at the bottom.
 
 ## 1. Before You Start

--- a/packages/tool-server/src/chromium-server/cdp-session.ts
+++ b/packages/tool-server/src/chromium-server/cdp-session.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { CDPClient } from "../utils/debugger/cdp-client";
 
-interface CdpTarget {
+export interface CdpTarget {
   id: string;
   type: string;
   title: string;
@@ -26,6 +26,19 @@ export async function ensureCdpReachable(
 }
 
 /**
+ * List the drivable "page" targets a CDP endpoint exposes — one per
+ * BrowserWindow / browser tab — excluding `devtools://` inspector pages and any
+ * target without a WebSocket URL (service/shared workers, etc.). Order matches
+ * Chromium's `/json/list`, which is roughly most-recently-focused first.
+ */
+export async function listPageTargets(port: number, signal?: AbortSignal): Promise<CdpTarget[]> {
+  const targets = await fetchJson<CdpTarget[]>(`http://127.0.0.1:${port}/json/list`, signal);
+  return targets.filter(
+    (t) => t.type === "page" && !!t.webSocketDebuggerUrl && !t.url.startsWith("devtools://")
+  );
+}
+
+/**
  * Probe a CDP endpoint for the renderer page we should drive. Chromium
  * typically exposes one "page" target per BrowserWindow plus a few
  * service_worker / shared_worker entries we don't care about.
@@ -34,21 +47,37 @@ export async function ensureCdpReachable(
  * the inspector instead of the real window is a hard-to-debug failure mode.
  */
 export async function discoverPrimaryPage(port: number, signal?: AbortSignal): Promise<CdpTarget> {
-  const targets = await fetchJson<CdpTarget[]>(`http://127.0.0.1:${port}/json/list`, signal);
-  const pages = targets.filter((t) => t.type === "page" && !!t.webSocketDebuggerUrl);
+  const pages = await listPageTargets(port, signal);
   if (pages.length === 0) {
+    // Distinguish "no pages at all" from "only devtools://" for a clearer hint.
+    const all = await fetchJson<CdpTarget[]>(`http://127.0.0.1:${port}/json/list`, signal);
+    if (all.some((t) => t.type === "page")) {
+      throw new Error(
+        `Chromium CDP on port ${port} has only devtools:// pages (the main BrowserWindow may be hidden or closed). ` +
+          `Bring the app window to the foreground and retry.`
+      );
+    }
     throw new Error(
       `Chromium CDP on port ${port} reported no page targets. Is the app started with --remote-debugging-port=${port}?`
     );
   }
-  const primary = pages.find((p) => !p.url.startsWith("devtools://"));
-  if (!primary) {
+  return pages[0]!;
+}
+
+/**
+ * The browser-level CDP WebSocket URL (from `/json/version`). Used for
+ * `Target.createTarget` / `Target.closeTarget`, which operate on the browser
+ * rather than a single page.
+ */
+export async function browserWebSocketUrl(port: number, signal?: AbortSignal): Promise<string> {
+  const version = await ensureCdpReachable(port, signal);
+  const url = version.webSocketDebuggerUrl;
+  if (!url) {
     throw new Error(
-      `Chromium CDP on port ${port} has only devtools:// pages (the main BrowserWindow may be hidden or closed). ` +
-        `Bring the app window to the foreground and retry.`
+      `Chromium CDP on port ${port} did not report a browser webSocketDebuggerUrl in /json/version.`
     );
   }
-  return primary;
+  return url;
 }
 
 async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {

--- a/packages/tool-server/src/chromium-server/index.ts
+++ b/packages/tool-server/src/chromium-server/index.ts
@@ -7,6 +7,7 @@ import { sendButton, sendKey, sendRotate, sendTouch, sendWheel, sendCharInsert }
 import { goBack, goForward, navigate, reload } from "./navigation";
 import { ScreencastManager } from "./screencast";
 import { captureScreenshot, copyScreenshotToClipboard } from "./screenshot";
+import { createTabsManager } from "./tabs";
 import type {
   ButtonType,
   ChromiumServer,
@@ -63,7 +64,7 @@ export interface CreateChromiumServerOpts {
 export async function createChromiumServer(
   opts: CreateChromiumServerOpts
 ): Promise<ChromiumServer> {
-  const { cdp, wsUrl } = await connectCdp(opts.port);
+  const { cdp, wsUrl, target } = await connectCdp(opts.port);
   await enableCoreDomains(cdp);
 
   let viewport: ViewportSize = await readViewport(cdp);
@@ -74,6 +75,20 @@ export async function createChromiumServer(
 
   cdp.events.on("disconnected", (err) => {
     events.emit("terminated", err ?? new Error(`Chromium CDP on port ${opts.port} disconnected`));
+  });
+
+  // Multi-tab: the manager re-points `cdp` in place when the active tab
+  // changes, so every page-scoped subsystem below (which captured `cdp`)
+  // automatically follows. After a switch we re-prime the page's core domains
+  // and refresh the cached viewport for the new document.
+  const tabs = createTabsManager({
+    cdp,
+    port: opts.port,
+    initialTargetId: target.id,
+    onActivated: async () => {
+      await enableCoreDomains(cdp);
+      viewport = await readViewport(cdp);
+    },
   });
 
   const server: ChromiumServer = {
@@ -123,6 +138,7 @@ export async function createChromiumServer(
       await goForward(cdp);
     },
     setFpsReporting: (enabled: boolean) => fps.setEnabled(enabled),
+    tabs,
     evaluate: async (
       expression: string,
       options?: { returnByValue?: boolean }
@@ -157,6 +173,7 @@ export async function createChromiumServer(
 
 // Re-exported for use from the blueprint when we need a low-level CDP handle.
 export { ensureCdpReachable, discoverPrimaryPage } from "./cdp-session";
+export type { TabInfo, TabsManager } from "./tabs";
 
 // Re-exported so the http-api / blueprint can call them directly without
 // pulling them out of a ChromiumServer instance.

--- a/packages/tool-server/src/chromium-server/tabs.ts
+++ b/packages/tool-server/src/chromium-server/tabs.ts
@@ -1,0 +1,208 @@
+import { CDPClient } from "../utils/debugger/cdp-client";
+import { browserWebSocketUrl, listPageTargets, type CdpTarget } from "./cdp-session";
+
+export interface TabInfo {
+  /** Stable per-session handle: `t1`, `t2`, … Never reused within a session. */
+  tabId: string;
+  /** Underlying CDP target id. */
+  targetId: string;
+  title: string;
+  url: string;
+  /** True for the tab the page-scoped tools (describe/tap/evaluate/…) act on. */
+  active: boolean;
+  /** Optional user-assigned label, usable interchangeably with `tabId`. */
+  label?: string;
+}
+
+export interface TabsManager {
+  /** Enumerate page targets (browser tabs / BrowserWindows) with stable ids. */
+  list(): Promise<TabInfo[]>;
+  /**
+   * Make `ref` (a `tabId` or a label) the active tab. Re-points the shared page
+   * CDP session so every other tool follows. No-op if already active.
+   */
+  select(ref: string): Promise<TabInfo[]>;
+  /** Open a new tab/page (optionally at `url`, optionally labelled) and, by default, activate it. */
+  open(opts?: { url?: string; label?: string; activate?: boolean }): Promise<TabInfo[]>;
+  /** Close a tab (`ref` = tabId or label; defaults to the active tab). */
+  close(ref?: string): Promise<TabInfo[]>;
+  /** CDP target id of the currently active tab. */
+  activeTargetId(): string;
+}
+
+interface TabsManagerDeps {
+  /** The shared page-scoped CDP client the per-page tools use; `reconnect`ed on switch. */
+  cdp: CDPClient;
+  port: number;
+  /** Target id the `cdp` client is connected to at construction (the initial active tab). */
+  initialTargetId: string;
+  /**
+   * Called after the active tab changes (post-`reconnect`). Used by the server
+   * to re-enable core domains and refresh the cached viewport for the new page.
+   */
+  onActivated: () => Promise<void>;
+}
+
+export function createTabsManager(deps: TabsManagerDeps): TabsManager {
+  const { cdp, port } = deps;
+
+  // Stable tabId ↔ CDP targetId mapping. tabIds are minted once and never
+  // reused, so a script/agent can keep referring to `t2` even as other tabs
+  // open and close (mirrors the `@eN` element-ref convention).
+  const targetToTab = new Map<string, string>();
+  const labelToTab = new Map<string, string>();
+  const tabToLabel = new Map<string, string>();
+  let ordinal = 0;
+  let activeTargetId = deps.initialTargetId;
+
+  function mintTabId(targetId: string): string {
+    const existing = targetToTab.get(targetId);
+    if (existing) return existing;
+    const tabId = `t${++ordinal}`;
+    targetToTab.set(targetId, tabId);
+    return tabId;
+  }
+
+  /** Drop ids/labels whose target no longer exists so stale handles don't linger. */
+  function prune(liveTargetIds: Set<string>): void {
+    for (const [targetId, tabId] of [...targetToTab]) {
+      if (!liveTargetIds.has(targetId)) {
+        targetToTab.delete(targetId);
+        const label = tabToLabel.get(tabId);
+        if (label) {
+          labelToTab.delete(label);
+          tabToLabel.delete(tabId);
+        }
+      }
+    }
+  }
+
+  function toInfo(target: CdpTarget): TabInfo {
+    const tabId = mintTabId(target.id);
+    const label = tabToLabel.get(tabId);
+    return {
+      tabId,
+      targetId: target.id,
+      title: target.title,
+      url: target.url,
+      active: target.id === activeTargetId,
+      ...(label ? { label } : {}),
+    };
+  }
+
+  async function listTargets(): Promise<CdpTarget[]> {
+    const targets = await listPageTargets(port);
+    prune(new Set(targets.map((t) => t.id)));
+    return targets;
+  }
+
+  async function list(): Promise<TabInfo[]> {
+    return (await listTargets()).map(toInfo);
+  }
+
+  function resolveTargetId(ref: string, targets: CdpTarget[]): string {
+    // A label?
+    const byLabel = labelToTab.get(ref);
+    // A tabId (directly, or resolved from the label)?
+    const wantTabId = byLabel ?? ref;
+    for (const t of targets) {
+      if (targetToTab.get(t.id) === wantTabId) return t.id;
+    }
+    // Or a raw CDP target id.
+    if (targets.some((t) => t.id === ref)) return ref;
+    throw new Error(
+      `No tab matches "${ref}". Use \`chromium-tabs action=list\` to see current tabIds and labels.`
+    );
+  }
+
+  async function activate(targetId: string, targets: CdpTarget[]): Promise<void> {
+    if (targetId === activeTargetId) return;
+    const target = targets.find((t) => t.id === targetId);
+    if (!target?.webSocketDebuggerUrl) {
+      throw new Error(
+        `Tab target ${targetId} has no webSocketDebuggerUrl (it may have just closed).`
+      );
+    }
+    await cdp.reconnect(target.webSocketDebuggerUrl);
+    activeTargetId = targetId;
+    await deps.onActivated();
+  }
+
+  async function select(ref: string): Promise<TabInfo[]> {
+    const targets = await listTargets();
+    await activate(resolveTargetId(ref, targets), targets);
+    return targets.map(toInfo);
+  }
+
+  async function withBrowserClient<T>(fn: (browser: CDPClient) => Promise<T>): Promise<T> {
+    // Target.createTarget / closeTarget are browser-level commands, so they need
+    // the browser endpoint rather than a page session. Use a short-lived client.
+    const browser = new CDPClient(await browserWebSocketUrl(port), { sendOrigin: false });
+    await browser.connect();
+    try {
+      return await fn(browser);
+    } finally {
+      await browser.disconnect().catch(() => {});
+    }
+  }
+
+  async function open(opts?: {
+    url?: string;
+    label?: string;
+    activate?: boolean;
+  }): Promise<TabInfo[]> {
+    const url = opts?.url ?? "about:blank";
+    const created = await withBrowserClient(async (browser) => {
+      const out = (await browser.send("Target.createTarget", { url })) as { targetId?: string };
+      if (!out.targetId) throw new Error("Target.createTarget returned no targetId.");
+      return out.targetId;
+    });
+    const tabId = mintTabId(created);
+    if (opts?.label) {
+      labelToTab.set(opts.label, tabId);
+      tabToLabel.set(tabId, opts.label);
+    }
+    if (opts?.activate !== false) {
+      // The new target needs a moment to appear in /json/list with a WS URL.
+      const targets = await listTargets();
+      await activate(created, targets);
+      return targets.map(toInfo);
+    }
+    return list();
+  }
+
+  async function close(ref?: string): Promise<TabInfo[]> {
+    const targets = await listTargets();
+    const targetId = ref ? resolveTargetId(ref, targets) : activeTargetId;
+    await withBrowserClient((browser) => browser.send("Target.closeTarget", { targetId }));
+
+    // Forget the closed tab's id/label.
+    const tabId = targetToTab.get(targetId);
+    targetToTab.delete(targetId);
+    if (tabId) {
+      const label = tabToLabel.get(tabId);
+      if (label) {
+        labelToTab.delete(label);
+        tabToLabel.delete(tabId);
+      }
+    }
+
+    // If we closed the active tab, fall back to another live page so the
+    // page-scoped tools keep working.
+    if (targetId === activeTargetId) {
+      const remaining = (await listTargets()).filter((t) => t.id !== targetId);
+      if (remaining.length > 0) {
+        await activate(remaining[0]!.id, remaining);
+      }
+    }
+    return list();
+  }
+
+  return {
+    list,
+    select,
+    open,
+    close,
+    activeTargetId: () => activeTargetId,
+  };
+}

--- a/packages/tool-server/src/chromium-server/types.ts
+++ b/packages/tool-server/src/chromium-server/types.ts
@@ -7,6 +7,7 @@
 
 import type { TypedEventEmitter } from "@argent/registry";
 import type { CDPClient } from "../utils/debugger/cdp-client";
+import type { TabsManager } from "./tabs";
 
 export type TouchType = "Down" | "Up" | "Move";
 export type KeyDirection = "Down" | "Up";
@@ -169,6 +170,9 @@ export interface ChromiumServer {
   setFpsReporting(enabled: boolean): void;
   /** Evaluate JS in the renderer's main world. */
   evaluate(expression: string, options?: { returnByValue?: boolean }): Promise<unknown>;
+  /** Multi-tab / window management. The active tab is the one `cdp` (and every
+   * page-scoped tool) is connected to; switching re-points `cdp` in place. */
+  readonly tabs: TabsManager;
   /** Event bus mirroring sim-server's broadcast channel. */
   readonly events: TypedEventEmitter<ServerEvents>;
   /** Tear down — closes CDP, stops screencast, removes listeners. */

--- a/packages/tool-server/src/tools/chromium-tabs/index.ts
+++ b/packages/tool-server/src/tools/chromium-tabs/index.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import type { ServiceRef, ToolCapability, ToolDefinition } from "@argent/registry";
+import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-cdp";
+import { resolveDevice } from "../../utils/device-info";
+import type { TabInfo } from "../../chromium-server";
+
+const zodSchema = z.object({
+  udid: z.string().describe("Chromium device id from `list-devices` (e.g. `chromium-cdp-9222`)."),
+  action: z
+    .enum(["list", "select", "new", "close"])
+    .describe(
+      "list: enumerate tabs/windows. select: make a tab active (every other tool then acts on it). new: open a tab. close: close a tab."
+    ),
+  tab: z
+    .string()
+    .optional()
+    .describe(
+      "Target tab for `select` / `close`: a tabId like `t2` or a label. `close` defaults to the active tab."
+    ),
+  url: z.string().optional().describe("`new` only: URL to open (defaults to about:blank)."),
+  label: z
+    .string()
+    .optional()
+    .describe("`new` only: a memorable label usable interchangeably with the tabId."),
+});
+
+type Params = z.infer<typeof zodSchema>;
+
+interface Result {
+  /** Tabs after the action, with `active` marking the one other tools drive. */
+  tabs: TabInfo[];
+}
+
+// Chromium-only: iOS/Android have no tab/window concept, so the capability gate
+// rejects them up-front (no apple/android blocks declared).
+const capability: ToolCapability = {
+  chromium: { app: true },
+};
+
+export const chromiumTabsTool: ToolDefinition<Params, Result> = {
+  id: "chromium-tabs",
+  description: `Manage tabs / windows of a Chromium (CDP) app — an Electron app's BrowserWindows or a Chromium browser's tabs.
+- action="list": enumerate page targets with stable ids (\`t1\`, \`t2\`, …), title, url, and which is active.
+- action="select" (tab=<tabId|label>): make that tab the active one. The active tab is what describe / gesture-tap / screenshot / debugger-evaluate / open-url all operate on, so switch before driving a different tab.
+- action="new" (url?, label?): open a new tab/page and activate it.
+- action="close" (tab?=<tabId|label>): close a tab (defaults to the active one); if the active tab is closed, another live tab becomes active.
+tabIds are stable for the session and never reused. Returns { tabs: [{ tabId, targetId, title, url, active, label? }] }. Chromium-only.`,
+  searchHint: "tab tabs window windows switch select close new open multi-tab chromium electron",
+  zodSchema,
+  capability,
+  services: (params): Record<string, ServiceRef> => {
+    const device = resolveDevice(params.udid);
+    if (device.platform === "chromium") {
+      return { chromium: chromiumCdpRef(device) };
+    }
+    // Non-chromium devices are rejected by the capability gate before execute.
+    return {};
+  },
+  async execute(services, params) {
+    const api = services.chromium as ChromiumCdpApi;
+    const { tabs } = api.server;
+    switch (params.action) {
+      case "list":
+        return { tabs: await tabs.list() };
+      case "select":
+        if (!params.tab) {
+          throw new Error("`select` requires `tab` (a tabId like `t2` or a label).");
+        }
+        return { tabs: await tabs.select(params.tab) };
+      case "new":
+        return { tabs: await tabs.open({ url: params.url, label: params.label }) };
+      case "close":
+        return { tabs: await tabs.close(params.tab) };
+    }
+  },
+};

--- a/packages/tool-server/src/tools/chromium-tabs/index.ts
+++ b/packages/tool-server/src/tools/chromium-tabs/index.ts
@@ -39,12 +39,13 @@ const capability: ToolCapability = {
 
 export const chromiumTabsTool: ToolDefinition<Params, Result> = {
   id: "chromium-tabs",
-  description: `Manage tabs / windows of a Chromium (CDP) app — an Electron app's BrowserWindows or a Chromium browser's tabs.
+  description: `List and switch the tabs / windows of a Chromium (CDP) app (an Electron app's BrowserWindows or a Chromium browser's tabs), and open or close them.
 - action="list": enumerate page targets with stable ids (\`t1\`, \`t2\`, …), title, url, and which is active.
 - action="select" (tab=<tabId|label>): make that tab the active one. The active tab is what describe / gesture-tap / screenshot / debugger-evaluate / open-url all operate on, so switch before driving a different tab.
 - action="new" (url?, label?): open a new tab/page and activate it.
 - action="close" (tab?=<tabId|label>): close a tab (defaults to the active one); if the active tab is closed, another live tab becomes active.
-tabIds are stable for the session and never reused. Returns { tabs: [{ tabId, targetId, title, url, active, label? }] }. Chromium-only.`,
+Use when an app exposes multiple windows or tabs and you need to inspect or drive one other than the current page, or to open/close a page during a flow. tabIds are stable for the session and never reused.
+Returns { tabs: [{ tabId, targetId, title, url, active, label? }] }. Fails if the device is not a Chromium (CDP) device, or the requested tabId/label no longer matches a live tab. Chromium-only.`,
   searchHint: "tab tabs window windows switch select close new open multi-tab chromium electron",
   zodSchema,
   capability,

--- a/packages/tool-server/src/utils/debugger/cdp-client.ts
+++ b/packages/tool-server/src/utils/debugger/cdp-client.ts
@@ -172,6 +172,40 @@ export class CDPClient {
     });
   }
 
+  /**
+   * Re-point this client at a different CDP WebSocket target (e.g. switching
+   * the active browser tab) WITHOUT emitting `disconnected`.
+   *
+   * Object identity is preserved, so existing references to this client
+   * (`server.cdp`, `api.cdp`, and every closure that captured it) automatically
+   * target the new tab after the swap — no rewiring needed. Callers that wire
+   * `disconnected` to teardown/termination therefore do not see a tab switch as
+   * a device loss.
+   *
+   * In-flight requests are rejected and per-connection state (enabled domains,
+   * parsed scripts) is reset — the new target starts fresh, so the caller must
+   * re-enable any domains it needs.
+   */
+  async reconnect(newWsUrl: string): Promise<void> {
+    const old = this.ws;
+    if (old) {
+      // Drop our handlers BEFORE closing so the impending close/error does not
+      // fire the `disconnected` event (which callers treat as a fatal teardown).
+      old.removeAllListeners();
+      this.ws = null;
+      try {
+        old.close();
+      } catch {
+        /* already closing */
+      }
+    }
+    // Reject in-flight requests and clear per-connection caches, but keep this
+    // client object alive to receive the new socket.
+    this.cleanup();
+    this.wsUrl = newWsUrl;
+    await this.connect();
+  }
+
   isConnected(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
   }

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -73,6 +73,7 @@ import { gatherWorkspaceDataTool } from "../tools/workspace/gather-workspace-dat
 import { updateArgentTool } from "../tools/system/update-argent";
 import { dismissUpdateTool } from "../tools/system/dismiss-update";
 import { screenshotDiffTool } from "../tools/screenshot-diff";
+import { chromiumTabsTool } from "../tools/chromium-tabs";
 
 export function createRegistry(): Registry {
   const registry = new Registry();
@@ -97,6 +98,7 @@ export function createRegistry(): Registry {
   registry.registerTool(screenshotTool);
   registry.registerTool(screenshotDiffTool);
   registry.registerTool(gestureTapTool);
+  registry.registerTool(chromiumTabsTool);
   registry.registerTool(gestureSwipeTool);
   registry.registerTool(gestureScrollTool);
   registry.registerTool(gestureDragTool);

--- a/packages/tool-server/test/cdp-client-reconnect.test.ts
+++ b/packages/tool-server/test/cdp-client-reconnect.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { WebSocketServer } from "ws";
+import { CDPClient } from "../src/utils/debugger/cdp-client";
+
+/** Minimal CDP-ish echo server: replies to any request with `{ server: <id> }`. */
+function startEchoServer(serverId: number): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" }, () => {
+      const addr = wss.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({
+        url: `ws://127.0.0.1:${port}/devtools/page/${serverId}`,
+        close: () => new Promise<void>((r) => wss.close(() => r())),
+      });
+    });
+    wss.on("connection", (sock) => {
+      sock.on("message", (raw) => {
+        const msg = JSON.parse(raw.toString());
+        sock.send(JSON.stringify({ id: msg.id, result: { server: serverId } }));
+      });
+    });
+  });
+}
+
+describe("CDPClient.reconnect", () => {
+  it("re-points to a new target without emitting `disconnected`", async () => {
+    const s1 = await startEchoServer(1);
+    const s2 = await startEchoServer(2);
+    const cdp = new CDPClient(s1.url, { sendOrigin: false });
+    await cdp.connect();
+
+    let disconnects = 0;
+    cdp.events.on("disconnected", () => {
+      disconnects++;
+    });
+
+    expect(await cdp.send("Test.ping")).toEqual({ server: 1 });
+
+    await cdp.reconnect(s2.url);
+
+    // Switched in place: same object, now talking to server 2, still connected,
+    // and crucially NO disconnected event fired (callers wire that to teardown).
+    expect(cdp.isConnected()).toBe(true);
+    expect(await cdp.send("Test.ping")).toEqual({ server: 2 });
+    expect(disconnects).toBe(0);
+
+    await cdp.disconnect();
+    await s1.close();
+    await s2.close();
+  });
+
+  it("rejects in-flight requests on the old socket when reconnecting", async () => {
+    // A server that never replies, so the request is still pending at reconnect.
+    const silent = await new Promise<{ url: string; close: () => Promise<void> }>((resolve) => {
+      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" }, () => {
+        const addr = wss.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        resolve({
+          url: `ws://127.0.0.1:${port}/devtools/page/silent`,
+          close: () => new Promise<void>((r) => wss.close(() => r())),
+        });
+      });
+    });
+    const s2 = await startEchoServer(9);
+    const cdp = new CDPClient(silent.url, { sendOrigin: false });
+    await cdp.connect();
+
+    const pending = cdp.send("Test.neverReplies", {}, 5000);
+    const settled = pending.then(
+      () => "resolved",
+      (e) => `rejected:${(e as Error).message}`
+    );
+
+    await cdp.reconnect(s2.url);
+    await expect(settled).resolves.toContain("rejected");
+    expect(await cdp.send("Test.ping")).toEqual({ server: 9 });
+
+    await cdp.disconnect();
+    await silent.close();
+    await s2.close();
+  });
+});

--- a/packages/tool-server/test/chromium-tabs.test.ts
+++ b/packages/tool-server/test/chromium-tabs.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock the CDP-session HTTP helpers tabs.ts depends on ─────────────────────
+vi.mock("../src/chromium-server/cdp-session", () => ({
+  listPageTargets: vi.fn(),
+  browserWebSocketUrl: vi.fn(async () => "ws://127.0.0.1:9222/devtools/browser/x"),
+}));
+
+// ── Mock the transient browser CDPClient used for create/close ───────────────
+const browserSend = vi.fn(async (method: string, _params?: Record<string, unknown>) => {
+  if (method === "Target.createTarget") return { targetId: "TID-NEW" };
+  return {};
+});
+vi.mock("../src/utils/debugger/cdp-client", () => ({
+  // A class so `new CDPClient(...)` works; methods delegate to the shared spy.
+  CDPClient: class {
+    connect() {
+      return Promise.resolve();
+    }
+    send(method: string, params?: Record<string, unknown>) {
+      return browserSend(method, params);
+    }
+    disconnect() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+import { createTabsManager } from "../src/chromium-server/tabs";
+import { listPageTargets } from "../src/chromium-server/cdp-session";
+
+const listMock = listPageTargets as unknown as ReturnType<typeof vi.fn>;
+
+function tgt(id: string) {
+  return {
+    id,
+    type: "page",
+    title: `Title ${id}`,
+    url: `https://${id}.test/`,
+    webSocketDebuggerUrl: `ws://127.0.0.1:9222/devtools/page/${id}`,
+  };
+}
+
+describe("TabsManager", () => {
+  let cdp: { reconnect: ReturnType<typeof vi.fn> };
+  let onActivated: ReturnType<typeof vi.fn>;
+  let mgr: ReturnType<typeof createTabsManager>;
+
+  beforeEach(() => {
+    browserSend.mockClear();
+    listMock.mockReset();
+    cdp = { reconnect: vi.fn(async () => {}) };
+    onActivated = vi.fn(async () => {});
+    mgr = createTabsManager({
+      cdp: cdp as never,
+      port: 9222,
+      initialTargetId: "A",
+      onActivated: onActivated as never,
+    });
+  });
+
+  it("list() assigns stable t1/t2 ids and marks the active tab", async () => {
+    listMock.mockResolvedValue([tgt("A"), tgt("B")]);
+    const tabs = await mgr.list();
+    expect(tabs.map((t) => t.tabId)).toEqual(["t1", "t2"]);
+    expect(tabs.find((t) => t.targetId === "A")!.active).toBe(true);
+    expect(tabs.find((t) => t.targetId === "B")!.active).toBe(false);
+
+    // ids are stable across calls (B stays t2 even though A is listed first).
+    const again = await mgr.list();
+    expect(again.find((t) => t.targetId === "B")!.tabId).toBe("t2");
+  });
+
+  it("select() re-points cdp to the target's ws, re-primes, and sets active", async () => {
+    listMock.mockResolvedValue([tgt("A"), tgt("B")]);
+    await mgr.list();
+    const tabs = await mgr.select("t2");
+    expect(cdp.reconnect).toHaveBeenCalledWith("ws://127.0.0.1:9222/devtools/page/B");
+    expect(onActivated).toHaveBeenCalledOnce();
+    expect(mgr.activeTargetId()).toBe("B");
+    expect(tabs.find((t) => t.targetId === "B")!.active).toBe(true);
+  });
+
+  it("select() of the already-active tab is a no-op (no reconnect)", async () => {
+    listMock.mockResolvedValue([tgt("A")]);
+    await mgr.list();
+    await mgr.select("t1");
+    expect(cdp.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("select() resolves a label to its tab", async () => {
+    // open assigns label "docs" to the created target, then select by label.
+    listMock.mockResolvedValue([tgt("A"), tgt("TID-NEW")]);
+    await mgr.open({ label: "docs" }); // activates TID-NEW
+    cdp.reconnect.mockClear();
+    await mgr.select("A" /* raw target id also works */);
+    expect(cdp.reconnect).toHaveBeenCalledWith("ws://127.0.0.1:9222/devtools/page/A");
+    cdp.reconnect.mockClear();
+    await mgr.select("docs");
+    expect(cdp.reconnect).toHaveBeenCalledWith("ws://127.0.0.1:9222/devtools/page/TID-NEW");
+  });
+
+  it("open() creates a target via Target.createTarget, activates it, applies label", async () => {
+    listMock.mockResolvedValue([tgt("A"), tgt("TID-NEW")]);
+    const tabs = await mgr.open({ url: "https://x.test", label: "docs" });
+    expect(browserSend).toHaveBeenCalledWith("Target.createTarget", { url: "https://x.test" });
+    expect(cdp.reconnect).toHaveBeenCalledWith("ws://127.0.0.1:9222/devtools/page/TID-NEW");
+    expect(mgr.activeTargetId()).toBe("TID-NEW");
+    const created = tabs.find((t) => t.targetId === "TID-NEW")!;
+    expect(created.active).toBe(true);
+    expect(created.label).toBe("docs");
+  });
+
+  it("close() closes the target and re-activates a remaining tab when the active one closed", async () => {
+    // active is "A" (initialTargetId). Close it; fall back to "B".
+    listMock
+      .mockResolvedValueOnce([tgt("A"), tgt("B")]) // initial list() to assign ids
+      .mockResolvedValueOnce([tgt("A"), tgt("B")]) // close(): resolve ref
+      .mockResolvedValueOnce([tgt("B")]) // close(): remaining after closeTarget
+      .mockResolvedValue([tgt("B")]); // final list()
+    await mgr.list();
+    const tabs = await mgr.close("t1");
+    expect(browserSend).toHaveBeenCalledWith("Target.closeTarget", { targetId: "A" });
+    expect(cdp.reconnect).toHaveBeenCalledWith("ws://127.0.0.1:9222/devtools/page/B");
+    expect(mgr.activeTargetId()).toBe("B");
+    expect(tabs.map((t) => t.targetId)).toEqual(["B"]);
+  });
+});
+
+// ── Tool: capability gate + action dispatch ──────────────────────────────────
+import { chromiumTabsTool } from "../src/tools/chromium-tabs";
+import { assertSupported, UnsupportedOperationError } from "../src/utils/capability";
+import { resolveDevice } from "../src/utils/device-info";
+
+describe("chromium-tabs tool", () => {
+  it("capability accepts chromium and rejects iOS/Android", () => {
+    const chromium = resolveDevice("chromium-cdp-9222");
+    const ios = resolveDevice("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA");
+    const android = resolveDevice("emulator-5554");
+    expect(() =>
+      assertSupported("chromium-tabs", chromiumTabsTool.capability, chromium)
+    ).not.toThrow();
+    expect(() => assertSupported("chromium-tabs", chromiumTabsTool.capability, ios)).toThrow(
+      UnsupportedOperationError
+    );
+    expect(() => assertSupported("chromium-tabs", chromiumTabsTool.capability, android)).toThrow(
+      UnsupportedOperationError
+    );
+  });
+
+  it("dispatches each action to the matching TabsManager method", async () => {
+    const tabsApi = {
+      list: vi.fn(async () => [{ tabId: "t1", targetId: "A", title: "", url: "", active: true }]),
+      select: vi.fn(async () => []),
+      open: vi.fn(async () => []),
+      close: vi.fn(async () => []),
+      activeTargetId: () => "A",
+    };
+    const services = { chromium: { server: { tabs: tabsApi } } } as never;
+
+    await chromiumTabsTool.execute(services, { udid: "chromium-cdp-9222", action: "list" });
+    expect(tabsApi.list).toHaveBeenCalledOnce();
+
+    await chromiumTabsTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      action: "select",
+      tab: "t2",
+    });
+    expect(tabsApi.select).toHaveBeenCalledWith("t2");
+
+    await chromiumTabsTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      action: "new",
+      url: "https://x.test",
+      label: "docs",
+    });
+    expect(tabsApi.open).toHaveBeenCalledWith({ url: "https://x.test", label: "docs" });
+
+    await chromiumTabsTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      action: "close",
+      tab: "t1",
+    });
+    expect(tabsApi.close).toHaveBeenCalledWith("t1");
+  });
+
+  it("select without a tab throws a helpful error", async () => {
+    const services = { chromium: { server: { tabs: {} } } } as never;
+    await expect(
+      chromiumTabsTool.execute(services, { udid: "chromium-cdp-9222", action: "select" })
+    ).rejects.toThrow(/requires `tab`/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **`chromium-tabs`** tool to list / select / open / close the tabs (or Electron `BrowserWindow`s) of a Chromium (CDP) device. This closes the biggest gap vs general browser-automation tools — argent previously drove only the single primary page.

First of three stacked PRs (tabs → network → cookies/storage).

## How it works

- **`CDPClient.reconnect(wsUrl)`** re-points the client at a different page target *in place* — same object identity, and crucially **without emitting `disconnected`** (which callers wire to teardown/termination). So when the active tab changes, every page-scoped subsystem that captured `cdp` (`describe`, `gesture-*`, `screenshot`, `debugger-evaluate`, `open-url`, …) follows automatically with **zero per-tool changes**.
- **`TabsManager`** (`chromium-server/tabs.ts`): stable `tabId`↔`targetId` map (`t1`, `t2`, … never reused), optional **labels** usable interchangeably with the id, lists via `/json/list`, creates/closes via browser-level `Target.createTarget` / `Target.closeTarget`. Switching reconnects the shared page client, re-primes core domains, and refreshes the viewport. Closing the active tab falls back to another live tab.
- **`chromium-tabs` tool**: `action = list | select | new | close` (+ `tab` / `url` / `label`). Chromium-only; iOS/Android rejected by the capability gate.

## Test plan

- [x] 11 new unit tests: `reconnect` is quiet + re-points + rejects in-flight requests (real ws servers); `TabsManager` list / select (by id **and** label) / open / close-with-active-fallback + stable-id assertions; tool capability gate + action dispatch.
- [x] Full suite **1127 pass**; `tsc --build` + `typecheck:tests` + prettier clean.
- [x] **Live (Electron)**: testbed lists its single window as `t1`.
- [x] **Live (Chrome for Testing)**: `list` (1) → `new`+activate (2) → `select` by tabId → `select` by **label** → `close` active with fallback. Active-follows verified by reading `location.hostname` after each switch (t1↔t2 distinct origins tracked correctly).

## Known caveat

A cross-process navigation (some redirects, e.g. observed with an `iana.org` redirect) can swap a tab's underlying CDP target id; re-run `chromium-tabs action=list` to pick it up under a fresh id. Documented in the `argent-device-interact` skill. This is a property of the page-WS model, not introduced here.