### PR TITLE
feat: `GET /artifacts/` endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3914,6 +3914,7 @@
       "name": "@argent/tool-server",
       "version": "0.11.0",
       "dependencies": {
+        "@argent/configuration-core": "file:../configuration-core",
         "@argent/native-devtools-android": "file:../native-devtools-android",
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
         "@argent/registry": "file:../registry",

--- a/packages/configuration-core/src/flags.ts
+++ b/packages/configuration-core/src/flags.ts
@@ -48,6 +48,10 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     name: "disable-auto-screenshot",
     description: "Disable the automatic screenshot captured after interaction tools.",
   },
+  {
+    name: "artifacts-list-endpoint",
+    description: "Expose GET /artifacts for remote artifact inventory consumers.",
+  },
 ];
 
 // Look up a flag's definition — exported for consumers that want the

--- a/packages/registry/src/artifacts.ts
+++ b/packages/registry/src/artifacts.ts
@@ -65,6 +65,15 @@ export interface ArtifactEntry {
   isDirectory: boolean;
 }
 
+/** Public metadata returned by the artifact inventory endpoint. */
+export interface ArtifactListItem {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  isDirectory: boolean;
+}
+
 const MIME_BY_EXT: Record<string, string> = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
@@ -136,5 +145,15 @@ export class ArtifactStore {
 
   get(id: string): ArtifactEntry | undefined {
     return this.entries.get(id);
+  }
+
+  list(): ArtifactListItem[] {
+    return [...this.entries.entries()].map(([id, entry]) => ({
+      id,
+      filename: entry.filename,
+      mimeType: entry.mimeType,
+      size: entry.size,
+      isDirectory: entry.isDirectory,
+    }));
   }
 }

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -19,7 +19,12 @@ export type {
   ToolDependency,
 } from "./types";
 export { ArtifactStore, ARTIFACT_MARKER } from "./artifacts";
-export type { ArtifactHandle, ArtifactEntry, RegisterArtifactOptions } from "./artifacts";
+export type {
+  ArtifactHandle,
+  ArtifactEntry,
+  ArtifactListItem,
+  RegisterArtifactOptions,
+} from "./artifacts";
 export {
   FILE_INPUT_MARKER,
   CLIENT_FILE_MARKER,

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -16,6 +16,7 @@
     "@argent/native-devtools-ios": "file:../native-devtools-ios",
     "@argent/native-devtools-android": "file:../native-devtools-android",
     "@argent/registry": "file:../registry",
+    "@argent/configuration-core": "file:../configuration-core",
     "@argent/update-core": "file:../update-core",
     "@clack/prompts": "^1.1.0",
     "express": "^4.19.2",

--- a/packages/tool-server/src/artifacts.ts
+++ b/packages/tool-server/src/artifacts.ts
@@ -17,13 +17,20 @@ import { access } from "node:fs/promises";
 import { dirname, basename } from "node:path";
 import { spawn } from "node:child_process";
 import type { Request, Response } from "express";
-import type { Registry, ArtifactEntry, ArtifactStore, ToolContext } from "@argent/registry";
+import type {
+  Registry,
+  ArtifactEntry,
+  ArtifactListItem,
+  ArtifactStore,
+  ToolContext,
+} from "@argent/registry";
 
 export {
   ArtifactStore,
   ARTIFACT_MARKER,
   type ArtifactHandle,
   type ArtifactEntry,
+  type ArtifactListItem,
   type RegisterArtifactOptions,
 } from "@argent/registry";
 
@@ -83,6 +90,17 @@ export function makeArtifactRoute(registry: Registry) {
       else res.destroy();
     });
     stream.pipe(res);
+  };
+}
+
+/**
+ * Build the Express handler for `GET /artifacts`. Returns the current
+ * in-memory artifact inventory without exposing tool-server host paths.
+ */
+export function makeArtifactListRoute(registry: Registry) {
+  return function handleArtifactListRequest(_req: Request, res: Response): void {
+    const artifacts: ArtifactListItem[] = registry.artifacts.list();
+    res.json({ artifacts });
   };
 }
 

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response } from "express";
+import { isFlagEnabled } from "@argent/configuration-core";
 import type { FileInputSpec, Registry, ResolvedFileInput } from "@argent/registry";
 import { ToolNotFoundError } from "@argent/registry";
 import { createIdleTimer } from "./utils/idle-timer";
@@ -31,6 +32,7 @@ const AUTO_SUPPRESS_MS = 30 * 60 * 1000; // 30 minutes
 
 const AUTH_TOKEN_ENV = "ARGENT_AUTH_TOKEN";
 const BEARER_PREFIX = "Bearer ";
+const ARTIFACTS_LIST_ENDPOINT_FLAG = "artifacts-list-endpoint";
 
 // Constant-time comparison so a leaked token can't be recovered byte-by-byte
 // via response-timing measurements. Both strings must be the same length to
@@ -218,7 +220,9 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
   // Artifact retrieval: streams files produced by tools (screenshots, profiler
   // exports) over the remote-aware HTTP boundary so the MCP client can fetch
   // them via TOOLS_URL instead of an unreachable 127.0.0.1 host path/URL.
-  app.get("/artifacts", makeArtifactListRoute(registry));
+  if (isFlagEnabled(ARTIFACTS_LIST_ENDPOINT_FLAG)) {
+    app.get("/artifacts", makeArtifactListRoute(registry));
+  }
   app.get("/artifacts/:id", makeArtifactRoute(registry));
 
   // Per-Chromium-device HTTP surface that mirrors sim-server's API: a

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -7,7 +7,7 @@ import { formatErrorForAgent } from "./utils/format-error";
 import { getUpdateState, isUpdateNoteSuppressed, suppressUpdateNote } from "./utils/update-checker";
 import { buildUpdateNote } from "./update-utils";
 import { createPreviewRouter } from "./preview";
