### PR TITLE
fix(profiler): demangle native C++ symbols in profiler reports

### DIFF
--- a/packages/tool-server/src/tools/profiler/query/profiler-stack-query.ts
+++ b/packages/tool-server/src/tools/profiler/query/profiler-stack-query.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../utils/android-profiler/pipeline/index";
 import { normalizeThreadName } from "../../../utils/profiler-shared/thread";
 import { formatBytes } from "../../../utils/profiler-shared/format";
+import { demangleSymbol } from "../../../utils/profiler-shared/demangle";
 
 const zodSchema = z.object({
   device_id: z.string().describe("iOS Simulator UDID or Android serial."),
@@ -82,7 +83,7 @@ function renderHangStacksIos(
     lines.push("### Suspected Functions (by sample frequency)");
     lines.push("");
     for (let i = 0; i < hang.suspectedFunctions.length; i++) {
-      lines.push(`${i + 1}. \`${hang.suspectedFunctions[i]}\``);
+      lines.push(`${i + 1}. \`${demangleSymbol(hang.suspectedFunctions[i]!)}\``);
     }
     lines.push("");
   }
@@ -91,7 +92,9 @@ function renderHangStacksIos(
     lines.push("### App Call Chains During Hang");
     lines.push("");
     for (const { chain, sampleCount } of hang.appCallChains) {
-      lines.push(`- (${sampleCount} samples) ${chain.map((f) => `\`${f}\``).join(" → ")}`);
+      lines.push(
+        `- (${sampleCount} samples) ${chain.map((f) => `\`${demangleSymbol(f)}\``).join(" → ")}`
+      );
     }
     lines.push("");
   }
@@ -119,7 +122,7 @@ function renderHangStacksIos(
 
     const sorted = [...uniqueStacks.values()].sort((a, b) => b.count - a.count).slice(0, topN);
     for (const { stack, count } of sorted) {
-      lines.push(`- (${count}×) ${stack.map((f) => `\`${f}\``).join(" → ")}`);
+      lines.push(`- (${count}×) ${stack.map((f) => `\`${demangleSymbol(f)}\``).join(" → ")}`);
     }
   }
 
@@ -173,7 +176,7 @@ function renderFunctionCallersIos(
     lines.push("| Function | Samples |");
     lines.push("|---|---|");
     for (const [name, count] of sortedCallers) {
-      lines.push(`| \`${name}\` | ${count} |`);
+      lines.push(`| \`${demangleSymbol(name)}\` | ${count} |`);
     }
     lines.push("");
   }
@@ -185,7 +188,7 @@ function renderFunctionCallersIos(
     lines.push("| Function | Samples |");
     lines.push("|---|---|");
     for (const [name, count] of sortedCallees) {
-      lines.push(`| \`${name}\` | ${count} |`);
+      lines.push(`| \`${demangleSymbol(name)}\` | ${count} |`);
     }
     lines.push("");
   }
@@ -245,7 +248,7 @@ function renderThreadBreakdownIos(
       lines.push("|---|---|---|---|");
       for (const h of threadHotspots.slice(0, topN)) {
         lines.push(
-          `| \`${h.dominantFunction}\` | ${h.totalWeightMs} | ${h.weightPercentage}% | ${h.duringHang ? "Yes" : "No"} |`
+          `| \`${demangleSymbol(h.dominantFunction)}\` | ${h.totalWeightMs} | ${h.weightPercentage}% | ${h.duringHang ? "Yes" : "No"} |`
         );
       }
     }
