### PR TITLE
feat(chromium): cookies & local/session storage

### DIFF
--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -11,6 +11,8 @@ All interaction tools below accept a `udid` parameter and auto-dispatch iOS vs A
 
 **Multi-tab / windows (Chromium only):** a Chromium device may have several tabs / BrowserWindows. Use `chromium-tabs` to `list` them (stable ids `t1`, `t2`, …, optional labels), open a `new` one, `select` which is active, or `close` one. Every other tool (`describe`, `gesture-tap`, `screenshot`, `debugger-evaluate`, `open-url`, …) acts on the **active** tab, so `chromium-tabs action=select` before driving a different tab. Note: a cross-process navigation (some redirects) can swap a tab's underlying CDP target — re-run `chromium-tabs action=list` to pick it up under a fresh id.
 
+**Cookies & storage (Chromium only):** `chromium-cookies` reads/writes cookies via the Network domain (so HttpOnly cookies are visible): `action=get` (optionally scoped by `url`), `set` (`name`, `value`, + `url`/`domain`, optional `secure`/`httpOnly`/`sameSite`/`expires`), `delete` (`name`), `clear` (all). `chromium-storage` reads/writes Web Storage for the active page: `store=local|session`, `action=get` (one `key` or all entries), `set`, `remove`, `clear`. Both are per-origin / active-tab. Handy for seeding auth before a flow or asserting app state after one.
+
 For platform-specific caveats (Metro `adb reverse`, locked-screen describe errors, etc.), see § 9 Platform-specific notes at the bottom.
 
 ## 1. Before You Start

