### PR TITLE
feat(ios-profiling): signed-binary build + local-test pull

### DIFF
--- a/packages/argent-ios-profiling/ios-profiler.entitlements
+++ b/packages/argent-ios-profiling/ios-profiler.entitlements
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Entitlements applied when argent-private's build-native-binaries.yml signs
+    ios-profiler-capture / ios-profiler-mem with a Developer ID under hardened
+    runtime (`codesign --options runtime`).
+
+    disable-library-validation: the capture binary dlopen()s Xcode's private
+    frameworks (CoreSimulator, DTXConnectionServices, DVTInstruments*) to drive
+    the Instruments DTServiceHub. Those are Apple-signed under a *different* Team
+    ID than our Developer ID, so hardened runtime's library validation would
+    refuse the load and the DTX channel would never open. This entitlement lifts
+    that restriction for these two host-side tools.
+
+    NOTE: this is the suspected-sufficient set, mirroring ax-service's recipe.
+    It MUST be verified on a clean second Mac (download the CI-signed binary and
+    confirm `coreprofile channel=...` still connects) before relying on it for
+    distribution — the dev-machine validation in PR #350 used clang's ad-hoc
+    signature, which is a different trust context.
+  -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/argent-ios-profiling/ios-profiler.entitlements
+++ b/packages/argent-ios-profiling/ios-profiler.entitlements
@@ -5,7 +5,7 @@
   <!--
     Entitlements applied when argent-private's build-native-binaries.yml signs
     ios-profiler-capture / ios-profiler-mem with a Developer ID under hardened
-    runtime (`codesign --options runtime`).
+    runtime (`codesign -o runtime`).
 
     disable-library-validation: the capture binary dlopen()s Xcode's private
     frameworks (CoreSimulator, DTXConnectionServices, DVTInstruments*) to drive

--- a/packages/argent-ios-profiling/scripts/build.sh
+++ b/packages/argent-ios-profiling/scripts/build.sh
@@ -28,7 +28,12 @@ if [[ "$(uname)" != "Darwin" ]]; then
   exit 1
 fi
 
-CFLAGS=(-fno-objc-arc -fobjc-exceptions -O2 -I"$DIR/objc_src" -framework Foundation -framework Security)
+# Universal host binary (arm64 + x86_64). These run on the host Mac (not the
+# simulator), so the default macOS SDK is correct — but both host arches must be
+# built or x86_64 / Rosetta hosts get an ENOEXEC at spawn. Mirrors the dylib CI
+# build matrix (-arch arm64 -arch x86_64). The signed release artifacts produced
+# by argent-private's build-native-binaries.yml use the same flags.
+CFLAGS=(-fno-objc-arc -fobjc-exceptions -O2 -arch arm64 -arch x86_64 -I"$DIR/objc_src" -framework Foundation -framework Security)
 
 echo "building ios-profiler-capture ..."
 clang "${CFLAGS[@]}" -o "$OUT/ios-profiler-capture" "$DIR/objc_src/capture.m"

