### PR TITLE
chore(eslint): fail CI on warnings and unused disable directives

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,14 @@ export default tseslint.config(
     ],
   },
 
+  // Keep the gate honest: a stale or unjustified `eslint-disable` is a hard
+  // error, so suppressions can't quietly pile up or be used to dodge a rule.
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+    },
+  },
+
   // Type-aware linting for the TypeScript sources — this is where the value is
   // (floating promises, misused promises, throwing non-Errors, etc.).
   {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pack:mcp:local": "npm run download:simulator-server && npm run build:ios-binaries && npm run build:android-binaries && npm run download:trace-processor && npm run build && npm run build -w @swmansion/argent && npm pack -w @swmansion/argent --pack-destination .",
     "dev": "node scripts/dev.cjs",
     "format": "prettier --write .",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json"
   },


### PR DESCRIPTION
Small follow-up to #349 (which added the ESLint gate). Makes the gate strict so it can't be silently bypassed or accumulate dead suppressions:

- **`reportUnusedDisableDirectives: "error"`** — a stale or unjustified `eslint-disable` is now a hard failure. (The tree had dead directives before the gate existed; #349's `--fix` removed them — this stops them creeping back.)
- **`--max-warnings 0`** in the `lint` script — a future `"warn"`-level rule can't pass CI silently.

Both are no-ops against the current tree (0 disable directives, 0 warnings) — pure guardrails.

Verified locally: `npm run lint` (strict), `tsc --build`, and `prettier --check` all pass.