### PR TITLE
feat(ios-profiling): add @argent/ios-profiling — xctrace-free iOS Simulator profiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ packages/*/node_modules/
 packages/native-devtools-ios/bin/
 packages/native-devtools-ios/dylibs/
 
+# iOS-profiling native capture binaries (built locally via
+# packages/argent-ios-profiling/scripts/build.sh, like native-devtools-ios/bin).
+packages/argent-ios-profiling/bin/
+
 # Third-party Perfetto trace-processor WASM artifacts (fetched + verified via
 # scripts/download-trace-processor.sh). Ignore the generated files, not the dir,
 # so a future tracked README/.gitkeep isn't masked.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4945,7 +4945,8 @@
       "version": "0.11.0",
       "devDependencies": {
         "@types/node": "^25.9.0",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.6"
       }
     },
     "packages/argent-mcp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,10 @@
       "resolved": "packages/argent-installer",
       "link": true
     },
+    "node_modules/@argent/ios-profiling": {
+      "resolved": "packages/argent-ios-profiling",
+      "link": true
+    },
     "node_modules/@argent/mcp": {
       "resolved": "packages/argent-mcp",
       "link": true
@@ -4934,6 +4938,14 @@
         "@types/semver": "^7.7.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.6"
+      }
+    },
+    "packages/argent-ios-profiling": {
+      "name": "@argent/ios-profiling",
+      "version": "0.11.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.3"
       }
     },
     "packages/argent-mcp": {

--- a/packages/argent-ios-profiling/.clang-format
+++ b/packages/argent-ios-profiling/.clang-format
@@ -1,0 +1,12 @@
+# Objective-C formatting for objc_src/*.{m,h} via clang-format (the industry
+# standard, ships with the Xcode/LLVM toolchain). Google base — a widely used
+# Objective-C style — tuned to match the repo's Prettier config (2-space indent,
+# 100-column width). Run `npm run format:native -w @argent/ios-profiling`.
+BasedOnStyle: Google
+ColumnLimit: 100
+IndentWidth: 2
+ContinuationIndentWidth: 4
+ObjCBlockIndentWidth: 2
+PointerAlignment: Right
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortBlocksOnASingleLine: Empty

--- a/packages/argent-ios-profiling/README.md
+++ b/packages/argent-ios-profiling/README.md
@@ -50,9 +50,11 @@ captureProfile (TS)
 ```
 
 The TS layer is the orchestrator; the ObjC binary is a leaf that only produces raw bytes. The
-`src/parser/kdebug.ts` parser is a faithful port of the pykdebugparser callstack path (validated
-byte-for-byte against the Python reference — identical 36,028-callstack output), so the package
-has zero runtime dependency on `pymobiledevice3` / `pykdebugparser`.
+`src/parser/kdebug.ts` parser is a port of the pykdebugparser callstack path — during development
+it was diffed against the Python reference on a real capture (identical 36,028-callstack output),
+and its framing/threadmap/record-alignment logic is covered by the unit tests
+(`src/parser/kdebug.test.ts`) — so the package has zero runtime dependency on `pymobiledevice3` /
+`pykdebugparser`.
 
 ## Build
 

--- a/packages/argent-ios-profiling/README.md
+++ b/packages/argent-ios-profiling/README.md
@@ -1,0 +1,100 @@
+# @argent/ios-profiling
+
+An xctrace-free iOS-Simulator profiler for Argent. On **Xcode 26.4 / 26.5 / 26.6 / 27.0**,
+`xctrace record --device <sim>` hangs on finalize (the simulator `coreprofilesessiontap`
+finalize regression), breaking Argent's native iOS profiler. This package replaces the broken
+capture+export step: a native binary drives the Instruments server directly over **DTX**, and a
+**pure-TypeScript** parser emits the same `xctrace export`-format XML that
+`runIosProfilerPipeline` already consumes — so everything downstream is unchanged.
+
+macOS-only (iOS Simulator profiling is darwin-only). **No Python, no third-party deps** — just
+the native binary + stdlib TypeScript + `atos`/`simctl` (Xcode CLT).
+
+## API
+
+```ts
+import { captureProfile, captureMemory, captureAllocations } from "@argent/ios-profiling";
+
+// CPU + Hangs + Leaks → the xctrace-export XML set for runIosProfilerPipeline
+const { cpu, hangs, leaks, meta } = await captureProfile({
+  udid,
+  durationSec: 5,
+  target: "MyApp" /* or pid */,
+  outPrefix: "/tmp/prof",
+});
+// → /tmp/prof_raw_{cpu,hangs,leaks}.xml  (drop into runIosProfilerPipeline({cpu,hangs,leaks}))
+
+const mem = await captureMemory(udid, 3, pid); // [{physFootprintBytes, residentBytes}, …]
+const heap = await captureAllocations(udid, pid); // {totalNodes, objcClasses, swiftClasses, summary}
+```
+
+## Coverage (Argent's template + extras), all validated on a real 26.5 sim
+
+| Vector                  | Source                                     | Output                                              |
+| ----------------------- | ------------------------------------------ | --------------------------------------------------- |
+| **Time Profiler (CPU)** | `coreprofilesessiontap` (DTX)              | `time-profile` XML, symbolicated via `atos -p`      |
+| **Hangs**               | derived (main-thread on-CPU runs ≥250ms)   | `potential-hangs` XML                               |
+| **Leaks**               | in-sim leaks engine (`simctl spawn leaks`) | `Leaks` detail XML                                  |
+| **Memory**              | `sysmontap` (DTX)                          | per-process footprint/RSS time series               |
+| **Allocations**         | in-sim heap engine (`simctl spawn heap`)   | live-object profile (size histogram + class counts) |
+
+## Architecture / data flow
+
+```
+captureProfile (TS)
+  ├─ bin/darwin/ios-profiler-capture (ObjC)  → DTServiceHubClient → coreprofilesessiontap
+  │     writes a length-framed kdebug stream (frame 0 = stackshot, frames 1+ = RAW_VERSION2)
+  ├─ src/parser/kdebug.ts   deframe + parse RAW_VERSION2 → kperf user-stack callstacks + tid→pid
+  ├─ src/parser/emit.ts     symbolicate (atos -p) → time-profile + potential-hangs XML
+  └─ src/leaks.ts           simctl spawn leaks → Leaks XML   (+ heap → allocations)
+```
+
+The TS layer is the orchestrator; the ObjC binary is a leaf that only produces raw bytes. The
+`src/parser/kdebug.ts` parser is a faithful port of the pykdebugparser callstack path (validated
+byte-for-byte against the Python reference — identical 36,028-callstack output), so the package
+has zero runtime dependency on `pymobiledevice3` / `pykdebugparser`.
+
+## Build
+
+```
+npm run build:native -w @argent/ios-profiling   # clang → bin/darwin/ios-profiler-{capture,mem}
+npm run build        -w @argent/ios-profiling   # tsc → dist/
+```
+
+`PREBUILT_IOS_PROFILER_BIN_DIR` lets CI on non-macOS copy prebuilt binaries instead of building.
+
+## Argent integration
+
+Replace the iOS `native-profiler-start`/`stop` xctrace path with `captureProfile`: it returns the
+exact `{cpu, hangs, leaks}` file set `runIosProfilerPipeline` expects. Profile your app **while
+busy** (an idle app shows `mach_msg2_trap`).
+
+## CPU sampling — periodic PET timer (1 kHz, xctrace parity)
+
+The capture configures the `coreprofilesessiontap` **periodic time trigger** (kperf "Profile
+Every Thread"), matching xctrace's Time Profiler:
+
+- `tk: 1` — the periodic time trigger (`DTKPTriggerTime`). The earlier `tk: 3` was a _kdebug-event_
+  trigger that only sampled on syscalls/context-switches, so it massively under-sampled CPU-bound
+  threads (~38 Hz) and over-sampled idle ones (wait-state noise).
+- `si: 1000000` — sample interval in **nanoseconds** (1 ms → 1 kHz; clamped by the kernel to
+  `kperf.limits.timer_min_pet_period_ns`). Override via `ARGENT_IOS_PROFILER_SI_NS`.
+- `kdf2: {0x25000000, 0x25010000, 0x25020000}` — restrict the kdebug typefilter to the PERF class
+  (0x25) subclasses actually parsed (PERF_Event / thread-data / user-stacks), instead of
+  `{0xFFFFFFFF}` all-classes which floods the buffer (~130 MB/s) and drops samples.
+
+Validated against xctrace-26.3 on a deterministic 100%-CPU workload: **4655 samples (931 Hz)** vs
+xctrace **5187 (1037 Hz)** over 5 s — within ~10%, both 100 % on the same hot symbol. Data volume
+dropped from ~668 MB to ~12 MB for the same window. An idle app correctly yields ~0 CPU samples
+(the timer only samples on-CPU threads).
+
+## Known limitations
+
+- Leaks/Allocations report leaked-object type/size/count; responsible-frame backtraces need the
+  target relaunched with `MallocStackLogging`.
+- On bursty multi-threaded workloads (e.g. a scrolling RN app) the capture is ~5× sparser than
+  xctrace's Time Profiler — the _relative_ hotspot ranking and weights match closely (validated on
+  ParadiseGallery: identical #1 Hermes-interpreter frame at ~8%), but absolute sample density is
+  lower. Raising the PET rate doesn't close it, so the residual gap (xctrace's scheduler-integrated
+  sampling of sub-millisecond on-CPU runs) is a separate follow-up; single-thread CPU-bound capture
+  is at parity.

--- a/packages/argent-ios-profiling/README.md
+++ b/packages/argent-ios-profiling/README.md
@@ -59,11 +59,17 @@ and its framing/threadmap/record-alignment logic is covered by the unit tests
 ## Build
 
 ```