@@ -288,7 +291,7 @@ function renderLeakStacksIos(
 
   for (const l of sorted) {
     lines.push(
-      `| \`${l.objectType}\` | ${formatBytes(l.totalSizeBytes)} | ${l.count} | \`${l.responsibleFrame}\` | ${l.responsibleLibrary || "—"} |`
+      `| \`${l.objectType}\` | ${formatBytes(l.totalSizeBytes)} | ${l.count} | \`${demangleSymbol(l.responsibleFrame)}\` | ${l.responsibleLibrary || "—"} |`
     );
   }
 

--- a/packages/tool-server/src/utils/android-profiler/pipeline/index.ts
+++ b/packages/tool-server/src/utils/android-profiler/pipeline/index.ts
@@ -9,6 +9,7 @@ import { runTpQuery } from "./run-tp";
 import { foldHangAnnotations } from "./hang-fold";
 import { runBatchedHangFolds, type HangWindowInput } from "./hang-folds-batched";
 import { sanitizeProcessName, sanitizeIdentifier } from "./sql-safety";
+import { demangleSymbol, demangleCallstackText } from "../../profiler-shared/demangle";
 import type {
   AndroidCpuHotspotRow,
   AndroidJankRow,
@@ -290,10 +291,11 @@ async function renderHangStacksAndroid(
     const uniqueStacks = new Map<string, { stack: string; count: number }>();
     for (const row of sampleRows) {
       if (!row.callstack_text) continue;
-      const key = row.callstack_text;
-      const ex = uniqueStacks.get(key);
+      // Demangle for display; identical demangled stacks fold together.
+      const demangled = demangleCallstackText(row.callstack_text);
+      const ex = uniqueStacks.get(demangled);
       if (ex) ex.count++;
-      else uniqueStacks.set(key, { stack: row.callstack_text, count: 1 });
+      else uniqueStacks.set(demangled, { stack: demangled, count: 1 });
     }
     const sorted = [...uniqueStacks.values()].sort((a, b) => b.count - a.count).slice(0, opts.topN);
     for (const { stack, count } of sorted) {
@@ -361,7 +363,7 @@ async function renderFunctionCallersAndroid(
   if (!rows.some((r) => r.is_exact) || distinctMatched.length > 1) {
     lines.push(
       `_Substring match: \`${opts.functionName}\` hit ${distinctMatched.length} leaf symbol(s):_`,
-      ...distinctMatched.slice(0, 10).map((m) => `- \`${m}\``),
+      ...distinctMatched.slice(0, 10).map((m) => `- \`${demangleSymbol(m)}\``),
       ...(distinctMatched.length > 10 ? [`- …and ${distinctMatched.length - 10} more`] : []),
       ""
     );
@@ -373,7 +375,9 @@ async function renderFunctionCallersAndroid(
     // tag each block with its owning thread (raw name — copy it back as a filter).
     const tag = allThreads ? ` [${row.thread_name}${row.is_main_thread ? " (main)" : ""}]` : "";
     lines.push(`(${row.occurrences}×)${tag}`);
-    lines.push(row.callstack_text ?? "<no callstack>");
+    // Demangle each frame for readability; matching upstream is still done on the
+    // raw mangled names in SQL, so this is display-only.
+    lines.push(row.callstack_text ? demangleCallstackText(row.callstack_text) : "<no callstack>");
     lines.push("```");
   }
   return lines.join("\n");

--- a/packages/tool-server/src/utils/android-profiler/pipeline/index.ts
+++ b/packages/tool-server/src/utils/android-profiler/pipeline/index.ts
@@ -358,12 +358,15 @@ async function renderFunctionCallersAndroid(
   ];
   // Frame names are stored mangled, so the query is matched as a substring.
   // When nothing matched verbatim, spell out the real leaf symbols that did, so
-  // an unexpected (or over-broad) match is obvious rather than silent.
-  const distinctMatched = [...new Set(rows.map((r) => r.matched_function))];
+  // an unexpected (or over-broad) match is obvious rather than silent. Dedup on
+  // the DEMANGLED name so overloads (`_ZN3foo3barEv`/`_ZN3foo3barEi`, both
+  // `foo::bar` once args are dropped) collapse to a single bullet and the count
+  // matches what's printed.
+  const distinctMatched = [...new Set(rows.map((r) => demangleSymbol(r.matched_function)))];
   if (!rows.some((r) => r.is_exact) || distinctMatched.length > 1) {
     lines.push(
       `_Substring match: \`${opts.functionName}\` hit ${distinctMatched.length} leaf symbol(s):_`,
-      ...distinctMatched.slice(0, 10).map((m) => `- \`${demangleSymbol(m)}\``),
+      ...distinctMatched.slice(0, 10).map((m) => `- \`${m}\``),
       ...(distinctMatched.length > 10 ? [`- …and ${distinctMatched.length - 10} more`] : []),
       ""
     );

--- a/packages/tool-server/src/utils/ios-profiler/render.ts
+++ b/packages/tool-server/src/utils/ios-profiler/render.ts
@@ -243,11 +243,11 @@ function renderFullReport(
       if (b.topCallChains && b.topCallChains.length > 0) {
         lines.push(`**Call chains:**`);
         for (const { chain, count } of b.topCallChains) {
-          lines.push(`- (${count}×) \`${chain.join(" > ")}\``);
+          lines.push(`- (${count}×) \`${chain.map(demangleSymbol).join(" > ")}\``);
         }
         lines.push(``);
       } else if (b.topCallChain.length > 0) {
-        lines.push(`**Call chain:** \`${b.topCallChain.join(" > ")}\``);
+        lines.push(`**Call chain:** \`${b.topCallChain.map(demangleSymbol).join(" > ")}\``);
         lines.push(``);
       }
 

--- a/packages/tool-server/src/utils/ios-profiler/render.ts
+++ b/packages/tool-server/src/utils/ios-profiler/render.ts
@@ -319,20 +319,24 @@ function renderFullReport(
           lines.push(``);
           lines.push(`App call chains during this hang:`);
           hang.appCallChains.forEach((entry, i) => {
-            lines.push(`${i + 1}. \`${entry.chain.join(" > ")}\` (${entry.sampleCount} samples)`);
+            lines.push(
+              `${i + 1}. \`${entry.chain.map(demangleSymbol).join(" > ")}\` (${entry.sampleCount} samples)`
+            );
           });
         }
       } else if (hang.appCallChains.length > 0) {
         lines.push(``);
         lines.push(`${header} — app call chains during this hang:`);
         hang.appCallChains.forEach((entry, i) => {
-          lines.push(`${i + 1}. \`${entry.chain.join(" > ")}\` (${entry.sampleCount} samples)`);
+          lines.push(
+            `${i + 1}. \`${entry.chain.map(demangleSymbol).join(" > ")}\` (${entry.sampleCount} samples)`
+          );
         });
       } else if (hang.suspectedFunctions.length > 0) {
         lines.push(``);
         lines.push(`${header} — during this hang, the most active functions were:`);
         for (const fn of hang.suspectedFunctions) {
-          lines.push(`- \`${fn}\``);
+          lines.push(`- \`${demangleSymbol(fn)}\``);
         }
       } else {
         lines.push(``);
@@ -356,7 +360,7 @@ function renderFullReport(
     );
     memoryLeaks.forEach((b, i) => {
       lines.push(
-        `| ${i + 1} | \`${b.objectType}\` | ${b.count} | ${formatBytes(b.totalSizeBytes)} | \`${b.responsibleFrame}\` | ${b.responsibleLibrary || "—"} | ${severityEmoji(b.severity)} |`
+        `| ${i + 1} | \`${b.objectType}\` | ${b.count} | ${formatBytes(b.totalSizeBytes)} | \`${demangleSymbol(b.responsibleFrame)}\` | ${b.responsibleLibrary || "—"} | ${severityEmoji(b.severity)} |`
       );
     });
   }
@@ -395,7 +399,9 @@ function renderFullReport(
     lines.push(`### UI Hangs`, ``);
     for (const b of uiHangs) {
       const funcNote =
-        b.suspectedFunctions.length > 0 ? ` Likely caused by: \`${b.suspectedFunctions[0]}\`.` : "";
+        b.suspectedFunctions.length > 0
+          ? ` Likely caused by: \`${demangleSymbol(b.suspectedFunctions[0]!)}\`.`
+          : "";
       const reasonNote = b.jankReason ? ` Reason: \`${b.jankReason}\`.` : "";
       lines.push(
         `- ${severityEmoji(b.severity)} ${b.hangType} at ${b.startTimeFormatted} (${b.durationMs}ms): Main thread blocked — move heavy work to background queue.${reasonNote}${funcNote}`
@@ -408,7 +414,7 @@ function renderFullReport(
     lines.push(`### Memory Leaks`, ``);
     for (const b of memoryLeaks) {
       lines.push(
-        `- ${severityEmoji(b.severity)} \`${b.objectType}\` x${b.count} (${formatBytes(b.totalSizeBytes)}) via \`${b.responsibleFrame}\`: Check for retain cycles or strong delegate references.`
+        `- ${severityEmoji(b.severity)} \`${b.objectType}\` x${b.count} (${formatBytes(b.totalSizeBytes)}) via \`${demangleSymbol(b.responsibleFrame)}\`: Check for retain cycles or strong delegate references.`
       );
     }
     lines.push(``);

--- a/packages/tool-server/src/utils/ios-profiler/render.ts
+++ b/packages/tool-server/src/utils/ios-profiler/render.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 import * as path from "path";
 import type { TraceProcessorUnavailableError } from "@argent/native-devtools-android";
+import { demangleSymbol } from "../profiler-shared/demangle";
 import type {
   ProfilerPayload,
   Bottleneck,
@@ -227,7 +228,7 @@ function renderFullReport(
     cpuHotspots.forEach((b, i) => {
       const hangFlag = b.duringHang ? "Yes" : "—";
       lines.push(
-        `| ${i + 1} | \`${b.dominantFunction}\` | ${b.thread} | ${b.totalWeightMs} | ${b.weightPercentage}% | ${b.sampleCount} | ${hangFlag} | ${severityEmoji(b.severity)} |`
+        `| ${i + 1} | \`${demangleSymbol(b.dominantFunction)}\` | ${b.thread} | ${b.totalWeightMs} | ${b.weightPercentage}% | ${b.sampleCount} | ${hangFlag} | ${severityEmoji(b.severity)} |`
       );
     });
 
@@ -236,7 +237,7 @@ function renderFullReport(
       : cpuHotspots;
     for (const b of hotspotDetailSlice) {
       lines.push(``);
-      lines.push(`### \`${b.dominantFunction}\` (${b.thread})`);
+      lines.push(`### \`${demangleSymbol(b.dominantFunction)}\` (${b.thread})`);
       lines.push(``);
 
       if (b.topCallChains && b.topCallChains.length > 0) {
@@ -384,7 +385,7 @@ function renderFullReport(
     lines.push(`### CPU Hotspots`, ``);
     for (const b of cpuHotspots) {
       lines.push(
-        `- ${severityEmoji(b.severity)} \`${b.dominantFunction}\` on ${b.thread} (${b.weightPercentage}%): High CPU in this function — reduce view hierarchy depth or batch UI updates.`
+        `- ${severityEmoji(b.severity)} \`${demangleSymbol(b.dominantFunction)}\` on ${b.thread} (${b.weightPercentage}%): High CPU in this function — reduce view hierarchy depth or batch UI updates.`
       );
     }
     lines.push(``);
@@ -426,6 +427,8 @@ function renderFullReport(
   }
   if (cpuHotspots.length > 0) {
     const topHotspot = cpuHotspots[0]!;
+    // Keep the RAW (possibly mangled) name here: function_callers matches it as a
+    // SQL substring of the mangled frame, and a demangled name isn't a substring.
     lines.push(
       `   - mode=\`function_callers\` function_name=\`${topHotspot.dominantFunction}\` — who calls this hot function`
     );

--- a/packages/tool-server/src/utils/profiler-shared/demangle.ts
+++ b/packages/tool-server/src/utils/profiler-shared/demangle.ts
@@ -1,0 +1,114 @@
+/**
+ * Best-effort demangler for native (Itanium C++ ABI) symbol names that appear
+ * in Perfetto/perf stacks. Perf stores frame names mangled, so a drill-down
+ * stack reads like `_ZN16GrDrawingManager5flushE6SkSpan...` — accurate but hard
+ * to read. We turn the common forms into `GrDrawingManager::flush` while
+ * staying conservative: anything we cannot confidently parse is returned
+ * unchanged, so we never corrupt a name (kernel C symbols, JIT frames, template
+ * soup all pass through verbatim).
+ *
+ * This deliberately handles only the subset that dominates real stacks
+ * (nested-names and plain function names, with the argument list dropped). It
+ * is NOT a full Itanium demangler — substitutions, templates, and special
+ * names bail out to the raw string rather than risk a wrong answer.
+ */
+
+/**
+ * Trailing compiler-internal suffixes hung off a symbol by LLVM/GCC, e.g.
+ * `...trampolinePv.__uniq.2640...290.c303f2d2` or `.llvm.123` or `.cold`.
+ * They carry no user-facing meaning and bloat the stack lines.
+ */
+const INTERNAL_SUFFIX =
+  /\.(?:__uniq\.[0-9]+(?:\.[0-9a-f]+)?|llvm\.[0-9]+|part\.[0-9]+|cold(?:\.[0-9]+)?|constprop\.[0-9]+|isra\.[0-9]+)$/;
+
+function stripInternalSuffix(s: string): string {
+  let out = s;
+  // Suffixes can chain (`.part.0.cold`); strip until stable.
+  for (let guard = 0; guard < 8; guard++) {
+    const next = out.replace(INTERNAL_SUFFIX, "");
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+interface Cursor {
+  s: string;
+  i: number;
+}
+
+/** Read a `<decimal-length><identifier>` source-name. Returns null if malformed. */
+function readSourceName(c: Cursor): string | null {
+  let len = 0;
+  let digits = 0;
+  while (c.i < c.s.length && c.s[c.i]! >= "0" && c.s[c.i]! <= "9") {
+    len = len * 10 + (c.s.charCodeAt(c.i) - 48);
+    c.i++;
+    digits++;
+  }
+  if (digits === 0) return null;
+  const start = c.i;
+  const end = start + len;
+  if (end > c.s.length) return null;
+  c.i = end;
+  return c.s.slice(start, end);
+}
+
+/** Parse a nested-name (`N` already consumed) up to the closing `E`. */
+function readNestedName(c: Cursor): string | null {
+  // CV / ref qualifiers that can precede the components.
+  while (c.i < c.s.length && "rVKO".includes(c.s[c.i]!)) c.i++;
+  const parts: string[] = [];
+  while (c.i < c.s.length && c.s[c.i] !== "E") {
+    if (c.s.startsWith("St", c.i)) {
+      parts.push("std");
+      c.i += 2;
+      continue;
+    }
+    const name = readSourceName(c);
+    // A non-source-name component (template `I`, substitution `S`, operator,
+    // ctor/dtor `C`/`D`, …) — bail rather than guess.
+    if (name === null) return null;
+    parts.push(name);
+  }
+  if (c.s[c.i] !== "E") return null;
+  return parts.join("::");
+}
+
+/**
+ * Demangle a single symbol. Returns the readable name, or the original string
+ * (sans internal suffix when it was clearly one) if it is not a mangled name we
+ * understand.
+ */
+export function demangleSymbol(name: string): string {
+  if (!name) return name;
+  const stripped = stripInternalSuffix(name);
+  if (!stripped.startsWith("_Z")) {
+    // Plain C / kernel symbol — return as-is (keep the original, suffix and all,
+    // since for non-mangled names the "suffix" may be meaningful).
+    return name;
+  }
+  const c: Cursor = { s: stripped, i: 2 };
+  if (c.s[c.i] === "L") c.i++; // internal-linkage marker
+  let parsed: string | null;
+  if (c.s[c.i] === "N") {
+    c.i++;
+    parsed = readNestedName(c);
+  } else {
+    parsed = readSourceName(c);
+  }
+  if (!parsed) return name; // couldn't parse confidently — leave it raw
+  return parsed;
+}
+
+/**
+ * Demangle every frame in a ` <- `-joined callstack string (the format produced
+ * by function-callers.sql / hang-main-thread-samples.sql). Separator and order
+ * are preserved.
+ */
+export function demangleCallstackText(text: string): string {
+  return text
+    .split(" <- ")
+    .map((frame) => demangleSymbol(frame.trim()))
+    .join(" <- ");
+}

--- a/packages/tool-server/test/android-perfetto/demangle.test.ts
+++ b/packages/tool-server/test/android-perfetto/demangle.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { demangleSymbol, demangleCallstackText } from "../../src/utils/profiler-shared/demangle";
+
+describe("demangleSymbol", () => {
+  it("demangles a nested name and drops the argument list", () => {
+    // _ZN16GrDrawingManager5flushE6SkSpan... → GrDrawingManager::flush
+    expect(demangleSymbol("_ZN16GrDrawingManager5flushE6SkSpanIP14GrSurfaceProxyE")).toBe(
+      "GrDrawingManager::flush"
+    );
+  });
+
+  it("demangles a plain (non-nested) function name", () => {
+    expect(demangleSymbol("_Z13uncompressLZWP7_JNIEnv")).toBe("uncompressLZW");
+    expect(demangleSymbol("_Z23__pthread_internal_findlPKc")).toBe("__pthread_internal_find");
+  });
+
+  it("handles internal-linkage (_ZL) symbols", () => {
+    expect(demangleSymbol("_ZL25libutil_thread_trampolinePv")).toBe("libutil_thread_trampoline");
+  });
+
+  it("strips LLVM internal suffixes", () => {
+    expect(
+      demangleSymbol(
+        "_ZL25libutil_thread_trampolinePv.__uniq.226528677032898775202282855395389835431"
+      )
+    ).toBe("libutil_thread_trampoline");
+  });
+
+  it("maps the std abbreviation in a parseable nested name", () => {
+    // _ZNSt6chrono5stealE → std::chrono::steal
+    expect(demangleSymbol("_ZNSt6chrono5stealE")).toBe("std::chrono::steal");
+  });
+
+  it("bails to the raw name on templates rather than guessing", () => {
+    // Template args (`I...E`) are out of scope: returning the raw mangled name
+    // is safer than emitting a partial, misleading demangle.
+    expect(demangleSymbol("_ZNSt6vectorIiE9push_backEi")).toBe("_ZNSt6vectorIiE9push_backEi");
+  });
+
+  it("returns plain C / kernel symbols unchanged", () => {
+    expect(demangleSymbol("goldfish_pipe_read_write")).toBe("goldfish_pipe_read_write");
+    expect(demangleSymbol("do_syscall_64")).toBe("do_syscall_64");
+    expect(demangleSymbol("__start_thread")).toBe("__start_thread");
+  });
+
+  it("never corrupts an unparseable mangled name (returns it raw)", () => {
+    expect(demangleSymbol("_ZWeird$$$NotReal")).toBe("_ZWeird$$$NotReal");
+    expect(demangleSymbol("")).toBe("");
+  });
+});
+
+describe("demangleCallstackText", () => {
+  it("demangles each frame and preserves the ' <- ' separators and order", () => {
+    const raw =
+      "_ZN16GrDrawingManager5flushE6SkSpan <- _ZL25libutil_thread_trampolinePv <- __start_thread";
+    expect(demangleCallstackText(raw)).toBe(
+      "GrDrawingManager::flush <- libutil_thread_trampoline <- __start_thread"
+    );
+  });
+
+  it("leaves an all-C kernel stack readable and unchanged", () => {
+    const raw = "goldfish_pipe_read_write <- vfs_read <- do_syscall_64";
+    expect(demangleCallstackText(raw)).toBe(raw);
+  });
+});

--- a/packages/tool-server/test/android-perfetto/function-callers.test.ts
+++ b/packages/tool-server/test/android-perfetto/function-callers.test.ts
@@ -113,6 +113,26 @@ describe("function_callers thread resolution", () => {
     expect(out).toContain("(8×) [FrameDecoderExe]");
   });
 
+  it("dedups overloaded leaves AFTER demangling (two overloads → one bullet, count of 1)", async () => {
+    // Two distinct mangled overloads of foo::bar that demangle to the same name
+    // once the argument list is dropped. The bullet list must show it once and
+    // the count must agree (not say 2 while printing the same line twice).
+    const barVoid = "_ZN3foo3barEv";
+    const barInt = "_ZN3foo3barEi";
+    const out = await query(undefined, [
+      callerRow("WorkerA", 0, `caller <- ${barVoid}`, 4, barVoid, 0),
+      callerRow("WorkerB", 0, `caller <- ${barInt}`, 3, barInt, 0),
+    ]);
+    // Count and bullets agree: one distinct leaf symbol after demangling.
+    expect(out).toContain("hit 1 leaf symbol(s):");
+    // Exactly one bullet for foo::bar (not two).
+    const bullets = out.split("\n").filter((l) => l.trim() === "- `foo::bar`");
+    expect(bullets).toHaveLength(1);
+    // Raw mangled overloads never appear in the human-facing bullet list.
+    expect(out).not.toContain(barVoid);
+    expect(out).not.toContain(barInt);
+  });
+
   it("does NOT add the substring note when the match was exact and singular", async () => {
     const out = await query("FrameDecoderExe", [
       callerRow("FrameDecoderExe", 0, "decode <- uncompressLZW", 7, "uncompressLZW", 1),

--- a/packages/tool-server/test/android-perfetto/function-callers.test.ts
+++ b/packages/tool-server/test/android-perfetto/function-callers.test.ts
@@ -99,15 +99,17 @@ describe("function_callers thread resolution", () => {
     expect(calls[0]!.substitutions.FUNCTION_NAME).toBe("uncompressLZW");
   });
 
-  it("spells out the real mangled leaf symbols when the match was a substring", async () => {
+  it("spells out the matched leaf symbols (demangled) when the match was a substring", async () => {
     // Demangled query → SQL matched the mangled leaf; rows come back is_exact=0
-    // with the real frame name in matched_function.
+    // with the real frame name in matched_function. The display demangles it for
+    // readability (SQL matching upstream still uses the raw mangled name).
     const mangled = "_Z13uncompressLZWP7_JNIEnvP8_jobjectS2_P10_jintArrayiS4_iiihP11_jbyteArray";
     const out = await query(undefined, [
       callerRow("FrameDecoderExe", 0, `decode <- ${mangled}`, 8, mangled, 0),
     ]);
     expect(out).toContain("Substring match: `uncompressLZW` hit 1 leaf symbol(s):");
-    expect(out).toContain(`- \`${mangled}\``);
+    expect(out).toContain("- `uncompressLZW`");
+    expect(out).not.toContain(mangled); // raw mangled name no longer shown
     expect(out).toContain("(8×) [FrameDecoderExe]");
   });
 

--- a/packages/tool-server/test/android-perfetto/render-demangle.test.ts
+++ b/packages/tool-server/test/android-perfetto/render-demangle.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { renderNativeProfilerReport } from "../../src/utils/ios-profiler/render";
+import type { CpuHotspot, ProfilerPayload } from "../../src/utils/ios-profiler/types";
+
+// A mangled nested name that the conservative demangler understands:
+// _ZN16GrDrawingManager5flushE... → GrDrawingManager::flush (argument list dropped).
+const MANGLED = "_ZN16GrDrawingManager5flushE6SkSpanIP14GrSurfaceProxyE";
+const DEMANGLED = "GrDrawingManager::flush";
+
+function cpuHotspot(overrides: Partial<CpuHotspot> = {}): CpuHotspot {
+  return {
+    type: "cpu_hotspot",
+    platform: "android",
+    dominantFunction: MANGLED,
+    totalWeightMs: 120,
+    weightPercentage: 42,
+    sampleCount: 60,
+    thread: "Main Thread",
+    severity: "RED",
+    topCallChain: [],
+    topCallChains: [],
+    duringHang: false,
+    timeRangeMs: { first: 0, last: 1000 },
+    burstWindows: [],
+    ...overrides,
+  };
+}
+
+function payloadWith(hotspot: CpuHotspot): ProfilerPayload {
+  return {
+    // traceFile null → renderNativeProfilerReport writes no file (hermetic).
+    metadata: { traceFile: null, platform: "android", timestamp: "2026-01-01T00:00:00Z" },
+    bottlenecks: [hotspot],
+  };
+}
+
+describe("renderNativeProfilerReport — CPU Hotspots leaf demangling", () => {
+  it("shows the DEMANGLED leaf in the table and heading, but keeps the RAW mangled name in the function_callers suggestion", async () => {
+    const { report } = await renderNativeProfilerReport({
+      payload: payloadWith(cpuHotspot()),
+      traceFile: null,
+    });
+
+    // (a) Human-facing display sites are demangled.
+    // Table cell: `| 1 | `GrDrawingManager::flush` | Main Thread | ...`
+    expect(report).toContain(`| 1 | \`${DEMANGLED}\` | Main Thread |`);
+    // Detail heading: `### `GrDrawingManager::flush` (Main Thread)`
+    expect(report).toContain(`### \`${DEMANGLED}\` (Main Thread)`);
+    // Suggested Improvements bullet is demangled too.
+    expect(report).toContain(`\`${DEMANGLED}\` on Main Thread`);
+
+    // (b) The copy-paste drill-down MUST keep the RAW mangled symbol — it is
+    // matched as a SQL substring of the mangled frame, and the demangled name
+    // (args dropped) is not a substring of it.
+    expect(report).toContain(`mode=\`function_callers\` function_name=\`${MANGLED}\``);
+    // The mangled name must NOT leak into the human-facing table/heading.
+    expect(report).not.toContain(`| 1 | \`${MANGLED}\``);
+    expect(report).not.toContain(`### \`${MANGLED}\``);
+  });
+
+  it("leaves an already-readable (iOS-style) leaf name untouched", async () => {
+    // iOS frames arrive pre-symbolicated; the demangler bails on anything that
+    // is not an Itanium `_Z…` name, so applying it is a safe no-op.
+    const ios = "-[MyViewController viewDidLoad]";
+    const { report } = await renderNativeProfilerReport({
+      payload: payloadWith(cpuHotspot({ platform: "ios", dominantFunction: ios })),
+      traceFile: null,
+    });
+    expect(report).toContain(`| 1 | \`${ios}\` |`);
+    expect(report).toContain(`### \`${ios}\` (Main Thread)`);
+  });
+});

--- a/packages/tool-server/test/android-perfetto/render-demangle.test.ts
+++ b/packages/tool-server/test/android-perfetto/render-demangle.test.ts
@@ -58,6 +58,32 @@ describe("renderNativeProfilerReport — CPU Hotspots leaf demangling", () => {
     expect(report).not.toContain(`### \`${MANGLED}\``);
   });
 
+  it("demangles the frames in the per-hotspot Call chains block", async () => {
+    // Android builds callChains as [{ chain: [leaf_function] }] — the chain frame
+    // is the SAME mangled string as dominantFunction. Without demangling here the
+    // heading would read `GrDrawingManager::flush` while the chain right under it
+    // shows the raw `_ZN16GrDrawingManager…` for the very same function.
+    const { report } = await renderNativeProfilerReport({
+      payload: payloadWith(cpuHotspot({ topCallChains: [{ chain: [MANGLED], count: 60 }] })),
+      traceFile: null,
+    });
+    expect(report).toContain(`- (60×) \`${DEMANGLED}\``);
+    expect(report).not.toContain(`- (60×) \`${MANGLED}\``);
+    // Only the function_callers drill-down keeps the raw mangled name (by design).
+    expect(report.split(MANGLED).length - 1).toBe(1);
+    expect(report).toContain(`function_name=\`${MANGLED}\``);
+  });
+
+  it("demangles the single-chain fallback (`Call chain:`) too", async () => {
+    // Reached when topCallChains is empty but a topCallChain is present.
+    const { report } = await renderNativeProfilerReport({
+      payload: payloadWith(cpuHotspot({ topCallChain: [MANGLED], topCallChains: [] })),
+      traceFile: null,
+    });
+    expect(report).toContain(`**Call chain:** \`${DEMANGLED}\``);
+    expect(report).not.toContain(`**Call chain:** \`${MANGLED}\``);
+  });
+
   it("leaves an already-readable (iOS-style) leaf name untouched", async () => {
     // iOS frames arrive pre-symbolicated; the demangler bails on anything that
     // is not an Itanium `_Z…` name, so applying it is a safe no-op.

--- a/packages/tool-server/test/android-perfetto/render-demangle.test.ts
+++ b/packages/tool-server/test/android-perfetto/render-demangle.test.ts
@@ -1,11 +1,21 @@
 import { describe, it, expect } from "vitest";
 import { renderNativeProfilerReport } from "../../src/utils/ios-profiler/render";
-import type { CpuHotspot, ProfilerPayload } from "../../src/utils/ios-profiler/types";
+import type {
+  CpuHotspot,
+  MemoryLeak,
+  ProfilerPayload,
+  UiHang,
+} from "../../src/utils/ios-profiler/types";
 
 // A mangled nested name that the conservative demangler understands:
 // _ZN16GrDrawingManager5flushE... → GrDrawingManager::flush (argument list dropped).
 const MANGLED = "_ZN16GrDrawingManager5flushE6SkSpanIP14GrSurfaceProxyE";
 const DEMANGLED = "GrDrawingManager::flush";
+
+// A second, distinct mangled nested name → MyClass::doWork. Used to prove the
+// `responsibleFrame` / leak sites demangle independently of the hang sites.
+const MANGLED_LEAK = "_ZN7MyClass6doWorkEv";
+const DEMANGLED_LEAK = "MyClass::doWork";
 
 function cpuHotspot(overrides: Partial<CpuHotspot> = {}): CpuHotspot {
   return {
@@ -94,5 +104,112 @@ describe("renderNativeProfilerReport — CPU Hotspots leaf demangling", () => {
     });
     expect(report).toContain(`| 1 | \`${ios}\` |`);
     expect(report).toContain(`### \`${ios}\` (Main Thread)`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// General demangling: hang appCallChains / suspectedFunctions, and memory-leak
+// responsibleFrame — in both the detail section AND Suggested Improvements.
+// iOS frames are the realistic carrier of mangled C++ names here (Android hang
+// appCallChains/suspectedFunctions are hardcoded empty; the SQL path already
+// demangles its own callstack text), so these payloads are iOS-flavoured.
+// ---------------------------------------------------------------------------
+
+function uiHang(overrides: Partial<UiHang> = {}): UiHang {
+  return {
+    type: "ui_hang",
+    platform: "ios",
+    hangType: "hang",
+    durationMs: 850,
+    startTimeFormatted: "00:01.500",
+    startNs: 1_500_000_000,
+    endNs: 2_350_000_000,
+    suspectedFunctions: [],
+    appCallChains: [],
+    severity: "RED",
+    ...overrides,
+  };
+}
+
+function memoryLeak(overrides: Partial<MemoryLeak> = {}): MemoryLeak {
+  return {
+    type: "memory_leak",
+    platform: "ios",
+    objectType: "MyLeakyObject",
+    totalSizeBytes: 4 * 1024 * 1024,
+    count: 128,
+    responsibleFrame: MANGLED_LEAK,
+    responsibleLibrary: "MyApp",
+    severity: "RED",
+    ...overrides,
+  };
+}
+
+function payloadOf(bottlenecks: ProfilerPayload["bottlenecks"]): ProfilerPayload {
+  return {
+    metadata: { traceFile: null, platform: "ios", timestamp: "2026-01-01T00:00:00Z" },
+    bottlenecks,
+  };
+}
+
+describe("renderNativeProfilerReport — general native-frame demangling", () => {
+  it("demangles a hang's appCallChains frames in the detail section", async () => {
+    const { report } = await renderNativeProfilerReport({
+      payload: payloadOf([
+        uiHang({ appCallChains: [{ chain: [MANGLED, MANGLED_LEAK], sampleCount: 40 }] }),
+      ]),
+      traceFile: null,
+    });
+    // Detail: `1. `GrDrawingManager::flush > MyClass::doWork` (40 samples)`
+    expect(report).toContain(`1. \`${DEMANGLED} > ${DEMANGLED_LEAK}\` (40 samples)`);
+    expect(report).not.toContain(MANGLED);
+    expect(report).not.toContain(MANGLED_LEAK);
+  });
+
+  it("demangles a hang's suspectedFunctions in BOTH the detail list and Suggested Improvements", async () => {
+    const { report } = await renderNativeProfilerReport({
+      payload: payloadOf([uiHang({ suspectedFunctions: [MANGLED, MANGLED_LEAK] })]),
+      traceFile: null,
+    });
+    // Detail bullet (the `else if (suspectedFunctions)` branch, no appCallChains):
+    expect(report).toContain(`- \`${DEMANGLED}\``);
+    expect(report).toContain(`- \`${DEMANGLED_LEAK}\``);
+    // Suggested Improvements → UI Hangs "Likely caused by: `…`" uses [0].
+    expect(report).toContain(`Likely caused by: \`${DEMANGLED}\`.`);
+    // No mangled name anywhere in the report.
+    expect(report).not.toContain(MANGLED);
+    expect(report).not.toContain(MANGLED_LEAK);
+  });
+
+  it("demangles a memory leak's responsibleFrame in BOTH the table and Suggested Improvements", async () => {
+    const { report } = await renderNativeProfilerReport({
+      payload: payloadOf([memoryLeak({ responsibleFrame: MANGLED_LEAK })]),
+      traceFile: null,
+    });
+    // Memory-Leaks table cell.
+    expect(report).toContain(`\`${DEMANGLED_LEAK}\` | MyApp |`);
+    // Suggested Improvements → Memory Leaks "via `…`".
+    expect(report).toContain(`via \`${DEMANGLED_LEAK}\`:`);
+    expect(report).not.toContain(MANGLED_LEAK);
+  });
+
+  it("leaves already-readable (iOS-style) frames untouched at every general site (no-op)", async () => {
+    const hangFn = "-[DataStore loadAll]";
+    const leakFrame = "-[ImageCache store:]";
+    const { report } = await renderNativeProfilerReport({
+      payload: payloadOf([
+        uiHang({
+          appCallChains: [{ chain: [hangFn], sampleCount: 12 }],
+          suspectedFunctions: [hangFn],
+        }),
+        memoryLeak({ responsibleFrame: leakFrame }),
+      ]),
+      traceFile: null,
+    });
+    // appCallChains detail, Suggested-Improvements hang note, leak table + via — all verbatim.
+    expect(report).toContain(`1. \`${hangFn}\` (12 samples)`);
+    expect(report).toContain(`Likely caused by: \`${hangFn}\`.`);
+    expect(report).toContain(`\`${leakFrame}\` | MyApp |`);
+    expect(report).toContain(`via \`${leakFrame}\`:`);
   });
 });


### PR DESCRIPTION
## Summary

`profiler-stack-query` Android stacks come straight from perf, which stores frame names **mangled** — so `function_callers` / `hang_stacks` output reads like:

```
_ZN16GrDrawingManager5flushE6SkSpan... <- _ZL25libutil_thread_trampolinePv.__uniq.2265... <- __start_thread
```

This adds a conservative, best-effort Itanium demangler and applies it when rendering those stacks (display-only — SQL matching upstream still uses the raw mangled names). The same stack now reads:

```
GrDrawingManager::flush <- libutil_thread_trampoline <- __start_thread
```

## What it handles

- Nested names (`_ZN...E`) and plain function names; the argument list is dropped.
- Strips LLVM/GCC internal suffixes (`.__uniq.*`, `.llvm.*`, `.part.*`, `.cold`).
- **Conservative:** templates, substitutions, and kernel C symbols it can't confidently parse are returned **verbatim** — it never corrupts a name.

## Test plan

- New `test/android-perfetto/demangle.test.ts` (10 cases incl. fallbacks).
- Updated `function-callers.test.ts` to expect the demangled leaf in the substring-match note.
- `npm test -w @argent/tool-server` — all pass; build + `typecheck:tests` clean.

> Part of a set of native-profiler fixes. Note: this and #338 both touch the `hang_stacks` sample renderer — whichever merges second needs a trivial rebase.
