### PR TITLE
fix(native-devtools): re-apply DYLD env after out-of-band sim reboot

### DIFF
--- a/packages/tool-server/src/blueprints/native-devtools.ts
+++ b/packages/tool-server/src/blueprints/native-devtools.ts
@@ -146,6 +146,15 @@ export interface NativeDevtoolsApi {
   isEnvSetup(): boolean;
   readonly socketPath: string;
   ensureEnvReady(): Promise<void>;
+  /**
+   * Force a fresh `ensureEnv` pass, bypassing the one-shot `ensureEnvReady`
+   * latch. `ensureEnvReady` caches success and never runs again, so it cannot
+   * notice that an out-of-band simulator reboot wiped `DYLD_INSERT_LIBRARIES`
+   * from launchd. Callers that have evidence the env may be stale (e.g. a
+   * running app that isn't connected) use this to re-apply it. `ensureEnv` is
+   * idempotent, so this is a cheap no-op when the env is already correct.
+   */
+  reverifyEnv(): Promise<void>;
   getInitFailure(): NativeDevtoolsInitFailure | null;
 
   // App-level — all keyed by bundleId
@@ -396,8 +405,9 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
       process.stderr.write(message);
     };
 
-    const ensureEnvReady = (): Promise<void> => {
-      if (envSetup || initFailure?.givenUp) return Promise.resolve();
+    // Runs `ensureEnv` under the in-flight concurrency guard with no latch
+    // check. Overlapping callers collapse onto the same promise.
+    const runEnsureEnv = (): Promise<void> => {
       if (inFlight) return inFlight;
 
       inFlight = Promise.resolve()
@@ -415,6 +425,21 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
         });
 
       return inFlight;
