### PR TITLE
chore(deps): npm-minor-patch group excluding tree-sitter (fixes #348)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,16 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
       include: "scope"
+    ignore:
+      # tree-sitter 0.25.0 ships no Node 24 prebuilds and its binding.gyp forces
+      # C++17 while Node 22+ v8 (cppgc) headers require C++20, so the native
+      # build fails `npm install`/`npm ci` on current Node. Stay on ^0.21.1,
+      # which ships N-API prebuilds (no compile). Patch updates stay allowed;
+      # drop this ignore once upstream restores prebuilt binaries.
+      - dependency-name: "tree-sitter"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     groups:
       # Batch all minor + patch updates into one PR per week to cut noise.
       npm-minor-patch:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@eslint/js": "^10.0.1",
         "eslint": "^10.5.0",
         "globals": "^17.6.0",
-        "prettier": "^3.8.3",
+        "prettier": "^3.8.4",
         "typescript-eslint": "^8.61.1"
       }
     },
@@ -69,9 +69,9 @@
       "link": true
     },
     "node_modules/@clack/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==",
       "license": "MIT",
       "dependencies": {
         "fast-wrap-ansi": "^0.2.0",
@@ -82,12 +82,12 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.4.0.tgz",
-      "integrity": "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.1.tgz",
+      "integrity": "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.3.1",
+        "@clack/core": "1.4.1",
         "fast-string-width": "^3.0.2",
         "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
@@ -1673,9 +1673,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2093,16 +2093,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2111,13 +2111,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.6",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2138,9 +2138,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2151,13 +2151,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2165,14 +2165,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2191,13 +2191,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3084,9 +3084,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
-      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
@@ -3806,6 +3806,8 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4146,9 +4148,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4336,9 +4338,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4972,19 +4974,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5012,12 +5014,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5203,15 +5205,15 @@
         "@argent/installer": "file:../argent-installer",
         "@argent/mcp": "file:../argent-mcp",
         "@argent/tools-client": "file:../argent-tools-client",
-        "@clack/prompts": "^1.1.0",
-        "@types/node": "^25.9.0",
+        "@clack/prompts": "^1.5.1",
+        "@types/node": "^25.9.3",
         "@types/semver": "^7.7.1",
-        "esbuild": "^0.28.0",
+        "esbuild": "^0.28.1",
         "picocolors": "^1.1.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.4",
         "smol-toml": "^1.6.1",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6",
+        "vitest": "^4.1.9",
         "yaml": "^2.8.3"
       },
       "optionalDependencies": {
@@ -5224,13 +5226,13 @@
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/tools-client": "file:../argent-tools-client",
-        "@clack/prompts": "^1.1.0",
+        "@clack/prompts": "^1.5.1",
         "picocolors": "^1.1.1"
       },
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     },
     "packages/argent-installer": {
@@ -5239,18 +5241,18 @@
       "dependencies": {
         "@argent/tools-client": "file:../argent-tools-client",
         "@argent/update-core": "file:../update-core",
-        "@clack/prompts": "^1.4.0",
+        "@clack/prompts": "^1.5.1",
         "jsonc-parser": "^3.3.1",
         "picocolors": "^1.1.1",
-        "semver": "^7.8.0",
+        "semver": "^7.8.4",
         "smol-toml": "^1.6.1",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^25.9.3",
         "@types/semver": "^7.7.1",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     },
     "packages/argent-mcp": {
@@ -5262,45 +5264,45 @@
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     },
     "packages/argent-tools-client": {
       "name": "@argent/tools-client",
       "version": "0.12.0",
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     },
     "packages/configuration-core": {
       "name": "@argent/configuration-core",
       "version": "0.12.0",
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     },
     "packages/native-devtools-android": {
       "name": "@argent/native-devtools-android",
       "version": "0.12.0",
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
       "version": "0.12.0",
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     },
     "packages/preview-window": {
@@ -5320,7 +5322,7 @@
       },
       "devDependencies": {
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     },
     "packages/skills": {
@@ -5372,13 +5374,13 @@
       "name": "@argent/update-core",
       "version": "0.12.0",
       "dependencies": {
-        "semver": "^7.7.4"
+        "semver": "^7.8.4"
       },
       "devDependencies": {
-        "@types/node": "^25.9.0",
+        "@types/node": "^25.9.3",
         "@types/semver": "^7.7.1",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.9"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@eslint/js": "^10.0.1",
     "eslint": "^10.5.0",
     "globals": "^17.6.0",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "typescript-eslint": "^8.61.1"
   }
 }

--- a/packages/argent-cli/package.json
+++ b/packages/argent-cli/package.json
@@ -14,12 +14,12 @@
   "dependencies": {
     "@argent/configuration-core": "file:../configuration-core",
     "@argent/tools-client": "file:../argent-tools-client",
-    "@clack/prompts": "^1.1.0",
+    "@clack/prompts": "^1.5.1",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -14,17 +14,17 @@
   "dependencies": {
     "@argent/tools-client": "file:../argent-tools-client",
     "@argent/update-core": "file:../update-core",
-    "@clack/prompts": "^1.4.0",
+    "@clack/prompts": "^1.5.1",
     "jsonc-parser": "^3.3.1",
     "picocolors": "^1.1.1",
-    "semver": "^7.8.0",
+    "semver": "^7.8.4",
     "smol-toml": "^1.6.1",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.3",
     "@types/semver": "^7.7.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/argent-mcp/package.json
+++ b/packages/argent-mcp/package.json
@@ -17,8 +17,8 @@
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/argent-tools-client/package.json
+++ b/packages/argent-tools-client/package.json
@@ -12,8 +12,8 @@
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -51,15 +51,15 @@
     "@argent/installer": "file:../argent-installer",
     "@argent/mcp": "file:../argent-mcp",
     "@argent/tools-client": "file:../argent-tools-client",
-    "@clack/prompts": "^1.1.0",
-    "@types/node": "^25.9.0",
+    "@clack/prompts": "^1.5.1",
+    "@types/node": "^25.9.3",
     "@types/semver": "^7.7.1",
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.28.1",
     "picocolors": "^1.1.1",
-    "semver": "^7.7.4",
+    "semver": "^7.8.4",
     "smol-toml": "^1.6.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6",
+    "vitest": "^4.1.9",
     "yaml": "^2.8.3"
   }
 }

--- a/packages/configuration-core/package.json
+++ b/packages/configuration-core/package.json
@@ -12,8 +12,8 @@
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/native-devtools-android/package.json
+++ b/packages/native-devtools-android/package.json
@@ -16,8 +16,8 @@
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/native-devtools-ios/package.json
+++ b/packages/native-devtools-ios/package.json
@@ -13,8 +13,8 @@
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/update-core/package.json
+++ b/packages/update-core/package.json
@@ -12,12 +12,12 @@
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
-    "semver": "^7.7.4"
+    "semver": "^7.8.4"
   },
   "devDependencies": {
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.3",
     "@types/semver": "^7.7.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.9"
   }
 }