--- a/scripts/download-ios-profiler.sh
+++ b/scripts/download-ios-profiler.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads the SIGNED ios-profiler host binaries (ios-profiler-capture,
+# ios-profiler-mem) from argent-private-releases into the package's bin/darwin/,
+# so @argent/ios-profiling runs the real signed artifact without a full npm
+# release. This is the local-testing seam: pair it with the package's build.sh
+# PREBUILT_IOS_PROFILER_BIN_DIR hook, or just drop the binaries straight in.
+#
+# The binaries are built + Developer-ID-signed (hardened runtime + entitlements)
+# by argent-private's build-native-binaries.yml and published as release assets
+# alongside the dylibs/ax-service under the same tag.
+#
+# Usage: ./scripts/download-ios-profiler.sh [release-tag]
+#   release-tag  Tag to download from. Defaults to argent-main.
+#                Use argent-daily for the prerelease (workflow_dispatch with
+#                prerelease=true) dev loop.
+#
+# Requires:
+#   - gh CLI (no authentication needed — the releases repo is public)
+
+REPO="software-mansion/argent-private-releases"
+TAG="${1:-argent-main}"
+DEST="packages/argent-ios-profiling/bin/darwin"
+
+if ! gh release view "${TAG}" --repo "${REPO}" &>/dev/null; then
+  echo "Error: release '${TAG}' not found in ${REPO}." >&2
+  echo "Build and publish the ios-profiler binaries for this tag first, then retry." >&2
+  exit 1
+fi
+
+mkdir -p "${DEST}"
+
+for b in ios-profiler-capture ios-profiler-mem; do
+  echo "  Downloading ${b}..."
+  if ! gh release download "${TAG}" \
+    --repo "${REPO}" \
+    --pattern "${b}" \
+    --dir "${DEST}" \
+    --clobber; then
+    echo "Error: '${b}' not found in release '${TAG}'." >&2
+    echo "The signing pipeline may not have shipped it for this tag yet." >&2
+    exit 1
+  fi
+  chmod +x "${DEST}/${b}"
+done
+
+echo "Downloaded signed ios-profiler binaries to ${DEST}/"
+
+if command -v codesign &>/dev/null; then
+  for b in ios-profiler-capture ios-profiler-mem; do
+    codesign -dvv "${DEST}/${b}" 2>&1 || echo "Warning: signature verification failed for ${b}"
+  done
+fi


### PR DESCRIPTION
## What

The public half of getting `@argent/ios-profiling`'s native binaries **signed and shippable** through the existing signed-artifact pipeline — without putting any Apple identity in this public repo.

Stacked on #350 (the profiler package only exists on that branch). Paired with an `argent-private` PR that adds the build+sign+publish step.

### Pipeline (after both PRs)

```
software-mansion/argent (PUBLIC)            ── ObjC source stays here (open)
   │  read-only checkout by private CI
   ▼
software-mansion/argent-private (PRIVATE)   ── build-native-binaries.yml: build UNIVERSAL,
   │                                            codesign (Developer ID + hardened runtime + entitlements)
   ▼
software-mansion/argent-private-releases    ── ios-profiler-capture, ios-profiler-mem (per tag)
   │
   ├─ full release  → download-native-binaries.sh → bundle-tools → @swmansion/argent
   └─ local testing → download-ios-profiler.sh argent-daily → bin/darwin (no npm pack/publish)
```

Signed binaries flow one way: private CI → releases → consumers. Never committed to git, never built locally for distribution.

## Changes

- **`build.sh`** — build a **universal** binary (`-arch arm64 -arch x86_64`). It was host-arch-only, which would `ENOEXEC` on x86_64 / Rosetta hosts and ship a broken artifact. Now matches the dylib CI build matrix.
- **`ios-profiler.entitlements`** (new) — hardened-runtime entitlements (`com.apple.security.cs.disable-library-validation`) consumed by argent-private's `codesign --options runtime` step, so the signed binary can `dlopen` Xcode's Apple-signed private frameworks (CoreSimulator / DTX) under a different Team ID. Mirrors the existing `ax-service.entitlements` recipe.
- **`scripts/download-ios-profiler.sh`** (new) — pull the **signed** binaries from `argent-private-releases` into `bin/darwin/` for local testing (`argent-daily` for the prerelease dev loop), decoupled from any npm publish. Pairs with `build.sh`'s existing `PREBUILT_IOS_PROFILER_BIN_DIR` hook.

## Not included (deliberate follow-ups)

- Wiring `bin/darwin/ios-profiler-*` into the published `@swmansion/argent` (bundle-tools + publish verify + `files`) — only needed once the tool-server consumes the package (it's `private: true` and unwired today).

## ⚠️ Must verify before relying on signed artifacts

The entitlements set is **suspected-sufficient**, mirroring ax-service. PR #350 validated with clang's **ad-hoc** signature — Developer ID + hardened runtime is a different trust context. **Acceptance gate: download the CI-signed binary onto a clean second Mac and confirm `coreprofile channel=...` still connects.** If `disable-library-validation` is insufficient, the fallback is ad-hoc signing for these two (documented as non-notarized).