### PR TITLE
feat(tool-server): add tool-server event log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1540,7 +1540,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1668,7 +1667,6 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -2009,7 +2007,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2844,7 +2841,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3074,7 +3070,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3625,7 +3620,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5657,7 +5651,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5694,7 +5687,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5763,7 +5755,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6117,7 +6108,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,40 +143,6 @@
         "undici": "^7.24.4"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
@@ -1441,6 +1407,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/bunyan": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
+      "integrity": "sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/bytes": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.5.tgz",
@@ -1564,6 +1540,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1691,6 +1668,7 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -2031,6 +2009,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2282,6 +2261,24 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bunyan": {
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
+      "engines": [
+        "node >=0.10.0"
+      ],
+      "license": "MIT",
+      "bin": {
+        "bunyan": "bin/bunyan"
+      },
+      "optionalDependencies": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "license": "MIT",
@@ -2445,6 +2442,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -2625,6 +2629,20 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "hasInstallScript": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/dunder-proto": {
@@ -2826,6 +2844,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3055,6 +3074,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3473,6 +3493,24 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3484,6 +3522,37 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -3556,6 +3625,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3632,6 +3702,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -4197,17 +4279,62 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -4240,6 +4367,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "ncp": "bin/ncp"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -4425,6 +4562,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -4728,6 +4875,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^6.0.1"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -4805,6 +4966,13 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5489,6 +5657,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5525,6 +5694,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5593,6 +5763,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5946,6 +6117,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6158,6 +6330,7 @@
         "@fails-components/webtransport-transport-http3-quiche": "^1.6.3",
         "@moq/lite": "^0.2.4",
         "@moq/net": "^0.1.1",
+        "bunyan": "^1.8.15",
         "bytes": "^3.1.2",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -6175,6 +6348,7 @@
         "zod": "^4.0.0"
       },
       "devDependencies": {
+        "@types/bunyan": "^1.8.11",
         "@types/bytes": "^3.1.5",
         "@types/express": "^5.0.6",
         "@types/ini": "^4.1.1",

--- a/packages/configuration-core/src/flags.ts
+++ b/packages/configuration-core/src/flags.ts
@@ -57,6 +57,10 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     name: "artifacts-list-endpoint",
     description: "Expose GET /artifacts for remote artifact inventory consumers.",
   },
+  {
+    name: "tool-server-event-log",
+    description: "Write structured tool-server lifecycle events to a JSONL file.",
+  },
 ];
 
 // Look up a flag's definition — exported for consumers that want the