+    };
+
+    // Hot path: skip the simctl round-trips once the env has been applied
+    // successfully (or we've given up). Most tool calls hit this.
+    const ensureEnvReady = (): Promise<void> => {
+      if (envSetup || initFailure?.givenUp) return Promise.resolve();
+      return runEnsureEnv();
+    };
+
+    // Recovery path: re-apply the env even when the latch says it's already
+    // set, so a sim reboot that cleared DYLD_INSERT_LIBRARIES is repaired.
+    // Still honours the give-up guard so a hard-failed sim doesn't spin.
+    const reverifyEnv = (): Promise<void> => {
+      if (initFailure?.givenUp) return Promise.resolve();
+      return runEnsureEnv();
     };
 
     const isAppRunning = async (bundleId: string): Promise<boolean> => {
@@ -558,6 +583,7 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
       isEnvSetup: () => envSetup,
       socketPath,
       ensureEnvReady,
+      reverifyEnv,
       getInitFailure: () => initFailure,
 
       isConnected: (bundleId) => connections.has(bundleId),
@@ -567,8 +593,10 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
       async requiresAppRestart(bundleId) {
         if (connections.has(bundleId)) return false;
         // Re-verify and re-set env — handles the case where the simulator was
-        // rebooted and launchd cleared DYLD_INSERT_LIBRARIES
-        await ensureEnvReady();
+        // rebooted and launchd cleared DYLD_INSERT_LIBRARIES. Must use
+        // reverifyEnv (not ensureEnvReady): the latter latches after the first
+        // success and would skip re-applying the wiped env.
+        await reverifyEnv();
         return true;
       },
 

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -448,6 +448,13 @@ async function bootIos(
 
   const ndRef = nativeDevtoolsRef({ id: udid, platform: "ios", kind: "simulator" });
   const ndApi = await registry.resolveService<NativeDevtoolsApi>(ndRef.urn, ndRef.options);
+  // We just (re)booted the sim, which wipes DYLD_INSERT_LIBRARIES from launchd.
+  // If this service was already initialized (e.g. by the simulator watcher),
+  // `resolveService` returns the cached instance whose one-shot env latch is
+  // set, so the env would never be re-applied and the next launch wouldn't be
+  // injected. Force a re-apply so describe / native tools work without an
+  // extra restart-app round-trip. Failures surface via getInitFailure below.
+  await ndApi.reverifyEnv().catch(() => {});
   const initFailure = ndApi.getInitFailure();
   if (initFailure?.givenUp) {
     return buildInitFailedResult(udid, initFailure);

--- a/packages/tool-server/src/tools/native-devtools/native-devtools-status.ts
+++ b/packages/tool-server/src/tools/native-devtools/native-devtools-status.ts
@@ -54,7 +54,17 @@ Fails if the simulator server is not running for the given UDID or the bundleId 
 
     const appRunning = await api.isAppRunning(params.bundleId);
     const connected = api.isConnected(params.bundleId);
+
+    // When the app isn't connected, the cached env latch can be stale: an
+    // out-of-band simulator reboot wipes DYLD_INSERT_LIBRARIES from launchd
+    // while isEnvSetup() still reports the stale `true`. Re-apply it so the
+    // reported envSetup / nextLaunchWillBeInjected reflect reality — and so a
+    // subsequent launch actually gets injected. Idempotent no-op when correct.
+    if (!connected) {
+      await api.reverifyEnv().catch(() => {});
+    }
     const envSetup = api.isEnvSetup();
+
     return {
       envSetup,
       appRunning,

--- a/packages/tool-server/test/boot-device.test.ts
+++ b/packages/tool-server/test/boot-device.test.ts
@@ -80,7 +80,8 @@ describe("boot-device — iOS path", () => {
   });
 
   it("pre-boots AX prefs on a Shutdown sim then waits for boot completion and native-devtools init", async () => {
-    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const reverifyEnv = vi.fn(async () => {});
+    const resolveService = vi.fn(async () => ({ getInitFailure: () => null, reverifyEnv }));
     const registry = {
       resolveService,
     } as unknown as Registry;
@@ -140,10 +141,17 @@ describe("boot-device — iOS path", () => {
     expect(resolveService.mock.invocationCallOrder[0]).toBeLessThan(
       mockExecFile.mock.invocationCallOrder[2]
     );
+    // The (re)boot wipes launchd's DYLD_INSERT_LIBRARIES; boot-device must
+    // force a re-apply so a cached/latched native-devtools service can't leave
+    // the env unset (which would make the next launch uninjected).
+    expect(reverifyEnv).toHaveBeenCalledOnce();
   });
 
   it("skips pre-boot plist write when the sim is already Booted and falls back to ensureAutomationEnabled", async () => {
-    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const resolveService = vi.fn(async () => ({
+      getInitFailure: () => null,
+      reverifyEnv: async () => {},
+    }));
     const registry = { resolveService } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
@@ -163,7 +171,10 @@ describe("boot-device — iOS path", () => {
     // writes prefs best-effort.
     listIosSimulatorsMock.mockResolvedValueOnce([]);
 
-    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const resolveService = vi.fn(async () => ({
+      getInitFailure: () => null,
+      reverifyEnv: async () => {},
+    }));
     const registry = { resolveService } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
@@ -180,7 +191,10 @@ describe("boot-device — iOS path", () => {
     // ensureAutomationEnabled writes prefs best-effort post-boot.
     setAccessibilityPrefsPreBootMock.mockRejectedValueOnce(new Error("plutil missing"));
 
-    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const resolveService = vi.fn(async () => ({
+      getInitFailure: () => null,
+      reverifyEnv: async () => {},
+    }));
     const registry = { resolveService } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
@@ -197,6 +211,7 @@ describe("boot-device — iOS path", () => {
 
   it("returns a structured init_failed result when native-devtools has given up", async () => {
     const resolveService = vi.fn(async () => ({
+      reverifyEnv: async () => {},
       getInitFailure: () => ({
         attempts: 3,
         lastError: "simctl spawn timed out",
@@ -229,7 +244,10 @@ describe("boot-device — iOS path", () => {
         return {} as never;
       });
 
-    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const resolveService = vi.fn(async () => ({
+      getInitFailure: () => null,
+      reverifyEnv: async () => {},
+    }));
     const registry = { resolveService } as unknown as Registry;
 
     const tool = createBootDeviceTool(registry);
@@ -256,7 +274,10 @@ describe("boot-device — iOS path", () => {
   });
 
   it("force=true on a Booted sim triggers shutdown → pre-boot write → boot", async () => {
-    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const resolveService = vi.fn(async () => ({
+      getInitFailure: () => null,
+      reverifyEnv: async () => {},
+    }));
     const registry = { resolveService } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 
@@ -283,7 +304,10 @@ describe("boot-device — iOS path", () => {
   });
 
   it("force not set on a Booted sim does not shut down", async () => {
-    const resolveService = vi.fn(async () => ({ getInitFailure: () => null }));
+    const resolveService = vi.fn(async () => ({
+      getInitFailure: () => null,
+      reverifyEnv: async () => {},
+    }));
     const registry = { resolveService } as unknown as Registry;
     const tool = createBootDeviceTool(registry);
 

--- a/packages/tool-server/test/describe-tool.test.ts
+++ b/packages/tool-server/test/describe-tool.test.ts
@@ -35,6 +35,7 @@ function makeNativeDevtoolsApi(options: {
     isEnvSetup: () => true,
     socketPath: "/tmp/test.sock",
     ensureEnvReady: async () => {},
+    reverifyEnv: async () => {},
     getInitFailure: () => null,
     isConnected: (bundleId) => connected.has(bundleId),
     isAppRunning: async () => true,

--- a/packages/tool-server/test/native-devtools-status.test.ts
+++ b/packages/tool-server/test/native-devtools-status.test.ts
@@ -12,9 +12,16 @@ function makeNativeApi(options: {
   connected?: boolean;
   appRunning?: boolean;
   initFailure?: NativeDevtoolsInitFailure | null;
-}): { api: NativeDevtoolsApi; ensureEnvReady: ReturnType<typeof vi.fn> } {
+}): {
+  api: NativeDevtoolsApi;
+  ensureEnvReady: ReturnType<typeof vi.fn>;
+  reverifyEnv: ReturnType<typeof vi.fn>;
+} {
   let envSetup = options.envSetup ?? false;
   const ensureEnvReady = vi.fn(async () => {
+    envSetup = true;
+  });
+  const reverifyEnv = vi.fn(async () => {
     envSetup = true;
   });
 
@@ -23,6 +30,7 @@ function makeNativeApi(options: {
       isEnvSetup: () => envSetup,
       socketPath: "/tmp/mock.sock",
       ensureEnvReady,
+      reverifyEnv,
       getInitFailure: () => options.initFailure ?? null,
       isConnected: () => options.connected ?? false,
       isAppRunning: async () => options.appRunning ?? false,
@@ -40,6 +48,7 @@ function makeNativeApi(options: {
       queryViewHierarchy: async () => ({}),
     },
     ensureEnvReady,
+    reverifyEnv,
   };
 }
 
@@ -61,6 +70,50 @@ describe("native-devtools-status tool", () => {
     });
 
     expect(ensureEnvReady).toHaveBeenCalledOnce();
+  });
+
+  it("re-applies the env when the app is not connected (repairs a stale latch after a sim reboot)", async () => {
+    // envSetup:false models the cleared launchd state after an out-of-band
+    // reboot; reverifyEnv must run and bring it back to true.
+    const { api, reverifyEnv } = makeNativeApi({
+      appRunning: true,
+      connected: false,
+      envSetup: false,
+    });
+
+    await expect(
+      nativeDevtoolsStatusTool.execute(
+        { nativeDevtools: api },
+        { udid: "11111111-1111-1111-1111-111111111111", bundleId: "com.example.app" }
+      )
+    ).resolves.toEqual({
+      envSetup: true,
+      appRunning: true,
+      connected: false,
+      requiresRestart: true,
+      nextLaunchWillBeInjected: true,
+    });
+
+    expect(reverifyEnv).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-apply the env when the app is already connected", async () => {
+    const { api, reverifyEnv } = makeNativeApi({ appRunning: true, connected: true });
+
+    await expect(
+      nativeDevtoolsStatusTool.execute(
+        { nativeDevtools: api },
+        { udid: "11111111-1111-1111-1111-111111111111", bundleId: "com.example.app" }
+      )
+    ).resolves.toEqual({
+      envSetup: true,
+      appRunning: true,
+      connected: true,
+      requiresRestart: false,
+      nextLaunchWillBeInjected: true,
+    });
+
+    expect(reverifyEnv).not.toHaveBeenCalled();
   });
 
   it("reports a stopped app as launch-ready without requiring restart", async () => {

--- a/packages/tool-server/test/native-target-app.test.ts
+++ b/packages/tool-server/test/native-target-app.test.ts
@@ -25,6 +25,7 @@ function makeApi(apps: NativeAppState[]): NativeDevtoolsApi {
     isEnvSetup: () => true,
     socketPath: "/tmp/mock.sock",
     ensureEnvReady: async () => {},
+    reverifyEnv: async () => {},
     getInitFailure: () => null,
     isConnected: (bundleId) => byBundleId.has(bundleId),
     isAppRunning: async (bundleId) => byBundleId.has(bundleId),

--- a/packages/tool-server/test/simulator-watcher-init-failure.test.ts
+++ b/packages/tool-server/test/simulator-watcher-init-failure.test.ts
@@ -65,6 +65,7 @@ function makeFailingApi(): { api: NativeDevtoolsApi; ensureCalls: () => number }
       };
       throw new Error("stub ensureEnv failure");
     },
+    reverifyEnv: async () => {},
     getInitFailure: () => initFailure,
     isConnected: () => false,
     isAppRunning: async () => false,
@@ -166,6 +167,7 @@ describe("simulator-watcher with api-owned init failure state", () => {
       ensureEnvReady: async () => {
         calls += 1;
       },
+      reverifyEnv: async () => {},
       getInitFailure: () => null,
       isConnected: () => false,
       isAppRunning: async () => false,


### PR DESCRIPTION
## Summary

After an iOS simulator loses its launchd `DYLD_INSERT_LIBRARIES` (any reboot — out-of-band *or* an argent `boot-device`), `native-devtools-status` keeps reporting `envSetup: true` / `nextLaunchWillBeInjected: true` while the env is actually **empty**. Freshly launched apps aren't injected and native feature tools (`native-describe-screen`, `native-find-views`, …) fail with `restart_required` — and `restart-app` couldn't break out of it.

## Root cause

`envSetup` is a **write-once latch**. `ensureEnvReady()` short-circuits once it flips `true`, and nothing resets it, so the env is never re-applied after a reboot clears it. Two paths relied on that latched function and so never recovered:

1. `requiresAppRestart()` — written to recover from the reboot case, but called the latched `ensureEnvReady()`.
2. `boot-device` — primes the native-devtools service after (re)booting, but the simulator watcher usually initialized it earlier, so `resolveService` returns the cached/latched instance and the wiped env is never re-applied. A clean argent `boot-device` + `launch-app` therefore produced an uninjected app and a spurious `restart_required`.

## Fix

- Split a latch-free `runEnsureEnv()` out of `ensureEnvReady()` and add `reverifyEnv()` — re-applies the env even when the latch says it's set (still honouring the give-up guard). `ensureEnv` is already idempotent, so it's a cheap no-op when correct.
- `requiresAppRestart()` → uses `reverifyEnv()` (fixes the native feature tools' recovery; precheck routes through it).
- `native-devtools-status` → calls `reverifyEnv()` when the app isn't connected, so its flags reflect reality and a later launch is injected.
- `boot-device` → forces `reverifyEnv()` after the (re)boot, so a clean argent boot injects on first launch with no restart.

The hot path (`ensureEnvReady`, app already connected) is unchanged — no added latency on normal calls; the extra simctl round-trips only fire when there's evidence the env is stale.

## Verified end-to-end on a real iOS 26.3 sim (patched tool-server)

- **Clean argent boot → launch → just works:** prime service, `boot-device force`, `launch-app` → `connected:true`, `requiresRestart:false`, `native-describe-screen` returns the full tree. `DYLD_INSERT_LIBRARIES` is present immediately after `boot-device` returns. ✅
- **Out-of-band reboot → `native-devtools-status`:** status call self-heals the env; next launch is injected. ✅
- **Out-of-band reboot → launch → native tool → `restart-app`:** the previously dead-end recovery now works. ✅
- **Before the fix (same hardware):** status claimed `envSetup:true` with the env empty; launches uninjected; `restart-app` and `boot-device force` did not recover.

## Tests

- New regression tests: `native-devtools-status` re-applies when disconnected / does not when connected; `boot-device` forces a re-apply after boot.
- Full `packages/tool-server` suite green (1155), typecheck + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)