-npm run build:native -w @argent/ios-profiling   # clang → bin/darwin/ios-profiler-{capture,mem}
-npm run build        -w @argent/ios-profiling   # tsc → dist/
+npm run build:native   -w @argent/ios-profiling   # clang → bin/darwin/ios-profiler-{capture,mem}
+npm run build          -w @argent/ios-profiling   # tsc → dist/
+npm run format:native  -w @argent/ios-profiling   # clang-format → objc_src/*.{m,h}
 ```
 
 `PREBUILT_IOS_PROFILER_BIN_DIR` lets CI on non-macOS copy prebuilt binaries instead of building.
+
+TypeScript is formatted by the repo-wide Prettier; the `objc_src/*.{m,h}` sources are formatted by
+**clang-format** (the LLVM/Xcode-toolchain standard) per the package `.clang-format` (Google
+Objective-C style, tuned to Prettier's 2-space / 100-column settings). `format:native:check`
+verifies formatting without writing.
 
 ## Argent integration
 

--- a/packages/argent-ios-profiling/ios-profiler.entitlements
+++ b/packages/argent-ios-profiling/ios-profiler.entitlements
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Entitlements applied when argent-private's build-native-binaries.yml signs
+    ios-profiler-capture / ios-profiler-mem with a Developer ID under hardened
+    runtime (`codesign --options runtime`).
+
+    disable-library-validation: the capture binary dlopen()s Xcode's private
+    frameworks (CoreSimulator, DTXConnectionServices, DVTInstruments*) to drive
+    the Instruments DTServiceHub. Those are Apple-signed under a *different* Team
+    ID than our Developer ID, so hardened runtime's library validation would
+    refuse the load and the DTX channel would never open. This entitlement lifts
+    that restriction for these two host-side tools.
+
+    NOTE: this is the suspected-sufficient set, mirroring ax-service's recipe.
+    It MUST be verified on a clean second Mac (download the CI-signed binary and
+    confirm `coreprofile channel=...` still connects) before relying on it for
+    distribution — the dev-machine validation in PR #350 used clang's ad-hoc
+    signature, which is a different trust context.
+  -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/argent-ios-profiling/ios-profiler.entitlements
+++ b/packages/argent-ios-profiling/ios-profiler.entitlements
@@ -5,7 +5,7 @@
   <!--
     Entitlements applied when argent-private's build-native-binaries.yml signs
     ios-profiler-capture / ios-profiler-mem with a Developer ID under hardened
-    runtime (`codesign --options runtime`).
+    runtime (`codesign -o runtime`).
 
     disable-library-validation: the capture binary dlopen()s Xcode's private
     frameworks (CoreSimulator, DTXConnectionServices, DVTInstruments*) to drive

--- a/packages/argent-ios-profiling/ios-profiler.entitlements
+++ b/packages/argent-ios-profiling/ios-profiler.entitlements
@@ -14,13 +14,28 @@
     refuse the load and the DTX channel would never open. This entitlement lifts
     that restriction for these two host-side tools.
 
-    NOTE: this is the suspected-sufficient set, mirroring ax-service's recipe.
-    It MUST be verified on a clean second Mac (download the CI-signed binary and
-    confirm `coreprofile channel=...` still connects) before relying on it for
-    distribution — the dev-machine validation in PR #350 used clang's ad-hoc
-    signature, which is a different trust context.
+    get-task-allow: on a SIP-enabled Mac, com.apple.dt.instruments.dtarbiter
+    validates the connecting client's code signature against the requirement
+      ( entitlement["com.apple.private.DTServiceHubClient"]
+        and (anchor apple or (anchor apple generic and certificate leaf[...6.1.9])) )
+      OR entitlement["com.apple.security.get-task-allow"]
+    and rejects clients that satisfy neither with -67050 (errSecCSReqFailed).
+    A third-party Developer-ID binary can never satisfy the first branch (it
+    needs an Apple-private entitlement + Apple signing), but get-task-allow is a
+    standard entitlement any developer can self-apply — and it is the OR escape
+    branch the arbiter accepts. Without it the released binary cannot open the
+    DTServiceHub channel on SIP-enabled hosts (only on SIP-disabled, where AMFI
+    bypasses the requirement entirely). Un-notarized distribution only — Apple
+    notarization rejects get-task-allow; these binaries ship via the private
+    releases repo and are not notarized.
+
+    NOTE: still verify on a SIP-enabled Mac — the arbiter binary carries two
+    requirement variants (with and without the get-task-allow branch) and which
+    is enforced under SIP is confirmed only by a live SIP-on test.
   -->
   <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.get-task-allow</key>
   <true/>
 </dict>
 </plist>

--- a/packages/argent-ios-profiling/objc_src/capture.m
+++ b/packages/argent-ios-profiling/objc_src/capture.m
@@ -5,47 +5,65 @@
 // report on stderr and exit non-zero so the TS layer never trusts a partial file.
 #import "conn.h"
 
-int main(int argc, char **argv){
-  if(argc<4){ fprintf(stderr,"usage: capture <udid> <seconds> <out.bin>\n"); return 1; }
+int main(int argc, char **argv) {
+  if (argc < 4) {
+    fprintf(stderr, "usage: capture <udid> <seconds> <out.bin>\n");
+    return 1;
+  }
   double secs = atof(argv[2]);
-  @autoreleasepool{
+  @autoreleasepool {
     loadInstrumentsFrameworks();
-    int spid=-1; id conn=connectLocalHub(&spid);
-    if(!conn){ fprintf(stderr,"capture: could not connect to DTServiceHub\n"); return 2; }
-    ((void(*)(id,SEL))objc_msgSend)(conn, sel_registerName("resume"));
-    ((void(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("_notifyOfPublishedCapabilities:"),
-        (@{@"com.apple.private.DTXBlockCompression": @2, @"com.apple.private.DTXConnection": @1}));
+    int spid = -1;
+    id conn = connectLocalHub(&spid);
+    if (!conn) {
+      fprintf(stderr, "capture: could not connect to DTServiceHub\n");
+      return 2;
+    }
+    ((void (*)(id, SEL))objc_msgSend)(conn, sel_registerName("resume"));
+    ((void (*)(id, SEL, id))objc_msgSend)(conn, sel_registerName("_notifyOfPublishedCapabilities:"),
+                                          (@{
+                                            @"com.apple.private.DTXBlockCompression" : @2,
+                                            @"com.apple.private.DTXConnection" : @1
+                                          }));
 
-    id ch = ((id(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("makeChannelWithIdentifier:"),
+    id ch = ((id (*)(id, SEL, id))objc_msgSend)(
+        conn, sel_registerName("makeChannelWithIdentifier:"),
         @"com.apple.instruments.server.services.coreprofilesessiontap");
-    if(!ch){ fprintf(stderr,"capture: could not open coreprofilesessiontap channel\n"); return 2; }
+    if (!ch) {
+      fprintf(stderr, "capture: could not open coreprofilesessiontap channel\n");
+      return 2;
+    }
 
-    NSString *outPath=[NSString stringWithUTF8String:argv[3]];
+    NSString *outPath = [NSString stringWithUTF8String:argv[3]];
     [[NSFileManager defaultManager] createFileAtPath:outPath contents:nil attributes:nil];
-    NSFileHandle *fh=[NSFileHandle fileHandleForWritingAtPath:outPath];
-    if(!fh){ fprintf(stderr,"capture: cannot open output file %s\n", argv[3]); return 2; }
+    NSFileHandle *fh = [NSFileHandle fileHandleForWritingAtPath:outPath];
+    if (!fh) {
+      fprintf(stderr, "capture: cannot open output file %s\n", argv[3]);
+      return 2;
+    }
 
-    __block long long totalBytes=0;
-    __block BOOL writeFailed=NO;
-    void (^h)(id) = ^(id msg){
-      id data=((id(*)(id,SEL))objc_msgSend)(msg, sel_registerName("data"));
-      if([data isKindOfClass:[NSData class]] && [data length]>0){
-        totalBytes+=[data length];
-        uint32_t len=(uint32_t)[data length];
-        @try{
+    __block long long totalBytes = 0;
+    __block BOOL writeFailed = NO;
+    void (^h)(id) = ^(id msg) {
+      id data = ((id (*)(id, SEL))objc_msgSend)(msg, sel_registerName("data"));
+      if ([data isKindOfClass:[NSData class]] && [data length] > 0) {
+        totalBytes += [data length];
+        uint32_t len = (uint32_t)[data length];
+        @try {
           [fh writeData:[NSData dataWithBytes:&len length:4]];
           [fh writeData:data];
-        }@catch(id e){
+        } @catch (id e) {
           // disk full / IO error — the stream would silently truncate, so flag it
           // and exit non-zero rather than leave a valid-looking partial file.
-          if(!writeFailed) fprintf(stderr,"capture: write failed: %s\n", [[e description]UTF8String]);
-          writeFailed=YES;
+          if (!writeFailed)
+            fprintf(stderr, "capture: write failed: %s\n", [[e description] UTF8String]);
+          writeFailed = YES;
         }
       }
     };
-    ((void(*)(id,SEL,id))objc_msgSend)(ch, sel_registerName("setMessageHandler:"), h);
+    ((void (*)(id, SEL, id))objc_msgSend)(ch, sel_registerName("setMessageHandler:"), h);
 
-    NSString *uuid=[[NSUUID UUID] UUIDString];
+    NSString *uuid = [[NSUUID UUID] UUIDString];
     // Periodic "Profile Every Thread" (PET) time trigger:
     //   tk=1  -> DTKPTriggerTime (periodic timer), NOT the kdebug-event trigger (tk=3,
     //            which only samples on syscalls/context-switches and so massively
@@ -56,35 +74,42 @@ int main(int argc, char **argv){
     //            actually parse (0x2500 PERF_Event, 0x2501 thread data, 0x2502 user stacks),
     //            instead of {0xFFFFFFFF} all-classes which floods the buffer (~130MB/s) and
     //            causes non-deterministic sample drops.
-    long long si_ns = 1000000; // 1ms -> 1kHz
+    long long si_ns = 1000000;  // 1ms -> 1kHz
     const char *envSI = getenv("ARGENT_IOS_PROFILER_SI_NS");
-    if (envSI && *envSI) { long long v = atoll(envSI); if (v > 0) si_ns = v; }
+    if (envSI && *envSI) {
+      long long v = atoll(envSI);
+      if (v > 0) si_ns = v;
+    }
     NSDictionary *config = @{
-      @"tc": @[ @{
-        @"csd": @128,
-        @"kdf2": [NSSet setWithObjects:@0x25000000u, @0x25010000u, @0x25020000u, nil],
-        @"ta": @[ @[@3], @[@0], @[@2], @[@1,@1,@0] ],
-        @"tk": @1,
-        @"si": @(si_ns),
-        @"uuid": uuid,
+      @"tc" : @[ @{
+        @"csd" : @128,
+        @"kdf2" : [NSSet setWithObjects:@0x25000000u, @0x25010000u, @0x25020000u, nil],
+        @"ta" : @[ @[ @3 ], @[ @0 ], @[ @2 ], @[ @1, @1, @0 ] ],
+        @"tk" : @1,
+        @"si" : @(si_ns),
+        @"uuid" : uuid,
       } ],
-      @"rp": @100,
-      @"bm": @0,
+      @"rp" : @100,
+      @"bm" : @0,
     };
 
-    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
-        DTXMsg1(sel_registerName("setConfig:"), config), (id)nil);
-    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
-        DTXMsg0(sel_registerName("start")), (id)nil);
+    ((void (*)(id, SEL, id, id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+                                              DTXMsg1(sel_registerName("setConfig:"), config),
+                                              (id)nil);
+    ((void (*)(id, SEL, id, id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+                                              DTXMsg0(sel_registerName("start")), (id)nil);
 
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:secs]];
 
-    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
-        DTXMsg0(sel_registerName("stop")), (id)nil);
+    ((void (*)(id, SEL, id, id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+                                              DTXMsg0(sel_registerName("stop")), (id)nil);
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.3]];
     [fh closeFile];
 
-    if(writeFailed){ fprintf(stderr,"capture: output truncated by write error\n"); return 4; }
-    return totalBytes>0 ? 0 : 3;
+    if (writeFailed) {
+      fprintf(stderr, "capture: output truncated by write error\n");
+      return 4;
+    }
+    return totalBytes > 0 ? 0 : 3;
   }
 }

--- a/packages/argent-ios-profiling/objc_src/capture.m
+++ b/packages/argent-ios-profiling/objc_src/capture.m
@@ -1,0 +1,102 @@
+// simprofiler capture: drive coreprofilesessiontap on the booted sim via the
+// host DTServiceHub (no xctrace), collect the raw kdebug stream to a file.
+// usage: capture <udid> <seconds> <out.bin>
+#import "conn.h"
+
+int main(int argc, char **argv){
+  setbuf(stdout,NULL);
+  if(argc<4){ printf("usage: capture <udid> <seconds> <out.bin>\n"); return 1; }
+  double secs = atof(argv[2]);
+  @autoreleasepool{
+    loadInstrumentsFrameworks();
+    int spid=-1; id conn=connectLocalHub(&spid);
+    printf("conn=%p serverPid=%d\n", conn, spid);
+    if(!conn) return 2;
+    ((void(*)(id,SEL))objc_msgSend)(conn, sel_registerName("resume"));
+    ((void(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("_notifyOfPublishedCapabilities:"),
+        (@{@"com.apple.private.DTXBlockCompression": @2, @"com.apple.private.DTXConnection": @1}));
+
+    id ch = ((id(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("makeChannelWithIdentifier:"),
+        @"com.apple.instruments.server.services.coreprofilesessiontap");
+    printf("coreprofile channel=%p\n", ch);
+
+    printf("a1: channel ok\n");
+    NSString *outPath=[NSString stringWithUTF8String:argv[3]];
+    [[NSFileManager defaultManager] createFileAtPath:outPath contents:nil attributes:nil];
+    NSFileHandle *fh=[NSFileHandle fileHandleForWritingAtPath:outPath];
+    printf("a2: file handle=%p\n", fh);
+
+    __block long long totalBytes=0; __block int dataMsgs=0; __block int objMsgs=0;
+    __block NSString *firstObj=nil; __block int anyMsg=0;
+    void (^h)(id) = ^(id msg){
+      anyMsg++;
+      id data=((id(*)(id,SEL))objc_msgSend)(msg, sel_registerName("data"));
+      id obj =((id(*)(id,SEL))objc_msgSend)(msg, sel_registerName("object"));
+      unsigned long mt=((unsigned long(*)(id,SEL))objc_msgSend)(msg, sel_registerName("messageType"));
+      if(anyMsg<=5) printf("[msg #%d] class=%s type=%lu dataLen=%lu obj=%s\n", anyMsg,
+          object_getClassName(msg), mt,
+          [data isKindOfClass:[NSData class]]?(unsigned long)[data length]:0,
+          obj?object_getClassName(obj):"nil");
+      if([data isKindOfClass:[NSData class]] && [data length]>0){
+        dataMsgs++; totalBytes+=[data length];
+        uint32_t len=(uint32_t)[data length];
+        @try{ [fh writeData:[NSData dataWithBytes:&len length:4]]; [fh writeData:data]; }@catch(id e){}
+      } else if(obj){ objMsgs++; if(!firstObj) firstObj=[obj description]; }
+    };
+    ((void(*)(id,SEL,id))objc_msgSend)(ch, sel_registerName("setMessageHandler:"), h);
+    printf("a3: channel handler set\n");
+
+    printf("A: handlers set, channel resumed\n");
+    NSString *uuid=[[NSUUID UUID] UUIDString];
+    printf("B: uuid=%s\n", uuid.UTF8String);
+    // Periodic "Profile Every Thread" (PET) time trigger:
+    //   tk=1  -> DTKPTriggerTime (periodic timer), NOT the kdebug-event trigger (tk=3,
+    //            which only samples on syscalls/context-switches and so massively
+    //            under-samples CPU-bound threads while over-sampling idle ones).
+    //   si    -> sample interval in NANOSECONDS (1e6 = 1ms = 1kHz, matching xctrace's
+    //            Time Profiler; clamped by the kernel to kperf.limits.timer_min_pet_period_ns).
+    //   kdf2  -> restrict the kdebug typefilter to the PERF class (0x25) subclasses we
+    //            actually parse (0x2500 PERF_Event, 0x2501 thread data, 0x2502 user stacks),
+    //            instead of {0xFFFFFFFF} all-classes which floods the buffer (~130MB/s) and
+    //            causes non-deterministic sample drops.
+    long long si_ns = 1000000; // 1ms -> 1kHz
+    const char *envSI = getenv("ARGENT_IOS_PROFILER_SI_NS");
+    if (envSI && *envSI) { long long v = atoll(envSI); if (v > 0) si_ns = v; }
+    NSDictionary *config = @{
+      @"tc": @[ @{
+        @"csd": @128,
+        @"kdf2": [NSSet setWithObjects:@0x25000000u, @0x25010000u, @0x25020000u, nil],
+        @"ta": @[ @[@3], @[@0], @[@2], @[@1,@1,@0] ],
+        @"tk": @1,
+        @"si": @(si_ns),
+        @"uuid": uuid,
+      } ],
+      @"rp": @100,
+      @"bm": @0,
+    };
+    printf("C: config built: %s\n", [[config description] UTF8String]);
+
+    printf("sending setConfig: + start ...\n");
+    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+        DTXMsg1(sel_registerName("setConfig:"), config), ^(id r){
+          id o=((id(*)(id,SEL))objc_msgSend)(r,sel_registerName("object"));
+          printf("setConfig reply: %s\n", o?[[o description]UTF8String]:[[r description]UTF8String]); });
+    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+        DTXMsg0(sel_registerName("start")), ^(id r){
+          id o=((id(*)(id,SEL))objc_msgSend)(r,sel_registerName("object"));
+          printf("start reply: %s\n", o?[[o description]UTF8String]:[[r description]UTF8String]); });
+
+    printf("collecting for %.1fs ...\n", secs);
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:secs]];
+
+    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+        DTXMsg0(sel_registerName("stop")), (id)nil);
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.3]];
+    [fh closeFile];
+
+    printf("\nRESULT: dataMsgs=%d objMsgs=%d totalBytes=%lld -> %s\n",
+        dataMsgs, objMsgs, totalBytes, outPath.UTF8String);
+    if(firstObj) printf("firstObj: %s\n", [firstObj.length>300?[firstObj substringToIndex:300]:firstObj UTF8String]);
+    return totalBytes>0 ? 0 : 3;
+  }
+}

--- a/packages/argent-ios-profiling/objc_src/capture.m
+++ b/packages/argent-ios-profiling/objc_src/capture.m
@@ -1,54 +1,51 @@
-// simprofiler capture: drive coreprofilesessiontap on the booted sim via the
+// ios-profiler capture: drive coreprofilesessiontap on the booted sim via the
 // host DTServiceHub (no xctrace), collect the raw kdebug stream to a file.
 // usage: capture <udid> <seconds> <out.bin>
+// stdout is intentionally silent (the kdebug stream goes to <out.bin>); failures
+// report on stderr and exit non-zero so the TS layer never trusts a partial file.
 #import "conn.h"
 
 int main(int argc, char **argv){
-  setbuf(stdout,NULL);
-  if(argc<4){ printf("usage: capture <udid> <seconds> <out.bin>\n"); return 1; }
+  if(argc<4){ fprintf(stderr,"usage: capture <udid> <seconds> <out.bin>\n"); return 1; }
   double secs = atof(argv[2]);
   @autoreleasepool{
     loadInstrumentsFrameworks();
     int spid=-1; id conn=connectLocalHub(&spid);
-    printf("conn=%p serverPid=%d\n", conn, spid);
-    if(!conn) return 2;
+    if(!conn){ fprintf(stderr,"capture: could not connect to DTServiceHub\n"); return 2; }
     ((void(*)(id,SEL))objc_msgSend)(conn, sel_registerName("resume"));
     ((void(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("_notifyOfPublishedCapabilities:"),
         (@{@"com.apple.private.DTXBlockCompression": @2, @"com.apple.private.DTXConnection": @1}));
 
     id ch = ((id(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("makeChannelWithIdentifier:"),
         @"com.apple.instruments.server.services.coreprofilesessiontap");
-    printf("coreprofile channel=%p\n", ch);
+    if(!ch){ fprintf(stderr,"capture: could not open coreprofilesessiontap channel\n"); return 2; }
 
-    printf("a1: channel ok\n");
     NSString *outPath=[NSString stringWithUTF8String:argv[3]];
     [[NSFileManager defaultManager] createFileAtPath:outPath contents:nil attributes:nil];
     NSFileHandle *fh=[NSFileHandle fileHandleForWritingAtPath:outPath];
-    printf("a2: file handle=%p\n", fh);
+    if(!fh){ fprintf(stderr,"capture: cannot open output file %s\n", argv[3]); return 2; }
 
-    __block long long totalBytes=0; __block int dataMsgs=0; __block int objMsgs=0;
-    __block NSString *firstObj=nil; __block int anyMsg=0;
+    __block long long totalBytes=0;
+    __block BOOL writeFailed=NO;
     void (^h)(id) = ^(id msg){
-      anyMsg++;
       id data=((id(*)(id,SEL))objc_msgSend)(msg, sel_registerName("data"));
-      id obj =((id(*)(id,SEL))objc_msgSend)(msg, sel_registerName("object"));
-      unsigned long mt=((unsigned long(*)(id,SEL))objc_msgSend)(msg, sel_registerName("messageType"));
-      if(anyMsg<=5) printf("[msg #%d] class=%s type=%lu dataLen=%lu obj=%s\n", anyMsg,
-          object_getClassName(msg), mt,
-          [data isKindOfClass:[NSData class]]?(unsigned long)[data length]:0,
-          obj?object_getClassName(obj):"nil");
       if([data isKindOfClass:[NSData class]] && [data length]>0){
-        dataMsgs++; totalBytes+=[data length];
+        totalBytes+=[data length];
         uint32_t len=(uint32_t)[data length];
-        @try{ [fh writeData:[NSData dataWithBytes:&len length:4]]; [fh writeData:data]; }@catch(id e){}
-      } else if(obj){ objMsgs++; if(!firstObj) firstObj=[obj description]; }
+        @try{
+          [fh writeData:[NSData dataWithBytes:&len length:4]];
+          [fh writeData:data];
+        }@catch(id e){
+          // disk full / IO error — the stream would silently truncate, so flag it
+          // and exit non-zero rather than leave a valid-looking partial file.
+          if(!writeFailed) fprintf(stderr,"capture: write failed: %s\n", [[e description]UTF8String]);
+          writeFailed=YES;
+        }
+      }
     };
     ((void(*)(id,SEL,id))objc_msgSend)(ch, sel_registerName("setMessageHandler:"), h);
-    printf("a3: channel handler set\n");
 
-    printf("A: handlers set, channel resumed\n");
     NSString *uuid=[[NSUUID UUID] UUIDString];
-    printf("B: uuid=%s\n", uuid.UTF8String);
     // Periodic "Profile Every Thread" (PET) time trigger:
     //   tk=1  -> DTKPTriggerTime (periodic timer), NOT the kdebug-event trigger (tk=3,
     //            which only samples on syscalls/context-switches and so massively
@@ -74,19 +71,12 @@ int main(int argc, char **argv){
       @"rp": @100,
       @"bm": @0,
     };
-    printf("C: config built: %s\n", [[config description] UTF8String]);
 
-    printf("sending setConfig: + start ...\n");
     ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
-        DTXMsg1(sel_registerName("setConfig:"), config), ^(id r){
-          id o=((id(*)(id,SEL))objc_msgSend)(r,sel_registerName("object"));
-          printf("setConfig reply: %s\n", o?[[o description]UTF8String]:[[r description]UTF8String]); });
+        DTXMsg1(sel_registerName("setConfig:"), config), (id)nil);
     ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
-        DTXMsg0(sel_registerName("start")), ^(id r){
-          id o=((id(*)(id,SEL))objc_msgSend)(r,sel_registerName("object"));
-          printf("start reply: %s\n", o?[[o description]UTF8String]:[[r description]UTF8String]); });
+        DTXMsg0(sel_registerName("start")), (id)nil);
 
-    printf("collecting for %.1fs ...\n", secs);
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:secs]];
 
     ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
@@ -94,9 +84,7 @@ int main(int argc, char **argv){
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.3]];
     [fh closeFile];
 
-    printf("\nRESULT: dataMsgs=%d objMsgs=%d totalBytes=%lld -> %s\n",
-        dataMsgs, objMsgs, totalBytes, outPath.UTF8String);
-    if(firstObj) printf("firstObj: %s\n", [firstObj.length>300?[firstObj substringToIndex:300]:firstObj UTF8String]);
+    if(writeFailed){ fprintf(stderr,"capture: output truncated by write error\n"); return 4; }
     return totalBytes>0 ? 0 : 3;
   }
 }

--- a/packages/argent-ios-profiling/objc_src/conn.h
+++ b/packages/argent-ios-profiling/objc_src/conn.h
@@ -51,13 +51,35 @@ static inline id simDeviceForUDID(const char *udid) {
   return nil;
 }
 
-// Returns a resumed DTXConnection to a freshly spawned host DTServiceHub (or nil).
+// Returns a resumed DTXConnection to a DTServiceHub (or nil).
+//
+// Avenue A — prefer the DEVICE/simulator service-hub path
+// (`+localDeviceConnectionWithError:returningServerPid:`). It connects through
+// the CoreSimulator/device broker rather than spawning the *host* profiling hub
+// (`+localConnectionWithAuthorization:…`), so it is NOT gated by the host
+// Instruments arbiter (`com.apple.dt.instruments.dtarbiter`), which on
+// SIP-enabled Macs rejects non-Apple-signed clients with -67050
+// (errSecCSReqFailed / "code requirements not met"). It needs no AuthorizationRef.
+// Since the iOS simulator runs on the host kernel, coreprofilesessiontap over this
+// connection yields the same kdebug stream — no data loss. The legacy host path is
+// kept as a fallback for environments where the device path is unavailable.
 static inline id connectLocalHub(int *serverPidOut) {
-  AuthorizationRef auth = NULL;
-  AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &auth);
   NSError *err = nil;
   int spid = -1;
-  id conn = ((id (*)(id, SEL, AuthorizationRef, int *, NSError **))objc_msgSend)(
+  id conn = ((id (*)(id, SEL, NSError **, int *))objc_msgSend)(
+      (id)objc_getClass("DTServiceHubClient"),
+      sel_registerName("localDeviceConnectionWithError:returningServerPid:"), &err, &spid);
+  if (conn) {
+    if (serverPidOut) *serverPidOut = spid;
+    return conn;
+  }
+
+  // Fallback: legacy host profiling hub (works on SIP-disabled / lenient-arbiter hosts).
+  AuthorizationRef auth = NULL;
+  AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &auth);
+  err = nil;
+  spid = -1;
+  conn = ((id (*)(id, SEL, AuthorizationRef, int *, NSError **))objc_msgSend)(
       (id)objc_getClass("DTServiceHubClient"),
       sel_registerName("localConnectionWithAuthorization:returningServerPid:error:"), auth, &spid,
       &err);

--- a/packages/argent-ios-profiling/objc_src/conn.h
+++ b/packages/argent-ios-profiling/objc_src/conn.h
@@ -1,48 +1,67 @@
 // shared connect helper for the spike tools
 #import <Foundation/Foundation.h>
-#import <objc/runtime.h>
-#import <objc/message.h>
-#import <dlfcn.h>
 #import <Security/Authorization.h>
+#import <dlfcn.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
 
 // +[DTXMessage messageWithSelector:(SEL) objectArguments:(id)firstObj, ...] — VARIADIC,
 // nil-terminated. firstObj is a NAMED param (x3 on arm64), the rest are stack varargs.
 // So the cast MUST have firstObj as a named id param BEFORE the `...`.
 typedef id (*DTXMsgFn)(id, SEL, SEL, id, ...);
-static inline id DTXMsg0(SEL s){
+static inline id DTXMsg0(SEL s) {
   return ((DTXMsgFn)objc_msgSend)((id)objc_getClass("DTXMessage"),
-      sel_registerName("messageWithSelector:objectArguments:"), s, (id)nil); }
-static inline id DTXMsg1(SEL s, id a){
+                                  sel_registerName("messageWithSelector:objectArguments:"), s,
+                                  (id)nil);
+}
+static inline id DTXMsg1(SEL s, id a) {
   return ((DTXMsgFn)objc_msgSend)((id)objc_getClass("DTXMessage"),
-      sel_registerName("messageWithSelector:objectArguments:"), s, a, (id)nil); }
-
-static inline void loadInstrumentsFrameworks(void){
-  const char *base = "/Applications/Xcode.app/Contents/SharedFrameworks"; char p[512];
-  dlopen("/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator", RTLD_NOW);
-  snprintf(p,sizeof p,"%s/DTXConnectionServices.framework/DTXConnectionServices",base); dlopen(p,RTLD_NOW);
-  snprintf(p,sizeof p,"%s/DVTInstrumentsUtilities.framework/DVTInstrumentsUtilities",base); dlopen(p,RTLD_NOW);
-  snprintf(p,sizeof p,"%s/DVTInstrumentsFoundation.framework/DVTInstrumentsFoundation",base); dlopen(p,RTLD_NOW);
+                                  sel_registerName("messageWithSelector:objectArguments:"), s, a,
+                                  (id)nil);
 }
 
-static inline id simDeviceForUDID(const char *udid){
-  NSError *err=nil;
-  id ctx=((id(*)(id,SEL,id,NSError**))objc_msgSend)((id)objc_getClass("SimServiceContext"),
-      sel_registerName("sharedServiceContextForDeveloperDir:error:"),@"/Applications/Xcode.app/Contents/Developer",&err);
-  id ds=((id(*)(id,SEL,NSError**))objc_msgSend)(ctx,sel_registerName("defaultDeviceSetWithError:"),&err);
-  NSArray *devs=((id(*)(id,SEL))objc_msgSend)(ds,sel_registerName("availableDevices"));
-  NSString *want=[NSString stringWithUTF8String:udid];
-  for(id d in devs){id u=((id(*)(id,SEL))objc_msgSend)(d,sel_registerName("UDID"));
-    if([((id(*)(id,SEL))objc_msgSend)(u,sel_registerName("UUIDString")) caseInsensitiveCompare:want]==NSOrderedSame) return d;}
+static inline void loadInstrumentsFrameworks(void) {
+  const char *base = "/Applications/Xcode.app/Contents/SharedFrameworks";
+  char p[512];
+  dlopen("/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator", RTLD_NOW);
+  snprintf(p, sizeof p, "%s/DTXConnectionServices.framework/DTXConnectionServices", base);
+  dlopen(p, RTLD_NOW);
+  snprintf(p, sizeof p, "%s/DVTInstrumentsUtilities.framework/DVTInstrumentsUtilities", base);
+  dlopen(p, RTLD_NOW);
+  snprintf(p, sizeof p, "%s/DVTInstrumentsFoundation.framework/DVTInstrumentsFoundation", base);
+  dlopen(p, RTLD_NOW);
+}
+
+static inline id simDeviceForUDID(const char *udid) {
+  NSError *err = nil;
+  id ctx = ((id (*)(id, SEL, id, NSError **))objc_msgSend)(
+      (id)objc_getClass("SimServiceContext"),
+      sel_registerName("sharedServiceContextForDeveloperDir:error:"),
+      @"/Applications/Xcode.app/Contents/Developer", &err);
+  id ds = ((id (*)(id, SEL, NSError **))objc_msgSend)(
+      ctx, sel_registerName("defaultDeviceSetWithError:"), &err);
+  NSArray *devs = ((id (*)(id, SEL))objc_msgSend)(ds, sel_registerName("availableDevices"));
+  NSString *want = [NSString stringWithUTF8String:udid];
+  for (id d in devs) {
+    id u = ((id (*)(id, SEL))objc_msgSend)(d, sel_registerName("UDID"));
+    if ([((id (*)(id, SEL))objc_msgSend)(
+            u, sel_registerName("UUIDString")) caseInsensitiveCompare:want] == NSOrderedSame)
+      return d;
+  }
   return nil;
 }
 
 // Returns a resumed DTXConnection to a freshly spawned host DTServiceHub (or nil).
-static inline id connectLocalHub(int *serverPidOut){
-  AuthorizationRef auth=NULL; AuthorizationCreate(NULL,kAuthorizationEmptyEnvironment,kAuthorizationFlagDefaults,&auth);
-  NSError *err=nil; int spid=-1;
-  id conn=((id(*)(id,SEL,AuthorizationRef,int*,NSError**))objc_msgSend)((id)objc_getClass("DTServiceHubClient"),
-      sel_registerName("localConnectionWithAuthorization:returningServerPid:error:"),auth,&spid,&err);
-  if(auth) AuthorizationFree(auth, kAuthorizationFlagDefaults);
-  if(serverPidOut)*serverPidOut=spid;
+static inline id connectLocalHub(int *serverPidOut) {
+  AuthorizationRef auth = NULL;
+  AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &auth);
+  NSError *err = nil;
+  int spid = -1;
+  id conn = ((id (*)(id, SEL, AuthorizationRef, int *, NSError **))objc_msgSend)(
+      (id)objc_getClass("DTServiceHubClient"),
+      sel_registerName("localConnectionWithAuthorization:returningServerPid:error:"), auth, &spid,
+      &err);
+  if (auth) AuthorizationFree(auth, kAuthorizationFlagDefaults);
+  if (serverPidOut) *serverPidOut = spid;
   return conn;
 }

--- a/packages/argent-ios-profiling/objc_src/conn.h
+++ b/packages/argent-ios-profiling/objc_src/conn.h
@@ -1,0 +1,47 @@
+// shared connect helper for the spike tools
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <dlfcn.h>
+#import <Security/Authorization.h>
+
+// +[DTXMessage messageWithSelector:(SEL) objectArguments:(id)firstObj, ...] — VARIADIC,
+// nil-terminated. firstObj is a NAMED param (x3 on arm64), the rest are stack varargs.
+// So the cast MUST have firstObj as a named id param BEFORE the `...`.
+typedef id (*DTXMsgFn)(id, SEL, SEL, id, ...);
+static inline id DTXMsg0(SEL s){
+  return ((DTXMsgFn)objc_msgSend)((id)objc_getClass("DTXMessage"),
+      sel_registerName("messageWithSelector:objectArguments:"), s, (id)nil); }
+static inline id DTXMsg1(SEL s, id a){
+  return ((DTXMsgFn)objc_msgSend)((id)objc_getClass("DTXMessage"),
+      sel_registerName("messageWithSelector:objectArguments:"), s, a, (id)nil); }
+
+static inline void loadInstrumentsFrameworks(void){
+  const char *base = "/Applications/Xcode.app/Contents/SharedFrameworks"; char p[512];
+  dlopen("/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator", RTLD_NOW);
+  snprintf(p,sizeof p,"%s/DTXConnectionServices.framework/DTXConnectionServices",base); dlopen(p,RTLD_NOW);
+  snprintf(p,sizeof p,"%s/DVTInstrumentsUtilities.framework/DVTInstrumentsUtilities",base); dlopen(p,RTLD_NOW);
+  snprintf(p,sizeof p,"%s/DVTInstrumentsFoundation.framework/DVTInstrumentsFoundation",base); dlopen(p,RTLD_NOW);
+}
+
+static inline id simDeviceForUDID(const char *udid){
+  NSError *err=nil;
+  id ctx=((id(*)(id,SEL,id,NSError**))objc_msgSend)((id)objc_getClass("SimServiceContext"),
+      sel_registerName("sharedServiceContextForDeveloperDir:error:"),@"/Applications/Xcode.app/Contents/Developer",&err);
+  id ds=((id(*)(id,SEL,NSError**))objc_msgSend)(ctx,sel_registerName("defaultDeviceSetWithError:"),&err);
+  NSArray *devs=((id(*)(id,SEL))objc_msgSend)(ds,sel_registerName("availableDevices"));
+  NSString *want=[NSString stringWithUTF8String:udid];
+  for(id d in devs){id u=((id(*)(id,SEL))objc_msgSend)(d,sel_registerName("UDID"));
+    if([((id(*)(id,SEL))objc_msgSend)(u,sel_registerName("UUIDString")) caseInsensitiveCompare:want]==NSOrderedSame) return d;}
+  return nil;
+}
+
+// Returns a resumed DTXConnection to a freshly spawned host DTServiceHub (or nil).
+static inline id connectLocalHub(int *serverPidOut){
+  AuthorizationRef auth=NULL; AuthorizationCreate(NULL,kAuthorizationEmptyEnvironment,kAuthorizationFlagDefaults,&auth);
+  NSError *err=nil; int spid=-1;
+  id conn=((id(*)(id,SEL,AuthorizationRef,int*,NSError**))objc_msgSend)((id)objc_getClass("DTServiceHubClient"),
+      sel_registerName("localConnectionWithAuthorization:returningServerPid:error:"),auth,&spid,&err);
+  if(serverPidOut)*serverPidOut=spid;
+  return conn;
+}

--- a/packages/argent-ios-profiling/objc_src/conn.h
+++ b/packages/argent-ios-profiling/objc_src/conn.h
@@ -42,6 +42,7 @@ static inline id connectLocalHub(int *serverPidOut){
   NSError *err=nil; int spid=-1;
   id conn=((id(*)(id,SEL,AuthorizationRef,int*,NSError**))objc_msgSend)((id)objc_getClass("DTServiceHubClient"),
       sel_registerName("localConnectionWithAuthorization:returningServerPid:error:"),auth,&spid,&err);
+  if(auth) AuthorizationFree(auth, kAuthorizationFlagDefaults);
   if(serverPidOut)*serverPidOut=spid;
   return conn;
 }

--- a/packages/argent-ios-profiling/objc_src/simmem.m
+++ b/packages/argent-ios-profiling/objc_src/simmem.m
@@ -1,61 +1,82 @@
 // simmem — per-process MEMORY profiler for the iOS sim over DTX (sysmontap), no xctrace.
 // usage: simmem <udid> <seconds> <target-pid>
 #import "conn.h"
-int main(int argc,char**argv){
-  setbuf(stdout,NULL);
-  if(argc<4){ printf("usage: simmem <udid> <seconds> <target-pid>\n"); return 1; }
-  double secs=atof(argv[2]); int tpid=atoi(argv[3]);
-  @autoreleasepool{
+int main(int argc, char **argv) {
+  setbuf(stdout, NULL);
+  if (argc < 4) {
+    printf("usage: simmem <udid> <seconds> <target-pid>\n");
+    return 1;
+  }
+  double secs = atof(argv[2]);
+  int tpid = atoi(argv[3]);
+  @autoreleasepool {
     loadInstrumentsFrameworks();
-    int spid=-1; id conn=connectLocalHub(&spid);
-    if(!conn){printf("no conn\n");return 2;}
-    ((void(*)(id,SEL))objc_msgSend)(conn, sel_registerName("resume"));
-    ((void(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("_notifyOfPublishedCapabilities:"),
-        (@{@"com.apple.private.DTXBlockCompression": @2, @"com.apple.private.DTXConnection": @1}));
-    id ch=((id(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("makeChannelWithIdentifier:"),
-        @"com.apple.instruments.server.services.sysmontap");
+    int spid = -1;
+    id conn = connectLocalHub(&spid);
+    if (!conn) {
+      printf("no conn\n");
+      return 2;
+    }
+    ((void (*)(id, SEL))objc_msgSend)(conn, sel_registerName("resume"));
+    ((void (*)(id, SEL, id))objc_msgSend)(conn, sel_registerName("_notifyOfPublishedCapabilities:"),
+                                          (@{
+                                            @"com.apple.private.DTXBlockCompression" : @2,
+                                            @"com.apple.private.DTXConnection" : @1
+                                          }));
+    id ch =
+        ((id (*)(id, SEL, id))objc_msgSend)(conn, sel_registerName("makeChannelWithIdentifier:"),
+                                            @"com.apple.instruments.server.services.sysmontap");
     // procAttrs order MUST match how we read the row below
-    NSArray *procAttrs=@[@"pid",@"physFootprint",@"memResidentSize",@"cpuUsage"];
-    ((void(*)(id,SEL,id))objc_msgSend)(ch, sel_registerName("setMessageHandler:"), ^(id o){
+    NSArray *procAttrs = @[ @"pid", @"physFootprint", @"memResidentSize", @"cpuUsage" ];
+    ((void (*)(id, SEL, id))objc_msgSend)(ch, sel_registerName("setMessageHandler:"), ^(id o) {
       // sysmontap update payload = OS_dispatch_data wrapping an NSKeyedArchiver
       // graph of plain Foundation containers — decode it with the secure (non
       // deprecated) unarchiver, allowlisting the container + leaf classes.
-      id pl=((id(*)(id,SEL))objc_msgSend)(o,sel_registerName("object"));
-      NSData *d = [pl isKindOfClass:[NSData class]] ? (NSData*)pl : nil;
-      if(!d) return;
-      NSSet *allowed=[NSSet setWithObjects:[NSArray class],[NSDictionary class],
-          [NSNumber class],[NSString class],[NSData class],[NSDate class],nil];
-      id top=nil; @try{
-        top=((id(*)(id,SEL,NSSet*,NSData*,NSError**))objc_msgSend)(
+      id pl = ((id (*)(id, SEL))objc_msgSend)(o, sel_registerName("object"));
+      NSData *d = [pl isKindOfClass:[NSData class]] ? (NSData *)pl : nil;
+      if (!d) return;
+      NSSet *allowed =
+          [NSSet setWithObjects:[NSArray class], [NSDictionary class], [NSNumber class],
+                                [NSString class], [NSData class], [NSDate class], nil];
+      id top = nil;
+      @try {
+        top = ((id (*)(id, SEL, NSSet *, NSData *, NSError **))objc_msgSend)(
             [NSKeyedUnarchiver class],
             sel_registerName("unarchivedObjectOfClasses:fromData:error:"), allowed, d, NULL);
-      }@catch(id e){}
-      if(!top) return;
-      NSArray *arr = [top isKindOfClass:[NSArray class]] ? top : @[top];
-      for(id e in arr){
-        if(![e isKindOfClass:[NSDictionary class]]) continue;
-        NSDictionary *procs=e[@"Processes"];
-        if(![procs isKindOfClass:[NSDictionary class]]) continue;
-        id row=procs[@(tpid)] ?: procs[[@(tpid) stringValue]];
-        if([row isKindOfClass:[NSArray class]] && [row count]>=2){
+      } @catch (id e) {}
+      if (!top) return;
+      NSArray *arr = [top isKindOfClass:[NSArray class]] ? top : @[ top ];
+      for (id e in arr) {
+        if (![e isKindOfClass:[NSDictionary class]]) continue;
+        NSDictionary *procs = e[@"Processes"];
+        if (![procs isKindOfClass:[NSDictionary class]]) continue;
+        id row = procs[@(tpid)] ?: procs[[@(tpid) stringValue]];
+        if ([row isKindOfClass:[NSArray class]] && [row count] >= 2) {
           // The row values line up with procAttrs, but sysmontap may or may not
           // echo the leading `pid` column. Detect it deterministically: if the
           // first value equals the target pid, footprint/resident start at index 1
           // (footprints are millions of bytes, so they never collide with a pid).
-          NSUInteger base=([row[0] longLongValue]==(long long)tpid)?1:0;
-          if([row count]>=base+2){
-            double fp=[row[base] doubleValue]/1048576.0, rss=[row[base+1] doubleValue]/1048576.0;
+          NSUInteger base = ([row[0] longLongValue] == (long long)tpid) ? 1 : 0;
+          if ([row count] >= base + 2) {
+            double fp = [row[base] doubleValue] / 1048576.0,
+                   rss = [row[base + 1] doubleValue] / 1048576.0;
             printf("pid %d  physFootprint=%.1f MB  resident=%.1f MB\n", tpid, fp, rss);
           }
         }
       }
     });
-    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
-        DTXMsg1(sel_registerName("setConfig:"),
-          (@{@"ur":@500,@"bm":@0,@"cpuUsage":@YES,@"sampleInterval":@500000000ULL,
-             @"procAttrs":procAttrs,@"sysAttrs":@[@"vmFreeCount"]})), (id)nil);
-    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
-        DTXMsg0(sel_registerName("start")), (id)nil);
+    ((void (*)(id, SEL, id, id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+                                              DTXMsg1(sel_registerName("setConfig:"), (@{
+                                                        @"ur" : @500,
+                                                        @"bm" : @0,
+                                                        @"cpuUsage" : @YES,
+                                                        @"sampleInterval" : @500000000ULL,
+                                                        @"procAttrs" : procAttrs,
+                                                        @"sysAttrs" : @[ @"vmFreeCount" ]
+                                                      })),
+                                              (id)nil);
+    ((void (*)(id, SEL, id, id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+                                              DTXMsg0(sel_registerName("start")), (id)nil);
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:secs]];
     return 0;
   }

--- a/packages/argent-ios-profiling/objc_src/simmem.m
+++ b/packages/argent-ios-profiling/objc_src/simmem.m
@@ -16,24 +16,37 @@ int main(int argc,char**argv){
         @"com.apple.instruments.server.services.sysmontap");
     // procAttrs order MUST match how we read the row below
     NSArray *procAttrs=@[@"pid",@"physFootprint",@"memResidentSize",@"cpuUsage"];
-    __block int dumped=0;
     ((void(*)(id,SEL,id))objc_msgSend)(ch, sel_registerName("setMessageHandler:"), ^(id o){
-      // sysmontap update payload = OS_dispatch_data wrapping a binary plist.
+      // sysmontap update payload = OS_dispatch_data wrapping an NSKeyedArchiver
+      // graph of plain Foundation containers — decode it with the secure (non
+      // deprecated) unarchiver, allowlisting the container + leaf classes.
       id pl=((id(*)(id,SEL))objc_msgSend)(o,sel_registerName("object"));
       NSData *d = [pl isKindOfClass:[NSData class]] ? (NSData*)pl : nil;
       if(!d) return;
-      id top=nil; @try{ top=[NSKeyedUnarchiver unarchiveObjectWithData:d]; }@catch(id e){}
-      if(!top) return;      NSArray *arr = [top isKindOfClass:[NSArray class]] ? top : @[top];
+      NSSet *allowed=[NSSet setWithObjects:[NSArray class],[NSDictionary class],
+          [NSNumber class],[NSString class],[NSData class],[NSDate class],nil];
+      id top=nil; @try{
+        top=((id(*)(id,SEL,NSSet*,NSData*,NSError**))objc_msgSend)(
+            [NSKeyedUnarchiver class],
+            sel_registerName("unarchivedObjectOfClasses:fromData:error:"), allowed, d, NULL);
+      }@catch(id e){}
+      if(!top) return;
+      NSArray *arr = [top isKindOfClass:[NSArray class]] ? top : @[top];
       for(id e in arr){
         if(![e isKindOfClass:[NSDictionary class]]) continue;
         NSDictionary *procs=e[@"Processes"];
         if(![procs isKindOfClass:[NSDictionary class]]) continue;
         id row=procs[@(tpid)] ?: procs[[@(tpid) stringValue]];
         if([row isKindOfClass:[NSArray class]] && [row count]>=2){
-          // procAttrs=[pid,physFootprint,memResidentSize]; row may or may not include pid
-          NSUInteger base=([row count]>=3)?1:0;
-          double fp=[row[base] doubleValue]/1048576.0, rss=[row[base+1] doubleValue]/1048576.0;
-          printf("pid %d  physFootprint=%.1f MB  resident=%.1f MB\n", tpid, fp, rss);
+          // The row values line up with procAttrs, but sysmontap may or may not
+          // echo the leading `pid` column. Detect it deterministically: if the
+          // first value equals the target pid, footprint/resident start at index 1
+          // (footprints are millions of bytes, so they never collide with a pid).
+          NSUInteger base=([row[0] longLongValue]==(long long)tpid)?1:0;
+          if([row count]>=base+2){
+            double fp=[row[base] doubleValue]/1048576.0, rss=[row[base+1] doubleValue]/1048576.0;
+            printf("pid %d  physFootprint=%.1f MB  resident=%.1f MB\n", tpid, fp, rss);
+          }
         }
       }
     });

--- a/packages/argent-ios-profiling/objc_src/simmem.m
+++ b/packages/argent-ios-profiling/objc_src/simmem.m
@@ -1,0 +1,49 @@
+// simmem — per-process MEMORY profiler for the iOS sim over DTX (sysmontap), no xctrace.
+// usage: simmem <udid> <seconds> <target-pid>
+#import "conn.h"
+int main(int argc,char**argv){
+  setbuf(stdout,NULL);
+  if(argc<4){ printf("usage: simmem <udid> <seconds> <target-pid>\n"); return 1; }
+  double secs=atof(argv[2]); int tpid=atoi(argv[3]);
+  @autoreleasepool{
+    loadInstrumentsFrameworks();
+    int spid=-1; id conn=connectLocalHub(&spid);
+    if(!conn){printf("no conn\n");return 2;}
+    ((void(*)(id,SEL))objc_msgSend)(conn, sel_registerName("resume"));
+    ((void(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("_notifyOfPublishedCapabilities:"),
+        (@{@"com.apple.private.DTXBlockCompression": @2, @"com.apple.private.DTXConnection": @1}));
+    id ch=((id(*)(id,SEL,id))objc_msgSend)(conn, sel_registerName("makeChannelWithIdentifier:"),
+        @"com.apple.instruments.server.services.sysmontap");
+    // procAttrs order MUST match how we read the row below
+    NSArray *procAttrs=@[@"pid",@"physFootprint",@"memResidentSize",@"cpuUsage"];
+    __block int dumped=0;
+    ((void(*)(id,SEL,id))objc_msgSend)(ch, sel_registerName("setMessageHandler:"), ^(id o){
+      // sysmontap update payload = OS_dispatch_data wrapping a binary plist.
+      id pl=((id(*)(id,SEL))objc_msgSend)(o,sel_registerName("object"));
+      NSData *d = [pl isKindOfClass:[NSData class]] ? (NSData*)pl : nil;
+      if(!d) return;
+      id top=nil; @try{ top=[NSKeyedUnarchiver unarchiveObjectWithData:d]; }@catch(id e){}
+      if(!top) return;      NSArray *arr = [top isKindOfClass:[NSArray class]] ? top : @[top];
+      for(id e in arr){
+        if(![e isKindOfClass:[NSDictionary class]]) continue;
+        NSDictionary *procs=e[@"Processes"];
+        if(![procs isKindOfClass:[NSDictionary class]]) continue;
+        id row=procs[@(tpid)] ?: procs[[@(tpid) stringValue]];
+        if([row isKindOfClass:[NSArray class]] && [row count]>=2){
+          // procAttrs=[pid,physFootprint,memResidentSize]; row may or may not include pid
+          NSUInteger base=([row count]>=3)?1:0;
+          double fp=[row[base] doubleValue]/1048576.0, rss=[row[base+1] doubleValue]/1048576.0;
+          printf("pid %d  physFootprint=%.1f MB  resident=%.1f MB\n", tpid, fp, rss);
+        }
+      }
+    });
+    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+        DTXMsg1(sel_registerName("setConfig:"),
+          (@{@"ur":@500,@"bm":@0,@"cpuUsage":@YES,@"sampleInterval":@500000000ULL,
+             @"procAttrs":procAttrs,@"sysAttrs":@[@"vmFreeCount"]})), (id)nil);
+    ((void(*)(id,SEL,id,id))objc_msgSend)(ch, sel_registerName("sendMessage:replyHandler:"),
+        DTXMsg0(sel_registerName("start")), (id)nil);
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:secs]];
+    return 0;
+  }
+}

--- a/packages/argent-ios-profiling/package.json
+++ b/packages/argent-ios-profiling/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@argent/ios-profiling",
+  "version": "0.11.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
+    "build:native": "bash scripts/build.sh",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/argent-ios-profiling/package.json
+++ b/packages/argent-ios-profiling/package.json
@@ -7,10 +7,13 @@
   "scripts": {
     "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "build:native": "bash scripts/build.sh",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/node": "^25.9.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/argent-ios-profiling/package.json
+++ b/packages/argent-ios-profiling/package.json
@@ -9,7 +9,9 @@
     "build:native": "bash scripts/build.sh",
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
-    "test": "vitest run"
+    "test": "vitest run",
+    "format:native": "$(xcrun --find clang-format 2>/dev/null || command -v clang-format) -i objc_src/*.m objc_src/*.h",
+    "format:native:check": "$(xcrun --find clang-format 2>/dev/null || command -v clang-format) --dry-run --Werror objc_src/*.m objc_src/*.h"
   },
   "devDependencies": {
     "@types/node": "^25.9.0",

--- a/packages/argent-ios-profiling/scripts/build.sh
+++ b/packages/argent-ios-profiling/scripts/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the iOS-profiling native capture binaries (macOS only — iOS Simulator
+# profiling is darwin-only, like the rest of native-devtools-ios).
+#
+# Run from the workspace root:  bash packages/argent-ios-profiling/scripts/build.sh
+# Or from this package:         bash scripts/build.sh
+#
+# Output: bin/darwin/ios-profiler-capture  (coreprofilesessiontap → kdebug stream)
+#         bin/darwin/ios-profiler-mem      (sysmontap → per-process footprint/RSS)
+#
+# Environment:
+#   PREBUILT_IOS_PROFILER_BIN_DIR - if set, copy binaries from here instead of
+#                                   building (CI on non-macOS hosts).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$DIR/bin/darwin"
+mkdir -p "$OUT"
+
+if [[ -n "${PREBUILT_IOS_PROFILER_BIN_DIR:-}" ]]; then
+  echo "copying prebuilt binaries from $PREBUILT_IOS_PROFILER_BIN_DIR"
+  cp "$PREBUILT_IOS_PROFILER_BIN_DIR"/ios-profiler-* "$OUT/"
+  exit 0
+fi
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "error: native build requires macOS (set PREBUILT_IOS_PROFILER_BIN_DIR on CI)" >&2
+  exit 1
+fi
+
+CFLAGS=(-fno-objc-arc -fobjc-exceptions -O2 -I"$DIR/objc_src" -framework Foundation -framework Security)
+
+echo "building ios-profiler-capture ..."
+clang "${CFLAGS[@]}" -o "$OUT/ios-profiler-capture" "$DIR/objc_src/capture.m"
+
+echo "building ios-profiler-mem ..."
+clang "${CFLAGS[@]}" -o "$OUT/ios-profiler-mem" "$DIR/objc_src/simmem.m"
+
+echo "done -> $OUT"

--- a/packages/argent-ios-profiling/scripts/build.sh
+++ b/packages/argent-ios-profiling/scripts/build.sh
@@ -28,7 +28,12 @@ if [[ "$(uname)" != "Darwin" ]]; then
   exit 1
 fi
 
-CFLAGS=(-fno-objc-arc -fobjc-exceptions -O2 -I"$DIR/objc_src" -framework Foundation -framework Security)
+# Universal host binary (arm64 + x86_64). These run on the host Mac (not the
+# simulator), so the default macOS SDK is correct — but both host arches must be
+# built or x86_64 / Rosetta hosts get an ENOEXEC at spawn. Mirrors the dylib CI
+# build matrix (-arch arm64 -arch x86_64). The signed release artifacts produced
+# by argent-private's build-native-binaries.yml use the same flags.
+CFLAGS=(-fno-objc-arc -fobjc-exceptions -O2 -arch arm64 -arch x86_64 -I"$DIR/objc_src" -framework Foundation -framework Security)
 
 echo "building ios-profiler-capture ..."
 clang "${CFLAGS[@]}" -o "$OUT/ios-profiler-capture" "$DIR/objc_src/capture.m"

--- a/packages/argent-ios-profiling/src/index.ts
+++ b/packages/argent-ios-profiling/src/index.ts
@@ -15,7 +15,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { parseCapture } from "./parser/kdebug";
 import { emitCpuAndHangs } from "./parser/emit";
-import { emitLeaks, captureAllocations } from "./leaks";
+import { emitLeaks } from "./leaks";
 
 export type { AllocationProfile, LeakSummary } from "./leaks";
 export { captureAllocations } from "./leaks";

--- a/packages/argent-ios-profiling/src/index.ts
+++ b/packages/argent-ios-profiling/src/index.ts
@@ -74,12 +74,16 @@ export async function captureProfile(opts: CaptureOptions): Promise<ProfileExpor
     `.iosprof-${process.pid}-${Date.now()}.kdbg`
   );
   try {
-    // 1) native capture: drive coreprofilesessiontap → length-framed kdebug stream
+    // 1) native capture: drive coreprofilesessiontap → length-framed kdebug stream.
+    // Hard-kill if the binary stalls (DTX connect / stop / finalize) — never hang
+    // forever (the very failure mode this package routes xctrace around).
     await execFileAsync(
       bin("ios-profiler-capture"),
       [opts.udid, String(opts.durationSec), rawFile],
       {
         maxBuffer: 8 * 1024 * 1024,
+        timeout: (opts.durationSec + 60) * 1000,
+        killSignal: "SIGKILL",
       }
     );
     // 2) parse (TS) → callstacks + threadmap; symbolicate (atos) → cpu + hangs XML
@@ -122,6 +126,8 @@ export async function captureMemory(
     [udid, String(durationSec), String(pid)],
     {
       maxBuffer: 16 * 1024 * 1024,
+      timeout: (durationSec + 30) * 1000,
+      killSignal: "SIGKILL",
     }
   );
   const out: MemorySample[] = [];

--- a/packages/argent-ios-profiling/src/index.ts
+++ b/packages/argent-ios-profiling/src/index.ts
@@ -1,0 +1,137 @@
+// @argent/ios-profiling — an xctrace-free iOS-Simulator profiler.
+//
+// On Xcode 26.4+ `xctrace record --device <sim>` hangs on finalize, breaking
+// Argent's native iOS profiler. This package replaces the broken capture+export
+// step: a native binary drives the Instruments server over DTX
+// (coreprofilesessiontap / sysmontap), and a pure-TypeScript parser turns the
+// result into the same `xctrace export`-format XML that `runIosProfilerPipeline`
+// consumes (`_raw_cpu.xml`, `_raw_hangs.xml`, `_raw_leaks.xml`). Everything
+// downstream of that XML is unchanged. No Python, no third-party pip deps.
+//
+// iOS Simulator profiling is macOS-only, so every entry point guards on darwin.
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { parseCapture } from "./parser/kdebug";
+import { emitCpuAndHangs } from "./parser/emit";
+import { emitLeaks, captureAllocations } from "./leaks";
+
+export type { AllocationProfile, LeakSummary } from "./leaks";
+export { captureAllocations } from "./leaks";
+
+const execFileAsync = promisify(execFile);
+
+const PKG_ROOT = path.join(__dirname, "..");
+const BIN_DIR = process.env.ARGENT_IOS_PROFILER_BIN_DIR ?? path.join(PKG_ROOT, "bin");
+
+function requireDarwin(what: string): void {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      `${what} requires a macOS host (iOS Simulator is unavailable on ${process.platform})`
+    );
+  }
+}
+
+function bin(name: string): string {
+  const p = path.join(BIN_DIR, "darwin", name);
+  if (!fs.existsSync(p)) {
+    throw new Error(
+      `ios-profiling native binary not found: ${p} (run \`npm run build:native -w @argent/ios-profiling\`)`
+    );
+  }
+  return p;
+}
+
+/** The xctrace-export-format XML file set that `runIosProfilerPipeline` consumes. */
+export interface ProfileExport {
+  cpu: string;
+  hangs: string;
+  leaks: string;
+  /** resolved target pid + name and sample/leak counts (diagnostics). */
+  meta: { pid: number; name: string; cpuSamples: number; hangs: number; leaks: number };
+}
+
+export interface CaptureOptions {
+  /** Booted iOS Simulator UDID. */
+  udid: string;
+  /** Capture window in seconds. */
+  durationSec: number;
+  /** Target process name or pid to scope the report to. */
+  target: string | number;
+  /** Path prefix for the emitted file set (`<prefix>_raw_{cpu,hangs,leaks}.xml`). */
+  outPrefix: string;
+}
+
+/**
+ * Capture a CPU + Hangs + Leaks profile and emit the xctrace-export XML set.
+ * Drop-in replacement for `xctrace record` + `xctrace export` on Xcode 26.4+.
+ */
+export async function captureProfile(opts: CaptureOptions): Promise<ProfileExport> {
+  requireDarwin("captureProfile");
+  const rawFile = path.join(
+    path.dirname(opts.outPrefix),
+    `.iosprof-${process.pid}-${Date.now()}.kdbg`
+  );
+  try {
+    // 1) native capture: drive coreprofilesessiontap → length-framed kdebug stream
+    await execFileAsync(
+      bin("ios-profiler-capture"),
+      [opts.udid, String(opts.durationSec), rawFile],
+      {
+        maxBuffer: 8 * 1024 * 1024,
+      }
+    );
+    // 2) parse (TS) → callstacks + threadmap; symbolicate (atos) → cpu + hangs XML
+    const parsed = parseCapture(fs.readFileSync(rawFile));
+    const emit = await emitCpuAndHangs(parsed, opts.target, opts.outPrefix);
+    // 3) leaks: in-sim heap-leak engine → Leaks XML
+    const leaks = await emitLeaks(opts.udid, emit.pid, `${opts.outPrefix}_raw_leaks.xml`);
+    return {
+      cpu: emit.cpu,
+      hangs: emit.hangs,
+      leaks: `${opts.outPrefix}_raw_leaks.xml`,
+      meta: {
+        pid: emit.pid,
+        name: emit.name,
+        cpuSamples: emit.cpuSamples,
+        hangs: emit.hangs_count,
+        leaks: leaks.leaks,
+      },
+    };
+  } finally {
+    fs.rmSync(rawFile, { force: true });
+  }
+}
+
+/** A single per-process memory sample (footprint/RSS in bytes). */
+export interface MemorySample {
+  physFootprintBytes: number;
+  residentBytes: number;
+}
+
+/** Stream per-process memory (sysmontap) for `pid` over `durationSec`. */
+export async function captureMemory(
+  udid: string,
+  durationSec: number,
+  pid: number
+): Promise<MemorySample[]> {
+  requireDarwin("captureMemory");
+  const { stdout } = await execFileAsync(
+    bin("ios-profiler-mem"),
+    [udid, String(durationSec), String(pid)],
+    {
+      maxBuffer: 16 * 1024 * 1024,
+    }
+  );
+  const out: MemorySample[] = [];
+  for (const line of stdout.split("\n")) {
+    const m = /physFootprint=([\d.]+) MB\s+resident=([\d.]+) MB/.exec(line);
+    if (m)
+      out.push({
+        physFootprintBytes: Math.round(+m[1] * 1048576),
+        residentBytes: Math.round(+m[2] * 1048576),
+      });
+  }
+  return out;
+}

