### PR TITLE
fix(debugger): return object/array results from debugger-evaluate

### DIFF
--- a/packages/tool-server/src/tools/debugger/debugger-evaluate.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-evaluate.ts
@@ -19,7 +19,7 @@ export const debuggerEvaluateTool: ToolDefinition<
 > = {
   id: "debugger-evaluate",
   description: `Execute arbitrary JavaScript in the app's JS runtime via CDP — Hermes on iOS / Android, V8 on Chromium.
-Returns the evaluation result as a JSON-serializable value, along with deviceName, appName, and logicalDeviceId for context. Use when you need to read app state, call app functions, or test logic at runtime. Fails if the expression throws or the runtime is not connected.`,
+Returns the evaluation result as a JSON-serializable value, along with deviceName, appName, and logicalDeviceId for context. Use when you need to read app state, call app functions, or test logic at runtime. The result is serialized by value, so cyclic objects (many RN runtime values — fiber nodes, navigation refs, global — are cyclic) fail with a serialization error rather than returning silently. Fails if the expression throws or the runtime is not connected.`,
   zodSchema,
   capability: DEBUGGER_TOOL_CAPABILITY,
   services: (params) => ({

--- a/packages/tool-server/src/utils/debugger/cdp-client.ts
+++ b/packages/tool-server/src/utils/debugger/cdp-client.ts
@@ -238,8 +238,25 @@ export class CDPClient {
     });
   }
 
-  async evaluate(expression: string, options?: { timeout?: number }): Promise<unknown> {
-    const result = (await this.send("Runtime.evaluate", { expression }, options?.timeout)) as {
+  async evaluate(
+    expression: string,
+    options?: { timeout?: number; returnByValue?: boolean; awaitPromise?: boolean }
+  ): Promise<unknown> {
+    // returnByValue must default to true: without it CDP returns a RemoteObject
+    // reference (objectId + preview) for any object/array result and leaves
+    // `result.value` undefined, so the caller silently gets nothing back for
+    // non-primitive expressions. awaitPromise defaults to true so an expression
+    // that evaluates to a Promise resolves to its value instead of returning a
+    // bare Promise handle. Callers that drive a script via a side binding (see
+    // evaluateWithBinding) opt out of both to keep their fire-and-forget wire
+    // shape unchanged.
+    const returnByValue = options?.returnByValue ?? true;
+    const awaitPromise = options?.awaitPromise ?? true;
+    const result = (await this.send(
+      "Runtime.evaluate",
+      { expression, returnByValue, awaitPromise },
+      options?.timeout
+    )) as {
       result?: { type?: string; value?: unknown; description?: string };
       exceptionDetails?: CDPExceptionDetails;
     };
@@ -275,11 +292,16 @@ export class CDPClient {
 
       this.pendingBindings.set(id, { resolve, reject, timer });
 
-      this.evaluate(expression, { timeout }).catch((err) => {
-        this.pendingBindings.delete(id);
-        clearTimeout(timer);
-        reject(err instanceof Error ? err : new Error(String(err)));
-      });
+      // The script delivers its payload through the side binding, not through
+      // the Runtime.evaluate return value — keep returnByValue/awaitPromise off
+      // so we don't serialize or block on the script's own (ignored) result.
+      this.evaluate(expression, { timeout, returnByValue: false, awaitPromise: false }).catch(
+        (err) => {
+          this.pendingBindings.delete(id);
+          clearTimeout(timer);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      );
     });
   }
 

--- a/packages/tool-server/test/metro/cdp-client.test.ts
+++ b/packages/tool-server/test/metro/cdp-client.test.ts
@@ -180,4 +180,70 @@ describe("CDPClient", () => {
 
     await client.disconnect();
   });
+
+  it("evaluate requests returnByValue + awaitPromise and returns object results", async () => {
+    const client = new CDPClient(`ws://localhost:${port}`);
+    await client.connect();
+
+    const ws = await waitForServer();
+    let evalParams: Record<string, unknown> | undefined;
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.method === "Runtime.evaluate") {
+        evalParams = msg.params;
+        // A returnByValue response carries the deep-serialized value. Without
+        // returnByValue, Hermes/V8 return a RemoteObject ref with no `value`,
+        // which is exactly the dropped-object bug this guards against.
+        ws.send(
+          JSON.stringify({
+            id: msg.id,
+            result: { result: { type: "object", value: { a: 1, b: [2, 3] } } },
+          })
+        );
+      }
+    });
+
+    const value = await client.evaluate("({ a: 1, b: [2, 3] })");
+
+    expect(evalParams?.returnByValue).toBe(true);
+    expect(evalParams?.awaitPromise).toBe(true);
+    expect(value).toEqual({ a: 1, b: [2, 3] });
+
+    await client.disconnect();
+  });
+
+  it("evaluateWithBinding drives the script with returnByValue + awaitPromise off", async () => {
+    const client = new CDPClient(`ws://localhost:${port}`);
+    await client.connect();
+
+    const ws = await waitForServer();
+    let evalParams: Record<string, unknown> | undefined;
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.method === "Runtime.evaluate") {
+        evalParams = msg.params;
+        ws.send(JSON.stringify({ id: msg.id, result: { result: { value: "ok" } } }));
+        setTimeout(() => {
+          ws.send(
+            JSON.stringify({
+              method: "Runtime.bindingCalled",
+              params: {
+                name: "__argent_callback",
+                payload: JSON.stringify({ requestId: "req-1", data: "x" }),
+              },
+            })
+          );
+        }, 10);
+      }
+    });
+
+    await client.evaluateWithBinding("someScript()", "req-1", { timeout: 5000 });
+
+    // The binding delivers the payload; the script's own return must not be
+    // serialized or awaited, or fire-and-forget binding scripts would hang.
+    expect(evalParams?.returnByValue).toBe(false);
+    expect(evalParams?.awaitPromise).toBe(false);
+
+    await client.disconnect();
+  });
 });


### PR DESCRIPTION
## Problem
`debugger-evaluate` silently returns nothing for any expression that evaluates to an object or array. `CDPClient.evaluate` calls `Runtime.evaluate` without `returnByValue`, so a non-primitive result comes back as a RemoteObject reference with no `value` field, and the tool drops it (only primitives/strings came through).

## Fix
Pass `returnByValue` + `awaitPromise` (default on) so objects/arrays serialize by value and promise-returning expressions resolve to their value. `evaluateWithBinding` opts both off to keep its fire-and-forget binding path unchanged (it delivers its payload via a side binding, not the evaluate return).

## Verification
- New cdp-client unit tests assert `evaluate` sends `returnByValue:true` + `awaitPromise:true` and returns an object result, and that `evaluateWithBinding` sends both `false`.
- Full cdp-client + reconnect suites pass; 1254 tool-server tests pass; eslint + prettier clean.
- The real-Hermes `returnByValue` path is already exercised in production by `react-profiler-fiber-tree` / `react-profiler-renders`.