--- a/packages/tool-server/src/chromium-server/index.ts
+++ b/packages/tool-server/src/chromium-server/index.ts
@@ -187,6 +187,7 @@ export async function createChromiumServer(
 export { ensureCdpReachable, discoverPrimaryPage } from "./cdp-session";
 export type { TabInfo, TabsManager } from "./tabs";
 export type { NetworkManager, NetworkRequestRecord } from "./network";
+export type { Cookie, SetCookieParams, DeleteCookieParams, StorageType } from "./storage";
 
 // Re-exported so the http-api / blueprint can call them directly without
 // pulling them out of a ChromiumServer instance.

--- a/packages/tool-server/src/chromium-server/storage.ts
+++ b/packages/tool-server/src/chromium-server/storage.ts
@@ -1,0 +1,126 @@
+import type { CDPClient } from "../utils/debugger/cdp-client";
+
+/**
+ * Cookie + Web Storage helpers for a Chromium (CDP) page session. Cookies go
+ * through the CDP Network domain (so httpOnly cookies are visible/settable);
+ * localStorage / sessionStorage go through `Runtime.evaluate` against the
+ * active page (simple and origin-correct).
+ */
+
+export interface Cookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  expires?: number;
+  size?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  session?: boolean;
+  sameSite?: "Strict" | "Lax" | "None";
+}
+
+export interface SetCookieParams {
+  name: string;
+  value: string;
+  /** Either `url`, or `domain` (+ optional `path`), must scope the cookie. */
+  url?: string;
+  domain?: string;
+  path?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  sameSite?: "Strict" | "Lax" | "None";
+  /** Unix seconds. Omit for a session cookie. */
+  expires?: number;
+}
+
+export interface DeleteCookieParams {
+  name: string;
+  url?: string;
+  domain?: string;
+  path?: string;
+}
+
+export async function getCookies(cdp: CDPClient, urls?: string[]): Promise<Cookie[]> {
+  const out = (await cdp.send("Network.getCookies", urls && urls.length ? { urls } : {})) as {
+    cookies?: Cookie[];
+  };
+  return out.cookies ?? [];
+}
+
+export async function setCookie(cdp: CDPClient, params: SetCookieParams): Promise<boolean> {
+  if (!params.url && !params.domain) {
+    throw new Error("setCookie requires either `url` or `domain` to scope the cookie.");
+  }
+  const out = (await cdp.send("Network.setCookie", { ...params })) as { success?: boolean };
+  return out.success === true;
+}
+
+export async function deleteCookies(cdp: CDPClient, params: DeleteCookieParams): Promise<void> {
+  await cdp.send("Network.deleteCookies", { ...params });
+}
+
+export async function clearCookies(cdp: CDPClient): Promise<void> {
+  await cdp.send("Network.clearBrowserCookies");
+}
+
+export type StorageType = "local" | "session";
+
+function storeRef(type: StorageType): string {
+  return type === "local" ? "localStorage" : "sessionStorage";
+}
+
+async function evalValue(cdp: CDPClient, expression: string): Promise<unknown> {
+  const out = (await cdp.send("Runtime.evaluate", { expression, returnByValue: true })) as {
+    result?: { value?: unknown };
+    exceptionDetails?: { text?: string };
+  };
+  if (out.exceptionDetails) {
+    throw new Error(`Storage evaluation failed: ${out.exceptionDetails.text ?? "threw"}`);
+  }
+  return out.result?.value;
+}
+
+export async function getStorageAll(
+  cdp: CDPClient,
+  type: StorageType
+): Promise<Record<string, string>> {
+  const value = await evalValue(
+    cdp,
+    `(() => { const s = ${storeRef(type)}; const o = {}; for (let i = 0; i < s.length; i++) { const k = s.key(i); o[k] = s.getItem(k); } return o; })()`
+  );
+  return (value as Record<string, string>) ?? {};
+}
+
+export async function getStorageItem(
+  cdp: CDPClient,
+  type: StorageType,
+  key: string
+): Promise<string | null> {
+  const value = await evalValue(cdp, `${storeRef(type)}.getItem(${JSON.stringify(key)})`);
+  return (value as string | null) ?? null;
+}
+
+export async function setStorageItem(
+  cdp: CDPClient,
+  type: StorageType,
+  key: string,
+  value: string
+): Promise<void> {
+  await evalValue(
+    cdp,
+    `${storeRef(type)}.setItem(${JSON.stringify(key)}, ${JSON.stringify(value)})`
+  );
+}
+
+export async function removeStorageItem(
+  cdp: CDPClient,
+  type: StorageType,
+  key: string
+): Promise<void> {
+  await evalValue(cdp, `${storeRef(type)}.removeItem(${JSON.stringify(key)})`);
+}
+
+export async function clearStorage(cdp: CDPClient, type: StorageType): Promise<void> {
+  await evalValue(cdp, `${storeRef(type)}.clear()`);
+}