### PR DESCRIPTION
## What

Applies the safe updates from dependabot #348 (`npm-minor-patch` group) and **excludes the one bump that breaks the build**, `tree-sitter`.

| Package | From | To |
| --- | --- | --- |
| prettier | 3.8.3 | 3.8.4 |
| @clack/prompts | 1.1.0 / 1.4.0 | 1.5.1 |
| @types/node | 25.9.0 | 25.9.3 |
| esbuild | 0.28.0 | 0.28.1 |
| semver | 7.7.4 / 7.8.0 | 7.8.4 |
| vitest | 4.1.6 | 4.1.9 |
| tree-sitter | 0.21.1 | **held at 0.21.1** |

(`ws` was part of #348's group but is already at 8.21.0 on `main`, so it's untouched here.)

## Why tree-sitter is excluded

`tree-sitter@0.25.0` ships **no Node 24 prebuilds**, and its `binding.gyp` forces `-std=c++17` while Node 22+ v8 (cppgc) headers require C++20, so the native build fails `npm ci`/`npm install` on current Node. That's exactly why #348's `ESLint` job (Node 24) fails at install:

```
.../node_modules/tree-sitter ... node-gyp-build
.../include/node/v8config.h:13:2: error: #error "C++20 or later required."
```

(#348's `Unit tests` job is pinned to Node 20, where it still compiles — which is why that PR looks half-green.) There is no tree-sitter release between 0.22.4 and 0.25.0, so there's no newer working version. `^0.21.1` ships N-API prebuilds (no compile) and installs cleanly on Node 20 / 22 / 24.

This PR also adds a Dependabot `ignore` for tree-sitter minor/major so the group stops re-proposing the broken bump. Patch updates stay allowed; drop the ignore once upstream restores prebuilt binaries.

## Verification (local)

- Lockfile regenerated on **Node 20 / npm 10.8.2** (`npm install --package-lock-only --ignore-scripts`), idempotent under a re-run — won't trip the strict lockfile check. tree-sitter resolves to 0.21.1 (prebuilt, no native compile).
- Full CI-equivalent on **Node 20**: `tsc --build`, `eslint --max-warnings 0`, `prettier --check`, `typecheck:tests`/`typecheck:scripts`, full unit suite incl. **1250 tool-server tests** — all green.
- `npm ci` from the committed lockfile succeeds.
- **Live device E2E**: ran the built tool-server with the bumped deps, captured a real screenshot of a booted iPhone 16 Pro Max (`simulator-client` uses `ws`), then downloaded the PNG artifact over HTTP — `200`, 331 KB PNG.

Supersedes #348 (Dependabot auto-closes it once the safe bumps land and tree-sitter is ignored).
