### PR TITLE
fix(profiler): enable native stack-query and combined-report on Android

### DIFF
--- a/packages/tool-server/src/tools/profiler/combined/profiler-combined-report.ts
+++ b/packages/tool-server/src/tools/profiler/combined/profiler-combined-report.ts
@@ -25,7 +25,7 @@ import { readCpuProfile, readCommitTree } from "../../../utils/react-profiler/de
 
 const zodSchema = z.object({
   port: z.coerce.number().default(8081).describe("Metro server port"),
-  device_id: z.string().describe("iOS Simulator or device UDID"),
+  device_id: z.string().describe("iOS Simulator/device UDID or Android serial"),
 });
 
 interface HangCommitCorrelation {
@@ -48,9 +48,13 @@ Call this tool when both profilers were run in parallel on the same session.
 Returns a markdown report correlating hangs with React commits, memory leaks, and investigation hints.
 Fails if either react-profiler-analyze or native-profiler-analyze has not been called first.`,
   zodSchema,
-  // iOS-only: combines React (Hermes) + iOS native (xctrace) traces. The
-  // capture half exists on neither Android nor Chromium.
-  capability: { apple: { simulator: true, device: true } },
+  // Combines React (Hermes) + native traces. iOS reads xctrace output;
+  // Android re-queries the Perfetto .pftrace via loadAndroidCombinedData. The
+  // capture half exists on neither platform's Chromium.
+  capability: {
+    apple: { simulator: true, device: true },
+    android: { emulator: true, device: true, unknown: true },
+  },
   services: (params) => ({
     nativeSession: nativeProfilerSessionRef(resolveDevice(params.device_id)),
   }),

--- a/packages/tool-server/src/tools/profiler/combined/profiler-combined-report.ts
+++ b/packages/tool-server/src/tools/profiler/combined/profiler-combined-report.ts
@@ -67,8 +67,14 @@ Fails if either react-profiler-analyze or native-profiler-analyze has not been c
     let uiHangs: UiHang[];
     let memoryLeaks: MemoryLeak[];
     if (nativeApi.platform === "android") {
-      if (!nativeApi.traceFile) {
-        throw new Error("No native profiler data. Run native-profiler-analyze first.");
+      // Gate on the exported .pftrace (set at stop), not just traceFile (set at
+      // start) -- otherwise a session that started native profiling but never ran
+      // stop/analyze would silently render an empty "0 hangs" report instead of
+      // this clear error. Mirrors profiler-stack-query's Android gate.
+      if (!nativeApi.exportedFiles?.pftrace || !nativeApi.traceFile) {
+        throw new Error(
+          "No Android trace loaded. Run native-profiler-stop → native-profiler-analyze first."
+        );
       }
       const data = await loadAndroidCombinedData(nativeApi.traceFile, nativeApi.appProcess ?? "");
       uiHangs = data.uiHangs;

--- a/packages/tool-server/src/tools/profiler/query/profiler-stack-query.ts
+++ b/packages/tool-server/src/tools/profiler/query/profiler-stack-query.ts
@@ -357,9 +357,13 @@ Use when drilling into native hang stacks, thread CPU breakdown, or memory leaks
 Returns a markdown report with native call stacks, thread weights, or leak details for the selected mode.
 Fails if native-profiler-analyze has not been run or no parsed trace data is in memory.`,
   zodSchema,
-  // iOS-only: reads xctrace output. Android native profiling is on the roadmap;
-  // Chromium has no native trace capture.
-  capability: { apple: { simulator: true, device: true } },
+  // iOS: reads xctrace output. Android: queries the Perfetto .pftrace via the
+  // in-process trace-processor engine (see executeAndroid). Chromium has no
+  // native trace capture.
+  capability: {
+    apple: { simulator: true, device: true },
+    android: { emulator: true, device: true, unknown: true },
+  },
   services: (params) => ({
     session: nativeProfilerSessionRef(resolveDevice(params.device_id)),
   }),

--- a/packages/tool-server/test/android-perfetto/profiler-query-android-capability.test.ts
+++ b/packages/tool-server/test/android-perfetto/profiler-query-android-capability.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { assertSupported } from "../../src/utils/capability";
+import type { DeviceInfo } from "@argent/registry";
+
+// runAndroidStackQuery is stubbed so the leak_stacks guard test never touches a
+// real .pftrace. It should never be called for leak_stacks (the guard returns
+// early), so we make it throw to prove the early return.
+vi.mock("../../src/utils/android-profiler/pipeline/index", async (importActual) => ({
+  ...(await importActual<typeof import("../../src/utils/android-profiler/pipeline/index")>()),
+  runAndroidStackQuery: vi.fn(async () => {
+    throw new Error("runAndroidStackQuery should not be reached for leak_stacks on Android");
+  }),
+}));
+
+import { profilerStackQueryTool } from "../../src/tools/profiler/query/profiler-stack-query";
+import { profilerCombinedReportTool } from "../../src/tools/profiler/combined/profiler-combined-report";
+import type { NativeProfilerSessionApi } from "../../src/blueprints/native-profiler-session";
+
+const iosSim: DeviceInfo = { id: "ios-sim", platform: "ios", kind: "simulator" };
+const iosDevice: DeviceInfo = { id: "ios-dev", platform: "ios", kind: "device" };
+const androidEmu: DeviceInfo = { id: "emulator-5554", platform: "android", kind: "emulator" };
+const androidDevice: DeviceInfo = { id: "android-dev", platform: "android", kind: "device" };
+const androidUnknown: DeviceInfo = { id: "android-unknown", platform: "android", kind: "unknown" };
+
+describe("profiler-stack-query / profiler-combined-report Android capability", () => {
+  // Both tools ship complete Android implementations (executeAndroid /
+  // loadAndroidCombinedData). These tests pin the capability so the Android
+  // path can actually be reached by the dispatcher.
+  for (const tool of [profilerStackQueryTool, profilerCombinedReportTool]) {
+    describe(tool.id, () => {
+      it("is supported on Android emulator / device / unknown", () => {
+        expect(() => assertSupported(tool.id, tool.capability, androidEmu)).not.toThrow();
+        expect(() => assertSupported(tool.id, tool.capability, androidDevice)).not.toThrow();
+        expect(() => assertSupported(tool.id, tool.capability, androidUnknown)).not.toThrow();
+      });
+
+      it("is still supported on Apple simulator + device", () => {
+        expect(() => assertSupported(tool.id, tool.capability, iosSim)).not.toThrow();
+        expect(() => assertSupported(tool.id, tool.capability, iosDevice)).not.toThrow();
+      });
+    });
+  }
+});
+
+describe("profiler-stack-query leak_stacks on Android", () => {
+  it("returns the iOS-only guidance message without querying the trace", async () => {
+    const api: Partial<NativeProfilerSessionApi> = {
+      platform: "android",
+      traceFile: "/fake.pftrace",
+      exportedFiles: { pftrace: "/fake.pftrace" },
+      appProcess: "com.example.app",
+    };
+
+    const out = await profilerStackQueryTool.execute({ session: api } as never, {
+      device_id: androidEmu.id,
+      mode: "leak_stacks",
+      top_n: 15,
+    });
+
+    expect(out).toContain("Memory leak detection is not yet supported on Android");
+    expect(out).toContain("adb shell am dumpheap");
+  });
+});

--- a/packages/tool-server/test/android-perfetto/profiler-query-android-trace-gate.test.ts
+++ b/packages/tool-server/test/android-perfetto/profiler-query-android-trace-gate.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Both gates short-circuit BEFORE any .pftrace query, so the Android pipeline
+// helpers are stubbed to throw: if a gate were missing, the tool would reach
+// loadAndroidCombinedData / runAndroidStackQuery and we'd see that explosion
+// instead of the expected "No Android trace loaded" error.
+vi.mock("../../src/utils/android-profiler/pipeline/index", async (importActual) => ({
+  ...(await importActual<typeof import("../../src/utils/android-profiler/pipeline/index")>()),
+  loadAndroidCombinedData: vi.fn(async () => {
+    throw new Error("loadAndroidCombinedData should not be reached when the trace gate trips");
+  }),
+  runAndroidStackQuery: vi.fn(async () => {
+    throw new Error("runAndroidStackQuery should not be reached when the trace gate trips");
+  }),
+}));
+
+import { profilerStackQueryTool } from "../../src/tools/profiler/query/profiler-stack-query";
+import { profilerCombinedReportTool } from "../../src/tools/profiler/combined/profiler-combined-report";
+import type { NativeProfilerSessionApi } from "../../src/blueprints/native-profiler-session";
+
+const DEVICE_ID = "emulator-5554";
+
+// traceFile is set at native-profiler-start; exportedFiles.pftrace is only set
+// once native-profiler-stop has exported the trace. A session that started but
+// never stopped/analyzed therefore has traceFile WITHOUT exportedFiles.pftrace —
+// the exact state both gates guard against (so the tools error clearly instead
+// of rendering an empty "0 hangs" report off an unexported trace).
+const startedButNotStopped: Partial<NativeProfilerSessionApi> = {
+  platform: "android",
+  traceFile: "/fake.pftrace",
+  exportedFiles: undefined,
+  appProcess: "com.example.app",
+  wallClockStartMs: 1_700_000_000_000,
+};
+
+const GATE_MESSAGE =
+  "No Android trace loaded. Run native-profiler-stop → native-profiler-analyze first.";
+
+describe("profiler-combined-report Android trace gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws the trace-not-loaded error when exportedFiles.pftrace is absent (does not render an empty report)", async () => {
+    await expect(
+      profilerCombinedReportTool.execute({ nativeSession: startedButNotStopped } as never, {
+        port: 8081,
+        device_id: DEVICE_ID,
+      })
+    ).rejects.toThrow(GATE_MESSAGE);
+  });
+});
+
+describe("profiler-stack-query Android trace gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // thread_breakdown is a non-leak Android mode, so it would normally fall
+  // through to runAndroidStackQuery — the gate at executeAndroid must trip first.
+  it("throws the trace-not-loaded error for thread_breakdown when exportedFiles.pftrace is absent", async () => {
+    await expect(
+      profilerStackQueryTool.execute({ session: startedButNotStopped } as never, {
+        device_id: DEVICE_ID,
+        mode: "thread_breakdown",
+        top_n: 15,
+      })
+    ).rejects.toThrow(GATE_MESSAGE);
+  });
+
+  it("also gates leak_stacks (which would otherwise short-circuit to the iOS-only message)", async () => {
+    await expect(
+      profilerStackQueryTool.execute({ session: startedButNotStopped } as never, {
+        device_id: DEVICE_ID,
+        mode: "leak_stacks",
+        top_n: 15,
+      })
+    ).rejects.toThrow(GATE_MESSAGE);
+  });
+});

