### PR TITLE
fix(stop-metro): only kill the listener (keep execFileSync, no shell)

### DIFF
--- a/packages/tool-server/src/tools/simulator/stop-metro.ts
+++ b/packages/tool-server/src/tools/simulator/stop-metro.ts
@@ -26,7 +26,13 @@ export const stopMetroTool: ToolDefinition<
       // execFileSync (no shell) so `port` can never be shell-interpreted,
       // even if a caller bypasses the zod schema. `port` is also validated to
       // an int by registry.invokeTool before reaching here.
-      const output = execFileSync("lsof", ["-ti", `tcp:${port}`], {
+      //
+      // `-sTCP:LISTEN` restricts the match to the process *listening* on the
+      // port (Metro itself). Without it, `lsof -ti tcp:<port>` also returns
+      // every process holding an ESTABLISHED connection to that port — which
+      // includes the Argent tool-server's own CDP client socket to Metro. We
+      // would then SIGTERM the tool-server along with Metro.
+      const output = execFileSync("lsof", ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
         encoding: "utf-8",
         timeout: 5_000,
       }).trim();


### PR DESCRIPTION
## Problem
`stop-metro` runs `lsof -ti tcp:<port>`, which returns **every** process with a socket on the port — including `ESTABLISHED` connections, not just the listener. The Argent tool-server holds a CDP client socket to Metro on that port, so `stop-metro` `SIGTERM`s the tool-server along with Metro (it then auto-respawns, dropping in-memory profiler session state and disrupting any connected editor).

## Fix
Add `-sTCP:LISTEN` so only the process *listening* on the port (Metro) matches.

This keeps the existing `execFileSync` (no shell) call — `port` is never shell-interpreted, preserving the defense-in-depth in the original code.

> Note: there is an existing branch `fix/stop-metro-listener-only` with the same `-sTCP:LISTEN` idea, but it switches to `execSync` with the port interpolated into a shell string. `port` is zod-validated to an int so it's safe in practice, but it reintroduces a shell surface the original deliberately avoided. This PR is the no-shell alternative — pick whichever you prefer.

## Verification
Listener-vs-client repro: `lsof -ti tcp:<port>` returns both the listener and a connected client pid; `lsof -ti tcp:<port> -sTCP:LISTEN` returns only the listener.
