### PR TITLE
feat(android): drive connected physical Android devices

### DIFF
--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -472,6 +472,20 @@ for (const platform of SUPPORTED_HOST_PLATFORMS) {
     fs.copyFileSync(src, dest);
     fs.chmodSync(dest, 0o755);
     console.log(`✓ Copied simulator-server (${platform}) → ${path.relative(process.cwd(), dest)}`);
+    // Ship the screen-sharing agent resources (jar + per-ABI .so) that the
+    // `android_device` controller pushes to a connected phone. They sit at
+    // <platform>/resources/android/ next to the binary (the simulator-server
+    // resolves them relative to its working directory, which the spawn sets to
+    // its own platform dir). download-simulator-server.sh extracts them there;
+    // optional because physical-device support degrades gracefully without them.
+    const resourcesSrc = path.join(BIN_SRC_ROOT, platform, "resources");
+    if (fs.existsSync(resourcesSrc)) {
+      const resourcesDest = path.join(destDir, "resources");
+      fs.cpSync(resourcesSrc, resourcesDest, { recursive: true });
+      console.log(
+        `✓ Copied screen-sharing agent resources (${platform}) → ${path.relative(process.cwd(), resourcesDest)}`
+      );
+    }
   } else if (platform === "darwin" && process.platform === "darwin") {
     throw new Error(
       `simulator-server binary not found at ${src}.\n` +

--- a/packages/tool-server/src/blueprints/simulator-server.ts
+++ b/packages/tool-server/src/blueprints/simulator-server.ts
@@ -57,9 +57,21 @@ export interface SimulatorServerApi {
 // per-tool zod schemas and the /preview device-list check.
 const SAFE_SIMULATOR_DEVICE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 
+/**
+ * The simulator-server subcommand that drives a given device. iOS simulators and
+ * Android emulators each have their own controller; a physical Android phone is
+ * a third controller (`android_device`) that runs the screen-sharing agent over
+ * adb and decodes its H264 stream, so it is selected by `kind === "device"`
+ * rather than by platform alone.
+ */
+function subcommandForDevice(device: DeviceInfo): "ios" | "android" | "android_device" {
+  if (device.platform === "ios") return "ios";
+  return device.kind === "device" ? "android_device" : "android";
+}
+
 function spawnSimulatorServerProcess(
   udid: string,
-  platform: "ios" | "android"
+  subcommand: "ios" | "android" | "android_device"
 ): Promise<{
   proc: ChildProcess;
   apiUrl: string;
@@ -72,7 +84,7 @@ function spawnSimulatorServerProcess(
   }
   const { BINARY_PATH, BINARY_DIR } = getPaths();
   return new Promise((resolve, reject) => {
-    const args = [platform, "--id", udid];
+    const args = [subcommand, "--id", udid];
 
     const proc = spawn(BINARY_PATH, args, {
       cwd: BINARY_DIR,
@@ -177,6 +189,8 @@ export const simulatorServerBlueprint: ServiceBlueprint<SimulatorServerApi, Devi
     if (device.platform === "ios") {
       await ensureAutomationEnabled(device.id).catch(() => {});
     } else if (device.platform === "android") {
+      // Both the emulator and the physical-device controller talk to the target
+      // through adb (gRPC bridge / screen-sharing agent respectively).
       await ensureDep("adb");
     } else {
       // The simulator-server binary only knows iOS and Android. Other platforms
@@ -189,7 +203,7 @@ export const simulatorServerBlueprint: ServiceBlueprint<SimulatorServerApi, Devi
 
     const { proc, apiUrl, streamUrl } = await spawnSimulatorServerProcess(
       device.id,
-      device.platform
+      subcommandForDevice(device)
     );
 
     const events = new TypedEventEmitter<ServiceEvents>();

--- a/packages/tool-server/src/tools/describe/platforms/android/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/index.ts
@@ -1,6 +1,7 @@
 import type { Registry, ToolDependency } from "@argent/registry";
 import type { DescribeTreeData } from "../../contract";
 import { adbExecOutBinary } from "../../../../utils/adb";
+import { resolveDevice } from "../../../../utils/device-info";
 import { getAndroidScreenSize } from "../../../../utils/android-screen";
 import { parseUiAutomatorDump } from "./uiautomator-parser";
 import {
@@ -24,7 +25,10 @@ export async function describeAndroid(
 ): Promise<DescribeTreeData> {
   if (registry) {
     try {
-      const device = { id: serial, platform: "android" as const, kind: "emulator" as const };
+      // The android-devtools helper is driven entirely over adb, so it works the
+      // same on an emulator or a physical device; resolve the real kind anyway so
+      // the handle is accurate (and so a physical serial isn't mislabelled).
+      const device = resolveDevice(serial);
       const ref = androidDevtoolsRef(device);
       const devtools = await registry.resolveService<AndroidDevtoolsApi>(ref.urn, ref.options);
       const [{ xml }, size] = await Promise.all([

--- a/packages/tool-server/src/tools/devices/list-devices.ts
+++ b/packages/tool-server/src/tools/devices/list-devices.ts
@@ -11,6 +11,11 @@ type AndroidDevice = {
   serial: string;
   state: string;
   isEmulator: boolean;
+  // "emulator" for a local AVD, "device" for a physical phone (USB or wireless
+  // adb). The two are driven by different simulator-server controllers, so the
+  // kind is surfaced here for parity with iOS terminology and so consumers can
+  // tell a connected phone apart from an emulator at a glance.
+  kind: "emulator" | "device";
   model: string | null;
   avdName: string | null;
   sdkLevel: number | null;
@@ -51,9 +56,10 @@ const zodSchema = z.object({});
 
 export const listDevicesTool: ToolDefinition<Record<string, never>, ListDevicesResult> = {
   id: "list-devices",
-  description: `List iOS simulators, Android devices/emulators, and running Chromium apps in one place.
+  description: `List iOS simulators, Android emulators, connected physical Android devices, and running Chromium apps in one place.
 Use at the start of a session to pick a target id ('udid' for iOS entries, 'serial' for Android, 'id' for Chromium) to pass to interaction tools, and to see which targets are already running.
 Returns { devices, avds } where each device carries a 'platform' discriminator ('ios', 'android', or 'chromium'), and 'avds' lists Android AVDs that can be booted via boot-device.
+Android entries also carry a 'kind' ('emulator' for a local AVD, 'device' for a physical phone connected over USB / wireless adb) — physical phones are detected from \`adb devices\` (any serial that is not an \`emulator-*\` one) and are driven through the same interaction tools as emulators; they do not need boot-device (just connect the phone with USB debugging authorised).
 Chromium apps are discovered by probing CDP debugging ports (default 9222; extend via the ARGENT_CHROMIUM_PORTS=<comma-separated-ports> env var). They must already be running with --remote-debugging-port=<port> — use boot-device with chromiumAppPath to launch one.
 Booted/ready devices are listed first. Platforms whose CLI is unavailable are silently omitted — an empty result usually means xcode-select or Android platform-tools is not installed.`,
   alwaysLoad: true,
@@ -75,6 +81,7 @@ Booted/ready devices are listed first. Platforms whose CLI is unavailable are si
       serial: d.serial,
       state: d.state,
       isEmulator: d.isEmulator,
+      kind: d.isEmulator ? "emulator" : "device",
       model: d.model,
       avdName: d.avdName,
       sdkLevel: d.sdkLevel,

--- a/packages/tool-server/src/utils/device-info.ts
+++ b/packages/tool-server/src/utils/device-info.ts
@@ -20,14 +20,39 @@ export function classifyDevice(udid: string): Platform {
 }
 
 /**
+ * Distinguish a physical Android phone from an emulator by serial shape. Local
+ * emulators always register with adb as `emulator-<port>` (set by the emulator
+ * itself), so any other Android serial — a USB device's hardware serial, or an
+ * `ip:port` from wireless debugging — is a physical device. This mirrors how
+ * radon detects connected phones (it filters the `emulator-` prefix out of
+ * `adb devices`) and, like the rest of this module, stays purely shape-based so
+ * it adds no `adb` round-trip on the hot path.
+ *
+ * The distinction matters because the two are driven by different
+ * simulator-server controllers: emulators stream decoded RGB over the emulator
+ * gRPC bridge (`android` subcommand), while physical devices run the
+ * screen-sharing agent and stream H264 over adb (`android_device` subcommand).
+ */
+export function isAndroidEmulatorSerial(serial: string): boolean {
+  return serial.startsWith("emulator-");
+}
+
+/**
  * Build a `DeviceInfo` from a raw udid. Fills the platform and a default kind
- * ('simulator' for iOS, 'emulator' for Android, 'app' for Chromium) — platform
- * impls can enrich with name/state/sdkLevel via simctl/adb if needed.
+ * ('simulator' for iOS, 'emulator'/'device' for Android by serial shape, 'app'
+ * for Chromium) — platform impls can enrich with name/state/sdkLevel via
+ * simctl/adb if needed.
  */
 export function resolveDevice(udid: string): DeviceInfo {
   const platform = classifyDevice(udid);
   const kind: DeviceKind =
-    platform === "ios" ? "simulator" : platform === "android" ? "emulator" : "app";
+    platform === "ios"
+      ? "simulator"
+      : platform === "android"
+        ? isAndroidEmulatorSerial(udid)
+          ? "emulator"
+          : "device"
+        : "app";
   return { id: udid, platform, kind };
 }
 

--- a/packages/tool-server/test/device-info.test.ts
+++ b/packages/tool-server/test/device-info.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { classifyDevice, resolveDevice } from "../src/utils/device-info";
+import { classifyDevice, isAndroidEmulatorSerial, resolveDevice } from "../src/utils/device-info";
 
 describe("classifyDevice", () => {
   it("classifies iOS simulator UUIDs as ios", () => {
@@ -21,9 +21,29 @@ describe("resolveDevice", () => {
     expect(d.id).toBe("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA");
   });
 
-  it("returns android+emulator for an adb serial", () => {
+  it("returns android+emulator for an emulator serial", () => {
     const d = resolveDevice("emulator-5554");
     expect(d.platform).toBe("android");
     expect(d.kind).toBe("emulator");
+  });
+
+  it("returns android+device for a physical phone's USB serial", () => {
+    const d = resolveDevice("HT82A0203045");
+    expect(d.platform).toBe("android");
+    expect(d.kind).toBe("device");
+  });
+
+  it("returns android+device for a wireless-adb ip:port serial", () => {
+    const d = resolveDevice("192.168.1.5:5555");
+    expect(d.platform).toBe("android");
+    expect(d.kind).toBe("device");
+  });
+});
+
+describe("isAndroidEmulatorSerial", () => {
+  it("is true only for emulator-* serials", () => {
+    expect(isAndroidEmulatorSerial("emulator-5554")).toBe(true);
+    expect(isAndroidEmulatorSerial("HT82A0203045")).toBe(false);
+    expect(isAndroidEmulatorSerial("192.168.1.5:5555")).toBe(false);
   });
 });

--- a/packages/tool-server/test/screenshot-diff-tool.test.ts
+++ b/packages/tool-server/test/screenshot-diff-tool.test.ts
@@ -46,7 +46,8 @@ describe("screenshotDiffTool", () => {
           device: {
             id: "ABC",
             platform: "android",
-            kind: "emulator",
+            // A non-`emulator-*` serial resolves to a physical device.
+            kind: "device",
           },
         },
       },

--- a/packages/tool-server/test/simulator-server-blueprint.test.ts
+++ b/packages/tool-server/test/simulator-server-blueprint.test.ts
@@ -138,6 +138,25 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
     expect(spawnMock.mock.calls[0]![1]).toEqual(["android", "--id", serial]);
   });
 
+  it("spawns the `android_device` subcommand for a physical Android device", async () => {
+    // A physical phone (kind 'device') is driven by a different simulator-server
+    // controller than an emulator — the screen-sharing-agent path. The blueprint
+    // selects it by kind, so the rest of the tool surface stays identical.
+    const fakeProc = makeFakeProc();
+    spawnMock.mockReturnValue(fakeProc);
+
+    const { simulatorServerBlueprint } = await import("../src/blueprints/simulator-server");
+
+    const serial = "HT82A0203045";
+    const device: DeviceInfo = { id: serial, platform: "android", kind: "device" };
+    const factoryPromise = simulatorServerBlueprint.factory({}, device, { device });
+    signalReady(fakeProc, 55559);
+    await factoryPromise;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock.mock.calls[0]![1]).toEqual(["android_device", "--id", serial]);
+  });
+
   it("trusts the supplied DeviceInfo and does not reclassify the id", async () => {
     // Single-source-of-truth: the blueprint must not run resolveDevice itself.
     // If a caller passes an Android device whose id happens to look like an

--- a/scripts/download-simulator-server.sh
+++ b/scripts/download-simulator-server.sh
@@ -96,6 +96,45 @@ echo ""
 echo "Downloaded simulator-server binaries:"
 find "${DEST_DIR}" -name simulator-server -type f -exec ls -la {} \;
 
+# Physical-Android-device support: the simulator-server `android_device`
+# controller pushes the screen-sharing agent (a host-independent .jar + a
+# per-ABI .so) to the phone over adb, resolving them at runtime from
+# `resources/android/` relative to its working directory — which the blueprint
+# sets to the binary's own platform dir. The agent payload runs on the phone,
+# not the host, so a single release tarball serves every host platform; extract
+# a copy next to each downloaded binary. Tolerate a missing asset the same way
+# as a missing binary so macOS/Linux-only consumers and older releases (before
+# the agent was published) still work — physical-device support just won't be
+# available until the asset is present.
+AGENT_ASSET="screen-sharing-agent.tar.gz"
+AGENT_TMP="$(mktemp -d)"
+echo ""
+echo "Downloading ${AGENT_ASSET} (Android physical-device screen-sharing agent)"
+GH_STDERR="$(mktemp)"
+if gh release download "${TAG}" \
+     --repo "${REPO}" \
+     --pattern "${AGENT_ASSET}" \
+     --dir "${AGENT_TMP}" \
+     --clobber 2>"${GH_STDERR}"; then
+  rm -f "${GH_STDERR}"
+  # Extract once into every platform dir that actually has a binary, so the
+  # agent sits at <platform>/resources/android/ next to simulator-server.
+  while IFS= read -r bin; do
+    plat_dir="$(dirname "${bin}")"
+    res_dir="${plat_dir}/resources/android"
+    rm -rf "${res_dir}"
+    mkdir -p "${res_dir}"
+    tar -xzf "${AGENT_TMP}/${AGENT_ASSET}" -C "${res_dir}"
+    echo "  ✓ screen-sharing agent → ${res_dir}"
+  done < <(find "${DEST_DIR}" -name simulator-server -type f)
+else
+  GH_MSG=$(<"${GH_STDERR}")
+  rm -f "${GH_STDERR}"
+  echo "  ⚠ ${AGENT_ASSET} not downloaded — physical Android device support will be unavailable"
+  [[ -n "${GH_MSG}" ]] && printf '    gh: %s\n' "${GH_MSG//$'\n'/$'\n    gh: '}"
+fi
+rm -rf "${AGENT_TMP}"
+
 # Only the macOS binary is signed and codesignable; the Linux ELF doesn't
 # carry an Apple signature, and `codesign` would noisily fail on it.
 if command -v codesign &>/dev/null && [[ -f "${DEST_DIR}/darwin/simulator-server" ]]; then


### PR DESCRIPTION
## What

Adds support for driving a **physically connected Android phone** (USB or wireless adb), not just emulators. Once a phone with USB debugging is attached, it shows up in `list-devices` and every existing interaction tool works against it — no new tools, no per-tool special-casing.

## How it works

A physical phone is driven by a different simulator-server controller than an emulator: it deploys the Android Studio **screen-sharing agent** to the device and streams **H264 over adb** (`android_device` subcommand), whereas an emulator streams decoded RGB over the emulator gRPC bridge (`android` subcommand). Both controllers expose the **same** HTTP/WebSocket/stdin API, so the only thing that has to change on the argent side is *which subcommand the device's service blueprint spawns*. Everything downstream — `screenshot`, the `gesture-*` family, `button`, `keyboard` (simulator-server) and `describe`, `launch-app`, `restart-app`, `reinstall-app`, `open-url` (adb) — is unchanged.

- **Classification** (`utils/device-info.ts`): a non-`emulator-*` Android serial (a USB hardware serial, or an `ip:port` from wireless debugging) resolves to kind `device` instead of `emulator`, purely from serial shape — the same signal radon uses to detect connected phones, and with no extra adb round-trip on the hot path. New `isAndroidEmulatorSerial` helper.
- **Routing** (`blueprints/simulator-server.ts`): spawn `android_device --id <serial>` for kind `device`, `android` for an emulator, `ios` for a simulator. The capability matrix already declared `android.device: true` across the tools, so nothing else gates physical devices out.
- **Surfacing** (`tools/devices/list-devices.ts`): Android entries now carry a `kind` (`"emulator"` | `"device"`); the tool description documents physical-device detection. Physical phones don't need `boot-device` — just connect them.
- **describe/android**: resolves the real device kind instead of hard-coding `emulator` (the adb path is identical either way).
- **Packaging**: `download-simulator-server.sh` fetches and `bundle-tools.cjs` ships the screen-sharing agent (`.jar` + per-ABI `.so`) next to each platform's simulator-server binary, where the `android_device` controller resolves it at runtime.

## Dependencies (draft)

This is a **draft** because it assumes the matching simulator-server changes land and publish:

- **software-mansion/radon#128** — Linux/cross-platform OpenH264 H264 *decoder* for the `android_device` controller (macOS keeps VideoToolbox). Gives the argent-built binary a decoder on every host.
- **software-mansion/radon#127** — enables `android-device` in `argent` builds and publishes the `screen-sharing-agent.tar.gz` release asset that the download script consumes.

Until those release artifacts are available, the download step degrades gracefully (warns, skips) and physical-device support is simply unavailable.

## Testing

Verified end-to-end against a physical **Galaxy S24** (`arm64-v8a`, Android API 36) by running the tool-server against a locally built argent simulator-server (radon#128) with the agent resources staged:

| tool | path exercised | result |
|------|----------------|--------|
| `list-devices` | adb | phone listed as `kind: "device"`, `isEmulator: false` |
| `screenshot` | screen-sharing agent → H264 → VideoToolbox decode | ✅ correct, correctly-oriented PNG |
| `button` (home) | simulator-server stdin `pressKey` | ✅ |
| `gesture-swipe` | simulator-server WebSocket touch | ✅ |
| `describe` | adb (android-devtools) | ✅ |

Full tool-server unit suite: **1157 passed**. Added coverage for the new classification (`device-info.test.ts`) and the `android_device` subcommand routing (`simulator-server-blueprint.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)