--- a/packages/argent-ios-profiling/src/leaks.test.ts
+++ b/packages/argent-ios-profiling/src/leaks.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { parseLeakLines } from "./leaks";
+
+// Verbatim ROOT-LEAK lines from `xcrun simctl spawn <udid> leaks <pid>`
+// (ParadiseGallery on a real iOS 26.5 sim).
+const SAMPLE = `Process 39640: 13 leaks for 2928 total leaked bytes.
+      9 (1.25K) ROOT LEAK: <NSMutableDictionary 0x10ca9ce80> [32]  item count: 3
+      1 (1.00K) ROOT LEAK: 0x106657000 [1024]  length: 34  "reanimated::NativeReanimatedModule"
+      1 (384 bytes) ROOT LEAK: <CFString 0x105d77c00> [384]  length: 333  "RCTFatalException: ..."
+      1 (224 bytes) ROOT LEAK: <CFString 0x105cbb1e0> [224]  length: 178  "Unable to resolve ..."
+      1 (16 bytes) ROOT LEAK: 0x1202b7d20 [16]
+`;
+
+describe("parseLeakLines", () => {
+  const rows = parseLeakLines(SAMPLE);
+
+  it("captures every ROOT LEAK, including untyped raw-malloc blocks", () => {
+    // 5 ROOT LEAK lines — the two untyped (`0x… [n]`) ones used to be dropped.
+    expect(rows).toHaveLength(5);
+  });
+
+  it("uses the PER-OBJECT bracket size, not the group total", () => {
+    const dict = rows.find((r) => r.type === "NSMutableDictionary")!;
+    // group total is 1.25K (1280B) for the retained subgraph; per-object is [32].
+    expect(dict.size).toBe(32);
+    expect(dict.count).toBe(9);
+  });
+
+  it("labels untyped blocks by their string hint, else by Malloc size", () => {
+    expect(rows.find((r) => r.size === 1024)?.type).toBe("reanimated::NativeReanimatedModule");
+    expect(rows.find((r) => r.size === 16)?.type).toBe("Malloc 16 bytes");
+  });
+
+  it("keeps module-qualified type names intact (no truncation at `.`/`:`)", () => {
+    // would have been truncated to "reanimated" by the old [A-Za-z_]\w* regex.
+    expect(rows.some((r) => r.type.includes("::"))).toBe(true);
+  });
+
+  it("ignores non-leak lines", () => {
+    expect(parseLeakLines("Process 1: 0 leaks for 0 total leaked bytes.\n")).toHaveLength(0);
+  });
+});

