### PR TITLE
fix(installer): soften host project engine gate for npx skill install (#298)

### DIFF
--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -25,6 +25,7 @@ import {
   globalInstallCommand,
   formatShellCommand,
   resolveProjectRoot,
+  withNpmForce,
   type ShellCommand,
 } from "./utils.js";
 import { refreshArgentSkills, formatSkillRefreshSummary } from "./skills.js";
@@ -495,9 +496,13 @@ export async function init(args: string[]): Promise<void> {
       skillsArgs.push("--skill", "*", "-y");
     }
 
-    const npxArgs = offlineWithCache ? ["--no-install", ...skillsArgs] : skillsArgs;
+    const baseArgs = offlineWithCache ? ["--no-install", ...skillsArgs] : skillsArgs;
+    // The spawned command carries `--force` to soften the host project's npm
+    // engine gate (see withNpmForce / issue #298). The displayed and
+    // manual-fallback commands stay clean so users see the real `npx skills`.
+    const npxArgs = withNpmForce(baseArgs);
 
-    p.log.info(`Running: ${pc.dim("npx")} ${pc.cyan(npxArgs.join(" "))}`);
+    p.log.info(`Running: ${pc.dim("npx")} ${pc.cyan(baseArgs.join(" "))}`);
 
     const spinner = p.spinner();
     if (skillsMethod === "default") {

--- a/packages/argent-installer/src/skills.ts
+++ b/packages/argent-installer/src/skills.ts
@@ -7,6 +7,7 @@ import {
   getProjectSkillLockPath,
   listArgentSkillsInLock,
   listBundledSkills,
+  withNpmForce,
   SKILLS_DIR,
 } from "./utils.js";
 
@@ -84,7 +85,7 @@ export function refreshArgentSkills(projectRoot: string): SkillScopeResult[] {
 
     if (bundled.size > 0) {
       try {
-        execFileSync("npx", spec.buildAddArgs(primarySource), {
+        execFileSync("npx", withNpmForce(spec.buildAddArgs(primarySource)), {
           stdio: ["ignore", "pipe", "pipe"],
         });
         result.synced = bundled.size;
@@ -94,7 +95,7 @@ export function refreshArgentSkills(projectRoot: string): SkillScopeResult[] {
             primaryErr instanceof Error ? primaryErr.message.split("\n")[0] : String(primaryErr);
         } else {
           try {
-            execFileSync("npx", spec.buildAddArgs(SKILLS_DIR), {
+            execFileSync("npx", withNpmForce(spec.buildAddArgs(SKILLS_DIR)), {
               stdio: ["ignore", "pipe", "pipe"],
             });
             result.synced = bundled.size;
@@ -110,7 +111,7 @@ export function refreshArgentSkills(projectRoot: string): SkillScopeResult[] {
 
     if (orphaned.length > 0) {
       try {
-        execFileSync("npx", [...spec.removeArgs, ...orphaned], {
+        execFileSync("npx", withNpmForce([...spec.removeArgs, ...orphaned]), {
           stdio: ["ignore", "pipe", "pipe"],
         });
         result.pruned = orphaned;

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -448,9 +448,21 @@ export function isGloballyInstalled(): boolean {
   return getGlobalBinaryPath() !== null;
 }
 
+// Every `npx` call is `npm exec`, which evaluates the host project's
+// package.json `engines` / `devEngines` gate before running the command. A
+// project that pins a runtime the user's machine doesn't match — e.g. Bluesky's
+// `devEngines.runtime: { node: "^24.15.0" }` — otherwise aborts with
+// EBADDEVENGINES (exit 1) before the skills CLI ever runs, so `argent init`
+// can't install skills on an older Node (issue #298). `--force` downgrades that
+// gate to a non-fatal warning; we scope it to argent's own skills commands so
+// nothing else is affected.
+export function withNpmForce(npxArgs: string[]): string[] {
+  return ["--force", ...npxArgs];
+}
+
 export function isSkillsCliAvailable(): boolean {
   try {
-    execSync("npx --no-install skills --version", {
+    execSync("npx --force --no-install skills --version", {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: PROBE_TIMEOUT_MS,
     });

--- a/packages/argent-installer/test/skills.test.ts
+++ b/packages/argent-installer/test/skills.test.ts
@@ -86,10 +86,15 @@ describe("refreshArgentSkills", () => {
       { scope: "project", synced: 2, syncError: null, pruned: [], pruneError: null },
     ]);
     expect(execFileSyncMock).toHaveBeenCalledTimes(1);
-    const [bin, args] = execFileSyncMock.mock.calls[0]!;
+    const [bin, args] = execFileSyncMock.mock.calls[0]! as [string, string[]];
     expect(bin).toBe("npx");
     expect(args).toContain("add");
     expect(args).not.toContain("-g");
+    // The host project's npm engine gate (engines/devEngines) must be softened
+    // via `--force` so re-sync never aborts with EBADDEVENGINES (#298). The
+    // flag has to precede the `skills` command for npm to consume it.
+    expect(args.indexOf("--force")).toBe(0);
+    expect(args.indexOf("--force")).toBeLessThan(args.indexOf("skills"));
   });
 
   it("resyncs a tracked global scope with the -g flag", () => {

--- a/packages/argent-installer/test/utils.test.ts
+++ b/packages/argent-installer/test/utils.test.ts
@@ -527,13 +527,15 @@ describe("isSkillsCliAvailable", () => {
     execSyncMock.mockReset();
   });
 
-  it("returns true when `npx --no-install skills --version` exits successfully", () => {
+  it("probes `npx --force --no-install skills --version` and returns true on success", () => {
     execSyncMock.mockReturnValue(Buffer.from("0.1.0\n"));
 
     expect(isSkillsCliAvailable()).toBe(true);
     expect(execSyncMock).toHaveBeenCalledTimes(1);
     const [cmd] = execSyncMock.mock.calls[0]!;
-    expect(cmd).toBe("npx --no-install skills --version");
+    // `--force` softens the host project's npm engine gate so the probe can't
+    // hard-fail with EBADDEVENGINES in a devEngines-pinned repo (#298).
+    expect(cmd).toBe("npx --force --no-install skills --version");
   });
 
   it("returns false when the probe throws (skills CLI not in npx cache)", () => {


### PR DESCRIPTION
Fixes #298.

## Problem

`argent init` installs skills by shelling out to `npx skills add …`. Because `npx` is `npm exec`, npm first evaluates the nearest `package.json`'s `engines` / `devEngines` gate against the user's machine **before** running anything.

[Bluesky's `package.json`](https://github.com/bluesky-social/social-app/blob/main/package.json) declares:

```json
"devEngines": { "runtime": { "name": "node", "version": "^24.15.0", "onFail": "download" } }
```

When the user's Node doesn't satisfy `^24.15.0` (common on Linux), npm aborts with **`EBADDEVENGINES` (exit 1)** — even with `onFail: "warn"`/`"download"` (npm doesn't honor `"download"` and treats a runtime mismatch as a hard error). The skills CLI never runs, so **skills don't install**. On a machine running Node 24.x it only prints a warning, which masked the failure — that's why it reproduced on Linux but not for everyone.

This breaks all three argent code paths that go through `npx`: `isSkillsCliAvailable()`, the `init.ts` skill install, and `refreshArgentSkills()`. (`npm install -g` for argent's own self-update is **not** affected — only `npm exec`/`npx` consults the host project's gate.)

> #292 only suppressed the cosmetic npm stderr in `getLatestVersion`; this is the "larger issue" the reporter flagged — the actual install failure.

## Why `--force`

npm has **no flag to disable a `devEngines` check**. `engine-strict` governs only the `engines` field, there is no `--ignore-engines`, and the npm maintainers have not added a skip option ([npm/cli#8003](https://github.com/npm/cli/issues/8003), [npm/cli#7888](https://github.com/npm/cli/issues/7888)). The only documented lever that lets the command proceed is **`--force`**, which downgrades the gate from a hard error to a non-fatal warning.

## Fix

Add a small `withNpmForce()` helper and prepend `--force` to every argent `npx` invocation. It is **scoped to argent's own skills commands** (it is never applied to the user's project installs), and argent already discards the child's stderr on success, so the `npm warn using --force` notice never reaches the user. The displayed and manual-fallback commands stay clean.

- `src/utils.ts` — `withNpmForce()` helper; `isSkillsCliAvailable()` probe gains `--force`.
- `src/skills.ts` — `refreshArgentSkills` add / fallback-add / remove wrapped.
- `src/init.ts` — skill install spawned with `--force`.
- Tests updated in `test/utils.test.ts` and `test/skills.test.ts`.

Net: **+34 / −9**, no temp dirs, no new runtime state.

## Verification

- Full installer suite: **263 tests pass**; `tsc --noEmit` clean.
- End-to-end against the **real `bluesky-social/social-app` repo**, driving the compiled `dist`, on **Node 22.22.3 (npm 10)** and **Node 24.16.0 (npm 11)**:

  | Node | before (`npx skills add`) | after (`npx --force skills add`) |
  |---|---|---|
  | 22.22.3 (< floor) | exit 1, `EBADDEVENGINES`, **0 skills** | exit 0, **11 skills** ✅ |
  | 24.16.0 (≥ floor) | exit 0, 11 skills (noisy warn) | exit 0, **11 skills** ✅ |

## Test plan

- [x] `npm run test -w packages/argent-installer`
- [x] Manual: real Bluesky repo on Node < 24.15 installs skills without `EBADDEVENGINES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)