--- a/packages/configuration-core/tests/flags.test.ts
+++ b/packages/configuration-core/tests/flags.test.ts
@@ -284,6 +284,7 @@ describe("FLAG_REGISTRY / getFlagDefinition", () => {
 
   it("getFlagDefinition defaults to the shipped registry", () => {
     expect(getFlagDefinition("disable-auto-screenshot")?.description).toMatch(/auto/i);
+    expect(getFlagDefinition("tool-server-event-log")?.description).toMatch(/event/i);
   });
 
   it("every shipped registry entry has a non-empty name and description", () => {

--- a/packages/registry/src/registry.ts
+++ b/packages/registry/src/registry.ts
@@ -17,6 +17,7 @@ import {
   ServiceInitializationError,
   ToolNotFoundError,
   ToolExecutionError,
+  getFailureSignalOrFallback,
 } from "./errors";
 import { parseURN } from "./urn";
 import { zodObjectToJsonSchema } from "./zod-to-json-schema";
@@ -105,7 +106,13 @@ export class Registry {
 
     const startTime = performance.now();
     const toolInvocationId = options?.toolInvocationId ?? randomUUID();
-    this.events.emit("toolInvoked", id, toolInvocationId);
+    let effectiveParams = params;
+
+    const startedMsg = formatInteractionMessage(
+      () => definition.interaction?.startedMsg?.({ params: effectiveParams }),
+      `Tool ${id} was invoked.`
+    );
+    this.events.emit("toolInvoked", id, toolInvocationId, startedMsg);
 
     try {
       // Validate params against the tool's zod schema for EVERY dispatch path,
@@ -115,7 +122,6 @@ export class Registry {
       // shell metacharacters past a tool's regex (→ injection at the sink).
       // `params ?? {}` mirrors the HTTP layer (express.json yields {} for an
       // empty body) so no-arg internal invokes still validate cleanly.
-      let effectiveParams = params;
       if (definition.zodSchema) {
         const parsed = definition.zodSchema.safeParse(params ?? {});
         if (!parsed.success) {
@@ -162,7 +168,15 @@ export class Registry {
       }
 
       const duration = performance.now() - startTime;
-      this.events.emit("toolCompleted", id, toolInvocationId, duration);
+      const completedMsg = formatInteractionMessage(
+        () =>
+          definition.interaction?.completedMsg?.({
+            params: effectiveParams,
+            result,
+          }),
+        `Tool ${id} completed in ${duration.toFixed(2)} ms.`
+      );
+      this.events.emit("toolCompleted", id, toolInvocationId, duration, completedMsg);
       return result as TResult;
     } catch (error) {
       const originalMsg = error instanceof Error ? error.message : String(error);
@@ -175,13 +189,24 @@ export class Registry {
           : new ToolExecutionError(id, originalMsg, {
               cause: error instanceof Error ? error : new Error(String(error)),
             });
+      const failureSignal = getFailureSignalOrFallback(wrappedError);
+      const failedMsg = formatInteractionMessage(
+        () =>
+          definition.interaction?.failedMsg?.({
+            params: effectiveParams,
+            error: wrappedError,
+            failureSignal,
+          }),
+        `Tool ${id} failed.`
+      );
 
       this.events.emit(
         "toolFailed",
         id,
         toolInvocationId,
         wrappedError,
-        performance.now() - startTime
+        performance.now() - startTime,
+        failedMsg
       );
       throw wrappedError;
     }
@@ -411,5 +436,13 @@ export class Registry {
     node.initPromise = null;
     node.dependents.clear();
     this._transition(node, cause ? ServiceState.ERROR : ServiceState.IDLE, cause);
+  }
+}
+
+function formatInteractionMessage(format: () => string | undefined, fallback: string): string {
+  try {
+    return format() ?? fallback;
+  } catch {
+    return fallback;
   }
 }

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -2,6 +2,7 @@ import { TypedEventEmitter } from "./event-emitter";
 import { z } from "zod";
 import type { ArtifactStore } from "./artifacts";
 import type { FileInputSpec, ResolvedFileInput } from "./file-inputs";
+import type { FailureSignal } from "./errors";
 
 // ── Service Types ──
 
@@ -213,6 +214,18 @@ export type ToolDependency = "adb" | "xcrun" | "emulator" | "sim-remote" | "vega
 
 export interface ToolDefinition<TParams = void, TResult = unknown> {
   id: string;
+  interaction?: {
+    startedMsg?: (context: { params: TParams }) => string;
+    completedMsg?: (context: {
+      params: TParams;
+      result: TResult;
+    }) => string;
+    failedMsg?: (context: {
+      params: TParams;
+      error: unknown;
+      failureSignal: FailureSignal;
+    }) => string;
+  };
   description?: string;
   /** Zod schema for tool input; used for runtime validation. When provided, inputSchema is auto-derived at registration time. */
   zodSchema?: z.ZodObject<any>;
@@ -296,7 +309,13 @@ export type RegistryEvents = {
   serviceError: (serviceId: string, error: Error) => void;
   serviceRegistered: (serviceId: string) => void;
   toolRegistered: (toolId: string) => void;
-  toolInvoked: (toolId: string, toolInvocationId: string) => void;
-  toolCompleted: (toolId: string, toolInvocationId: string, durationMs: number) => void;
-  toolFailed: (toolId: string, toolInvocationId: string, error: Error, durationMs?: number) => void;
+  toolInvoked: (toolId: string, toolInvocationId: string, msg: string) => void;
+  toolCompleted: (toolId: string, toolInvocationId: string, durationMs: number, msg: string) => void;
+  toolFailed: (
+    toolId: string,
+    toolInvocationId: string,
+    error: Error,
+    durationMs: number | undefined,
+    msg: string
+  ) => void;
 };

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -216,10 +216,7 @@ export interface ToolDefinition<TParams = void, TResult = unknown> {
   id: string;
   interaction?: {
     startedMsg?: (context: { params: TParams }) => string;
-    completedMsg?: (context: {
-      params: TParams;
-      result: TResult;
-    }) => string;
+    completedMsg?: (context: { params: TParams; result: TResult }) => string;
     failedMsg?: (context: {
       params: TParams;
       error: unknown;
@@ -310,7 +307,12 @@ export type RegistryEvents = {
   serviceRegistered: (serviceId: string) => void;
   toolRegistered: (toolId: string) => void;
   toolInvoked: (toolId: string, toolInvocationId: string, msg: string) => void;
-  toolCompleted: (toolId: string, toolInvocationId: string, durationMs: number, msg: string) => void;
+  toolCompleted: (
+    toolId: string,
+    toolInvocationId: string,
+    durationMs: number,
+    msg: string
+  ) => void;
   toolFailed: (
     toolId: string,
     toolInvocationId: string,

--- a/packages/registry/tests/logger.test.ts
+++ b/packages/registry/tests/logger.test.ts
@@ -105,7 +105,14 @@ describe("attachRegistryLogger — formatError via toolFailed", () => {
     const root = new Error("timeout");
     const outer = new Error("evaluate failed", { cause: root });
 
-    registry.events.emit("toolFailed", "my-tool", "11111111-1111-4111-8111-111111111111", outer);
+    registry.events.emit(
+      "toolFailed",
+      "my-tool",
+      "11111111-1111-4111-8111-111111111111",
+      outer,
+      undefined,
+      "Failed my-tool."
+    );
 
     const output = errorSpy.mock.calls[0]![0] as string;
     expect(output).toContain(
@@ -141,7 +148,12 @@ describe("attachRegistryLogger — happy-path events", () => {
     const registry = new Registry();
     attachRegistryLogger(registry);
 
-    registry.events.emit("toolInvoked", "my-tool", "11111111-1111-4111-8111-111111111111");
+    registry.events.emit(
+      "toolInvoked",
+      "my-tool",
+      "11111111-1111-4111-8111-111111111111",
+      "Starting my-tool."
+    );
 
     expect(logSpy).toHaveBeenCalledOnce();
     expect(logSpy.mock.calls[0]![0]).toContain(
@@ -157,7 +169,8 @@ describe("attachRegistryLogger — happy-path events", () => {
       "toolCompleted",
       "my-tool",
       "11111111-1111-4111-8111-111111111111",
-      123.456
+      123.456,
+      "Completed my-tool."
     );
 
     expect(logSpy).toHaveBeenCalledOnce();

--- a/packages/telemetry/test/registry-listener.test.ts
+++ b/packages/telemetry/test/registry-listener.test.ts
@@ -28,8 +28,8 @@ describe("attachRegistryTelemetry", () => {
     const handle = attachRegistryTelemetry(registry);
     handle.recordInvocation(INVOCATION_ID_1, { platform: "ios" });
 
-    registry.events.emit("toolInvoked", "gesture-tap", INVOCATION_ID_1);
-    registry.events.emit("toolCompleted", "gesture-tap", INVOCATION_ID_1, 42.5);
+    registry.events.emit("toolInvoked", "gesture-tap", INVOCATION_ID_1, "Starting tool.");
+    registry.events.emit("toolCompleted", "gesture-tap", INVOCATION_ID_1, 42.5, "Completed tool.");
 
     expect(trackSpy).toHaveBeenCalledTimes(2);
     expect(trackSpy.mock.calls[0]![0]).toBe("tool:invoke");
@@ -56,12 +56,12 @@ describe("attachRegistryTelemetry", () => {
     const handle = attachRegistryTelemetry(registry);
 
     handle.recordInvocation(INVOCATION_ID_1, { platform: "ios", ai_client: "codex" });
-    registry.events.emit("toolInvoked", "gesture-tap", INVOCATION_ID_1);
-    registry.events.emit("toolCompleted", "gesture-tap", INVOCATION_ID_1, 10);
+    registry.events.emit("toolInvoked", "gesture-tap", INVOCATION_ID_1, "Starting tool.");
+    registry.events.emit("toolCompleted", "gesture-tap", INVOCATION_ID_1, 10, "Completed tool.");
 
     handle.recordInvocation(INVOCATION_ID_2, { ai_client: "other" });
-    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_2);
-    registry.events.emit("toolFailed", "screenshot", INVOCATION_ID_2, new Error("boom"), 5);
+    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_2, "Starting tool.");
+    registry.events.emit("toolFailed", "screenshot", INVOCATION_ID_2, new Error("boom"), 5, "Failed tool.");
 
     expect(trackSpy.mock.calls[0]![1]).toMatchObject({ ai_client: "codex" });
     expect(trackSpy.mock.calls[1]![1]).toMatchObject({ ai_client: "codex" });
@@ -76,7 +76,7 @@ describe("attachRegistryTelemetry", () => {
     const handle = attachRegistryTelemetry(registry);
 
     handle.recordInvocation(INVOCATION_ID_1, { platform: "ios" });
-    registry.events.emit("toolInvoked", "gesture-tap", INVOCATION_ID_1);
+    registry.events.emit("toolInvoked", "gesture-tap", INVOCATION_ID_1, "Starting tool.");
 
     expect(trackSpy.mock.calls[0]![1]).not.toHaveProperty("ai_client");
 
@@ -90,7 +90,7 @@ describe("attachRegistryTelemetry", () => {
 
     handle.recordInvocation(INVOCATION_ID_1, { platform: "android" });
 
-    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_1);
+    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_1, "Starting tool.");
 
     class TimeoutError extends Error {}
     emitToolFailed(
@@ -156,8 +156,8 @@ describe("attachRegistryTelemetry", () => {
     const handle = attachRegistryTelemetry(registry);
 
     expect(handle.getTotalToolCalls()).toBe(0);
-    registry.events.emit("toolInvoked", "x", INVOCATION_ID_1);
-    registry.events.emit("toolInvoked", "y", INVOCATION_ID_2);
+    registry.events.emit("toolInvoked", "x", INVOCATION_ID_1, "Starting tool.");
+    registry.events.emit("toolInvoked", "y", INVOCATION_ID_2, "Starting tool.");
     expect(handle.getTotalToolCalls()).toBe(2);
     handle.detach();
   });
@@ -167,7 +167,7 @@ describe("attachRegistryTelemetry", () => {
     const registry = new Registry();
     const handle = attachRegistryTelemetry(registry);
     handle.detach();
-    registry.events.emit("toolInvoked", "x", INVOCATION_ID_1);
+    registry.events.emit("toolInvoked", "x", INVOCATION_ID_1, "Starting tool.");
     expect(trackSpy).not.toHaveBeenCalled();
   });
 
@@ -175,7 +175,7 @@ describe("attachRegistryTelemetry", () => {
     const trackSpy = vi.spyOn(telemetry, "track");
     const registry = new Registry();
     const handle = attachRegistryTelemetry(registry);
-    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_1);
+    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_1, "Starting tool.");
     expect(trackSpy.mock.calls[0]![1]).toEqual({
       tool: "screenshot",
       tool_invocation_id: INVOCATION_ID_1,
@@ -190,7 +190,7 @@ describe("attachRegistryTelemetry", () => {
     const release = handle.recordInvocation(INVOCATION_ID_1, { platform: "android" });
 
     release();
-    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_1);
+    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_1, "Starting tool.");
 
     expect(trackSpy.mock.calls[0]![1]).toEqual({
       tool: "screenshot",
@@ -207,10 +207,10 @@ describe("attachRegistryTelemetry", () => {
     handle.recordInvocation(INVOCATION_ID_2, { platform: "android" });
     handle.recordInvocation(INVOCATION_ID_1, { platform: "ios" });
 
-    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_1);
-    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_2);
-    registry.events.emit("toolCompleted", "screenshot", INVOCATION_ID_2, 20);
-    registry.events.emit("toolCompleted", "screenshot", INVOCATION_ID_1, 10);
+    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_1, "Starting tool.");
+    registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_2, "Starting tool.");
+    registry.events.emit("toolCompleted", "screenshot", INVOCATION_ID_2, 20, "Completed tool.");
+    registry.events.emit("toolCompleted", "screenshot", INVOCATION_ID_1, 10, "Completed tool.");
 
     expect(trackSpy.mock.calls.map((call) => call[1])).toEqual([
       expect.objectContaining({
@@ -249,7 +249,8 @@ function emitToolFailed(
     toolId: string,
     toolInvocationId: string,
     error: Error,
-    durationMs: number
+    durationMs: number,
+    msg: string
   ) => void;
-  emit("toolFailed", toolId, toolInvocationId, error, durationMs);
+  emit("toolFailed", toolId, toolInvocationId, error, durationMs, "Failed tool.");
 }

--- a/packages/telemetry/test/registry-listener.test.ts
+++ b/packages/telemetry/test/registry-listener.test.ts
@@ -61,7 +61,14 @@ describe("attachRegistryTelemetry", () => {
 
     handle.recordInvocation(INVOCATION_ID_2, { ai_client: "other" });
     registry.events.emit("toolInvoked", "screenshot", INVOCATION_ID_2, "Starting tool.");
-    registry.events.emit("toolFailed", "screenshot", INVOCATION_ID_2, new Error("boom"), 5, "Failed tool.");
+    registry.events.emit(
+      "toolFailed",
+      "screenshot",
+      INVOCATION_ID_2,
+      new Error("boom"),
+      5,
+      "Failed tool."
+    );
 
     expect(trackSpy.mock.calls[0]![1]).toMatchObject({ ai_client: "codex" });
     expect(trackSpy.mock.calls[1]![1]).toMatchObject({ ai_client: "codex" });

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -25,6 +25,7 @@
     "@fails-components/webtransport-transport-http3-quiche": "^1.6.3",
     "@moq/lite": "^0.2.4",
     "@moq/net": "^0.1.1",
+    "bunyan": "^1.8.15",
     "bytes": "^3.1.2",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
@@ -42,6 +43,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@types/bunyan": "^1.8.11",
     "@types/bytes": "^3.1.5",
     "@types/express": "^5.0.6",
     "@types/ini": "^4.1.1",

--- a/packages/tool-server/src/event-log.ts
+++ b/packages/tool-server/src/event-log.ts
@@ -22,11 +22,10 @@ export type EventLogRecord = { type: string; msg: string } & Record<
   EventLogValue | undefined
 >;
 
-type EventLogLevel = "debug" | "info" | "warn" | "error" | "fatal";
+type EventLogLevel = "info" | "warn" | "error" | "fatal";
 
 export interface ToolServerEventLog {
   filePath: string;
-  debug: (record: EventLogRecord) => void;
   info: (record: EventLogRecord) => void;
   warn: (record: EventLogRecord) => void;
   error: (record: EventLogRecord) => void;
@@ -78,7 +77,6 @@ export function createToolServerEventLog({
 
   return {
     filePath,
-    debug: (record) => log("debug", record),
     info: (record) => log("info", record),
     warn: (record) => log("warn", record),
     error: (record) => log("error", record),

--- a/packages/tool-server/src/event-log.ts
+++ b/packages/tool-server/src/event-log.ts
@@ -153,10 +153,10 @@ export function attachRegistryEventLogger(registry: Registry, eventLog: ToolServ
     });
   });
 
-  registry.events.on("toolInvoked", (toolId: string, toolInvocationId: string) => {
+  registry.events.on("toolInvoked", (toolId: string, toolInvocationId: string, msg: string) => {
     eventLog.info({
       type: "tool.invoked",
-      msg: `Tool ${toolId} was invoked.`,
+      msg,
       toolId,
       toolInvocationId,
     });
@@ -164,10 +164,10 @@ export function attachRegistryEventLogger(registry: Registry, eventLog: ToolServ
 
   registry.events.on(
     "toolCompleted",
-    (toolId: string, toolInvocationId: string, durationMs: number) => {
+    (toolId: string, toolInvocationId: string, durationMs: number, msg: string) => {
       eventLog.info({
         type: "tool.completed",
-        msg: `Tool ${toolId} completed in ${durationMs.toFixed(2)} ms.`,
+        msg,
         toolId,
         toolInvocationId,
         durationMs,
@@ -177,10 +177,16 @@ export function attachRegistryEventLogger(registry: Registry, eventLog: ToolServ
 
   registry.events.on(
     "toolFailed",
-    (toolId: string, toolInvocationId: string, error: Error, durationMs?: number) => {
+    (
+      toolId: string,
+      toolInvocationId: string,
+      error: Error,
+      durationMs: number | undefined,
+      msg: string
+    ) => {
       eventLog.error({
         type: "tool.failed",
-        msg: `Tool ${toolId} failed.`,
+        msg,
         toolId,
         toolInvocationId,
         failureSignal: {

--- a/packages/tool-server/src/event-log.ts
+++ b/packages/tool-server/src/event-log.ts
@@ -1,0 +1,157 @@
+import bunyan from "bunyan";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { Registry, ServiceState } from "@argent/registry";
+
+export type EventLogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | EventLogValue[]
+  | { [key: string]: EventLogValue | undefined };
+
+export type EventLogRecord = { type: string; msg: string; err?: Error } & Record<
+  string,
+  EventLogValue | Error | undefined
+>;
+
+type EventLogLevel = "debug" | "info" | "warn" | "error" | "fatal";
+
+export interface ToolServerEventLog {
+  filePath: string;
+  debug: (record: EventLogRecord) => void;
+  info: (record: EventLogRecord) => void;
+  warn: (record: EventLogRecord) => void;
+  error: (record: EventLogRecord) => void;
+  fatal: (record: EventLogRecord) => void;
+  dispose: () => void;
+}
+
+export interface CreateToolServerEventLogOptions {
+  filePath: string;
+}
+
+function serializeError(error: Error): Record<string, unknown> {
+  const serialized = bunyan.stdSerializers.err(error) as Record<string, unknown>;
+  if (error.cause instanceof Error) {
+    serialized.cause = serializeError(error.cause);
+  }
+  return serialized;
+}
+
+export function createToolServerEventLog({
+  filePath,
+}: CreateToolServerEventLogOptions): ToolServerEventLog {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, "");
+
+  const logger = bunyan.createLogger({
+    name: "argent-tool-server",
+    serializers: {
+      err: serializeError,
+    },
+    streams: [
+      {
+        level: "info",
+        type: "raw",
+        stream: {
+          write(record: object): void {
+            appendFileSync(filePath, JSON.stringify(record) + "\n");
+          },
+        },
+      },
+    ],
+  });
+
+  function log(level: EventLogLevel, record: EventLogRecord): void {
+    const { msg, ...fields } = record;
+    logger[level](fields, msg);
+  }
+
+  return {
+    filePath,
+    debug: (record) => log("debug", record),
+    info: (record) => log("info", record),
+    warn: (record) => log("warn", record),
+    error: (record) => log("error", record),
+    fatal: (record) => log("fatal", record),
+    dispose: () => {},
+  };
+}
+
+export function attachRegistryEventLogger(registry: Registry, eventLog: ToolServerEventLog): void {
+  registry.events.on(
+    "serviceStateChange",
+    (serviceId: string, from: ServiceState, to: ServiceState) => {
+      eventLog.info({
+        type: "service.state_change",
+        msg: `Service ${serviceId} changed state from ${from} to ${to}.`,
+        serviceId,
+        from,
+        to,
+      });
+    }
+  );
+
+  registry.events.on("serviceError", (serviceId: string, error: Error) => {
+    eventLog.error({
+      type: "service.error",
+      msg: `Service ${serviceId} failed.`,
+      serviceId,
+      err: error,
+    });
+  });
+
+  registry.events.on("serviceRegistered", (serviceId: string) => {
+    eventLog.info({
+      type: "service.registered",
+      msg: `Service ${serviceId} was registered.`,
+      serviceId,
+    });
+  });
+
+  registry.events.on("toolRegistered", (toolId: string) => {
+    eventLog.info({
+      type: "tool.registered",
+      msg: `Tool ${toolId} was registered.`,
+      toolId,
+    });
+  });
+
+  registry.events.on("toolInvoked", (toolId: string, toolInvocationId: string) => {
+    eventLog.info({
+      type: "tool.invoked",
+      msg: `Tool ${toolId} was invoked.`,
+      toolId,
+      toolInvocationId,
+    });
+  });
+
+  registry.events.on(
+    "toolCompleted",
+    (toolId: string, toolInvocationId: string, durationMs: number) => {
+      eventLog.info({
+        type: "tool.completed",
+        msg: `Tool ${toolId} completed in ${durationMs.toFixed(2)} ms.`,
+        toolId,
+        toolInvocationId,
+        durationMs,
+      });
+    }
+  );
+
+  registry.events.on(
+    "toolFailed",
+    (toolId: string, toolInvocationId: string, error: Error, durationMs?: number) => {
+      eventLog.error({
+        type: "tool.failed",
+        msg: `Tool ${toolId} failed.`,
+        toolId,
+        toolInvocationId,
+        err: error,
+        ...(durationMs !== undefined ? { durationMs } : {}),
+      });
+    }
+  );
+}

--- a/packages/tool-server/src/event-log.ts
+++ b/packages/tool-server/src/event-log.ts
@@ -1,7 +1,13 @@
 import bunyan from "bunyan";
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import type { Registry, ServiceState } from "@argent/registry";
+import {
+  FAILURE_CODES,
+  getFailureSignalOrFallback,
+  type FailureSignal,
+  type Registry,
+  type ServiceState,
+} from "@argent/registry";
 
 export type EventLogValue =
   | string
@@ -11,9 +17,9 @@ export type EventLogValue =
   | EventLogValue[]
   | { [key: string]: EventLogValue | undefined };
 
-export type EventLogRecord = { type: string; msg: string; err?: Error } & Record<
+export type EventLogRecord = { type: string; msg: string } & Record<
   string,
-  EventLogValue | Error | undefined
+  EventLogValue | undefined
 >;
 
 type EventLogLevel = "debug" | "info" | "warn" | "error" | "fatal";
@@ -32,14 +38,6 @@ export interface CreateToolServerEventLogOptions {
   filePath: string;
 }
 
-function serializeError(error: Error): Record<string, unknown> {
-  const serialized = bunyan.stdSerializers.err(error) as Record<string, unknown>;
-  if (error.cause instanceof Error) {
-    serialized.cause = serializeError(error.cause);
-  }
-  return serialized;
-}
-
 export function createToolServerEventLog({
   filePath,
 }: CreateToolServerEventLogOptions): ToolServerEventLog {
@@ -48,9 +46,6 @@ export function createToolServerEventLog({
 
   const logger = bunyan.createLogger({
     name: "argent-tool-server",
-    serializers: {
-      err: serializeError,
-    },
     streams: [
       {
         level: "info",
@@ -99,7 +94,14 @@ export function attachRegistryEventLogger(registry: Registry, eventLog: ToolServ
       type: "service.error",
       msg: `Service ${serviceId} failed.`,
       serviceId,
-      err: error,
+      failureSignal: {
+        ...getFailureSignalOrFallback(error, {
+          error_code: FAILURE_CODES.REGISTRY_SERVICE_INITIALIZATION_FAILED,
+          failure_stage: "registry_service_error_event",
+          failure_area: "registry",
+          error_kind: "unknown",
+        }),
+      },
     });
   });
 
@@ -149,7 +151,14 @@ export function attachRegistryEventLogger(registry: Registry, eventLog: ToolServ
         msg: `Tool ${toolId} failed.`,
         toolId,
         toolInvocationId,
-        err: error,
+        failureSignal: {
+          ...getFailureSignalOrFallback(error, {
+            error_code: FAILURE_CODES.REGISTRY_TOOL_FAILURE_UNCLASSIFIED,
+            failure_stage: "registry_tool_failed_event",
+            failure_area: "registry",
+            error_kind: "unknown",
+          }),
+        },
         ...(durationMs !== undefined ? { durationMs } : {}),
       });
     }

--- a/packages/tool-server/src/event-log.ts
+++ b/packages/tool-server/src/event-log.ts
@@ -4,7 +4,6 @@ import { dirname } from "node:path";
 import {
   FAILURE_CODES,
   getFailureSignalOrFallback,
-  type FailureSignal,
   type Registry,
   type ServiceState,
 } from "@argent/registry";

--- a/packages/tool-server/src/event-log.ts
+++ b/packages/tool-server/src/event-log.ts
@@ -1,5 +1,5 @@
 import bunyan from "bunyan";
-import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { createWriteStream, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import {
   FAILURE_CODES,
@@ -31,7 +31,7 @@ export interface ToolServerEventLog {
   warn: (record: EventLogRecord) => void;
   error: (record: EventLogRecord) => void;
   fatal: (record: EventLogRecord) => void;
-  dispose: () => void;
+  dispose: () => Promise<void>;
 }
 
 export interface CreateToolServerEventLogOptions {
@@ -43,6 +43,18 @@ export function createToolServerEventLog({
 }: CreateToolServerEventLogOptions): ToolServerEventLog {
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, "");
+  const fileStream = createWriteStream(filePath, { flags: "a" });
+  let disposed = false;
+  let disposePromise: Promise<void> | null = null;
+  let streamError: Error | null = null;
+
+  fileStream.on("error", (error) => {
+    disposed = true;
+    streamError = new Error(`Event log stream failed for ${filePath}: ${error.message}`, {
+      cause: error,
+    });
+    process.stderr.write(`[tool-server] ${streamError.message}\n`);
+  });
 
   const logger = bunyan.createLogger({
     name: "argent-tool-server",
@@ -52,7 +64,7 @@ export function createToolServerEventLog({
         type: "raw",
         stream: {
           write(record: object): void {
-            appendFileSync(filePath, JSON.stringify(record) + "\n");
+            if (!disposed) fileStream.write(JSON.stringify(record) + "\n");
           },
         },
       },
@@ -71,7 +83,30 @@ export function createToolServerEventLog({
     warn: (record) => log("warn", record),
     error: (record) => log("error", record),
     fatal: (record) => log("fatal", record),
-    dispose: () => {},
+    dispose: () => {
+      if (disposePromise) return disposePromise;
+      disposed = true;
+      disposePromise = new Promise<void>((resolve, reject) => {
+        if (streamError) {
+          reject(streamError);
+          return;
+        }
+        if (fileStream.closed || fileStream.destroyed) {
+          resolve();
+          return;
+        }
+        fileStream.once("error", (error) => {
+          reject(
+            streamError ??
+              new Error(`Event log stream failed for ${filePath}: ${error.message}`, {
+                cause: error,
+              })
+          );
+        });
+        fileStream.end(resolve);
+      });
+      return disposePromise;
+    },
   };
 }
 

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -297,7 +297,11 @@ export function start(): void {
     } catch (err) {
       process.stderr.write(`[tool-server] registry dispose failed: ${String(err)}\n`);
     }
-    eventLog?.dispose();
+    try {
+      await eventLog?.dispose();
+    } catch (err) {
+      process.stderr.write(`[tool-server] event log dispose failed: ${String(err)}\n`);
+    }
 
     // Capture toolserver:stop, then drain — the final telemetry action, so the
     // reason/signal are as fresh as possible. (A crash during the drain below is
@@ -376,7 +380,7 @@ export function start(): void {
       });
       // Surface bind failures (EADDRINUSE / EACCES on privileged ports) as a
       // clean exit instead of routing through uncaughtException → crashShutdown.
-      server.on("error", (err: NodeJS.ErrnoException) => {
+      server.on("error", async (err: NodeJS.ErrnoException) => {
         const code = err.code ? `${err.code}: ` : "";
         process.stderr.write(
           `[tool-server] Failed to bind ${HOST}:${PORT} — ${code}${err.message}\n`
@@ -393,7 +397,11 @@ export function start(): void {
             error_kind: "unknown",
           },
         });
-        eventLog?.dispose();
+        try {
+          await eventLog?.dispose();
+        } catch (err) {
+          process.stderr.write(`[tool-server] event log dispose failed: ${String(err)}\n`);
+        }
         process.exit(1);
       });
       // Bolt the per-Chromium-device WebSocket upgrade handler onto the live

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -1,3 +1,6 @@
+import * as path from "node:path";
+import { homedir } from "node:os";
+import { isFlagEnabled } from "@argent/configuration-core";
 import { FAILURE_CODES, attachRegistryLogger, type FailureSignal } from "@argent/registry";
 import {
   init as telemetryInit,
@@ -8,6 +11,7 @@ import {
   aiTelemetryFromMeta,
 } from "@argent/telemetry";
 import { createHttpApp } from "./http";
+import { attachRegistryEventLogger, createToolServerEventLog } from "./event-log";
 import { createRegistry } from "./utils/setup-registry";
 import { startSimulatorWatcher } from "./utils/simulator-watcher";
 import { startUpdateChecker } from "./utils/update-checker";
@@ -123,6 +127,19 @@ export function start(): void {
   // ── Bootstrap ─────────────────────────────────────────────────────
   const registry = createRegistry();
   attachRegistryLogger(registry);
+  const eventLog = isFlagEnabled("tool-server-event-log")
+    ? createToolServerEventLog({
+        filePath:
+          process.env.ARGENT_EVENT_LOG ||
+          path.join(homedir(), ".argent", "tool-server-events.jsonl"),
+      })
+    : null;
+  if (eventLog) {
+    attachRegistryEventLogger(registry, eventLog);
+  }
+  if (eventLog) {
+    process.stderr.write(`[tool-server] Event log: ${eventLog.filePath}\n`);
+  }
 
   // Tool events use the queued client; shutdown gets a bounded final flush.
   telemetryInit("tool_server");
@@ -146,7 +163,6 @@ export function start(): void {
   const serverStartedAt = Date.now();
   let shutdownReason: "idle" | "signal" | "crash" = "signal";
   let shutdownFailureSignal: FailureSignal | null = null;
-
   const updateChecker = startUpdateChecker();
 
   const { stop: stopWatcher, ready: watcherReady } = startSimulatorWatcher(registry);
@@ -236,7 +252,11 @@ export function start(): void {
     if (exitCode > finalExitCode) finalExitCode = exitCode;
     if (shuttingDown) return;
     shuttingDown = true;
-
+    eventLog?.info({
+      type: "tool_server.stopping",
+      msg: "Tool server is stopping.",
+      exitCode: finalExitCode,
+    });
     variantProposalStore.events.off("awaitParked", onAwaitParked);
     variantProposalStore.events.off("selectionSubmitted", onSelectionSubmitted);
     variantProposalStore.events.off("cliSessionChanged", onCliSessionChanged);
@@ -272,6 +292,7 @@ export function start(): void {
     } catch (err) {
       process.stderr.write(`[tool-server] registry dispose failed: ${String(err)}\n`);
     }
+    eventLog?.dispose();
 
     // Capture toolserver:stop, then drain — the final telemetry action, so the
     // reason/signal are as fresh as possible. (A crash during the drain below is
@@ -331,6 +352,13 @@ export function start(): void {
         process.stdout.write(`Tools server listening on ${origin}\n`);
         process.stderr.write(`  GET  ${origin}/tools\n`);
         process.stderr.write(`  POST ${origin}/tools/:name\n`);
+        eventLog?.info({
+          type: "tool_server.started",
+          msg: `Tool server started on ${origin}.`,
+          origin,
+          host: HOST,
+          port: boundPort,
+        });
         if (idleTimeoutMs > 0) {
           process.stderr.write(`  Idle timeout: ${idleMinutes}min\n`);
         }
@@ -348,6 +376,14 @@ export function start(): void {
         process.stderr.write(
           `[tool-server] Failed to bind ${HOST}:${PORT} — ${code}${err.message}\n`
         );
+        eventLog?.error({
+          type: "tool_server.bind_failed",
+          msg: `Tool server failed to bind ${HOST}:${PORT}.`,
+          host: HOST,
+          port: PORT,
+          err,
+        });
+        eventLog?.dispose();
         process.exit(1);
       });
       // Bolt the per-Chromium-device WebSocket upgrade handler onto the live
@@ -360,6 +396,11 @@ export function start(): void {
         process.stderr.write(
           `[tool-server] Failed to start: ${err instanceof Error ? err.message : err}\n`
         );
+        eventLog?.error({
+          type: "tool_server.start_failed",
+          msg: "Tool server failed to start.",
+          err: err instanceof Error ? err : new Error(String(err)),
+        });
         shutdownReason = "crash";
         await shutdown?.(1);
       })();

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -72,6 +72,8 @@ export function start(): void {
   // crash arriving mid-shutdown would be swallowed by the re-entrancy guard and
   // the in-flight shutdown(0) would exit 0, hiding the crash from supervisors.
   let finalExitCode = 0;
+  let shutdownReason: "idle" | "signal" | "crash" = "signal";
+  let shutdownFailureSignal: FailureSignal | null = null;
   let shutdown: ((exitCode?: number) => Promise<void>) | null = null;
 
   // The crash classification is passed in explicitly rather than re-derived from
@@ -127,13 +129,18 @@ export function start(): void {
   // ── Bootstrap ─────────────────────────────────────────────────────
   const registry = createRegistry();
   attachRegistryLogger(registry);
-  const eventLog = isFlagEnabled("tool-server-event-log")
-    ? createToolServerEventLog({
-        filePath:
-          process.env.ARGENT_EVENT_LOG ||
-          path.join(homedir(), ".argent", "tool-server-events.jsonl"),
-      })
-    : null;
+  let eventLog: ReturnType<typeof createToolServerEventLog> | null = null;
+  if (isFlagEnabled("tool-server-event-log")) {
+    const eventLogPath =
+      process.env.ARGENT_EVENT_LOG || path.join(homedir(), ".argent", "tool-server-events.jsonl");
+    try {
+      eventLog = createToolServerEventLog({ filePath: eventLogPath });
+    } catch (err) {
+      process.stderr.write(
+        `[tool-server] Failed to create event log at ${eventLogPath}: ${String(err)}\n`
+      );
+    }
+  }
   if (eventLog) {
     attachRegistryEventLogger(registry, eventLog);
   }
@@ -161,8 +168,6 @@ export function start(): void {
   const warmKeepAlive = setInterval(() => {}, 1_000);
   void identityWarm.finally(() => clearInterval(warmKeepAlive));
   const serverStartedAt = Date.now();
-  let shutdownReason: "idle" | "signal" | "crash" = "signal";
-  let shutdownFailureSignal: FailureSignal | null = null;
   const updateChecker = startUpdateChecker();
 
   const { stop: stopWatcher, ready: watcherReady } = startSimulatorWatcher(registry);

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -386,7 +386,12 @@ export function start(): void {
           msg: `Tool server failed to bind ${HOST}:${PORT}.`,
           host: HOST,
           port: PORT,
-          err,
+          failureSignal: {
+            error_code: FAILURE_CODES.ARGENT_UNCLASSIFIED_FAILURE,
+            failure_stage: "toolserver_bind",
+            failure_area: "tool_server",
+            error_kind: "unknown",
+          },
         });
         eventLog?.dispose();
         process.exit(1);
@@ -404,7 +409,12 @@ export function start(): void {
         eventLog?.error({
           type: "tool_server.start_failed",
           msg: "Tool server failed to start.",
-          err: err instanceof Error ? err : new Error(String(err)),
+          failureSignal: {
+            error_code: FAILURE_CODES.ARGENT_UNCLASSIFIED_FAILURE,
+            failure_stage: "toolserver_start",
+            failure_area: "tool_server",
+            error_kind: "unknown",
+          },
         });
         shutdownReason = "crash";
         await shutdown?.(1);

--- a/packages/tool-server/test/event-log.test.ts
+++ b/packages/tool-server/test/event-log.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Registry } from "@argent/registry";
+import { attachRegistryEventLogger, createToolServerEventLog } from "../src/event-log";
+
+function eventLogPath(): string {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "argent-events-")), "events.jsonl");
+}
+
+function readEvents(filePath: string): Array<Record<string, unknown>> {
+  return fs
+    .readFileSync(filePath, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("createToolServerEventLog", () => {
+  it("records structured events as JSONL", () => {
+    const filePath = eventLogPath();
+    const eventLog = createToolServerEventLog({ filePath });
+
+    eventLog.info({
+      type: "tool_server.started",
+      msg: "Tool server started on http://127.0.0.1:3001.",
+      origin: "http://127.0.0.1:3001",
+      host: "127.0.0.1",
+      port: 3001,
+    });
+    eventLog.dispose();
+
+    expect(readEvents(filePath)).toEqual([
+      expect.objectContaining({
+        time: expect.any(String),
+        msg: "Tool server started on http://127.0.0.1:3001.",
+        type: "tool_server.started",
+        origin: "http://127.0.0.1:3001",
+        host: "127.0.0.1",
+        port: 3001,
+        name: "argent-tool-server",
+        hostname: expect.any(String),
+        pid: process.pid,
+        level: 30,
+        v: 0,
+      }),
+    ]);
+  });
+
+  it("starts a fresh event log file", () => {
+    const filePath = eventLogPath();
+    fs.writeFileSync(filePath, "stale\n");
+
+    const eventLog = createToolServerEventLog({ filePath });
+    eventLog.info({ type: "tool_server.started", msg: "Tool server started." });
+    eventLog.dispose();
+
+    expect(fs.readFileSync(filePath, "utf8")).not.toContain("stale");
+    expect(readEvents(filePath)).toHaveLength(1);
+  });
+});
+
+describe("attachRegistryEventLogger", () => {
+  it("records registry lifecycle events into the tool-server event log", () => {
+    const registry = new Registry();
+    const filePath = eventLogPath();
+    const eventLog = createToolServerEventLog({ filePath });
+    attachRegistryEventLogger(registry, eventLog);
+
+    registry.events.emit("toolInvoked", "screenshot", "call-1");
+    registry.events.emit("toolCompleted", "screenshot", "call-1", 12.34);
+    eventLog.dispose();
+
+    expect(readEvents(filePath)).toEqual([
+      expect.objectContaining({
+        time: expect.any(String),
+        msg: "Tool screenshot was invoked.",
+        level: 30,
+        type: "tool.invoked",
+        toolId: "screenshot",
+        toolInvocationId: "call-1",
+      }),
+      expect.objectContaining({
+        time: expect.any(String),
+        msg: "Tool screenshot completed in 12.34 ms.",
+        level: 30,
+        type: "tool.completed",
+        toolId: "screenshot",
+        toolInvocationId: "call-1",
+        durationMs: 12.34,
+      }),
+    ]);
+  });
+
+  it("serializes failed tool errors with nested causes", () => {
+    const registry = new Registry();
+    const filePath = eventLogPath();
+    const eventLog = createToolServerEventLog({ filePath });
+    attachRegistryEventLogger(registry, eventLog);
+
+    const cause = new Error("socket closed");
+    registry.events.emit(
+      "toolFailed",
+      "debugger-evaluate",
+      "call-2",
+      new Error("evaluate failed", { cause })
+    );
+    eventLog.dispose();
+
+    const [event] = readEvents(filePath);
+    expect(event).toMatchObject({
+      msg: "Tool debugger-evaluate failed.",
+      level: 50,
+      type: "tool.failed",
+      toolId: "debugger-evaluate",
+      toolInvocationId: "call-2",
+      err: {
+        name: "Error",
+        message: "evaluate failed",
+        stack: expect.any(String),
+        cause: {
+          name: "Error",
+          message: "socket closed",
+          stack: expect.any(String),
+        },
+      },
+    });
+  });
+});

--- a/packages/tool-server/test/event-log.test.ts
+++ b/packages/tool-server/test/event-log.test.ts
@@ -69,13 +69,7 @@ describe("attachRegistryEventLogger", () => {
     attachRegistryEventLogger(registry, eventLog);
 
     registry.events.emit("toolInvoked", "screenshot", "call-1", "Capturing screenshot.");
-    registry.events.emit(
-      "toolCompleted",
-      "screenshot",
-      "call-1",
-      12.34,
-      "Captured screenshot."
-    );
+    registry.events.emit("toolCompleted", "screenshot", "call-1", 12.34, "Captured screenshot.");
     await eventLog.dispose();
 
     expect(readEvents(filePath)).toEqual([

--- a/packages/tool-server/test/event-log.test.ts
+++ b/packages/tool-server/test/event-log.test.ts
@@ -18,7 +18,7 @@ function readEvents(filePath: string): Array<Record<string, unknown>> {
 }
 
 describe("createToolServerEventLog", () => {
-  it("records structured events as JSONL", () => {
+  it("records structured events as JSONL", async () => {
     const filePath = eventLogPath();
     const eventLog = createToolServerEventLog({ filePath });
 
@@ -29,7 +29,7 @@ describe("createToolServerEventLog", () => {
       host: "127.0.0.1",
       port: 3001,
     });
-    eventLog.dispose();
+    await eventLog.dispose();
 
     expect(readEvents(filePath)).toEqual([
       expect.objectContaining({
@@ -48,13 +48,13 @@ describe("createToolServerEventLog", () => {
     ]);
   });
 
-  it("starts a fresh event log file", () => {
+  it("starts a fresh event log file", async () => {
     const filePath = eventLogPath();
     fs.writeFileSync(filePath, "stale\n");
 
     const eventLog = createToolServerEventLog({ filePath });
     eventLog.info({ type: "tool_server.started", msg: "Tool server started." });
-    eventLog.dispose();
+    await eventLog.dispose();
 
     expect(fs.readFileSync(filePath, "utf8")).not.toContain("stale");
     expect(readEvents(filePath)).toHaveLength(1);
@@ -62,7 +62,7 @@ describe("createToolServerEventLog", () => {
 });
 
 describe("attachRegistryEventLogger", () => {
-  it("records registry lifecycle events into the tool-server event log", () => {
+  it("records registry lifecycle events into the tool-server event log", async () => {
     const registry = new Registry();
     const filePath = eventLogPath();
     const eventLog = createToolServerEventLog({ filePath });
@@ -70,7 +70,7 @@ describe("attachRegistryEventLogger", () => {
 
     registry.events.emit("toolInvoked", "screenshot", "call-1");
     registry.events.emit("toolCompleted", "screenshot", "call-1", 12.34);
-    eventLog.dispose();
+    await eventLog.dispose();
 
     expect(readEvents(filePath)).toEqual([
       expect.objectContaining({
@@ -93,7 +93,7 @@ describe("attachRegistryEventLogger", () => {
     ]);
   });
 
-  it("serializes failed tool errors with nested causes", () => {
+  it("serializes failed tool errors with nested causes", async () => {
     const registry = new Registry();
     const filePath = eventLogPath();
     const eventLog = createToolServerEventLog({ filePath });
@@ -106,7 +106,7 @@ describe("attachRegistryEventLogger", () => {
       "call-2",
       new Error("evaluate failed", { cause })
     );
-    eventLog.dispose();
+    await eventLog.dispose();
 
     const [event] = readEvents(filePath);
     expect(event).toMatchObject({

--- a/packages/tool-server/test/event-log.test.ts
+++ b/packages/tool-server/test/event-log.test.ts
@@ -102,7 +102,7 @@ describe("attachRegistryEventLogger", () => {
     const cause = new Error("socket closed");
     registry.events.emit(
       "toolFailed",
-      "debugger-evaluate",
+      "screenshot",
       "call-2",
       new Error("evaluate failed", { cause })
     );
@@ -110,21 +110,19 @@ describe("attachRegistryEventLogger", () => {
 
     const [event] = readEvents(filePath);
     expect(event).toMatchObject({
-      msg: "Tool debugger-evaluate failed.",
+      msg: "Tool screenshot failed.",
       level: 50,
       type: "tool.failed",
-      toolId: "debugger-evaluate",
+      toolId: "screenshot",
       toolInvocationId: "call-2",
-      err: {
-        name: "Error",
-        message: "evaluate failed",
-        stack: expect.any(String),
-        cause: {
-          name: "Error",
-          message: "socket closed",
-          stack: expect.any(String),
-        },
+      failureSignal: {
+        error_code: "REGISTRY_TOOL_FAILURE_UNCLASSIFIED",
+        failure_stage: "registry_tool_failed_event",
+        failure_area: "registry",
+        error_kind: "unknown",
       },
     });
+    expect(JSON.stringify(event)).not.toContain("evaluate failed");
+    expect(JSON.stringify(event)).not.toContain("socket closed");
   });
 });

--- a/packages/tool-server/test/event-log.test.ts
+++ b/packages/tool-server/test/event-log.test.ts
@@ -68,14 +68,20 @@ describe("attachRegistryEventLogger", () => {
     const eventLog = createToolServerEventLog({ filePath });
     attachRegistryEventLogger(registry, eventLog);
 
-    registry.events.emit("toolInvoked", "screenshot", "call-1");
-    registry.events.emit("toolCompleted", "screenshot", "call-1", 12.34);
+    registry.events.emit("toolInvoked", "screenshot", "call-1", "Capturing screenshot.");
+    registry.events.emit(
+      "toolCompleted",
+      "screenshot",
+      "call-1",
+      12.34,
+      "Captured screenshot."
+    );
     await eventLog.dispose();
 
     expect(readEvents(filePath)).toEqual([
       expect.objectContaining({
         time: expect.any(String),
-        msg: "Tool screenshot was invoked.",
+        msg: "Capturing screenshot.",
         level: 30,
         type: "tool.invoked",
         toolId: "screenshot",
@@ -83,7 +89,7 @@ describe("attachRegistryEventLogger", () => {
       }),
       expect.objectContaining({
         time: expect.any(String),
-        msg: "Tool screenshot completed in 12.34 ms.",
+        msg: "Captured screenshot.",
         level: 30,
         type: "tool.completed",
         toolId: "screenshot",
@@ -104,13 +110,15 @@ describe("attachRegistryEventLogger", () => {
       "toolFailed",
       "screenshot",
       "call-2",
-      new Error("evaluate failed", { cause })
+      new Error("evaluate failed", { cause }),
+      undefined,
+      "Failed to capture screenshot."
     );
     await eventLog.dispose();
 
     const [event] = readEvents(filePath);
     expect(event).toMatchObject({
-      msg: "Tool screenshot failed.",
+      msg: "Failed to capture screenshot.",
       level: 50,
       type: "tool.failed",
       toolId: "screenshot",


### PR DESCRIPTION
We want to display a nicely parsed and rendered log of events that happened over a span of an Argent session.

Current log file is not designed to be machine-readable, so adding a JSONL-formatted log of events (gated by `tool-server-event-log`).

I eventually want this 😋 https://x.com/j3nnings/status/2069072177584849192

When enabled, the tool server writes Bunyan-compatible records to `ARGENT_EVENT_LOG` or `~/.argent/tool-server-events.jsonl`. The log captures tool-server lifecycle events and registry lifecycle events, including tool invocations and others.

To make messages nicer, added `interaction` object to tool definition. This allows tools to define a nicer message in log (print "Screenshot capture completed." instead of "Tool `screenshot` completed.") Adding these to the existing tools is a follow up PR matter I think.