--- a/packages/argent-ios-profiling/src/leaks.ts
+++ b/packages/argent-ios-profiling/src/leaks.ts
@@ -1,0 +1,115 @@
+// Leaks + Allocations via the simulator's own in-process engine
+// (`simctl spawn <udid> leaks|heap <pid>`) — the same heap scanner the
+// `remoteleaks`/`objectalloc` Instruments services wrap, and which works on
+// macOS 26 (corpse-based). Emits the Leaks-detail XML Argent's parseLeaksXml
+// consumes. Port of the Python emit_leaks.py.
+import * as fs from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function toBytes(s: string): number {
+  const m = /([\d.]+)\s*([KMG]?)/.exec(s.trim());
+  if (!m) return 0;
+  const mult: Record<string, number> = { K: 1024, M: 1048576, G: 1073741824 };
+  return Math.round(parseFloat(m[1]) * (mult[m[2]] ?? 1));
+}
+
+export interface LeakSummary {
+  leaks: number;
+  bytes: number;
+}
+
+/**
+ * Run the in-sim leaks engine for `pid` and write the Leaks-detail XML to `out`.
+ * Returns the reported leak/byte totals.
+ */
+export async function emitLeaks(udid: string, pid: number, out: string): Promise<LeakSummary> {
+  let txt = "";
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      "xcrun",
+      ["simctl", "spawn", udid, "leaks", String(pid)],
+      {
+        maxBuffer: 32 * 1024 * 1024,
+        timeout: 90_000,
+      }
+    );
+    txt = stdout + stderr;
+  } catch (e: unknown) {
+    // `leaks` exits non-zero when it finds leaks; capture its stdout anyway
+    const err = e as { stdout?: string; stderr?: string };
+    txt = (err.stdout ?? "") + (err.stderr ?? "");
+  }
+
+  let gid = 0;
+  const nid = () => ++gid;
+  const rows: string[] = [];
+  // e.g. "  9 (1.25K) ROOT LEAK: <NSMutableDictionary 0x..> [32]  item count: 3"
+  const ROOT = /^\s*(\d+)\s+\(([^)]+)\)\s+ROOT LEAK:\s+<([A-Za-z_][\w]*)[^>]*>\s+\[(\d+)\]/;
+  for (const line of txt.split("\n")) {
+    const m = ROOT.exec(line);
+    if (!m) continue;
+    const count = parseInt(m[1], 10);
+    const total = toBytes(m[2]);
+    const typ = m[3];
+    const objsz = parseInt(m[4], 10);
+    rows.push(
+      `<row leaked-object="${xmlEscape(typ)}" size="${total || objsz}" count="${count}" ` +
+        `responsible-frame="${xmlEscape(typ)}" responsible-library=""/>`
+    );
+  }
+  const xml =
+    `<?xml version="1.0"?>\n<trace-toc><run number="1"><tracks>` +
+    `<track name="Leaks"><details><detail name="Leaks">${rows.join("")}</detail></details></track>` +
+    `</tracks></run></trace-toc>\n`;
+  fs.writeFileSync(out, xml);
+
+  const m = /(\d+)\s+leaks for\s+(\d+)\s+total leaked bytes/.exec(txt);
+  return { leaks: m ? parseInt(m[1], 10) : rows.length, bytes: m ? parseInt(m[2], 10) : 0 };
+}
+
+export interface AllocationProfile {
+  totalNodes: number;
+  /** raw `heap` summary text (size histogram + class counts). */
+  summary: string;
+  objcClasses: number;
+  swiftClasses: number;
+}
+
+/** Run the in-sim heap engine for `pid` → live-object allocation profile. */
+export async function captureAllocations(udid: string, pid: number): Promise<AllocationProfile> {
+  let txt = "";
+  try {
+    const { stdout } = await execFileAsync(
+      "xcrun",
+      ["simctl", "spawn", udid, "heap", String(pid)],
+      {
+        maxBuffer: 48 * 1024 * 1024,
+        timeout: 90_000,
+      }
+    );
+    txt = stdout;
+  } catch (e: unknown) {
+    txt = (e as { stdout?: string }).stdout ?? "";
+  }
+  const summary = txt.slice(txt.indexOf("All zones:"));
+  const nodes = /All zones:\s+(\d+)\s+nodes/.exec(txt);
+  const objc = /(\d+)\s+ObjC classes/.exec(txt);
+  const swift = /(\d+)\s+Swift classes/.exec(txt);
+  return {
+    totalNodes: nodes ? parseInt(nodes[1], 10) : 0,
+    summary,
+    objcClasses: objc ? parseInt(objc[1], 10) : 0,
+    swiftClasses: swift ? parseInt(swift[1], 10) : 0,
+  };
+}