-import { makeArtifactRoute } from "./artifacts";
+import { makeArtifactListRoute, makeArtifactRoute } from "./artifacts";
 import { FileInputError, resolveFileInputs } from "./file-inputs";
 import {
   assertSupported,
@@ -218,6 +218,7 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
   // Artifact retrieval: streams files produced by tools (screenshots, profiler
   // exports) over the remote-aware HTTP boundary so the MCP client can fetch
   // them via TOOLS_URL instead of an unreachable 127.0.0.1 host path/URL.
+  app.get("/artifacts", makeArtifactListRoute(registry));
   app.get("/artifacts/:id", makeArtifactRoute(registry));
 
   // Per-Chromium-device HTTP surface that mirrors sim-server's API: a

--- a/packages/tool-server/test/artifacts.test.ts
+++ b/packages/tool-server/test/artifacts.test.ts
@@ -97,6 +97,66 @@ describe("ArtifactStore", () => {
     });
     expect(handle.archive).toBe("tar.gz");
   });
+
+  it("lists safe metadata for registered artifacts", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "artifact-list-store-"));
+    try {
+      const filePath = join(dir, "shot.png");
+      await writeFile(filePath, "png");
+      const store = new ArtifactStore();
+      const handle = await store.register(filePath, { mimeType: "image/png" });
+
+      expect(store.list()).toEqual([
+        {
+          id: handle.id,
+          filename: "shot.png",
+          mimeType: "image/png",
+          size: 3,
+          isDirectory: false,
+        },
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("GET /artifacts", () => {
+  let handle: HttpAppHandle | null = null;
+
+  afterEach(() => {
+    handle?.dispose();
+    handle = null;
+  });
+
+  it("returns registered artifact metadata without host paths", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "artifact-list-route-"));
+    try {
+      const filePath = join(dir, "img.png");
+      await writeFile(filePath, "image");
+      const registry = stubRegistry();
+      const artifact = await registry.artifacts.register(filePath, { mimeType: "image/png" });
+
+      handle = createHttpApp(registry);
+      const res = await supertest(handle.app).get("/artifacts");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        artifacts: [
+          {
+            id: artifact.id,
+            filename: "img.png",
+            mimeType: "image/png",
+            size: 5,
+            isDirectory: false,
+          },
+        ],
+      });
+      expect(JSON.stringify(res.body)).not.toContain(filePath);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("GET /artifacts/:id", () => {

--- a/packages/tool-server/test/artifacts.test.ts
+++ b/packages/tool-server/test/artifacts.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import supertest from "supertest";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -7,6 +7,8 @@ import { execFileSync } from "node:child_process";
 import { createHttpApp, type HttpAppHandle } from "../src/http";
 import { ArtifactStore } from "@argent/registry";
 import type { Registry } from "@argent/registry";
+
+const isFlagEnabledMock = vi.hoisted(() => vi.fn(() => false));
 
 // supertest/superagent doesn't buffer binary bodies (gzip) by default.
 function binaryParser(res: NodeJS.ReadableStream, cb: (err: Error | null, body: Buffer) => void) {
@@ -24,6 +26,10 @@ vi.mock("../src/utils/update-checker", () => ({
   })),
   isUpdateNoteSuppressed: vi.fn(() => true),
   suppressUpdateNote: vi.fn(),
+}));
+
+vi.mock("@argent/configuration-core", () => ({
+  isFlagEnabled: isFlagEnabledMock,
 }));
 
 // A minimal Registry carrying a real ArtifactStore — the `/artifacts/:id` route
@@ -124,9 +130,21 @@ describe("ArtifactStore", () => {
 describe("GET /artifacts", () => {
   let handle: HttpAppHandle | null = null;
 
+  beforeEach(() => {
+    isFlagEnabledMock.mockReturnValue(false);
+  });
+
   afterEach(() => {
     handle?.dispose();
     handle = null;
+    isFlagEnabledMock.mockReset();
+  });
+
+  it("is hidden unless the artifact list endpoint flag is enabled", async () => {
+    handle = createHttpApp(stubRegistry());
+    const res = await supertest(handle.app).get("/artifacts");
+
+    expect(res.status).toBe(404);
   });
 
   it("returns registered artifact metadata without host paths", async () => {
@@ -136,6 +154,7 @@ describe("GET /artifacts", () => {
       await writeFile(filePath, "image");
       const registry = stubRegistry();
       const artifact = await registry.artifacts.register(filePath, { mimeType: "image/png" });
+      isFlagEnabledMock.mockReturnValue(true);
 
       handle = createHttpApp(registry);
       const res = await supertest(handle.app).get("/artifacts");

--- a/packages/tool-server/tsconfig.json
+++ b/packages/tool-server/tsconfig.json
@@ -7,6 +7,7 @@
     "rootDir": "./src"
   },
   "references": [
+    { "path": "../configuration-core" },
     { "path": "../registry" },
     { "path": "../update-core" },
     { "path": "../native-devtools-ios" },


### PR DESCRIPTION
EAS is going to poll this endpoint for new artifacts and upload as session artifacts for later user inspection.

I'm open to better ways to integrate, this seems the easiest to merge and move forward.