--- a/packages/tool-server/src/tools/chromium-cookies/index.ts
+++ b/packages/tool-server/src/tools/chromium-cookies/index.ts
@@ -55,7 +55,8 @@ export const chromiumCookiesTool: ToolDefinition<Params, Result> = {
 - action="set" (name, value, + url OR domain, optional path/secure/httpOnly/sameSite/expires): create or update a cookie.
 - action="delete" (name, + url/domain/path): remove a matching cookie.
 - action="clear": remove ALL browser cookies.
-Chromium-only.`,
+Use when seeding an authenticated session before a flow (set the session cookie, then navigate) or asserting cookie state after one.
+Returns { cookies, count } for get, or a small status object ({ set } / { deleted } / { cleared }) otherwise. Fails if the device is not a Chromium (CDP) device, or set is missing name/value. Chromium-only.`,
   searchHint: "cookies cookie get set delete clear httponly samesite session auth chromium",
   zodSchema,
   capability,

--- a/packages/tool-server/src/tools/chromium-cookies/index.ts
+++ b/packages/tool-server/src/tools/chromium-cookies/index.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import type { ServiceRef, ToolCapability, ToolDefinition } from "@argent/registry";
+import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-cdp";
+import { resolveDevice } from "../../utils/device-info";
+import {
+  clearCookies,
+  deleteCookies,
+  getCookies,
+  setCookie,
+  type Cookie,
+} from "../../chromium-server/storage";
+
+const zodSchema = z.object({
+  udid: z.string().describe("Chromium device id from `list-devices` (e.g. `chromium-cdp-9222`)."),
+  action: z
+    .enum(["get", "set", "delete", "clear"])
+    .describe(
+      "get: read cookies. set: create/update a cookie. delete: remove a named cookie. clear: remove all browser cookies."
+    ),
+  name: z.string().optional().describe("set/delete: cookie name."),
+  value: z.string().optional().describe("set: cookie value."),
+  url: z
+    .string()
+    .optional()
+    .describe(
+      "get: restrict to these URLs (defaults to the active page). set/delete: scope the cookie by URL."
+    ),
+  domain: z.string().optional().describe("set/delete: scope the cookie by domain (alt to url)."),
+  path: z.string().optional().describe("set/delete: cookie path (default /)."),
+  secure: z.boolean().optional().describe("set: mark Secure."),
+  httpOnly: z.boolean().optional().describe("set: mark HttpOnly."),
+  sameSite: z.enum(["Strict", "Lax", "None"]).optional().describe("set: SameSite policy."),
+  expires: z
+    .number()
+    .optional()
+    .describe("set: expiry as a Unix timestamp (seconds). Omit for a session cookie."),
+});
+
+type Params = z.infer<typeof zodSchema>;
+
+type Result =
+  | { cookies: Cookie[]; count: number }
+  | { set: boolean }
+  | { deleted: true }
+  | { cleared: true };
+
+const capability: ToolCapability = {
+  chromium: { app: true },
+};
+
+export const chromiumCookiesTool: ToolDefinition<Params, Result> = {
+  id: "chromium-cookies",
+  description: `Read and write cookies of a Chromium (CDP) app (via the Network domain, so HttpOnly cookies are included).
+- action="get" (url?): list cookies, optionally restricted to given URLs (defaults to the active page).
+- action="set" (name, value, + url OR domain, optional path/secure/httpOnly/sameSite/expires): create or update a cookie.
+- action="delete" (name, + url/domain/path): remove a matching cookie.
+- action="clear": remove ALL browser cookies.
+Chromium-only.`,
+  searchHint: "cookies cookie get set delete clear httponly samesite session auth chromium",
+  zodSchema,
+  capability,
+  services: (params): Record<string, ServiceRef> => {
+    const device = resolveDevice(params.udid);
+    if (device.platform === "chromium") {
+      return { chromium: chromiumCdpRef(device) };
+    }
+    return {};
+  },
+  async execute(services, params): Promise<Result> {
+    const api = services.chromium as ChromiumCdpApi;
+    const cdp = api.cdp;
+    switch (params.action) {
+      case "get": {
+        const cookies = await getCookies(cdp, params.url ? [params.url] : undefined);
+        return { cookies, count: cookies.length };
+      }
+      case "set": {
+        if (!params.name || params.value == null) {
+          throw new Error("`set` requires `name` and `value`.");
+        }
+        const set = await setCookie(cdp, {
+          name: params.name,
+          value: params.value,
+          url: params.url,
+          domain: params.domain,
+          path: params.path,
+          secure: params.secure,
+          httpOnly: params.httpOnly,
+          sameSite: params.sameSite,
+          expires: params.expires,
+        });
+        return { set };
+      }
+      case "delete": {
+        if (!params.name) throw new Error("`delete` requires `name`.");
+        await deleteCookies(cdp, {
+          name: params.name,
+          url: params.url,
+          domain: params.domain,
+          path: params.path,
+        });
+        return { deleted: true };
+      }
+      case "clear":
+        await clearCookies(cdp);
+        return { cleared: true };
+    }
+  },
+};

--- a/packages/tool-server/src/tools/chromium-storage/index.ts
+++ b/packages/tool-server/src/tools/chromium-storage/index.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import type { ServiceRef, ToolCapability, ToolDefinition } from "@argent/registry";
+import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-cdp";
+import { resolveDevice } from "../../utils/device-info";
+import {
+  clearStorage,
+  getStorageAll,
+  getStorageItem,
+  removeStorageItem,
+  setStorageItem,
+} from "../../chromium-server/storage";
+
+const zodSchema = z.object({
+  udid: z.string().describe("Chromium device id from `list-devices` (e.g. `chromium-cdp-9222`)."),
+  store: z
+    .enum(["local", "session"])
+    .describe("Which Web Storage area: `local` (localStorage) or `session` (sessionStorage)."),
+  action: z
+    .enum(["get", "set", "remove", "clear"])
+    .describe(
+      "get: read one key (with `key`) or all entries. set: write `key`=`value`. remove: delete `key`. clear: empty the store."
+    ),
+  key: z.string().optional().describe("get (optional) / set / remove: the storage key."),
+  value: z.string().optional().describe("set: the value to store."),
+});
+
+type Params = z.infer<typeof zodSchema>;
+
+type Result =
+  | { value: string | null }
+  | { entries: Record<string, string>; count: number }
+  | { set: true }
+  | { removed: true }
+  | { cleared: true };
+
+const capability: ToolCapability = {
+  chromium: { app: true },
+};
+
+export const chromiumStorageTool: ToolDefinition<Params, Result> = {
+  id: "chromium-storage",
+  description: `Read and write localStorage / sessionStorage of a Chromium (CDP) app's active page.
+- action="get": with \`key\`, returns that value; without \`key\`, returns all entries.
+- action="set" (key, value): write an entry.
+- action="remove" (key): delete an entry.
+- action="clear": empty the store.
+Set \`store\` to "local" or "session". Storage is per-origin, so it reflects the active tab's document. Chromium-only.`,
+  searchHint:
+    "storage localstorage sessionstorage local session get set remove clear key value chromium",
+  zodSchema,
+  capability,
+  services: (params): Record<string, ServiceRef> => {
+    const device = resolveDevice(params.udid);
+    if (device.platform === "chromium") {
+      return { chromium: chromiumCdpRef(device) };
+    }
+    return {};
+  },
+  async execute(services, params): Promise<Result> {
+    const api = services.chromium as ChromiumCdpApi;
+    const cdp = api.cdp;
+    switch (params.action) {
+      case "get": {
+        if (params.key != null) {
+          return { value: await getStorageItem(cdp, params.store, params.key) };
+        }
+        const entries = await getStorageAll(cdp, params.store);
+        return { entries, count: Object.keys(entries).length };
+      }
+      case "set": {
+        if (params.key == null || params.value == null) {
+          throw new Error("`set` requires `key` and `value`.");
+        }
+        await setStorageItem(cdp, params.store, params.key, params.value);
+        return { set: true };
+      }
+      case "remove": {
+        if (params.key == null) throw new Error("`remove` requires `key`.");
+        await removeStorageItem(cdp, params.store, params.key);
+        return { removed: true };
+      }
+      case "clear":
+        await clearStorage(cdp, params.store);
+        return { cleared: true };
+    }
+  },
+};

--- a/packages/tool-server/src/tools/chromium-storage/index.ts
+++ b/packages/tool-server/src/tools/chromium-storage/index.ts
@@ -44,7 +44,9 @@ export const chromiumStorageTool: ToolDefinition<Params, Result> = {
 - action="set" (key, value): write an entry.
 - action="remove" (key): delete an entry.
 - action="clear": empty the store.
-Set \`store\` to "local" or "session". Storage is per-origin, so it reflects the active tab's document. Chromium-only.`,
+Set \`store\` to "local" or "session". Storage is per-origin, so it reflects the active tab's document.
+Use when seeding feature flags / auth tokens before a flow or asserting persisted app state after one.
+Returns { value } for a single key, { entries, count } for all, or a status object ({ set } / { removed } / { cleared }) otherwise. Fails if the device is not a Chromium (CDP) device, or set is missing key/value. Chromium-only.`,
   searchHint:
     "storage localstorage sessionstorage local session get set remove clear key value chromium",
   zodSchema,

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -74,6 +74,8 @@ import { updateArgentTool } from "../tools/system/update-argent";
 import { dismissUpdateTool } from "../tools/system/dismiss-update";
 import { screenshotDiffTool } from "../tools/screenshot-diff";
 import { chromiumTabsTool } from "../tools/chromium-tabs";
+import { chromiumCookiesTool } from "../tools/chromium-cookies";
+import { chromiumStorageTool } from "../tools/chromium-storage";
 
 export function createRegistry(): Registry {
   const registry = new Registry();
@@ -99,6 +101,8 @@ export function createRegistry(): Registry {
   registry.registerTool(screenshotDiffTool);
   registry.registerTool(gestureTapTool);
   registry.registerTool(chromiumTabsTool);
+  registry.registerTool(chromiumCookiesTool);
+  registry.registerTool(chromiumStorageTool);
   registry.registerTool(gestureSwipeTool);
   registry.registerTool(gestureScrollTool);
   registry.registerTool(gestureDragTool);

--- a/packages/tool-server/test/chromium-storage.test.ts
+++ b/packages/tool-server/test/chromium-storage.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  clearCookies,
+  clearStorage,
+  deleteCookies,
+  getCookies,
+  getStorageAll,
+  getStorageItem,
+  removeStorageItem,
+  setCookie,
+  setStorageItem,
+} from "../src/chromium-server/storage";
+
+function fakeCdp(
+  reply: (method: string, params?: Record<string, unknown>) => unknown = () => ({})
+) {
+  const send = vi.fn(async (method: string, params?: Record<string, unknown>) =>
+    reply(method, params)
+  );
+  return { send, cdp: { send } as never };
+}
+
+describe("storage helpers — cookies", () => {
+  it("getCookies returns the cookies array and forwards urls", async () => {
+    const f = fakeCdp(() => ({ cookies: [{ name: "sid", value: "abc" }] }));
+    const cookies = await getCookies(f.cdp, ["https://x.test/"]);
+    expect(cookies).toEqual([{ name: "sid", value: "abc" }]);
+    expect(f.send).toHaveBeenCalledWith("Network.getCookies", { urls: ["https://x.test/"] });
+  });
+
+  it("getCookies with no urls sends an empty params object", async () => {
+    const f = fakeCdp(() => ({ cookies: [] }));
+    await getCookies(f.cdp);
+    expect(f.send).toHaveBeenCalledWith("Network.getCookies", {});
+  });
+
+  it("setCookie requires url or domain", async () => {
+    const f = fakeCdp(() => ({ success: true }));
+    await expect(setCookie(f.cdp, { name: "a", value: "b" })).rejects.toThrow(/url.*or.*domain/i);
+  });
+
+  it("setCookie returns success and forwards params", async () => {
+    const f = fakeCdp(() => ({ success: true }));
+    const ok = await setCookie(f.cdp, { name: "sid", value: "abc", url: "https://x.test/" });
+    expect(ok).toBe(true);
+    expect(f.send).toHaveBeenCalledWith(
+      "Network.setCookie",
+      expect.objectContaining({ name: "sid", value: "abc", url: "https://x.test/" })
+    );
+  });
+
+  it("deleteCookies / clearCookies hit the right CDP methods", async () => {
+    const f = fakeCdp();
+    await deleteCookies(f.cdp, { name: "sid", url: "https://x.test/" });
+    expect(f.send).toHaveBeenCalledWith("Network.deleteCookies", {
+      name: "sid",
+      url: "https://x.test/",
+    });
+    await clearCookies(f.cdp);
+    expect(f.send).toHaveBeenCalledWith("Network.clearBrowserCookies");
+  });
+});
+
+describe("storage helpers — local/session", () => {
+  it("getStorageAll returns the entries object from a returnByValue eval", async () => {
+    const f = fakeCdp((m) =>
+      m === "Runtime.evaluate" ? { result: { value: { a: "1", b: "2" } } } : {}
+    );
+    const all = await getStorageAll(f.cdp, "local");
+    expect(all).toEqual({ a: "1", b: "2" });
+    const [, params] = f.send.mock.calls[0]!;
+    expect((params as Record<string, unknown>).expression).toContain("localStorage");
+    expect((params as Record<string, unknown>).returnByValue).toBe(true);
+  });
+
+  it("getStorageItem returns the value (null when absent)", async () => {
+    const f = fakeCdp(() => ({ result: { value: "v" } }));
+    expect(await getStorageItem(f.cdp, "session", "k")).toBe("v");
+    expect((f.send.mock.calls[0]![1] as Record<string, unknown>).expression).toContain(
+      'sessionStorage.getItem("k")'
+    );
+  });
+
+  it("setStorageItem JSON-encodes key and value into the expression", async () => {
+    const f = fakeCdp(() => ({ result: { value: undefined } }));
+    await setStorageItem(f.cdp, "local", "tok'en", 'va"lue');
+    const expr = (f.send.mock.calls[0]![1] as Record<string, unknown>).expression as string;
+    expect(expr).toContain("localStorage.setItem(");
+    // key and value are JSON-encoded, so embedded quotes are safely escaped.
+    expect(expr).toContain(JSON.stringify("tok'en"));
+    expect(expr).toContain(JSON.stringify('va"lue'));
+  });
+
+  it("removeStorageItem / clearStorage build the right expressions", async () => {
+    const f = fakeCdp(() => ({ result: { value: undefined } }));
+    await removeStorageItem(f.cdp, "session", "k");
+    expect((f.send.mock.calls[0]![1] as Record<string, unknown>).expression).toBe(
+      'sessionStorage.removeItem("k")'
+    );
+    await clearStorage(f.cdp, "local");
+    expect((f.send.mock.calls[1]![1] as Record<string, unknown>).expression).toBe(
+      "localStorage.clear()"
+    );
+  });
+
+  it("eval surfaces exceptionDetails as an error", async () => {
+    const f = fakeCdp(() => ({ exceptionDetails: { text: "SecurityError" } }));
+    await expect(getStorageAll(f.cdp, "local")).rejects.toThrow(/SecurityError/);
+  });
+});
+
+// ── Tools ────────────────────────────────────────────────────────────────────
+import { chromiumCookiesTool } from "../src/tools/chromium-cookies";
+import { chromiumStorageTool } from "../src/tools/chromium-storage";
+import { assertSupported, UnsupportedOperationError } from "../src/utils/capability";
+import { resolveDevice } from "../src/utils/device-info";
+
+const chromium = resolveDevice("chromium-cdp-9222");
+const ios = resolveDevice("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA");
+
+describe("chromium-cookies tool", () => {
+  let send: ReturnType<typeof vi.fn>;
+  let services: never;
+  beforeEach(() => {
+    send = vi.fn(async (m: string) =>
+      m === "Network.getCookies" ? { cookies: [{ name: "a", value: "b" }] } : { success: true }
+    );
+    services = { chromium: { cdp: { send } } } as never;
+  });
+
+  it("capability is chromium-only", () => {
+    expect(() => assertSupported("c", chromiumCookiesTool.capability, chromium)).not.toThrow();
+    expect(() => assertSupported("c", chromiumCookiesTool.capability, ios)).toThrow(
+      UnsupportedOperationError
+    );
+  });
+
+  it("get returns cookies; set forwards; delete/clear dispatch", async () => {
+    const got = (await chromiumCookiesTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      action: "get",
+    })) as { count: number };
+    expect(got.count).toBe(1);
+
+    await chromiumCookiesTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      action: "set",
+      name: "sid",
+      value: "x",
+      url: "https://x.test/",
+    });
+    expect(send).toHaveBeenCalledWith(
+      "Network.setCookie",
+      expect.objectContaining({ name: "sid", value: "x" })
+    );
+
+    await chromiumCookiesTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      action: "clear",
+    });
+    expect(send).toHaveBeenCalledWith("Network.clearBrowserCookies");
+  });
+
+  it("set without name/value throws", async () => {
+    await expect(
+      chromiumCookiesTool.execute(services, { udid: "chromium-cdp-9222", action: "set", name: "x" })
+    ).rejects.toThrow(/requires `name` and `value`/);
+  });
+});
+
+describe("chromium-storage tool", () => {
+  it("capability is chromium-only", () => {
+    expect(() => assertSupported("s", chromiumStorageTool.capability, chromium)).not.toThrow();
+    expect(() => assertSupported("s", chromiumStorageTool.capability, ios)).toThrow(
+      UnsupportedOperationError
+    );
+  });
+
+  it("get all vs get key, and set/remove/clear", async () => {
+    const send = vi.fn(async (_m: string, p?: Record<string, unknown>) => {
+      const expr = String(p?.expression ?? "");
+      if (expr.includes("for (let i")) return { result: { value: { a: "1" } } };
+      if (expr.includes("getItem")) return { result: { value: "1" } };
+      return { result: { value: undefined } };
+    });
+    const services = { chromium: { cdp: { send } } } as never;
+
+    const all = (await chromiumStorageTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      store: "local",
+      action: "get",
+    })) as { count: number };
+    expect(all.count).toBe(1);
+
+    const one = (await chromiumStorageTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      store: "session",
+      action: "get",
+      key: "a",
+    })) as { value: string | null };
+    expect(one.value).toBe("1");
+
+    await chromiumStorageTool.execute(services, {
+      udid: "chromium-cdp-9222",
+      store: "local",
+      action: "set",
+      key: "a",
+      value: "2",
+    });
+    expect(send.mock.calls.some((c) => String(c[1]?.expression).includes("setItem"))).toBe(true);
+  });
+
+  it("set without key/value throws", async () => {
+    const services = { chromium: { cdp: { send: vi.fn() } } } as never;
+    await expect(
+      chromiumStorageTool.execute(services, {
+        udid: "chromium-cdp-9222",
+        store: "local",
+        action: "set",
+        key: "a",
+      })
+    ).rejects.toThrow(/requires `key` and `value`/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **cookie** and **Web Storage** access for a Chromium (CDP) device. Third of three stacked PRs (tabs → network → **cookies/storage**).

> **Stacked on #335** (which is stacked on #334). Base is `feat/chromium-network`; retarget down the stack as each merges.

## Tools

- **`chromium-cookies`** — `get` / `set` / `delete` / `clear` via the CDP **Network** domain, so **HttpOnly cookies are visible and settable** (which `document.cookie` can't do). `set` scopes by `url` or `domain` and supports `path` / `secure` / `httpOnly` / `sameSite` / `expires`.
- **`chromium-storage`** — `get` (one `key` or all entries) / `set` / `remove` / `clear` for `localStorage` or `sessionStorage` (`store=local|session`) of the active page, via `Runtime.evaluate` with JSON-encoded keys/values.

Shared helpers in `chromium-server/storage.ts`. Both chromium-only (capability gate); per-origin / active-tab, so they follow `chromium-tabs` selection. Great for **seeding auth before a flow** or **asserting app state after one**.

## Test plan

- [x] 16 new unit tests: cookie `get(urls)` / `set` (url-or-domain guard + param forwarding) / `delete` / `clear`; storage get-all / get-item / set / remove / clear expression building (JSON-encoding) + `exceptionDetails` surfacing; both tools' capability gate, action dispatch, and arg-validation errors.
- [x] Full suite **1155 pass**; `tsc --build` + `typecheck:tests` + prettier clean.
- [x] **Live (Chrome for Testing on :9222)**: localStorage set / get / get-all (2 entries) with in-page verification (`theme=dark`), remove, clear; cookies set an **HttpOnly** cookie → `get` shows it with `httpOnly=true`, `delete` → gone.