### PR TITLE
fix(argent-lens): don't mark a visible element off-screen when the variant frame is a larger crop

### DIFF
--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -2553,18 +2553,33 @@
           );
         let best = null,
           bestScore = Infinity;
+        // The size gate is a PREFERENCE for the first match, never an eliminator.
+        // `fallback` keeps the nearest candidate even when the gate rejects it, so
+        // a clearly on-screen element is never reported off-screen just because the
+        // propose-time frame is a poor size hint: that frame is a thumbnail CROP
+        // region (often a whole component) while `match` can anchor on a small
+        // sub-element inside it — e.g. crop the header band, anchor on its tiny
+        // "Export" button — so the seed size legitimately dwarfs the real match.
+        let fallback = null,
+          fbScore = Infinity;
         for (const n of pool) {
           const f = n.frame;
           const score = anchor ? dist(f) : f.width * f.height;
+          if (score < fbScore) {
+            fbScore = score;
+            fallback = n;
+          }
           if (anchor && !hasDesc && !sizeMatches(f)) continue; // size gate only bootstraps identity
           if (score < bestScore) {
             bestScore = score;
             best = n;
           }
         }
-        // A locked identity must never be dropped over a size wobble: if the size
-        // gate isn't in play (hasDesc) `best` is simply the nearest identity match.
-        return best;
+        // A locked identity must never be dropped over a size wobble (hasDesc →
+        // `best` is the nearest identity match). When the size gate rejects every
+        // candidate (an unreliable propose-time frame), fall back to the nearest
+        // match rather than reporting a visible element off-screen.
+        return best || fallback;
       }
 
       // Topmost on-screen node whose frame contains a normalized point


### PR DESCRIPTION
## The bug
A variant proposed for the Favourites header (matched by text **"Export"**) was marked **off-screen / hidden** in Argent Lens even though the "Export" button was clearly visible. Found during E2E testing of the Pokémon app.

Repro proposal:
- `match: {by:"text", value:"Export"}`
- `variant.frame: {x:0, y:0, width:1, height:0.205}`

## Root cause
`vpMatchNode` (the on-screen matcher) seeds the match **anchor** from the proposal's `variant.frame`, then a **size gate** (`MAX_SIZE_RATIO = 2.5`) rejects candidates whose size differs too much from that seed.

But `variant.frame` is a thumbnail **crop region** — frequently a whole component — while `match` can anchor on a small **sub-element** inside it. Here the agent cropped the full-width header band (`{w:1, h:0.205}`) but anchored on the tiny "Export" button (live frame `{x:0.743, y:0.109, w:0.181, h:0.037}` from `describe`). The ~5.5× width gap tripped the gate, which eliminated the **only** on-screen candidate → `vpMatchNode` returned `null` → reported off-screen.

## Fix
Make the size gate a **preference**, not an eliminator (`packages/ui/index.html`, `vpMatchNode`): keep the nearest candidate even when the gate rejects it and fall back to it, so a clearly on-screen element is never dropped. The gate still disambiguates among multiple same-text candidates (size-matched wins), and the locked-identity re-match path is unchanged.

## Verification
Headless-Chrome repro against the real UI, injecting the live Favourites AX tree + the exact proposal:
- **before:** `onScreen: false` (bug reproduced)
- **after:** `onScreen: true`, matched "Export"

Full UI regression sweep (theme seed, stream-reconnect, off-screen pill, comment-Escape, reduced-motion) still green.

Follow-up to #271 (Argent Lens).