### PR TITLE
chore: add ESLint with typescript-eslint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          # ESLint 10 requires Node ^20.19 || ^22.13 || >=24.
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Type-aware rules need the referenced projects' declarations on disk so
+      # cross-package imports resolve to real types instead of `any`.
+      - name: Build workspace dependencies
+        run: npx tsc --build
+
+      - name: Lint
+        run: npm run lint

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,98 @@
+// @ts-check
+import eslint from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    // Not linted: build outputs, deps, generated/copied assets, and the
+    // argent-private submodule (it has its own repo and CI). Mirrors the
+    // ignores in .prettierignore + .gitignore.
+    ignores: [
+      "**/dist/",
+      "**/node_modules/",
+      "**/*.tsbuildinfo",
+      "packages/argent-private/",
+      "packages/argent/bin/",
+      "packages/argent/dylibs/",
+      "packages/argent/assets/",
+      "packages/argent/skills/",
+      "packages/argent/agents/",
+      "packages/argent/rules/",
+      "packages/native-devtools-ios/bin/",
+      "packages/native-devtools-ios/dylibs/",
+      "coverage/",
+    ],
+  },
+
+  // Type-aware linting for the TypeScript sources — this is where the value is
+  // (floating promises, misused promises, throwing non-Errors, etc.).
+  {
+    files: ["**/*.ts", "**/*.mts", "**/*.cts"],
+    extends: [eslint.configs.recommended, ...tseslint.configs.recommendedTypeChecked],
+    languageOptions: {
+      parserOptions: {
+        // Explicit project list rather than `projectService`: each package keeps
+        // its test files in a separate tsconfig.test.json (which projectService
+        // does not auto-discover), so we point the type-aware parser at both.
+        project: ["packages/*/tsconfig.json", "packages/*/tsconfig.test.json"],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      globals: { ...globals.node },
+    },
+    rules: {
+      // --- Kept on, tuned ---
+      // Catch the real promise hazards (a promise used in a condition or
+      // spread) while skipping the noisy void-return variant that flags
+      // legitimate async callbacks (event handlers, array iteration, etc.).
+      "@typescript-eslint/no-misused-promises": ["error", { checksVoidReturn: false }],
+      // Allow intentionally-unused identifiers when prefixed with `_`.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+
+      // --- Parked: pre-existing debt, out of scope for the initial rollout ---
+      // These flag broad classes of existing code (mostly `any` flowing across
+      // untyped boundaries, and stylistic cleanups). Turned off now so the gate
+      // is green; ratchet each back to "error" in follow-up passes.
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-redundant-type-constituents": "off",
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "@typescript-eslint/restrict-plus-operands": "off",
+      "@typescript-eslint/unbound-method": "off",
+      "@typescript-eslint/require-await": "off",
+      "@typescript-eslint/no-unnecessary-type-assertion": "off",
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+
+  // Test files lean on mocks/stubs and partial fixtures; relax the rules that
+  // fight that without losing the promise-correctness checks.
+  {
+    files: ["**/*.test.ts", "**/*.spec.ts", "**/test/**", "**/tests/**"],
+    rules: {
+      "@typescript-eslint/no-base-to-string": "off",
+      "no-empty": "off",
+    },
+  },
+
+  // Plain JS — this config plus the loosely-typed build/dev scripts. No type
+  // information available, so disable the type-checked rules for these.
+  {
+    files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
+    extends: [eslint.configs.recommended, tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
         "packages/*"
       ],
       "devDependencies": {
-        "prettier": "^3.8.3"
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.5.0",
+        "globals": "^17.6.0",
+        "prettier": "^3.8.3",
+        "typescript-eslint": "^8.61.1"
       }
     },
     "node_modules/@argent/cli": {
@@ -524,6 +528,159 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -534,6 +691,72 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1254,6 +1477,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1285,6 +1515,13 @@
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1386,6 +1623,336 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.61.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1523,6 +2090,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "dev": true,
@@ -1592,6 +2169,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "license": "MIT",
@@ -1612,6 +2199,19 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -1754,6 +2354,13 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "dev": true,
@@ -1869,6 +2476,213 @@
       "version": "1.0.3",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1877,6 +2691,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -1977,6 +2801,20 @@
       "version": "3.1.3",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "dev": true,
@@ -2040,6 +2878,19 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "license": "MIT",
@@ -2055,6 +2906,44 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/form-data": {
       "version": "4.0.5",
@@ -2156,6 +3045,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -2237,6 +3152,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -2257,6 +3192,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "license": "MIT"
@@ -2272,6 +3230,13 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
@@ -2280,11 +3245,42 @@
       "version": "8.0.2",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2547,6 +3543,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "dev": true,
@@ -2615,6 +3627,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
@@ -2637,6 +3665,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -2704,11 +3739,71 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -2793,6 +3888,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
@@ -2818,6 +3923,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3298,6 +4413,19 @@
         }
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "dev": true,
@@ -3348,6 +4476,19 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "license": "MIT",
@@ -3373,6 +4514,30 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -3385,6 +4550,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/utils-merge": {
@@ -3612,6 +4787,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
@@ -3656,6 +4841,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,15 @@
     "pack:mcp:local": "npm run download:simulator-server && npm run build:ios-binaries && npm run build:android-binaries && npm run download:trace-processor && npm run build && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
     "dev": "node scripts/dev.cjs",
     "format": "prettier --write .",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json"
   },
   "devDependencies": {
-    "prettier": "^3.8.3"
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.5.0",
+    "globals": "^17.6.0",
+    "prettier": "^3.8.3",
+    "typescript-eslint": "^8.61.1"
   }
 }

--- a/packages/argent-cli/src/link.ts
+++ b/packages/argent-cli/src/link.ts
@@ -425,7 +425,6 @@ export async function link(argv: string[]): Promise<void> {
 
   // Pre-flight health check (unless --no-verify)
   if (!flags.noVerify) {
-    // eslint-disable-next-line no-constant-condition
     while (true) {
       const spinnerActive = !flags.yes;
       let spinner: ReturnType<typeof p.spinner> | null = null;

--- a/packages/argent-cli/test/flags.test.ts
+++ b/packages/argent-cli/test/flags.test.ts
@@ -101,7 +101,7 @@ function withMockedConsole(fn: () => void): { stdout: string; stderr: string; th
 
 function captureConsole(fn: () => void): CapturedConsole {
   const { stdout, stderr, threw } = withMockedConsole(fn);
-  if (threw !== undefined) throw threw;
+  if (threw !== undefined) throw threw as Error;
   return { stdout, stderr };
 }
 

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -64,7 +64,7 @@ export async function update(args: string[]): Promise<void> {
 
   const pm = detectPackageManager();
   let latest: string | null = null;
-  let target: string | null = null;
+  let target: string | null;
   let minReleaseAgeMs = 0;
 
   if (requestedVersion !== null) {

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -14,7 +14,6 @@ import {
   getManagedContentTargets,
   injectCodexRules,
   removeCodexRules,
-  type McpConfigAdapter,
 } from "../src/mcp-configs.js";
 
 // ── homedir mock ──────────────────────────────────────────────────────────────

--- a/packages/argent-installer/test/uninstall.test.ts
+++ b/packages/argent-installer/test/uninstall.test.ts
@@ -8,7 +8,6 @@ import {
   addClaudePermission,
   removeClaudePermission,
 } from "../src/mcp-configs.js";
-import { readToml } from "../src/utils.js";
 import {
   cleanupSkillsLockFile,
   getBundledSkillNames,
@@ -17,11 +16,6 @@ import {
 } from "../src/uninstall.js";
 
 let tmpDir: string;
-
-function readConfigFile(filePath: string): Record<string, unknown> {
-  if (filePath.endsWith(".toml")) return readToml(filePath);
-  return JSON.parse(fs.readFileSync(filePath, "utf8"));
-}
 
 function writeFile(filePath: string, contents = "test"): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/packages/argent-installer/test/update.test.ts
+++ b/packages/argent-installer/test/update.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/packages/argent-tools-client/src/launcher.ts
+++ b/packages/argent-tools-client/src/launcher.ts
@@ -175,7 +175,7 @@ export async function isToolsServerHealthy(
   }
 }
 
-export interface SpawnToolsServerOptions extends BuildToolsServerEnvOptions {}
+export type SpawnToolsServerOptions = BuildToolsServerEnvOptions;
 
 export function spawnToolsServer(
   paths: ToolsServerPaths,

--- a/packages/argent/scripts/observe.cjs
+++ b/packages/argent/scripts/observe.cjs
@@ -4,7 +4,6 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const readline = require("readline");
 
 const LOG_FILE = process.env.ARGENT_MCP_LOG ?? path.join(os.homedir(), ".argent", "mcp-calls.log");
 

--- a/packages/argent/scripts/postinstall.cjs
+++ b/packages/argent/scripts/postinstall.cjs
@@ -15,10 +15,14 @@ try {
   if (state && state.pid) {
     try {
       process.kill(state.pid, "SIGTERM");
-    } catch {}
+    } catch {
+      /* process already gone — nothing to kill */
+    }
   }
   fs.unlinkSync(stateFile);
-} catch {}
+} catch {
+  /* no state file or unreadable — nothing to clean up */
+}
 
 if (process.env.ARGENT_SKIP_POSTINSTALL === "1") {
   process.exit(0);

--- a/packages/argent/src/cli.ts
+++ b/packages/argent/src/cli.ts
@@ -90,15 +90,12 @@ Package: ${PACKAGE_NAME}
 // scripts/bundle-tools.cjs and shipped alongside this dispatcher in dist/.
 // Typed against the workspace packages so calls are still checked.
 async function loadInstaller(): Promise<typeof Installer> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (await import("./installer.mjs" as any)) as typeof Installer;
 }
 async function loadMcp(): Promise<typeof Mcp> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (await import("./mcp-server.mjs" as any)) as typeof Mcp;
 }
 async function loadCli(): Promise<typeof Cli> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (await import("./cli-cmds.mjs" as any)) as typeof Cli;
 }
 

--- a/packages/native-devtools-android/src/wasm-trace-processor.ts
+++ b/packages/native-devtools-android/src/wasm-trace-processor.ts
@@ -192,7 +192,7 @@ function silenceDecoderWarning(): void {
   decoderWarningSilenced = true;
   const orig = console.warn.bind(console);
   console.warn = (...args: unknown[]): void => {
-    if (/Unexpected QueryResult field/.test(String(args[0] ?? ""))) return;
+    if (/Unexpected QueryResult field/.test(JSON.stringify(args[0] ?? ""))) return;
     orig(...args);
   };
 }

--- a/packages/registry/src/event-emitter.ts
+++ b/packages/registry/src/event-emitter.ts
@@ -1,7 +1,7 @@
 export class TypedEventEmitter<
   T extends Record<string, (...args: any[]) => void> = Record<string, (...args: any[]) => void>,
 > {
-  private listeners = new Map<keyof T, Set<Function>>();
+  private listeners = new Map<keyof T, Set<(...args: unknown[]) => void>>();
 
   on<K extends keyof T>(event: K, listener: T[K]): this {
     if (!this.listeners.has(event)) this.listeners.set(event, new Set());

--- a/packages/registry/src/registry.ts
+++ b/packages/registry/src/registry.ts
@@ -270,7 +270,7 @@ export class Registry {
       node.instance = instance as ServiceInstance;
 
       instance.events.on("terminated", (error?: Error) => {
-        this._teardown(urn, error);
+        void this._teardown(urn, error);
       });
 
       return instance.api as T;

--- a/packages/registry/tests/helpers.ts
+++ b/packages/registry/tests/helpers.ts
@@ -1,10 +1,5 @@
 import { TypedEventEmitter } from "../src/event-emitter";
-import type {
-  ServiceBlueprint,
-  ServiceEvents,
-  ServiceInstance,
-  ToolDefinition,
-} from "../src/types";
+import type { ServiceBlueprint, ServiceEvents, ToolDefinition } from "../src/types";
 
 export interface StaticBlueprintResult {
   blueprint: ServiceBlueprint<Record<string, unknown>, string>;

--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -190,7 +190,9 @@ function startListener(
     if (endpoint.transport === "unix") {
       try {
         fs.unlinkSync(endpoint.socketPath);
-      } catch {}
+      } catch {
+        /* no stale socket to remove; ignore */
+      }
     }
 
     const server = net.createServer(onConnection);
@@ -413,7 +415,9 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
       if (endpoint.transport === "unix") {
         try {
           fs.unlinkSync(endpoint.socketPath);
-        } catch {}
+        } catch {
+          /* best-effort socket cleanup; ignore errors */
+        }
       }
       throw err;
     }
@@ -478,7 +482,9 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
         if (endpoint.transport === "unix") {
           try {
             fs.unlinkSync(endpoint.socketPath);
-          } catch {}
+          } catch {
+            /* best-effort socket cleanup; ignore errors */
+          }
         }
       },
       events,

--- a/packages/tool-server/src/blueprints/chromium-js-runtime-debugger.ts
+++ b/packages/tool-server/src/blueprints/chromium-js-runtime-debugger.ts
@@ -31,10 +31,21 @@ export function chromiumJsRuntimeDebuggerRef(device: DeviceInfo): {
   };
 }
 
+function stringifyConsoleValue(value: unknown): string {
+  if (typeof value === "object" && value !== null) {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return Object.prototype.toString.call(value);
+    }
+  }
+  return String(value);
+}
+
 function formatConsoleArgs(params: ConsoleAPICalledParams): string {
   return params.args
     .map((arg) => {
-      if (arg.value !== undefined) return String(arg.value);
+      if (arg.value !== undefined) return stringifyConsoleValue(arg.value);
       if (arg.description) return arg.description;
       return `[${arg.type}]`;
     })

--- a/packages/tool-server/src/blueprints/js-runtime-debugger.ts
+++ b/packages/tool-server/src/blueprints/js-runtime-debugger.ts
@@ -32,10 +32,21 @@ export type ConsoleLogEvents = {
   log: (entry: ConsoleLogEntry) => void;
 };
 
+function stringifyConsoleValue(value: unknown): string {
+  if (typeof value === "object" && value !== null) {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return Object.prototype.toString.call(value);
+    }
+  }
+  return String(value);
+}
+
 function formatConsoleArgs(params: ConsoleAPICalledParams): string {
   return params.args
     .map((arg) => {
-      if (arg.value !== undefined) return String(arg.value);
+      if (arg.value !== undefined) return stringifyConsoleValue(arg.value);
       if (arg.description) return arg.description;
       return `[${arg.type}]`;
     })

--- a/packages/tool-server/src/blueprints/native-devtools.ts
+++ b/packages/tool-server/src/blueprints/native-devtools.ts
@@ -336,7 +336,7 @@ async function listRunningUIKitApplicationBundleIds(udid: string): Promise<Set<s
 
   const bundleIds = new Set<string>();
   for (const line of stdout.split("\n")) {
-    const match = line.match(/UIKitApplication:([^\[]+)/);
+    const match = line.match(/UIKitApplication:([^[]+)/);
     if (match) {
       bundleIds.add(match[1].trim());
     }
@@ -480,7 +480,9 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
     if (transport === "unix") {
       try {
         fs.unlinkSync(socketPath);
-      } catch {}
+      } catch {
+        /* no stale socket to remove; ignore */
+      }
     }
 
     // ── Socket server ─────────────────────────────────────────────────────────
@@ -689,7 +691,9 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
         if (transport === "unix") {
           try {
             fs.unlinkSync(socketPath);
-          } catch {}
+          } catch {
+            /* best-effort socket cleanup; ignore errors */
+          }
         }
         for (const { reject } of pendingRpc.values()) {
           reject(new Error("NativeDevtools service disposed"));

--- a/packages/tool-server/src/chromium-server/http-api.ts
+++ b/packages/tool-server/src/chromium-server/http-api.ts
@@ -144,7 +144,7 @@ export function createChromiumServerRouter(server: ChromiumServer): Router {
     let session: { stop: () => Promise<void> } | null = null;
     try {
       session = await server.startScreencast({ format: "jpeg", quality: 70 });
-    } catch (err) {
+    } catch {
       server.events.off("frame", onFrame);
       res.end();
       return;
@@ -250,9 +250,14 @@ function bindWsToServer(ws: WebSocket, server: ChromiumServer): void {
   });
 
   ws.on("message", async (raw) => {
+    const text = Buffer.isBuffer(raw)
+      ? raw.toString()
+      : Array.isArray(raw)
+        ? Buffer.concat(raw).toString()
+        : Buffer.from(raw).toString();
     let msg: WsRequest;
     try {
-      msg = JSON.parse(raw.toString()) as WsRequest;
+      msg = JSON.parse(text) as WsRequest;
     } catch (err) {
       sendJson({ status: "error", message: `parse error: ${(err as Error).message}` });
       return;

--- a/packages/tool-server/src/chromium-server/index.ts
+++ b/packages/tool-server/src/chromium-server/index.ts
@@ -13,7 +13,6 @@ import type {
   ButtonType,
   ChromiumServer,
   KeyDirection,
-  MediaReady,
   Point,
   Rotation,
   ScreencastFrame,

--- a/packages/tool-server/src/chromium-server/input.ts
+++ b/packages/tool-server/src/chromium-server/input.ts
@@ -93,19 +93,6 @@ export async function sendCharInsert(cdp: CDPClient, text: string): Promise<void
   await cdp.send("Input.dispatchKeyEvent", { type: "char", text });
 }
 
-const BUTTON_TO_KEY: Record<ButtonType, { key: string; codeName: string; vk: number } | null> = {
-  // Hardware buttons don't map cleanly to a desktop renderer. We do best-effort
-  // for the ones that *do* have an analogue, and reject the rest with a clear
-  // error so callers don't think they worked.
-  Home: null, // No browser equivalent — would need main-process ipc.
-  Back: { key: "Alt", codeName: "AltLeft", vk: 18 }, // Will be paired with ArrowLeft below.
-  Power: null,
-  VolumeUp: null,
-  VolumeDown: null,
-  AppSwitch: null,
-  ActionButton: null,
-};
-
 /**
  * Best-effort hardware-button translation. Only `Back` has a sane
  * desktop-renderer equivalent (Alt+Left to walk navigation history). The

--- a/packages/tool-server/src/chromium-server/screenshot.ts
+++ b/packages/tool-server/src/chromium-server/screenshot.ts
@@ -30,7 +30,6 @@ let sharpLoadWarningEmitted = false;
 function tryLoadSharp(): SharpModule | null {
   if (sharpCache !== undefined) return sharpCache;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const mod = require("sharp") as SharpModule;
     sharpCache = mod;
     return mod;

--- a/packages/tool-server/src/chromium-server/viewport.ts
+++ b/packages/tool-server/src/chromium-server/viewport.ts
@@ -23,7 +23,8 @@ export async function readViewport(cdp: CDPClient): Promise<ViewportSize> {
     parsed = JSON.parse(raw) as { w: number; h: number; dpr: number };
   } catch (err) {
     throw new Error(
-      `Chromium CDP: viewport payload was not JSON: ${err instanceof Error ? err.message : String(err)}`
+      `Chromium CDP: viewport payload was not JSON: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err }
     );
   }
   if (!parsed.w || !parsed.h) {

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -317,7 +317,11 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
       // server-readable paths BEFORE schema validation, so the tool's zod
       // schema only ever sees the string params it declares. 422 on a file
       // that is reachable neither in place nor via uploaded content.
-      let bodyArgs = req.body;
+      // Type kept as `any` (matching req.body) so the downstream optional-chained
+      // access below — parsedData?.udid / parsedData?.device_id — type-checks as
+      // it did before. The `= req.body` initializer was dead: the try always
+      // assigns bodyArgs before it is read, and the catch never falls through.
+      let bodyArgs: any;
       let resolvedFileInputs: Record<string, ResolvedFileInput> | undefined;
       try {
         const resolved = await resolveFileInputs(def, req.body);

--- a/packages/tool-server/src/tools/debugger/debugger-reload-metro.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-reload-metro.ts
@@ -37,7 +37,7 @@ Use when you want to apply code changes or reset JS state. Returns { reloaded, p
   services: (params) => ({
     debugger: `JsRuntimeDebugger:${params.port}:${params.device_id}`,
   }),
-  async execute(services, params) {
+  async execute(services, _params) {
     const api = services.debugger as JsRuntimeDebuggerApi;
     const port = api.port;
 
@@ -56,7 +56,7 @@ Use when you want to apply code changes or reset JS state. Returns { reloaded, p
 
     try {
       await api.cdp.send("Page.reload");
-      disableLogBox();
+      void disableLogBox();
       return { reloaded: true, port, method: "cdp", ...context };
     } catch {
       // Fall through to HTTP fallback
@@ -72,7 +72,7 @@ Use when you want to apply code changes or reset JS state. Returns { reloaded, p
         `Failed to reload: CDP Page.reload unsupported and Metro HTTP /reload returned ${res.status} ${res.statusText}.`
       );
     }
-    disableLogBox();
+    void disableLogBox();
     return { reloaded: true, port, method: "http", ...context };
   },
 };

--- a/packages/tool-server/src/tools/describe/platforms/android/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/index.ts
@@ -42,7 +42,7 @@ export async function describeAndroid(
       // recoverable because the legacy path has independent failure modes.
       // Surface at debug level so the failure is observable without leaking
       // into the per-call result.
-      // eslint-disable-next-line no-console
+
       console.debug(
         `[describe.android] devtools service failed, falling back to uiautomator dump: ${
           serviceErr instanceof Error ? serviceErr.message : String(serviceErr)

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -241,7 +241,8 @@ export async function describeChromium(api: ChromiumCdpApi): Promise<DescribeTre
     parsed = JSON.parse(payload);
   } catch (err) {
     throw new Error(
-      `Chromium describe: could not parse renderer payload: ${err instanceof Error ? err.message : String(err)}`
+      `Chromium describe: could not parse renderer payload: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err }
     );
   }
   if (parsed.error) {

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -8,11 +8,7 @@ import {
   type NativeDevtoolsApi,
   type NativeDevtoolsInitFailedResult,
 } from "../../blueprints/native-devtools";
-import {
-  ensureAutomationEnabled,
-  isEntitlementBypassActive,
-  setAccessibilityPrefsPreBoot,
-} from "../../blueprints/ax-service";
+import { ensureAutomationEnabled, setAccessibilityPrefsPreBoot } from "../../blueprints/ax-service";
 import {
   adbShell,
   checkSnapshotLoadable,
@@ -541,13 +537,19 @@ async function attemptBoot(params: {
         `Verify Android SDK Emulator is installed and on PATH, then retry.`
     );
   });
+  // `earlyExitError` is assigned only inside the event-handler closures above, so
+  // a direct synchronous read flow-narrows to `null`. Read the live value through
+  // this getter so the declared `Error | null` type (and thus the thrown Error)
+  // is preserved.
+  const readEarlyExitError = (): Error | null => earlyExitError;
 
   // Stage 2: wait for adb to see the new emulator.
   let serial: string | null = null;
   const adbDeadline = Math.min(params.attemptDeadline, Date.now() + params.adbRegisterBudgetMs);
   try {
     while (Date.now() < adbDeadline) {
-      if (earlyExitError) throw earlyExitError;
+      const launchError = readEarlyExitError();
+      if (launchError) throw launchError;
       const newSerials = await listNewEmulatorSerials(params.serialsBefore);
       if (newSerials.length >= 1) {
         if (newSerials.length === 1) {
@@ -567,9 +569,10 @@ async function attemptBoot(params: {
     throw err;
   }
   if (!serial) {
-    if (earlyExitError) {
+    const launchError = readEarlyExitError();
+    if (launchError) {
       killDetachedEmulator(child);
-      throw earlyExitError;
+      throw launchError;
     }
     killDetachedEmulator(child);
     throw new Error(
@@ -773,7 +776,8 @@ async function bootAndroidImpl(params: {
     throw new Error(
       `\`adb\` is not available on PATH (${
         err instanceof Error ? err.message : String(err)
-      }). Install Android SDK Platform Tools before booting an emulator.`
+      }). Install Android SDK Platform Tools before booting an emulator.`,
+      { cause: err }
     );
   }
 
@@ -788,7 +792,7 @@ async function bootAndroidImpl(params: {
   // instead of spawning a second emulator that would collide on AVD locks,
   // burn the full 90 s hot-boot budget in the probe + spawn failure, and
   // surface a misleading "Running multiple emulators" error.
-  let hotBootFailureReason: string | null = null;
+  let hotBootFailureReason: string | null;
   const alreadyRunning = existingDevices.find(
     (d) => d.isEmulator && d.avdName === params.avdName && d.state === "device"
   );
@@ -816,10 +820,7 @@ async function bootAndroidImpl(params: {
           avdName: params.avdName,
           booted: true,
         };
-      } catch (err) {
-        hotBootFailureReason = `running AVD framebuffer was wedged (${
-          err instanceof Error ? err.message : String(err)
-        }), respawning`;
+      } catch (_err) {
         // assertScreencapAlive already killed the emulator; refresh the
         // existing-devices snapshot so the killed serial is included in
         // serialsBefore (matching the hot-boot catch refresh below) and the
@@ -959,7 +960,8 @@ async function bootAndroidImpl(params: {
       : "";
     throw new Error(
       `${base} Emulator has been terminated so the next boot starts clean.` +
-        ` If this keeps happening, wipe the AVD with \`emulator -avd ${params.avdName} -wipe-data\`.${suffix}`
+        ` If this keeps happening, wipe the AVD with \`emulator -avd ${params.avdName} -wipe-data\`.${suffix}`,
+      { cause: err }
     );
   }
 

--- a/packages/tool-server/src/tools/devices/boot-electron.ts
+++ b/packages/tool-server/src/tools/devices/boot-electron.ts
@@ -176,7 +176,8 @@ export async function bootElectronApp(options: BootElectronOptions): Promise<Ele
     });
   } catch (err) {
     throw new Error(
-      `Electron boot: failed to spawn ${launcher.command}: ${err instanceof Error ? err.message : String(err)}`
+      `Electron boot: failed to spawn ${launcher.command}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err }
     );
   }
 

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -73,7 +73,7 @@ export function getFlowsDir(): string {
   return path.join(requireActiveProjectRoot(), FLOWS_DIR_NAME);
 }
 
-const FLOW_NAME_PATTERN = /^[A-Za-z0-9_\-]+$/;
+const FLOW_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 export function assertSafeFlowName(name: string): void {
   if (!FLOW_NAME_PATTERN.test(name)) {

--- a/packages/tool-server/src/tools/profiler/native-profiler/platforms/ios.ts
+++ b/packages/tool-server/src/tools/profiler/native-profiler/platforms/ios.ts
@@ -92,7 +92,8 @@ function enumerateRunningUserApps(udid: string): { info: AppInfo; pid: number }[
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
       `Failed to enumerate running processes on simulator ${udid} within ${DETECT_RUNNING_APP_TIMEOUT_MS} ms. ` +
-        `Verify the simulator is booted and responsive, then retry. Underlying error: ${msg}`
+        `Verify the simulator is booted and responsive, then retry. Underlying error: ${msg}`,
+      { cause: err }
     );
   }
 
@@ -100,7 +101,7 @@ function enumerateRunningUserApps(udid: string): { info: AppInfo; pid: number }[
   // (PID, status, label). Only lines with a numeric PID are actually running.
   const runningPids = new Map<string, number>();
   for (const line of launchctlOutput.split("\n")) {
-    const match = line.match(/^\s*(\d+)\s+\S+\s+UIKitApplication:([^\[]+)/);
+    const match = line.match(/^\s*(\d+)\s+\S+\s+UIKitApplication:([^[]+)/);
     if (match) {
       runningPids.set(match[2], Number(match[1]));
     }
@@ -122,7 +123,8 @@ function enumerateRunningUserApps(udid: string): { info: AppInfo; pid: number }[
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
       `Failed to list installed apps on simulator ${udid} within ${DETECT_RUNNING_APP_TIMEOUT_MS} ms. ` +
-        `Verify the simulator is booted and responsive, then retry. Underlying error: ${msg}`
+        `Verify the simulator is booted and responsive, then retry. Underlying error: ${msg}`,
+      { cause: err }
     );
   }
 

--- a/packages/tool-server/src/tools/restart-app/platforms/android.ts
+++ b/packages/tool-server/src/tools/restart-app/platforms/android.ts
@@ -33,7 +33,9 @@ export const androidImpl: PlatformImpl<
     try {
       assertAmStartOk(out);
     } catch (err) {
-      throw new Error(`relaunch failed: ${err instanceof Error ? err.message : String(err)}`);
+      throw new Error(`relaunch failed: ${err instanceof Error ? err.message : String(err)}`, {
+        cause: err,
+      });
     }
     return { restarted: true, bundleId };
   },

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -68,7 +68,7 @@ export async function emulatorSupportsFlag(
   const cached = emulatorFlagSupportCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
-  let output = "";
+  let output: string;
   try {
     const { stdout, stderr } = await execFileAsync(emulatorPath, ["-help"], {
       timeout: options.timeoutMs ?? 10_000,
@@ -381,7 +381,8 @@ export async function waitForBootCompleted(
       if (isTerminalAdbError(message)) {
         throw new Error(
           `Cannot wait for ${serial} to boot — adb reports the device is in a terminal state: ${message}.` +
-            ` Authorise the device, reconnect it, or pick a different target.`
+            ` Authorise the device, reconnect it, or pick a different target.`,
+          { cause: err }
         );
       }
       // Otherwise: device may be mid-boot; swallow and retry.

--- a/packages/tool-server/src/utils/android-helper-install.ts
+++ b/packages/tool-server/src/utils/android-helper-install.ts
@@ -30,7 +30,7 @@ async function probeInstalledVersion(
   serial: string,
   packageName: string
 ): Promise<InstalledVersionProbe> {
-  let out = "";
+  let out: string;
   try {
     out = await adbShell(serial, `cmd package list packages --show-versioncode ${packageName}`, {
       timeoutMs: 5_000,

--- a/packages/tool-server/src/utils/android-profiler/capture.ts
+++ b/packages/tool-server/src/utils/android-profiler/capture.ts
@@ -224,7 +224,7 @@ export interface StopPerfettoResult {
 export async function stopPerfetto(opts: StopPerfettoOptions): Promise<StopPerfettoResult> {
   // First-poll check: if the daemon is already gone, skip the SIGTERM and pull
   // whatever's on disk.
-  let aliveBeforeSignal = false;
+  let aliveBeforeSignal: boolean;
   try {
     const out = await adbShell(opts.serial, `[ -d /proc/${opts.pid} ] && echo alive || echo gone`, {
       timeoutMs: STOP_PROBE_TIMEOUT_MS,

--- a/packages/tool-server/src/utils/android-profiler/detect-app.ts
+++ b/packages/tool-server/src/utils/android-profiler/detect-app.ts
@@ -23,7 +23,8 @@ export async function detectAndroidRunningApp(serial: string): Promise<string> {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
       `Failed to enumerate running activities on ${serial} within ${DETECT_TIMEOUT_MS} ms. ` +
-        `Verify the device is booted and responsive, then retry. Underlying error: ${msg}`
+        `Verify the device is booted and responsive, then retry. Underlying error: ${msg}`,
+      { cause: err }
     );
   }
 
@@ -44,7 +45,8 @@ export async function detectAndroidRunningApp(serial: string): Promise<string> {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
       `Failed to list user-installed packages on ${serial} within ${DETECT_TIMEOUT_MS} ms. ` +
-        `Underlying error: ${msg}`
+        `Underlying error: ${msg}`,
+      { cause: err }
     );
   }
 

--- a/packages/tool-server/src/utils/android-profiler/pipeline/index.ts
+++ b/packages/tool-server/src/utils/android-profiler/pipeline/index.ts
@@ -119,9 +119,9 @@ export async function runAndroidProfilerPipeline(
     exportErrors.cpu =
       `No CPU samples were captured for cmdline \`${appPackage}\`. ` +
       `The most common cause is the target app being non-debuggable (release build) ` +
-      `without a \`<profileable shell=\"true\">\` entry in its AndroidManifest.xml. ` +
+      `without a \`<profileable shell="true">\` entry in its AndroidManifest.xml. ` +
       `Without that, Perfetto silently drops the linux.perf data source. ` +
-      `Add \`<profileable android:shell=\"true\"/>\` to the \`<application>\` element ` +
+      `Add \`<profileable android:shell="true"/>\` to the \`<application>\` element ` +
       `and rebuild, or run a debug variant of the app.`;
   }
 

--- a/packages/tool-server/src/utils/android-profiler/pipeline/sql-safety.ts
+++ b/packages/tool-server/src/utils/android-profiler/pipeline/sql-safety.ts
@@ -27,7 +27,7 @@ export function sanitizeProcessName(name: string): string {
  * templates/demangled names; rejects quotes/semicolons).
  */
 export function sanitizeIdentifier(name: string): string {
-  if (!/^[A-Za-z0-9_.:+\/\-<> ]+$/.test(name)) {
+  if (!/^[A-Za-z0-9_.:+/\-<> ]+$/.test(name)) {
     throw new Error(`Refusing to substitute identifier with unsafe characters: "${name}"`);
   }
   return name;

--- a/packages/tool-server/src/utils/debugger/cdp-client.ts
+++ b/packages/tool-server/src/utils/debugger/cdp-client.ts
@@ -278,7 +278,7 @@ export class CDPClient {
       this.evaluate(expression, { timeout }).catch((err) => {
         this.pendingBindings.delete(id);
         clearTimeout(timer);
-        reject(err);
+        reject(err instanceof Error ? err : new Error(String(err)));
       });
     });
   }
@@ -292,9 +292,14 @@ export class CDPClient {
   }
 
   private handleMessage(raw: WebSocket.RawData): void {
+    const text = Buffer.isBuffer(raw)
+      ? raw.toString()
+      : Array.isArray(raw)
+        ? Buffer.concat(raw).toString()
+        : Buffer.from(raw).toString();
     let msg: Record<string, unknown>;
     try {
-      msg = JSON.parse(raw.toString());
+      msg = JSON.parse(text);
     } catch {
       return;
     }

--- a/packages/tool-server/src/utils/ios-profiler/pipeline/xml-parser.ts
+++ b/packages/tool-server/src/utils/ios-profiler/pipeline/xml-parser.ts
@@ -310,7 +310,6 @@ export function parseLeaksXml(xml: string): RawLeak[] {
   const rowRe = /<row\s+([^>]*?)\/>/g;
   let rm;
   while ((rm = rowRe.exec(xml)) !== null) {
-    const rowAttrs = rm[1];
     const objectType = attr(rm[0], "leaked-object") ?? "Unknown";
     const sizeStr = attr(rm[0], "size");
     const sizeBytes = sizeStr ? parseInt(sizeStr, 10) : 0;

--- a/packages/tool-server/src/utils/react-profiler/metro/source-map.ts
+++ b/packages/tool-server/src/utils/react-profiler/metro/source-map.ts
@@ -34,7 +34,6 @@ function tryLoadLib(): SourceMapLib | null {
   libLoadAttempted = true;
   for (const pkg of ["source-map-js", "source-map"]) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
       lib = require(pkg) as SourceMapLib;
       return lib;
     } catch {

--- a/packages/tool-server/src/utils/react-profiler/pipeline/05-render.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/05-render.ts
@@ -189,8 +189,6 @@ function buildFullMarkdown(
     sessionContext.reactCompilerEnabled,
     anyRuntimeCompilerDetected
   );
-  const hotCount = input.hotCommitSummaries.filter((s) => !s.isMargin).length;
-
   const lines: string[] = [
     `# Profiling Analysis — ${durationS}s session`,
     `${compilerLine}  **Hot commits:** ${totalHotCommits} of ${input.reactCommits} total`,
@@ -296,7 +294,7 @@ function buildFullMarkdown(
 function renderCommit(
   summary: HotCommitSummary,
   annotations: Array<{ offsetMs: number; label: string }>,
-  sessionContext: SessionContext
+  _sessionContext: SessionContext
 ): string[] {
   const relativeMs = Math.max(0, summary.timestampMs);
   const relativeS = (relativeMs / 1000).toFixed(1);

--- a/packages/tool-server/src/utils/react-profiler/pipeline/06-resolve/ast-index.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/06-resolve/ast-index.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "fs";
 import { join } from "path";
 
 // Tree-sitter requires native bindings loaded via require (CJS context)
-// eslint-disable-next-line @typescript-eslint/no-require-imports
+
 const _require = require;
 
 export interface TreeSitterNode {
@@ -61,16 +61,14 @@ function loadTreeSitter(): {
   _treeSitterLoaded = true;
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const TSModule = _require("tree-sitter");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+
     _ParserClass = (TSModule.default ?? TSModule) as ParserCtor;
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const TSLang = _require("tree-sitter-typescript");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+
     _tsLanguage = TSLang.typescript ?? TSLang.default?.typescript;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+
     _tsxLanguage = TSLang.tsx ?? TSLang.default?.tsx;
   } catch {
     // tree-sitter not available

--- a/packages/tool-server/test/android-perfetto/capture.test.ts
+++ b/packages/tool-server/test/android-perfetto/capture.test.ts
@@ -27,7 +27,7 @@ const captureState = vi.hoisted(() => ({
 vi.mock("child_process", () => ({
   spawn: (_path: string, args: string[]) => {
     // Use eval to lazy-construct so the FakeChild reference isn't hoisted.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+
     const Mod = require("events");
     const child: FakeChild = new (class extends (Mod.EventEmitter as typeof EventEmitter) {
       pid = 9000;

--- a/packages/tool-server/test/chromium-cdp-blueprint.test.ts
+++ b/packages/tool-server/test/chromium-cdp-blueprint.test.ts
@@ -114,7 +114,7 @@ async function startFakeCdp(): Promise<FakeCdp> {
           }
         }
         ws.send(JSON.stringify({ id: msg.id, result }));
-      } catch (err) {
+      } catch {
         // Ignore malformed payloads — the blueprint guards against bad replies on its own.
       }
     });

--- a/packages/tool-server/test/chromium-js-runtime-debugger.test.ts
+++ b/packages/tool-server/test/chromium-js-runtime-debugger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { TypedEventEmitter } from "@argent/registry";
 import {
   chromiumJsRuntimeDebuggerBlueprint,

--- a/packages/tool-server/test/chromium-network.test.ts
+++ b/packages/tool-server/test/chromium-network.test.ts
@@ -142,7 +142,7 @@ describe("NetworkManager (recording)", () => {
 // ── view-network-logs / view-network-request-details: Chromium branch ────────
 import { networkLogsTool } from "../src/tools/network/network-logs";
 import { networkRequestTool } from "../src/tools/network/network-request";
-import { assertSupported, UnsupportedOperationError } from "../src/utils/capability";
+import { assertSupported } from "../src/utils/capability";
 import { resolveDevice } from "../src/utils/device-info";
 import type { NetworkRequestRecord } from "../src/chromium-server/network";
 

--- a/packages/tool-server/test/chromium-server-screenshot.test.ts
+++ b/packages/tool-server/test/chromium-server-screenshot.test.ts
@@ -70,7 +70,7 @@ describe("chromium-server/screenshot", () => {
     // Force the dynamic `require("sharp")` to throw — independent of whether
     // sharp is actually installed in the test environment — by stubbing
     // Module._resolveFilename to fail for "sharp" specifically.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+
     const Module = require("node:module") as {
       _resolveFilename: (...args: unknown[]) => string;
     };

--- a/packages/tool-server/test/debugger/inspect-at-point-guards.test.ts
+++ b/packages/tool-server/test/debugger/inspect-at-point-guards.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   INSPECT_NO_DEVTOOLS_HOOK_ERROR,
   INSPECT_NO_FIBER_ROOT_ERROR,

--- a/packages/tool-server/test/debugger/inspect-at-point-script.test.ts
+++ b/packages/tool-server/test/debugger/inspect-at-point-script.test.ts
@@ -235,7 +235,7 @@ describe("makeInspectScript — Fabric host fiber with unrealized public instanc
     const rnRoot = rootOf(comp("FreshButton", host));
     const rn = makeRenderer(comp("FreshButton", null));
 
-    const out = runInspect(makeHook([[1, rn.renderer, [rnRoot]]])); // fabric: true (default)
+    runInspect(makeHook([[1, rn.renderer, [rnRoot]]])); // fabric: true (default)
 
     expect(rn.fn).toHaveBeenCalledTimes(1);
     expect(rn.fn.mock.calls[0][0]).toBe(null);

--- a/packages/tool-server/test/idle-timeout.test.ts
+++ b/packages/tool-server/test/idle-timeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createHttpApp, type HttpAppHandle } from "../src/http";
+import { createHttpApp } from "../src/http";
 import type { Registry } from "@argent/registry";
 
 function stubRegistry() {

--- a/packages/tool-server/test/metro/cdp-client.test.ts
+++ b/packages/tool-server/test/metro/cdp-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { WebSocketServer, WebSocket } from "ws";
 import { CDPClient } from "../../src/utils/debugger/cdp-client";
 

--- a/packages/tool-server/test/simulator-watcher-init-failure.test.ts
+++ b/packages/tool-server/test/simulator-watcher-init-failure.test.ts
@@ -120,7 +120,7 @@ afterEach(() => {
 
 describe("simulator-watcher with api-owned init failure state", () => {
   it("stops calling ensureEnvReady after the api reports givenUp", async () => {
-    let bootedUdids: string[] = [UDID];
+    const bootedUdids: string[] = [UDID];
     execFileMock.mockImplementation((cmd: string) => {
       if (cmd === "xcrun") return bootedListResponse(bootedUdids);
       return { stdout: "", stderr: "" };
@@ -154,7 +154,7 @@ describe("simulator-watcher with api-owned init failure state", () => {
   });
 
   it("makes no further ensureEnvReady calls for a healthy UDID after init", async () => {
-    let bootedUdids: string[] = [UDID];
+    const bootedUdids: string[] = [UDID];
     execFileMock.mockImplementation((cmd: string) => {
       if (cmd === "xcrun") return bootedListResponse(bootedUdids);
       return { stdout: "", stderr: "" };

--- a/packages/tool-server/test/stop-tools.test.ts
+++ b/packages/tool-server/test/stop-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Registry, ServiceState } from "@argent/registry";
 import { createStopSimulatorServerTool } from "../src/tools/simulator/stop-simulator-server";
 import { createStopAllSimulatorServersTool } from "../src/tools/simulator/stop-all-simulator-servers";

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -61,7 +61,9 @@ async function waitForHttp(url, timeoutMs = 20_000) {
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(1000) });
       if (res.ok) return true;
-    } catch {}
+    } catch {
+      /* not up yet — keep polling until the deadline */
+    }
     await new Promise((r) => setTimeout(r, 400));
   }
   return false;
@@ -200,7 +202,9 @@ function restoreMcpEntry(configPath, originalEntry, existedBefore) {
   if (!existedBefore && Object.keys(config).length === 0) {
     try {
       fs.unlinkSync(configPath);
-    } catch {}
+    } catch {
+      /* file already absent — nothing to remove */
+    }
     return;
   }
 
@@ -265,7 +269,9 @@ function cleanup() {
   }
   try {
     fs.unlinkSync(STATE_FILE);
-  } catch {}
+  } catch {
+    /* state file already absent — nothing to remove */
+  }
 
   // Restore editor configs
   restoreMcpEntry(CLAUDE_JSON, originalArgentEntry, claudeConfigExists);
@@ -299,7 +305,9 @@ async function main() {
   }
   try {
     fs.unlinkSync(STATE_FILE);
-  } catch {}
+  } catch {
+    /* state file already absent — nothing to remove */
+  }
 
   // ── Step 6: Start tool-server from source ──────────────────────────────────
 


### PR DESCRIPTION
## What

Adds type-aware linting to the workspace. Until now the only static gate on JS/TS was Prettier (formatting) and `tsc` — there was no linter, so the whole class of bugs `tsc` doesn't catch (floating promises, misused promises, throwing non-Errors, unsafe stringification, dead code) went unguarded across ~450 TS files.

- **`eslint.config.mjs`** — flat config. `recommendedTypeChecked` runs on the TS sources via an explicit `project` list (each package keeps tests in a separate `tsconfig.test.json` that `projectService` can't auto-discover, so it's listed explicitly). Type-checked rules are disabled for the loosely-typed plain-JS build/dev scripts. The `argent-private` submodule and build artifacts are ignored (mirrors `.prettierignore`).
- **`lint` / `lint:fix`** npm scripts.
- **`.github/workflows/lint.yml`** — builds the workspace (type-aware rules need the referenced projects' declarations) then runs `eslint .`. Node 24 (ESLint 10 requires `^20.19 || ^22.13 || >=24`).

## Rule calibration

This is an adoption PR, so it's deliberately calibrated rather than maximal:

- **Kept on (bug-catchers):** `no-floating-promises`, `no-misused-promises` (with `checksVoidReturn: false` to drop the noisy callback variant), `only-throw-error`, `no-base-to-string`, `prefer-promise-reject-errors`, `no-unused-vars` (`_`-prefix escape hatch), plus the ESLint recommended set.
- **Parked off as documented debt:** the high-volume style/`any`-family rules — `no-unsafe-*`, `require-await`, `no-unnecessary-type-assertion`, `restrict-template-expressions`, `unbound-method`, `no-explicit-any`, etc. These flag broad classes of pre-existing code and are out of scope here; each is commented as a ratchet target for follow-up passes.

All findings from the kept-on rules are fixed in this PR (dead code/imports, error-cause chaining, **3 genuine floating promises**, non-Error throws, unsafe stringification). Stale unused `eslint-disable` directives left over in the tree were removed by `--fix`.

## Verification

Locally, all green: `eslint .` (0 errors), `tsc --build`, `typecheck:tests`/`typecheck:scripts`, the full `vitest` suite (no behavior change from the fixes), and `prettier --check`.

## Not included (intentionally)

Other static-analysis gates discussed (CodeQL, dependency-audit, ShellCheck, actionlint) are out of scope for this PR.