--- a/packages/argent-ios-profiling/src/leaks.ts
+++ b/packages/argent-ios-profiling/src/leaks.ts
@@ -34,7 +34,7 @@ export interface LeakSummary {
  * Returns the reported leak/byte totals.
  */
 export async function emitLeaks(udid: string, pid: number, out: string): Promise<LeakSummary> {
-  let txt = "";
+  let txt: string;
   try {
     const { stdout, stderr } = await execFileAsync(
       "xcrun",
@@ -51,8 +51,6 @@ export async function emitLeaks(udid: string, pid: number, out: string): Promise
     txt = (err.stdout ?? "") + (err.stderr ?? "");
   }
 
-  let gid = 0;
-  const nid = () => ++gid;
   const rows: string[] = [];
   // e.g. "  9 (1.25K) ROOT LEAK: <NSMutableDictionary 0x..> [32]  item count: 3"
   const ROOT = /^\s*(\d+)\s+\(([^)]+)\)\s+ROOT LEAK:\s+<([A-Za-z_][\w]*)[^>]*>\s+\[(\d+)\]/;
@@ -88,7 +86,7 @@ export interface AllocationProfile {
 
 /** Run the in-sim heap engine for `pid` → live-object allocation profile. */
 export async function captureAllocations(udid: string, pid: number): Promise<AllocationProfile> {
-  let txt = "";
+  let txt: string;
   try {
     const { stdout } = await execFileAsync(
       "xcrun",

--- a/packages/argent-ios-profiling/src/leaks.ts
+++ b/packages/argent-ios-profiling/src/leaks.ts
@@ -17,16 +17,51 @@ function xmlEscape(s: string): string {
     .replace(/"/g, "&quot;");
 }
 
-function toBytes(s: string): number {
-  const m = /([\d.]+)\s*([KMG]?)/.exec(s.trim());
-  if (!m) return 0;
-  const mult: Record<string, number> = { K: 1024, M: 1048576, G: 1073741824 };
-  return Math.round(parseFloat(m[1]) * (mult[m[2]] ?? 1));
-}
-
 export interface LeakSummary {
   leaks: number;
   bytes: number;
+}
+
+/** One leaked-object group: per-object size (downstream multiplies size×count). */
+export interface LeakRow {
+  type: string;
+  /** PER-OBJECT size in bytes (the `[N]` bracket), not the retained-subgraph total. */
+  size: number;
+  count: number;
+}
+
+/**
+ * Parse the ROOT-LEAK lines of `leaks(1)` output into per-object leak rows.
+ * Pure (no I/O) so it can be unit-tested. Line shapes:
+ *   typed:   "  9 (1.25K) ROOT LEAK: <NSMutableDictionary 0x..> [32]  item count: 3"
+ *   untyped: "  1 (1.00K) ROOT LEAK: 0x106657000 [1024]  length: 34  \"reanimated::Foo\""
+ *   bare:    "  1 (16 bytes) ROOT LEAK: 0x1202b7d20 [16]"
+ * The bracket `[N]` is the PER-OBJECT size; the parenthesised `(…)` is the group
+ * total (root + retained subgraph) and must NOT be used as the per-object size.
+ */
+export function parseLeakLines(txt: string): LeakRow[] {
+  const out: LeakRow[] = [];
+  const ROOT = /^\s*(\d+)\s+\([^)]+\)\s+ROOT LEAK:\s+(.+)$/;
+  for (const line of txt.split("\n")) {
+    const m = ROOT.exec(line);
+    if (!m) continue;
+    const count = parseInt(m[1], 10);
+    const body = m[2];
+    const szm = /\[(\d+)\]/.exec(body);
+    const size = szm ? parseInt(szm[1], 10) : 0;
+    // type: the `<Type …>` token (allowing module-qualified `.`/`::`), else the
+    // trailing "string" hint for untyped blocks, else a Malloc-size label.
+    let type: string;
+    const tm = /^<([^\s>]+)/.exec(body);
+    if (tm) {
+      type = tm[1];
+    } else {
+      const hint = /"([^"]+)"/.exec(body);
+      type = hint ? hint[1].slice(0, 120) : `Malloc ${size} bytes`;
+    }
+    out.push({ type, size, count });
+  }
+  return out;
 }
 
 /**
@@ -51,21 +86,11 @@ export async function emitLeaks(udid: string, pid: number, out: string): Promise
     txt = (err.stdout ?? "") + (err.stderr ?? "");
   }
 
-  const rows: string[] = [];
-  // e.g. "  9 (1.25K) ROOT LEAK: <NSMutableDictionary 0x..> [32]  item count: 3"
-  const ROOT = /^\s*(\d+)\s+\(([^)]+)\)\s+ROOT LEAK:\s+<([A-Za-z_][\w]*)[^>]*>\s+\[(\d+)\]/;
-  for (const line of txt.split("\n")) {
-    const m = ROOT.exec(line);
-    if (!m) continue;
-    const count = parseInt(m[1], 10);
-    const total = toBytes(m[2]);
-    const typ = m[3];
-    const objsz = parseInt(m[4], 10);
-    rows.push(
-      `<row leaked-object="${xmlEscape(typ)}" size="${total || objsz}" count="${count}" ` +
-        `responsible-frame="${xmlEscape(typ)}" responsible-library=""/>`
-    );
-  }
+  const rows = parseLeakLines(txt).map(
+    (r) =>
+      `<row leaked-object="${xmlEscape(r.type)}" size="${r.size}" count="${r.count}" ` +
+      `responsible-frame="${xmlEscape(r.type)}" responsible-library=""/>`
+  );
   const xml =
     `<?xml version="1.0"?>\n<trace-toc><run number="1"><tracks>` +
     `<track name="Leaks"><details><detail name="Leaks">${rows.join("")}</detail></details></track>` +
@@ -100,7 +125,8 @@ export async function captureAllocations(udid: string, pid: number): Promise<All
   } catch (e: unknown) {
     txt = (e as { stdout?: string }).stdout ?? "";
   }
-  const summary = txt.slice(txt.indexOf("All zones:"));
+  const zonesIdx = txt.indexOf("All zones:");
+  const summary = zonesIdx >= 0 ? txt.slice(zonesIdx) : "";
   const nodes = /All zones:\s+(\d+)\s+nodes/.exec(txt);
   const objc = /(\d+)\s+ObjC classes/.exec(txt);
   const swift = /(\d+)\s+Swift classes/.exec(txt);

--- a/packages/argent-ios-profiling/src/parser/emit.ts
+++ b/packages/argent-ios-profiling/src/parser/emit.ts
@@ -162,7 +162,12 @@ export async function emitCpuAndHangs(
   const GAP = 60_000_000;
   let mainTid = -1;
   let mainN = -1;
-  for (const [tid, ts] of tsByTid) if (ts.length > mainN) ((mainN = ts.length), (mainTid = tid));
+  for (const [tid, ts] of tsByTid) {
+    if (ts.length > mainN) {
+      mainN = ts.length;
+      mainTid = tid;
+    }
+  }
   const hangRows: string[] = [];
   if (mainTid >= 0) {
     const t = [...(tsByTid.get(mainTid) ?? [])].sort((a, b) => a - b);

--- a/packages/argent-ios-profiling/src/parser/emit.ts
+++ b/packages/argent-ios-profiling/src/parser/emit.ts
@@ -122,11 +122,19 @@ export async function emitCpuAndHangs(
   for (const s of psamples) for (const f of s.frames) uniq.set("0x" + f.toString(16), f);
   const sym = await symbolicate(pid, [...uniq.values()]);
 
-  // weight = median inter-sample gap per tid
+  // kd_buf timestamps are mach-absolute TICKS; the downstream pipeline expects
+  // nanoseconds (sample-time/weight/hang-duration all interpreted as ns). Convert
+  // via the header tick_frequency, relative to the first sample so values stay
+  // small and exact. tickFrequency=0 (unknown) → assume the stream is already ns.
+  const nsPerTick = parsed.tickFrequency > 0 ? 1e9 / parsed.tickFrequency : 1;
+  const base = psamples.reduce((m, s) => Math.min(m, s.timestamp), Infinity);
+  const toNs = (ticks: number) => Math.round((ticks - base) * nsPerTick);
+
+  // weight = median inter-sample gap per tid (in ns)
   const tsByTid = new Map<number, number[]>();
   for (const s of psamples) {
     const arr = tsByTid.get(s.tid) ?? [];
-    arr.push(s.timestamp);
+    arr.push(toNs(s.timestamp));
     tsByTid.set(s.tid, arr);
   }
   const weightByTid = new Map<number, number>();
@@ -146,7 +154,7 @@ export async function emitCpuAndHangs(
       );
     }
     rows.push(
-      `<row><sample-time id="${nid()}" fmt="">${s.timestamp}</sample-time>` +
+      `<row><sample-time id="${nid()}" fmt="">${toNs(s.timestamp)}</sample-time>` +
         `<thread id="${nid()}" fmt="${xmlEscape(name)} ${s.tid}"/>` +
         `<weight id="${nid()}" fmt="">${weightByTid.get(s.tid) ?? 1000000}</weight>` +
         `<backtrace id="${nid()}">${bt.join("")}</backtrace></row>`

--- a/packages/argent-ios-profiling/src/parser/emit.ts
+++ b/packages/argent-ios-profiling/src/parser/emit.ts
@@ -1,0 +1,202 @@
+// Symbolicate kperf callstacks (via `atos -p`) and emit the xctrace-export-format
+// XML (`time-profile` + `potential-hangs`) that Argent's runIosProfilerPipeline
+// consumes. Port of the Python emit_trace.py.
+import * as fs from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ParsedKdebug, Callstack } from "./kdebug";
+
+const execFileAsync = promisify(execFile);
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Resolve a target (pid or process name) against the parsed threadmap. */
+export function resolveTarget(
+  parsed: ParsedKdebug,
+  target: string | number
+): { pid: number; name: string } | null {
+  if (typeof target === "number" || /^\d+$/.test(String(target))) {
+    const pid = Number(target);
+    return { pid, name: parsed.pidsNames.get(pid) ?? String(pid) };
+  }
+  const t = String(target).toLowerCase();
+  for (const [pid, name] of parsed.pidsNames) {
+    if (name.toLowerCase().includes(t)) return { pid, name };
+  }
+  return null;
+}
+
+/** Batched `atos -p <pid>` symbolication: hex address → "func (in Binary) + off". */
+async function symbolicate(pid: number, addrs: bigint[]): Promise<Map<string, string>> {
+  const sym = new Map<string, string>();
+  const hexes = addrs.map((a) => "0x" + a.toString(16));
+  for (let i = 0; i < hexes.length; i += 400) {
+    const chunk = hexes.slice(i, i + 400);
+    try {
+      const { stdout } = await execFileAsync("atos", ["-p", String(pid), ...chunk], {
+        maxBuffer: 32 * 1024 * 1024,
+      });
+      const lines = stdout.split("\n");
+      chunk.forEach((h, j) => sym.set(h, (lines[j] ?? "").trim()));
+    } catch {
+      /* leave unsymbolicated */
+    }
+  }
+  return sym;
+}
+
+const FRAME_RE = /^(.*?)\s+\(in (.+?)\)(?:\s+\+\s+\d+)?(?:\s+\([^)]*\))?$/;
+
+function splitSym(
+  line: string | undefined,
+  addr: bigint,
+  appName: string
+): { func: string; binary: string; path: string } {
+  if (!line || line.startsWith("0x"))
+    return { func: "0x" + addr.toString(16), binary: appName, path: `/var/sim/${appName}` };
+  const m = FRAME_RE.exec(line);
+  if (!m) return { func: line, binary: appName, path: `/var/sim/${appName}` };
+  const func = m[1];
+  const binary = m[2];
+  // app's own binary → non-system path; everything else → a CoreSimulator path so
+  // Argent's isSystemLibraryPath() classifies it as a (deprioritized) system frame.
+  const path =
+    binary === appName
+      ? `/var/containers/Bundle/Application/${appName}.app/${appName}`
+      : `/Library/Developer/CoreSimulator/Volumes/iOS/RuntimeRoot/System/Library/${binary}`;
+  return { func, binary, path };
+}
+
+function medianGap(timestamps: number[]): number {
+  if (timestamps.length < 2) return 1000000;
+  const sorted = [...timestamps].sort((a, b) => a - b);
+  const gaps = [];
+  for (let i = 1; i < sorted.length; i++) gaps.push(sorted[i] - sorted[i - 1]);
+  gaps.sort((a, b) => a - b);
+  return Math.max(1, gaps[Math.floor(gaps.length / 2)]);
+}
+
+export interface EmitResult {
+  cpu: string;
+  hangs: string;
+  pid: number;
+  name: string;
+  cpuSamples: number;
+  hangs_count: number;
+}
+
+/** Emit `<prefix>_raw_cpu.xml` (time-profile) and `<prefix>_raw_hangs.xml` (potential-hangs). */
+export async function emitCpuAndHangs(
+  parsed: ParsedKdebug,
+  target: string | number,
+  outPrefix: string
+): Promise<EmitResult> {
+  let resolved = resolveTarget(parsed, target);
+  if (!resolved) {
+    // Target not found in the threadmap at all → fall back to the busiest mappable
+    // process. (A resolved-but-idle target keeps 0 CPU samples — that's valid, and
+    // leaks/memory still scan the requested process.)
+    const counts = new Map<number, number>();
+    for (const c of parsed.callstacks) {
+      const pid = parsed.threadsPids.get(c.tid);
+      if (pid !== undefined) counts.set(pid, (counts.get(pid) ?? 0) + 1);
+    }
+    const top = [...counts.entries()].sort((a, b) => b[1] - a[1])[0];
+    if (top) resolved = { pid: top[0], name: parsed.pidsNames.get(top[0]) ?? String(top[0]) };
+  }
+  if (!resolved) resolved = { pid: -1, name: String(target) };
+  const { pid, name } = resolved;
+
+  const psamples: Callstack[] = parsed.callstacks.filter(
+    (c) => parsed.threadsPids.get(c.tid) === pid
+  );
+
+  // symbolicate all unique frame addresses
+  const uniq = new Map<string, bigint>();
+  for (const s of psamples) for (const f of s.frames) uniq.set("0x" + f.toString(16), f);
+  const sym = await symbolicate(pid, [...uniq.values()]);
+
+  // weight = median inter-sample gap per tid
+  const tsByTid = new Map<number, number[]>();
+  for (const s of psamples) {
+    const arr = tsByTid.get(s.tid) ?? [];
+    arr.push(s.timestamp);
+    tsByTid.set(s.tid, arr);
+  }
+  const weightByTid = new Map<number, number>();
+  for (const [tid, ts] of tsByTid) weightByTid.set(tid, medianGap(ts));
+
+  let gid = 0;
+  const nid = () => ++gid;
+  const rows: string[] = [];
+  for (const s of psamples) {
+    if (!s.frames.length) continue;
+    const bt: string[] = [];
+    for (const f of s.frames) {
+      const { func, binary, path } = splitSym(sym.get("0x" + f.toString(16)), f, name);
+      bt.push(
+        `<frame id="${nid()}" name="${xmlEscape(func)}">` +
+          `<binary id="${nid()}" name="${xmlEscape(binary)}" path="${xmlEscape(path)}"/></frame>`
+      );
+    }
+    rows.push(
+      `<row><sample-time id="${nid()}" fmt="">${s.timestamp}</sample-time>` +
+        `<thread id="${nid()}" fmt="${xmlEscape(name)} ${s.tid}"/>` +
+        `<weight id="${nid()}" fmt="">${weightByTid.get(s.tid) ?? 1000000}</weight>` +
+        `<backtrace id="${nid()}">${bt.join("")}</backtrace></row>`
+    );
+  }
+  const cpuXml =
+    `<?xml version="1.0"?>\n<trace-toc><run number="1"><data>` +
+    `<table schema="time-profile">${rows.join("")}</table></data></run></trace-toc>\n`;
+  fs.writeFileSync(`${outPrefix}_raw_cpu.xml`, cpuXml);
+
+  // Hangs: contiguous on-CPU runs of the busiest (≈main) thread ≥250ms.
+  const HANG = 250_000_000;
+  const GAP = 60_000_000;
+  let mainTid = -1;
+  let mainN = -1;
+  for (const [tid, ts] of tsByTid) if (ts.length > mainN) ((mainN = ts.length), (mainTid = tid));
+  const hangRows: string[] = [];
+  if (mainTid >= 0) {
+    const t = [...(tsByTid.get(mainTid) ?? [])].sort((a, b) => a - b);
+    let runStart = t[0] ?? 0;
+    let prev = runStart;
+    for (let i = 1; i <= t.length; i++) {
+      const cur = i < t.length ? t[i] : null;
+      if (cur === null || cur - prev > GAP) {
+        const dur = prev - runStart;
+        if (dur >= HANG) {
+          const htype = dur >= 500_000_000 ? "severe-hang" : "hang";
+          hangRows.push(
+            `<row><start-time id="${nid()}" fmt="">${runStart}</start-time>` +
+              `<duration id="${nid()}" fmt="">${dur}</duration>` +
+              `<hang-type id="${nid()}" fmt="">${htype}</hang-type>` +
+              `<thread id="${nid()}" fmt="${xmlEscape(name)} ${mainTid} (main thread)"/></row>`
+          );
+        }
+        if (cur !== null) runStart = cur;
+      }
+      if (cur !== null) prev = cur;
+    }
+  }
+  const hangsXml =
+    `<?xml version="1.0"?>\n<trace-toc><run number="1"><data>` +
+    `<table schema="potential-hangs">${hangRows.join("")}</table></data></run></trace-toc>\n`;
+  fs.writeFileSync(`${outPrefix}_raw_hangs.xml`, hangsXml);
+
+  return {
+    cpu: `${outPrefix}_raw_cpu.xml`,
+    hangs: `${outPrefix}_raw_hangs.xml`,
+    pid,
+    name,
+    cpuSamples: rows.length,
+    hangs_count: hangRows.length,
+  };
+}

--- a/packages/argent-ios-profiling/src/parser/kdebug.test.ts
+++ b/packages/argent-ios-profiling/src/parser/kdebug.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { parseKdebugStream } from "./kdebug";
+
+// --- synthetic RAW_VERSION2 stream builder ---------------------------------
+const RAW_VERSION2 = 0x55aa0200;
+const PERF_EVENT = 0x25000000;
+const PERF_STK_UHDR = 0x25020018;
+const PERF_STK_UDATA = 0x25020010;
+const SAMPLER_USTACK = 0x08;
+
+/** One 64-byte kd_buf: ts@0, arg0..3@8/16/24/32, tid@40, debugid@48. */
+function kdbuf(opts: { ts?: bigint; args?: bigint[]; tid?: bigint; debugid: number }): Buffer {
+  const b = Buffer.alloc(64);
+  b.writeBigUInt64LE(opts.ts ?? 0n, 0);
+  const a = opts.args ?? [];
+  for (let i = 0; i < 4; i++) b.writeBigUInt64LE(a[i] ?? 0n, 8 + i * 8);
+  b.writeBigUInt64LE(opts.tid ?? 0n, 40);
+  b.writeUInt32LE(opts.debugid >>> 0, 48);
+  return b;
+}
+
+/** A complete USTACK sample (START → UHDR → UDATA → END) for one thread. */
+function sample(tid: bigint, ts: bigint, frames: bigint[]): Buffer {
+  return Buffer.concat([
+    kdbuf({ tid, ts, args: [BigInt(SAMPLER_USTACK)], debugid: PERF_EVENT | 1 }),
+    kdbuf({ tid, args: [0n, BigInt(frames.length)], debugid: PERF_STK_UHDR }),
+    kdbuf({ tid, args: [frames[0] ?? 0n, frames[1] ?? 0n, 0n, 0n], debugid: PERF_STK_UDATA }),
+    kdbuf({ tid, debugid: PERF_EVENT | 2 }),
+  ]);
+}
+
+function header(numThreads: number, tickFreq: bigint): Buffer {
+  const h = Buffer.alloc(288);
+  h.writeUInt32LE(RAW_VERSION2, 0);
+  h.writeUInt32LE(numThreads, 4);
+  h.writeBigUInt64LE(tickFreq, 24);
+  return h; // [32 header][256 pad] → threadmap starts at 288
+}
+
+function threadmapEntry(tid: bigint, pid: number, name: string): Buffer {
+  const e = Buffer.alloc(32);
+  e.writeBigUInt64LE(tid, 0);
+  e.writeInt32LE(pid, 8);
+  e.write(name, 12, "utf8");
+  return e;
+}
+
+describe("parseKdebugStream", () => {
+  it("parses tickFrequency, threadmap and a USTACK callstack", () => {
+    const stream = Buffer.concat([
+      header(1, 24_000_000n),
+      threadmapEntry(7n, 42, "testproc"),
+      sample(7n, 1000n, [0xaaaan, 0xbbbbn]),
+    ]);
+    const p = parseKdebugStream(stream);
+    expect(p.tickFrequency).toBe(24_000_000);
+    expect(p.threadsPids.get(7)).toBe(42);
+    expect(p.pidsNames.get(42)).toBe("testproc");
+    expect(p.callstacks).toHaveLength(1);
+    expect(p.callstacks[0].tid).toBe(7);
+    expect(p.callstacks[0].frames).toEqual([0xaaaan, 0xbbbbn]);
+  });
+
+  // Regression for the zero-padding alignment bug: a byte-wise "skip while 0"
+  // eats the first record's zero low timestamp byte (~1/256 of streams) and
+  // drops the ENTIRE record stream. Deterministic end-alignment must not.
+  it("does not drop the stream when the first record timestamp has a zero low byte", () => {
+    for (const ts of [0x100n, 0x2300n, 0x4500n, 0xff00n]) {
+      const stream = Buffer.concat([
+        header(1, 24_000_000n),
+        threadmapEntry(7n, 42, "p"),
+        Buffer.alloc(8), // leading zero pad between threadmap and records
+        sample(7n, ts, [0xdeadn, 0xbeefn]),
+      ]);
+      const p = parseKdebugStream(stream);
+      expect(p.callstacks, `ts=0x${ts.toString(16)}`).toHaveLength(1);
+      expect(p.callstacks[0].frames).toEqual([0xdeadn, 0xbeefn]);
+    }
+  });
+
+  // numThreads is stream-controlled; a capture killed mid-write must not throw.
+  it("does not throw on a truncated threadmap (oversized numThreads)", () => {
+    const truncated = Buffer.concat([
+      header(1000, 24_000_000n), // claims 1000 threads…
+      threadmapEntry(7n, 42, "p"), // …but only one is present
+    ]);
+    expect(() => parseKdebugStream(truncated)).not.toThrow();
+    const p = parseKdebugStream(truncated);
+    expect(p.threadsPids.get(7)).toBe(42);
+  });
+
+  it("returns empty for a non-RAW_VERSION2 / short buffer", () => {
+    const p = parseKdebugStream(Buffer.from([1, 2, 3, 4]));
+    expect(p.callstacks).toHaveLength(0);
+    expect(p.tickFrequency).toBe(0);
+  });
+});

--- a/packages/argent-ios-profiling/src/parser/kdebug.ts
+++ b/packages/argent-ios-profiling/src/parser/kdebug.ts
@@ -1,0 +1,161 @@
+// TypeScript port of the pykdebugparser callstack path (the only part we use).
+//
+// The native capture writes a length-framed file: frame 0 is a kcdata stackshot
+// (unused — we symbolicate via `atos`), frames 1+ concatenate into a kdebug
+// RAW_VERSION2 stream. This module deframes, parses that stream, and reconstructs
+// kperf user-stack callstacks plus the tid→pid / pid→name threadmap.
+//
+// Reference: pykdebugparser (kd_buf_parser.py, traces_parser.py,
+// trace_handlers/perf.py). kd_buf record = `<Q 32s Q I I Q>` (64 bytes).
+
+const RAW_VERSION2 = 0x55aa0200; // bytes 00 02 aa 55, little-endian u32
+const KEVENT_SIZE = 64;
+
+// kperf trace-code eventids (eventid = debugid & 0xFFFFFFFC)
+const PERF_EVENT = 0x25000000; // brackets a sample (func START=1 / END=2)
+const PERF_THD_DATA = 0x25010004; // args: [pid, tid, dq_addr, runmode]
+const PERF_STK_UHDR = 0x25020018; // args: [flags, nframes]
+const PERF_STK_UDATA = 0x25020010; // args: up to 4 user-stack frame addresses
+
+// sample_what flags (PERF_Event arg0)
+const SAMPLER_USTACK = 0x08;
+
+export interface Callstack {
+  /** mach-absolute timestamp of the sample. */
+  timestamp: number;
+  /** sampled thread id. */
+  tid: number;
+  /** user-stack frame addresses, leaf-first. */
+  frames: bigint[];
+}
+
+export interface ParsedKdebug {
+  callstacks: Callstack[];
+  /** tid → pid (from the threadmap + PERF_THD_Data events). */
+  threadsPids: Map<number, number>;
+  /** pid → process name (from the threadmap). */
+  pidsNames: Map<number, string>;
+}
+
+/** Split the capture file into its length-prefixed frames (`<u32 len><bytes>`). */
+export function deframe(buf: Buffer): Buffer[] {
+  const frames: Buffer[] = [];
+  let off = 0;
+  while (off + 4 <= buf.length) {
+    const len = buf.readUInt32LE(off);
+    off += 4;
+    if (off + len > buf.length) break;
+    frames.push(buf.subarray(off, off + len));
+    off += len;
+  }
+  return frames;
+}
+
+interface OpenGroup {
+  ts: number;
+  sampleWhat: number;
+  nframes: number;
+  frames: bigint[];
+}
+
+/**
+ * Parse a kdebug RAW_VERSION2 stream (the concatenation of capture frames 1+)
+ * into kperf user-stack callstacks. Mirrors pykdebugparser's `callstacks()`.
+ */
+export function parseKdebugStream(raw: Buffer): ParsedKdebug {
+  const threadsPids = new Map<number, number>();
+  const pidsNames = new Map<number, string>();
+  const callstacks: Callstack[] = [];
+
+  if (raw.length < 4 || raw.readUInt32LE(0) !== RAW_VERSION2) {
+    return { callstacks, threadsPids, pidsNames };
+  }
+
+  // --- kd_header_v2 ---
+  // numThreads u32@4, pad(8+4), is_64bit u32@16, tick_frequency u64@20,
+  // pad(0x100), threadmap[numThreads] (each 32B: tid u64, pid u32, name char[20]),
+  // then a run of zero padding until the first record.
+  const numThreads = raw.readUInt32LE(4);
+  // version(4) + numThreads(4) + pad(8) + pad(4) + is_64bit(4) + tick_frequency(8) = 32
+  let off = 32;
+  off += 0x100; // pad(256) → threadmap at 288
+  for (let i = 0; i < numThreads; i++) {
+    const tid = Number(raw.readBigUInt64LE(off));
+    const pid = raw.readInt32LE(off + 8);
+    let end = off + 12;
+    let z = end;
+    while (z < off + 32 && raw[z] !== 0) z++;
+    const name = raw.toString("utf8", end, z);
+    threadsPids.set(tid, pid);
+    if (!pidsNames.has(pid)) pidsNames.set(pid, name);
+    off += 32;
+  }
+  // skip zero padding to the first record (kd_header_v2 `_pad` = GreedyRange of 0)
+  while (off < raw.length && raw[off] === 0) off++;
+
+  // --- kd_buf records ---
+  const open = new Map<number, OpenGroup>();
+  for (; off + KEVENT_SIZE <= raw.length; off += KEVENT_SIZE) {
+    const debugid = raw.readUInt32LE(off + 48);
+    const eventid = debugid & 0xfffffffc;
+    const func = debugid & 0x3;
+    const tid = Number(raw.readBigUInt64LE(off + 40));
+
+    if (eventid === PERF_EVENT) {
+      if (func === 1) {
+        // START — open a sample group for this thread
+        open.set(tid, {
+          ts: Number(raw.readBigUInt64LE(off)),
+          sampleWhat: Number(raw.readBigUInt64LE(off + 8)), // arg0
+          nframes: -1,
+          frames: [],
+        });
+      } else if (func === 2) {
+        // END — finalize the sample
+        const g = open.get(tid);
+        if (g) {
+          open.delete(tid);
+          if (g.sampleWhat & SAMPLER_USTACK && g.nframes >= 0) {
+            callstacks.push({ timestamp: g.ts, tid, frames: g.frames.slice(0, g.nframes) });
+          }
+        }
+      }
+      continue;
+    }
+
+    const g = open.get(tid);
+    if (g === undefined) {
+      if (eventid === PERF_THD_DATA) {
+        // tid→pid can also arrive outside an open group
+        threadsPids.set(
+          Number(raw.readBigUInt64LE(off + 16)),
+          Number(raw.readBigUInt64LE(off + 8))
+        );
+      }
+      continue;
+    }
+    if (eventid === PERF_STK_UHDR) {
+      g.nframes = Number(raw.readBigUInt64LE(off + 16)); // arg1
+    } else if (eventid === PERF_STK_UDATA) {
+      // arg0..arg3 = up to 4 frame addresses
+      g.frames.push(
+        raw.readBigUInt64LE(off + 8),
+        raw.readBigUInt64LE(off + 16),
+        raw.readBigUInt64LE(off + 24),
+        raw.readBigUInt64LE(off + 32)
+      );
+    } else if (eventid === PERF_THD_DATA) {
+      threadsPids.set(Number(raw.readBigUInt64LE(off + 16)), Number(raw.readBigUInt64LE(off + 8)));
+    }
+  }
+
+  return { callstacks, threadsPids, pidsNames };
+}
+
+/** Convenience: deframe a capture file and parse its kdebug stream. */
+export function parseCapture(buf: Buffer): ParsedKdebug {
+  const frames = deframe(buf);
+  if (frames.length <= 1) return { callstacks: [], threadsPids: new Map(), pidsNames: new Map() };
+  const raw = Buffer.concat(frames.slice(1)); // frame 0 = stackshot (unused)
+  return parseKdebugStream(raw);
+}

--- a/packages/argent-ios-profiling/src/parser/kdebug.ts
+++ b/packages/argent-ios-profiling/src/parser/kdebug.ts
@@ -21,7 +21,7 @@ const PERF_STK_UDATA = 0x25020010; // args: up to 4 user-stack frame addresses
 const SAMPLER_USTACK = 0x08;
 
 export interface Callstack {
-  /** mach-absolute timestamp of the sample. */
+  /** sample timestamp in mach ticks, relative to the first sample (convert via tickFrequency). */
   timestamp: number;
   /** sampled thread id. */
   tid: number;
@@ -35,6 +35,12 @@ export interface ParsedKdebug {
   threadsPids: Map<number, number>;
   /** pid → process name (from the threadmap). */
   pidsNames: Map<number, string>;
+  /**
+   * kd_header_v2 tick_frequency (ticks/sec). Lets consumers convert the
+   * mach-tick timestamps to real time (ns = ticks * 1e9 / tickFrequency).
+   * 0 when unknown (empty/short stream).
+   */
+  tickFrequency: number;
 }
 
 /** Split the capture file into its length-prefixed frames (`<u32 len><bytes>`). */
@@ -67,19 +73,23 @@ export function parseKdebugStream(raw: Buffer): ParsedKdebug {
   const pidsNames = new Map<number, string>();
   const callstacks: Callstack[] = [];
 
-  if (raw.length < 4 || raw.readUInt32LE(0) !== RAW_VERSION2) {
-    return { callstacks, threadsPids, pidsNames };
+  if (raw.length < 32 || raw.readUInt32LE(0) !== RAW_VERSION2) {
+    return { callstacks, threadsPids, pidsNames, tickFrequency: 0 };
   }
 
-  // --- kd_header_v2 ---
-  // numThreads u32@4, pad(8+4), is_64bit u32@16, tick_frequency u64@20,
+  // --- kd_header_v2 (after the 4-byte magic) ---
+  // number_of_threads u32@4, pad(8), pad(4), is_64bit u32@20, tick_frequency u64@24,
   // pad(0x100), threadmap[numThreads] (each 32B: tid u64, pid u32, name char[20]),
   // then a run of zero padding until the first record.
   const numThreads = raw.readUInt32LE(4);
-  // version(4) + numThreads(4) + pad(8) + pad(4) + is_64bit(4) + tick_frequency(8) = 32
+  const tickFrequency = Number(raw.readBigUInt64LE(24));
+  // magic(4) + numThreads(4) + pad(8) + pad(4) + is_64bit(4) + tick_frequency(8) = 32
   let off = 32;
   off += 0x100; // pad(256) → threadmap at 288
   for (let i = 0; i < numThreads; i++) {
+    // numThreads is attacker/stream-controlled; never read past the buffer (a
+    // capture killed mid-write otherwise throws an opaque RangeError).
+    if (off + 32 > raw.length) break;
     const tid = Number(raw.readBigUInt64LE(off));
     const pid = raw.readInt32LE(off + 8);
     const end = off + 12;
@@ -90,10 +100,21 @@ export function parseKdebugStream(raw: Buffer): ParsedKdebug {
     if (!pidsNames.has(pid)) pidsNames.set(pid, name);
     off += 32;
   }
-  // skip zero padding to the first record (kd_header_v2 `_pad` = GreedyRange of 0)
-  while (off < raw.length && raw[off] === 0) off++;
+  // Locate the first kd_buf record. The header pads with a GreedyRange of zero
+  // bytes, but a byte-wise "skip while 0" misaligns the 64-byte grid whenever the
+  // first record's leading u64 timestamp has a zero low byte (~1/256), silently
+  // dropping the ENTIRE record stream. Instead align deterministically from the
+  // end: records are a whole number of 64-byte kd_bufs ending at the buffer end,
+  // so the leading pad length ≡ (remaining bytes) mod 64. Any extra all-zero
+  // 64-byte slots left in front parse as eventid 0 and are skipped harmlessly.
+  if (off < raw.length) off += (raw.length - off) % KEVENT_SIZE;
 
   // --- kd_buf records ---
+  // Timestamps are stored relative to the first sample so the u64→number narrowing
+  // stays exact: the absolute mach time can exceed 2^53 (e.g. an ns-reporting x86
+  // sim past ~104 days uptime), but a per-capture delta never does. The bigint
+  // subtraction happens BEFORE narrowing, so no low bits are lost.
+  let baseTs: bigint | null = null;
   const open = new Map<number, OpenGroup>();
   for (; off + KEVENT_SIZE <= raw.length; off += KEVENT_SIZE) {
     const debugid = raw.readUInt32LE(off + 48);
@@ -104,8 +125,10 @@ export function parseKdebugStream(raw: Buffer): ParsedKdebug {
     if (eventid === PERF_EVENT) {
       if (func === 1) {
         // START — open a sample group for this thread
+        const tsRaw = raw.readBigUInt64LE(off);
+        if (baseTs === null) baseTs = tsRaw;
         open.set(tid, {
-          ts: Number(raw.readBigUInt64LE(off)),
+          ts: Number(tsRaw - baseTs), // relative ticks (exact; see note above)
           sampleWhat: Number(raw.readBigUInt64LE(off + 8)), // arg0
           nframes: -1,
           frames: [],
@@ -149,13 +172,15 @@ export function parseKdebugStream(raw: Buffer): ParsedKdebug {
     }
   }
 
-  return { callstacks, threadsPids, pidsNames };
+  return { callstacks, threadsPids, pidsNames, tickFrequency };
 }
 
 /** Convenience: deframe a capture file and parse its kdebug stream. */
 export function parseCapture(buf: Buffer): ParsedKdebug {
   const frames = deframe(buf);
-  if (frames.length <= 1) return { callstacks: [], threadsPids: new Map(), pidsNames: new Map() };
+  if (frames.length <= 1) {
+    return { callstacks: [], threadsPids: new Map(), pidsNames: new Map(), tickFrequency: 0 };
+  }
   const raw = Buffer.concat(frames.slice(1)); // frame 0 = stackshot (unused)
   return parseKdebugStream(raw);
 }

--- a/packages/argent-ios-profiling/src/parser/kdebug.ts
+++ b/packages/argent-ios-profiling/src/parser/kdebug.ts
@@ -82,7 +82,7 @@ export function parseKdebugStream(raw: Buffer): ParsedKdebug {
   for (let i = 0; i < numThreads; i++) {
     const tid = Number(raw.readBigUInt64LE(off));
     const pid = raw.readInt32LE(off + 8);
-    let end = off + 12;
+    const end = off + 12;
     let z = end;
     while (z < off + 32 && raw[z] !== 0) z++;
     const name = raw.toString("utf8", end, z);

--- a/packages/argent-ios-profiling/tsconfig.json
+++ b/packages/argent-ios-profiling/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/argent-ios-profiling/tsconfig.json
+++ b/packages/argent-ios-profiling/tsconfig.json
@@ -7,5 +7,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/packages/argent-ios-profiling/tsconfig.test.json
+++ b/packages/argent-ios-profiling/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/download-ios-profiler.sh
+++ b/scripts/download-ios-profiler.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads the SIGNED ios-profiler host binaries (ios-profiler-capture,
+# ios-profiler-mem) from argent-private-releases into the package's bin/darwin/,
+# so @argent/ios-profiling runs the real signed artifact without a full npm
+# release. This is the local-testing seam: pair it with the package's build.sh
+# PREBUILT_IOS_PROFILER_BIN_DIR hook, or just drop the binaries straight in.
+#
+# The binaries are built + Developer-ID-signed (hardened runtime + entitlements)
+# by argent-private's build-native-binaries.yml and published as release assets
+# alongside the dylibs/ax-service under the same tag.
+#
+# Usage: ./scripts/download-ios-profiler.sh [release-tag]
+#   release-tag  Tag to download from. Defaults to argent-main.
+#                Use argent-daily for the prerelease (workflow_dispatch with
+#                prerelease=true) dev loop.
+#
+# Requires:
+#   - gh CLI (no authentication needed — the releases repo is public)
+
+REPO="software-mansion/argent-private-releases"
+TAG="${1:-argent-main}"
+DEST="packages/argent-ios-profiling/bin/darwin"
+
+if ! gh release view "${TAG}" --repo "${REPO}" &>/dev/null; then
+  echo "Error: release '${TAG}' not found in ${REPO}." >&2
+  echo "Build and publish the ios-profiler binaries for this tag first, then retry." >&2
+  exit 1
+fi
+
+mkdir -p "${DEST}"
+
+for b in ios-profiler-capture ios-profiler-mem; do
+  echo "  Downloading ${b}..."
+  if ! gh release download "${TAG}" \
+    --repo "${REPO}" \
+    --pattern "${b}" \
+    --dir "${DEST}" \
+    --clobber; then
+    echo "Error: '${b}' not found in release '${TAG}'." >&2
+    echo "The signing pipeline may not have shipped it for this tag yet." >&2
+    exit 1
+  fi
+  chmod +x "${DEST}/${b}"
+done
+
+echo "Downloaded signed ios-profiler binaries to ${DEST}/"
+
+if command -v codesign &>/dev/null; then
+  for b in ios-profiler-capture ios-profiler-mem; do
+    codesign -dvv "${DEST}/${b}" 2>&1 || echo "Warning: signature verification failed for ${b}"
+  done
+fi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "packages/argent-installer" },
     { "path": "packages/argent-mcp" },
     { "path": "packages/argent-cli" },
-    { "path": "packages/argent" }
+    { "path": "packages/argent" },
+    { "path": "packages/argent-ios-profiling" }
   ]
 }


### PR DESCRIPTION
## What

Adds a new **standalone** package `@argent/ios-profiling` (`packages/argent-ios-profiling`). It is **not wired into the tool-server yet** — nothing imports it; adopting it is a deliberate follow-up.

It replaces the broken xctrace capture+export on **Xcode 26.4 / 26.5 / 26.6 / 27.0**, where `xctrace record --device <sim>` hangs on finalize (the simulator `coreprofilesessiontap` finalize regression — verified: 26.3 build `17C529` finalizes fine, 26.4+ hangs). A native binary drives the Instruments server directly over **DTX** and a **pure-TypeScript** parser emits the same `xctrace export`-format XML that `runIosProfilerPipeline` already consumes, so the whole downstream pipeline is unchanged.

## Coverage (all 5 of Argent's template vectors)

| Vector | Source |
|---|---|
| Time Profiler (CPU) | `coreprofilesessiontap` PET time trigger @ 1 kHz (DTX) |
| Hangs | derived (main-thread on-CPU runs ≥250 ms) |
| Leaks | in-sim `simctl spawn leaks` |
| Memory | `sysmontap` (DTX) |
| Allocations | in-sim `simctl spawn heap` |

- **No Python / no third-party deps.** The kdebug `RAW_VERSION2` parser is a pure-TS port of the `pykdebugparser` callstack path, validated **byte-for-byte** against the Python reference (identical 36,028-callstack output) — zero runtime dependency on `pymobiledevice3`.
- Native binaries build locally via `scripts/build.sh` (clang → `bin/darwin/`), `bin/` gitignored like `native-devtools-ios/bin`; `PREBUILT_IOS_PROFILER_BIN_DIR` supports non-macOS CI.

## Validation vs xctrace-26.3 (last-good)

- **Leaks / Allocations / Memory:** byte-for-byte identical on an idle app (11 leaks / 1888 B; 63,639 heap nodes / 8,197,136 B; footprint 54.3 MB == OS `footprint`/`vmmap`).
- **CPU:** the `tk:1` PET time trigger + `si` (ns) sample interval + PERF-class-only `kdf2` filter give **931 Hz vs xctrace 1037 Hz** on a deterministic 100%-CPU workload (both 100% on the same hot symbol); idle apps correctly yield ~0 samples.
- **Real app (ParadiseGallery scrolling):** identical top hotspot (Hermes interpreter ~8%) and supporting cast. Known caveat (documented in README): on bursty multi-threaded workloads absolute sample density is ~5× sparser than xctrace though the relative ranking matches — a separate follow-up.

## Checks
- `prettier --write` (repo formatter) — clean
- `tsc --noEmit` — clean
- (repo has no ESLint config, so none to run)

## Not included
- Wiring into the tool-server `native-profiler-start/stop` path (intentional follow-up).