--- a/packages/tool-server/test/android-perfetto/stack-query-modes.test.ts
+++ b/packages/tool-server/test/android-perfetto/stack-query-modes.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Same mock harness as function-callers.test.ts: runTpQuery is stubbed to pop
+// planned responses in order (matched by query name), and we record each call so
+// we can assert which .sql files ran and with what substitutions. No real
+// .pftrace is ever touched.
+const queryResponses: Array<{ name: string; rows: unknown[] }> = [];
+const calls: Array<{ query: string; substitutions: Record<string, string> }> = [];
+
+vi.mock("@argent/native-devtools-android", () => {
+  const path = require("node:path");
+  return {
+    ensureTraceProcessorReady: vi.fn(async () => {}),
+    traceProcessorQueriesDir: () =>
+      path.resolve(__dirname, "../../../native-devtools-android/assets/queries"),
+  };
+});
+vi.mock("../../src/utils/android-profiler/pipeline/run-tp", async (importActual) => ({
+  ...(await importActual<typeof import("../../src/utils/android-profiler/pipeline/run-tp")>()),
+  runTpQuery: vi.fn(async (opts: { query: string; substitutions: Record<string, string> }) => {
+    calls.push({ query: opts.query, substitutions: opts.substitutions });
+    const next = queryResponses.shift();
+    if (!next) throw new Error(`runTpQuery called for "${opts.query}" with no queued response`);
+    if (next.name !== opts.query) {
+      throw new Error(`runTpQuery expected "${next.name}" but got "${opts.query}"`);
+    }
+    return next.rows;
+  }),
+  runTpInline: vi.fn(async () => []),
+  parseTpJsonOutput: vi.fn(),
+}));
+
+import { runAndroidStackQuery } from "../../src/utils/android-profiler/pipeline/index";
+
+const PKG = "com.example.app";
+
+beforeEach(() => {
+  queryResponses.length = 0;
+  calls.length = 0;
+});
+
+describe("hang_stacks mode (renderHangStacksAndroid)", () => {
+  function jankRow(kind: "anr" | "jank", ts_ns: number, dur_ns: number, reason: string | null) {
+    return { kind, ts_ns, dur_ns, process_name: PKG, reason, error_id: null };
+  }
+
+  it("renders state breakdown + deduped main-thread samples for a valid hang_index", async () => {
+    queryResponses.push(
+      {
+        name: "ui-hangs.sql",
+        rows: [jankRow("jank", 5_000_000, 250_000_000, "App Deadline Missed")],
+      },
+      {
+        name: "hang-state-breakdown.sql",
+        rows: [
+          {
+            state: "Uninterruptible Sleep",
+            blocked_function: "do_page_fault",
+            total_dur_ns: 180_000_000,
+            occurrences: 3,
+          },
+          { state: "Runnable", blocked_function: null, total_dur_ns: 70_000_000, occurrences: 5 },
+        ],
+      },
+      {
+        name: "hang-main-thread-samples.sql",
+        rows: [
+          { ts_ns: 5_100_000, callstack_text: "main <- onDraw <- inflate" },
+          { ts_ns: 5_200_000, callstack_text: "main <- onDraw <- inflate" },
+          { ts_ns: 5_300_000, callstack_text: "main <- measure" },
+          { ts_ns: 5_400_000, callstack_text: null },
+        ],
+      }
+    );
+
+    const out = await runAndroidStackQuery({
+      tracePath: "/fake.pftrace",
+      mode: "hang_stacks",
+      appPackage: PKG,
+      hangIndex: 0,
+      topN: 15,
+    });
+
+    expect(calls.map((c) => c.query)).toEqual([
+      "ui-hangs.sql",
+      "hang-state-breakdown.sql",
+      "hang-main-thread-samples.sql",
+    ]);
+    // Header: hang #0, kind, duration in ms, and reason.
+    expect(out).toContain("## Hang #0 — jank (250ms)");
+    expect(out).toContain("reason: `App Deadline Missed`");
+    // State breakdown table: ns → ms, null blocked_function → em dash.
+    expect(out).toContain("### Main-thread State Breakdown");
+    expect(out).toContain("| Uninterruptible Sleep | `do_page_fault` | 180ms |");
+    expect(out).toContain("| Runnable | — | 70ms |");
+    // Samples deduped by callstack_text; the null-callstack row is dropped, and
+    // the repeated stack collapses into a single (2×) block.
+    expect(out).toContain("### Main-thread Samples During Hang");
+    expect(out).toContain("(2×)");
+    expect(out).toContain("main <- onDraw <- inflate");
+    expect(out).toContain("(1×)");
+    expect(out).toContain("main <- measure");
+  });
+
+  it("returns the out-of-range guard message for an invalid hang_index without querying state/samples", async () => {
+    queryResponses.push({
+      name: "ui-hangs.sql",
+      rows: [jankRow("jank", 5_000_000, 120_000_000, null)],
+    });
+
+    const out = await runAndroidStackQuery({
+      tracePath: "/fake.pftrace",
+      mode: "hang_stacks",
+      appPackage: PKG,
+      hangIndex: 7,
+      topN: 15,
+    });
+
+    // Only the hang list is queried; the guard returns before state/sample queries.
+    expect(calls.map((c) => c.query)).toEqual(["ui-hangs.sql"]);
+    expect(out).toBe("_Invalid hang_index 7. There are 1 hangs (0-indexed)._");
+  });
+
+  it("throws when hang_index is omitted (the parameter is required for hang_stacks)", async () => {
+    await expect(
+      runAndroidStackQuery({
+        tracePath: "/fake.pftrace",
+        mode: "hang_stacks",
+        appPackage: PKG,
+        topN: 15,
+      })
+    ).rejects.toThrow("hang_stacks mode requires the hang_index parameter.");
+    // The guard runs before any query.
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("thread_breakdown mode (renderThreadBreakdownAndroid)", () => {
+  function threadRow(
+    thread_name: string,
+    sample_count: number,
+    pct_of_app: number,
+    is_main_thread: 0 | 1
+  ) {
+    return { thread_name, is_main_thread, sample_count, pct_of_app };
+  }
+
+  it("renders all threads as a table when no filter is given", async () => {
+    queryResponses.push({
+      name: "thread-breakdown.sql",
+      rows: [threadRow(".blueskyweb.app", 4200, 70, 1), threadRow("FrameDecoderExe", 800, 13, 0)],
+    });
+
+    const out = await runAndroidStackQuery({
+      tracePath: "/fake.pftrace",
+      mode: "thread_breakdown",
+      appPackage: PKG,
+      topN: 15,
+    });
+
+    expect(calls.map((c) => c.query)).toEqual(["thread-breakdown.sql"]);
+    expect(out).toContain("## Thread CPU Breakdown");
+    expect(out).not.toContain("filter:");
+    expect(out).toContain("| .blueskyweb.app | 4200 | 70% | Yes |");
+    expect(out).toContain("| FrameDecoderExe | 800 | 13% | — |");
+  });
+
+  it("applies a case-insensitive substring filter and labels it in the header", async () => {
+    queryResponses.push({
+      name: "thread-breakdown.sql",
+      rows: [
+        threadRow(".blueskyweb.app", 4200, 70, 1),
+        threadRow("FrameDecoderExe", 800, 13, 0),
+        threadRow("FrameDecoderExe-2", 200, 3, 0),
+      ],
+    });
+
+    const out = await runAndroidStackQuery({
+      tracePath: "/fake.pftrace",
+      mode: "thread_breakdown",
+      appPackage: PKG,
+      thread: "framedecoder",
+      topN: 15,
+    });
+
+    expect(out).toContain('## Thread CPU Breakdown (filter: "framedecoder")');
+    expect(out).toContain("| FrameDecoderExe | 800 | 13% | — |");
+    expect(out).toContain("| FrameDecoderExe-2 | 200 | 3% | — |");
+    // The non-matching main thread is excluded.
+    expect(out).not.toContain(".blueskyweb.app");
+  });
+
+  it("returns the no-match message when a filter excludes every thread", async () => {
+    queryResponses.push({
+      name: "thread-breakdown.sql",
+      rows: [threadRow(".blueskyweb.app", 4200, 70, 1)],
+    });
+
+    const out = await runAndroidStackQuery({
+      tracePath: "/fake.pftrace",
+      mode: "thread_breakdown",
+      appPackage: PKG,
+      thread: "nosuchthread",
+      topN: 15,
+    });
+
+    expect(out).toBe('_No samples found for thread matching "nosuchthread"._');
+  });
+
+  it("returns the no-CPU-samples message when the query yields no rows and no filter", async () => {
+    queryResponses.push({ name: "thread-breakdown.sql", rows: [] });
+
+    const out = await runAndroidStackQuery({
+      tracePath: "/fake.pftrace",
+      mode: "thread_breakdown",
+      appPackage: PKG,
+      topN: 15,
+    });
+
+    expect(out).toBe("_No CPU samples available._");
+  });
+
+  it("caps the table at top_n rows", async () => {
+    queryResponses.push({
+      name: "thread-breakdown.sql",
+      rows: [
+        threadRow("thread-a", 100, 50, 0),
+        threadRow("thread-b", 80, 40, 0),
+        threadRow("thread-c", 20, 10, 0),
+      ],
+    });
+
+    const out = await runAndroidStackQuery({
+      tracePath: "/fake.pftrace",
+      mode: "thread_breakdown",
+      appPackage: PKG,
+      topN: 2,
+    });
+
+    expect(out).toContain("| thread-a | 100 | 50% | — |");
+    expect(out).toContain("| thread-b | 80 | 40% | — |");
+    expect(out).not.toContain("thread-c");
+  });
+});


### PR DESCRIPTION
## Problem

`profiler-stack-query` and `profiler-combined-report` reject Android devices with:

> Tool '…' is not supported on android emulator (no android support declared)

even though **both tools already contain complete, working Android implementations**:

- `profiler-stack-query` has `executeAndroid` (queries the Perfetto `.pftrace` via `runAndroidStackQuery`) and an `api.platform === "android"` dispatch branch.
- `profiler-combined-report` has an `api.platform === "android"` branch using `loadAndroidCombinedData` and `buildPerfettoAnchor`.

The only thing gating Android was the `capability` declaration: `{ apple: { simulator: true, device: true } }` with no `android` block. `assertSupported` (`packages/tool-server/src/utils/capability.ts`) throws `UnsupportedOperationError` for any platform without a declared block — so it rejected the device *before* the Android code path could run.

This was a broken workflow: the sibling `native-profiler-analyze` (which **does** declare Android support) and `profiler-load`'s `load_native` output both tell Android users to drill down with `profiler-stack-query` — which then refused.

## Fix

Add `android: { emulator: true, device: true, unknown: true }` to the `capability` of both tools, matching `native-profiler-analyze`. The existing `apple` block is unchanged. No code in the handlers needed to change — the Android paths were already there.

### `leak_stacks` on Android

`leak_stacks` mode is iOS-only. `executeAndroid` already guards it: it returns a clean guidance message (`"Memory leak detection is not yet supported on Android. … adb shell am dumpheap"`) *before* touching the trace, so enabling the capability does not let `leak_stacks` reach any crashing code path. A test pins this behavior.

## Tests

New `packages/tool-server/test/android-perfetto/profiler-query-android-capability.test.ts`:
- both tools are supported on Android emulator / device / unknown,
- both tools are still supported on Apple simulator + device,
- `profiler-stack-query` `leak_stacks` on Android returns the iOS-only guidance message without querying the trace.

## Verification

- `npm test -w @argent/tool-server` — 131 files, 1158 tests passed.
- `npm test --workspaces` — all package suites green.
- `npm run build` (`tsc --build`) — clean.
- `prettier --write` on changed files — no changes.