### PR TITLE
ci: device E2E smoke tests for every hosted-CI platform

### DIFF
--- a/.github/actions/start-tool-server/action.yml
+++ b/.github/actions/start-tool-server/action.yml
@@ -1,0 +1,58 @@
+name: Start tool-server
+description: >-
+  Install dependencies, build the TypeScript, and start the Argent tool-server
+  in the background, polling until it answers on /tools. Shared by every
+  e2e-device-smoke job so the install/build boilerplate and the
+  TS_NODE_TRANSPILE_ONLY / port / readiness-poll logic live in exactly one place.
+
+inputs:
+  node-version:
+    description: Node.js version to set up.
+    required: false
+    default: "20"
+  port:
+    description: Port the tool-server binds to (ARGENT_PORT) and the readiness poll hits.
+    required: false
+    default: "3033"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install deps + build
+      shell: bash
+      run: |
+        npm ci
+        # Rollup's native binary ships as an optional dep that npm can skip
+        # (npm/cli#4828); install the one matching this runner explicitly so the
+        # tsc bundling step doesn't fail with "Cannot find module @rollup/rollup-*".
+        # RUNNER_OS is provided by GitHub Actions (Linux / macOS / Windows).
+        case "$RUNNER_OS" in
+          macOS) npm install @rollup/rollup-darwin-arm64 --no-save ;;
+          Linux) npm install @rollup/rollup-linux-x64-gnu --no-save ;;
+          *) echo "::error::start-tool-server: unsupported runner OS '$RUNNER_OS'"; exit 1 ;;
+        esac
+        npx tsc --build
+
+    - name: Start tool-server
+      shell: bash
+      env:
+        ARGENT_PORT: ${{ inputs.port }}
+      run: |
+        mkdir -p ~/.argent
+        : > ~/.argent/tool-server.log
+        cd packages/tool-server
+        # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
+        # typecheck job already enforces types). Without it a cold start on a
+        # loaded CI runner can take >60s to bind and flakily times out.
+        nohup env ARGENT_PORT="$ARGENT_PORT" TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
+          > ~/.argent/tool-server.log 2>&1 &
+        for i in $(seq 1 60); do
+          curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${ARGENT_PORT}/tools" | grep -q 200 \
+            && { echo "tool-server up t+${i}s"; exit 0; }
+          sleep 1
+        done
+        echo "tool-server failed to start"; cat ~/.argent/tool-server.log; exit 1

--- a/.github/workflows/e2e-device-smoke.yml
+++ b/.github/workflows/e2e-device-smoke.yml
@@ -38,6 +38,12 @@ on:
       - "packages/tool-server/src/tools/devices/**"
       - "packages/tool-server/src/tools/gesture-tap/**"
       - "packages/tool-server/src/tools/screenshot/**"
+      # Transport layer that drives screenshot/gesture-tap for each platform —
+      # where the #391 screenshot regression lived, so changes here must re-run
+      # these smoke jobs too.
+      - "packages/tool-server/src/blueprints/simulator-server.ts"
+      - "packages/tool-server/src/blueprints/chromium-cdp.ts"
+      - "packages/tool-server/src/utils/simulator-client.ts"
       - "packages/tool-server/test/fixtures/electron-smoke-app/**"
       - "scripts/e2e/drive-device.sh"
       - ".github/workflows/e2e-device-smoke.yml"

--- a/.github/workflows/e2e-device-smoke.yml
+++ b/.github/workflows/e2e-device-smoke.yml
@@ -1,0 +1,238 @@
+name: Device E2E smoke
+
+# Boot-and-drive smoke tests for every (target × host) cell of the support
+# matrix that runs on GitHub-hosted runners. Each job boots ONE device through
+# the tool-server and asserts the headless interaction pipeline end-to-end via
+# scripts/e2e/drive-device.sh: booted:true → screenshot has real pixels →
+# gesture-tap round-trips.
+#
+#   ┌────────────────────┬───────────────┬──────────────────────────────────┐
+#   │ target             │ host          │ where                            │
+#   ├────────────────────┼───────────────┼──────────────────────────────────┤
+#   │ Android emulator   │ Linux (KVM)   │ wayland-e2e.yml (separate file:  │
+#   │                    │               │ also asserts gpu.mode=swiftshader)│
+#   │ iOS simulator      │ macOS         │ ios-sim-macos (this file)        │
+#   │ Chromium / Electron│ Linux (Xvfb)  │ chromium-linux (this file)       │
+#   │ Chromium / Electron│ macOS         │ chromium-macos (this file)       │
+#   └────────────────────┴───────────────┴──────────────────────────────────┘
+#
+# KNOWN GAPS — cells Argent supports on real machines but that GitHub-hosted
+# runners can't run, so they are intentionally not jobs here:
+#   - Android emulator on macOS: the arm64 emulator needs HVF (`-enable-hvf`),
+#     but hosted macOS runners are themselves VMs with no nested virtualization
+#     — qemu dies with "HVF error: HV_UNSUPPORTED" seconds into boot. The
+#     Android boot/screenshot/tap path is already regression-guarded on Linux
+#     via KVM (wayland-e2e.yml), so macOS adds no runnable coverage here.
+#   - Physical devices: real iOS (CoreDevice HID) and real Android (adb-USB)
+#     have no attached hardware on hosted runners.
+#   Both would need self-hosted runners (a Mac exposing HVF / wired-up devices).
+#
+# Manual + on-change trigger only — the macOS jobs are slow and billed.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/tool-server/src/tools/devices/**"
+      - "packages/tool-server/src/tools/gesture-tap/**"
+      - "packages/tool-server/src/tools/screenshot/**"
+      - "packages/tool-server/test/fixtures/electron-smoke-app/**"
+      - "scripts/e2e/drive-device.sh"
+      - ".github/workflows/e2e-device-smoke.yml"
+
+jobs:
+  # ── iOS simulator on macOS ────────────────────────────────────────────────
+  ios-sim-macos:
+    name: Boot + drive iOS simulator (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install deps + build
+        run: |
+          npm ci
+          npm install @rollup/rollup-darwin-arm64 --no-save
+          npx tsc --build
+
+      - name: Download signed native binaries (darwin)
+        # iOS needs the simulator-server (screenshot/gesture-tap backend) AND the
+        # dylibs + ax-service: bootIos() only returns booted:true when native-
+        # devtools injection does NOT give up (boot-device.ts), so missing dylibs
+        # would surface here as a hard failure rather than a silent skip.
+        run: |
+          bash scripts/download-simulator-server.sh
+          bash scripts/download-native-binaries.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start tool-server
+        run: |
+          mkdir -p ~/.argent
+          : > ~/.argent/tool-server.log
+          cd packages/tool-server
+          # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
+          # typecheck job already enforces types). Without it a cold start on a
+          # loaded macOS arm runner can take >60s to bind and flakily times out.
+          nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
+            > ~/.argent/tool-server.log 2>&1 &
+          for i in $(seq 1 60); do
+            curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3033/tools | grep -q 200 \
+              && { echo "tool-server up t+${i}s"; exit 0; }
+            sleep 1
+          done
+          echo "tool-server failed to start"; cat ~/.argent/tool-server.log; exit 1
+
+      - name: Pick an available simulator UDID
+        run: |
+          UDID=$(xcrun simctl list devices available --json | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; print(next(dev['udid'] for rt in d for dev in d[rt] if dev.get('isAvailable') and 'iPhone' in dev['name']))")
+          echo "Chosen simulator: $UDID"
+          echo "UDID=$UDID" >> "$GITHUB_ENV"
+
+      - name: Boot + drive
+        run: bash scripts/e2e/drive-device.sh
+        env:
+          BOOT_JSON: '{"udid":"${{ env.UDID }}"}'
+          DEVICE_ID: ${{ env.UDID }}
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-ios-sim-macos
+          path: |
+            ${{ runner.temp }}/smoke-shot.png
+            ${{ runner.temp }}/smoke-shot.json
+            ~/.argent/tool-server.log
+          if-no-files-found: warn
+          retention-days: 7
+
+  # ── Chromium / Electron on Linux (Xvfb) ───────────────────────────────────
+  chromium-linux:
+    name: Boot + drive Electron (Linux/Xvfb)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install deps + build
+        run: |
+          npm ci
+          npm install @rollup/rollup-linux-x64-gnu --no-save
+          npx tsc --build
+
+      - name: Vendor the fixture's electron
+        # The fixture brings its own electron (kept out of the root lockfile);
+        # boot-electron resolves ./node_modules/.bin/electron from the app dir.
+        # Standalone project (not a packages/* workspace member), so this ci is
+        # independent of the root install.
+        run: npm ci
+        working-directory: packages/tool-server/test/fixtures/electron-smoke-app
+
+      - name: Start Xvfb
+        # boot-electron spawns the Electron child inheriting the tool-server's
+        # env, so DISPLAY must be set BEFORE the tool-server starts.
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends xvfb
+          Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+
+      - name: Start tool-server
+        run: |
+          mkdir -p ~/.argent
+          : > ~/.argent/tool-server.log
+          cd packages/tool-server
+          # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
+          # typecheck job already enforces types). Without it a cold start on a
+          # loaded macOS arm runner can take >60s to bind and flakily times out.
+          nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
+            > ~/.argent/tool-server.log 2>&1 &
+          for i in $(seq 1 60); do
+            curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3033/tools | grep -q 200 \
+              && { echo "tool-server up t+${i}s"; exit 0; }
+            sleep 1
+          done
+          echo "tool-server failed to start"; cat ~/.argent/tool-server.log; exit 1
+
+      - name: Boot + drive
+        run: bash scripts/e2e/drive-device.sh
+        env:
+          BOOT_JSON: '{"electronAppPath":"${{ github.workspace }}/packages/tool-server/test/fixtures/electron-smoke-app","electronPort":19222,"electronArgs":["--no-sandbox"]}'
+          DEVICE_ID: chromium-cdp-19222
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-chromium-linux
+          path: |
+            ${{ runner.temp }}/smoke-shot.png
+            ${{ runner.temp }}/smoke-shot.json
+            /tmp/xvfb.log
+            ~/.argent/tool-server.log
+          if-no-files-found: warn
+          retention-days: 7
+
+  # ── Chromium / Electron on macOS ──────────────────────────────────────────
+  chromium-macos:
+    name: Boot + drive Electron (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install deps + build
+        run: |
+          npm ci
+          npm install @rollup/rollup-darwin-arm64 --no-save
+          npx tsc --build
+
+      - name: Vendor the fixture's electron
+        run: npm ci
+        working-directory: packages/tool-server/test/fixtures/electron-smoke-app
+
+      - name: Start tool-server
+        run: |
+          mkdir -p ~/.argent
+          : > ~/.argent/tool-server.log
+          cd packages/tool-server
+          # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
+          # typecheck job already enforces types). Without it a cold start on a
+          # loaded macOS arm runner can take >60s to bind and flakily times out.
+          nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
+            > ~/.argent/tool-server.log 2>&1 &
+          for i in $(seq 1 60); do
+            curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3033/tools | grep -q 200 \
+              && { echo "tool-server up t+${i}s"; exit 0; }
+            sleep 1
+          done
+          echo "tool-server failed to start"; cat ~/.argent/tool-server.log; exit 1
+
+      - name: Boot + drive
+        # macOS runner has a window server and Electron's sandbox is fine there,
+        # so no Xvfb and no --no-sandbox.
+        run: bash scripts/e2e/drive-device.sh
+        env:
+          BOOT_JSON: '{"electronAppPath":"${{ github.workspace }}/packages/tool-server/test/fixtures/electron-smoke-app","electronPort":19222}'
+          DEVICE_ID: chromium-cdp-19222
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-chromium-macos
+          path: |
+            ${{ runner.temp }}/smoke-shot.png
+            ${{ runner.temp }}/smoke-shot.json
+            ~/.argent/tool-server.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/e2e-device-smoke.yml
+++ b/.github/workflows/e2e-device-smoke.yml
@@ -78,7 +78,7 @@ jobs:
           cd packages/tool-server
           # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
           # typecheck job already enforces types). Without it a cold start on a
-          # loaded macOS arm runner can take >60s to bind and flakily times out.
+          # loaded CI runner can take >60s to bind and flakily times out.
           nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
             > ~/.argent/tool-server.log 2>&1 &
           for i in $(seq 1 60); do
@@ -101,7 +101,7 @@ jobs:
           DEVICE_ID: ${{ env.UDID }}
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-ios-sim-macos
           path: |
@@ -152,7 +152,7 @@ jobs:
           cd packages/tool-server
           # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
           # typecheck job already enforces types). Without it a cold start on a
-          # loaded macOS arm runner can take >60s to bind and flakily times out.
+          # loaded CI runner can take >60s to bind and flakily times out.
           nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
             > ~/.argent/tool-server.log 2>&1 &
           for i in $(seq 1 60); do
@@ -169,7 +169,7 @@ jobs:
           DEVICE_ID: chromium-cdp-19222
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-chromium-linux
           path: |
@@ -208,7 +208,7 @@ jobs:
           cd packages/tool-server
           # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
           # typecheck job already enforces types). Without it a cold start on a
-          # loaded macOS arm runner can take >60s to bind and flakily times out.
+          # loaded CI runner can take >60s to bind and flakily times out.
           nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
             > ~/.argent/tool-server.log 2>&1 &
           for i in $(seq 1 60); do
@@ -227,7 +227,7 @@ jobs:
           DEVICE_ID: chromium-cdp-19222
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-chromium-macos
           path: |

--- a/.github/workflows/e2e-device-smoke.yml
+++ b/.github/workflows/e2e-device-smoke.yml
@@ -47,6 +47,14 @@ on:
       - "packages/tool-server/test/fixtures/electron-smoke-app/**"
       - "scripts/e2e/drive-device.sh"
       - ".github/workflows/e2e-device-smoke.yml"
+      # The shared composite action is part of the test harness too.
+      - ".github/actions/start-tool-server/action.yml"
+
+# Cancel superseded runs on the same ref: rapid pushes to a PR would otherwise
+# stack up the slow, billed macOS jobs (see header) with no cancellation.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # ── iOS simulator on macOS ────────────────────────────────────────────────
@@ -56,43 +64,22 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
 
-      - name: Install deps + build
-        run: |
-          npm ci
-          npm install @rollup/rollup-darwin-arm64 --no-save
-          npx tsc --build
+      - uses: ./.github/actions/start-tool-server
 
       - name: Download signed native binaries (darwin)
         # iOS needs the simulator-server (screenshot/gesture-tap backend) AND the
         # dylibs + ax-service: bootIos() only returns booted:true when native-
         # devtools injection does NOT give up (boot-device.ts), so missing dylibs
-        # would surface here as a hard failure rather than a silent skip.
+        # would surface here as a hard failure rather than a silent skip. Only
+        # consumed at boot time, so it can run after the server starts — and after
+        # start-tool-server has set up Node (download-native-binaries.sh reads the
+        # Android manifest version with `node -p`).
         run: |
           bash scripts/download-simulator-server.sh
           bash scripts/download-native-binaries.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Start tool-server
-        run: |
-          mkdir -p ~/.argent
-          : > ~/.argent/tool-server.log
-          cd packages/tool-server
-          # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
-          # typecheck job already enforces types). Without it a cold start on a
-          # loaded CI runner can take >60s to bind and flakily times out.
-          nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
-            > ~/.argent/tool-server.log 2>&1 &
-          for i in $(seq 1 60); do
-            curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3033/tools | grep -q 200 \
-              && { echo "tool-server up t+${i}s"; exit 0; }
-            sleep 1
-          done
-          echo "tool-server failed to start"; cat ~/.argent/tool-server.log; exit 1
 
       - name: Pick an available simulator UDID
         run: |
@@ -124,49 +111,27 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-
-      - name: Install deps + build
-        run: |
-          npm ci
-          npm install @rollup/rollup-linux-x64-gnu --no-save
-          npx tsc --build
-
-      - name: Vendor the fixture's electron
-        # The fixture brings its own electron (kept out of the root lockfile);
-        # boot-electron resolves ./node_modules/.bin/electron from the app dir.
-        # Standalone project (not a packages/* workspace member), so this ci is
-        # independent of the root install.
-        run: npm ci
-        working-directory: packages/tool-server/test/fixtures/electron-smoke-app
 
       - name: Start Xvfb
         # boot-electron spawns the Electron child inheriting the tool-server's
-        # env, so DISPLAY must be set BEFORE the tool-server starts.
+        # env, so DISPLAY must be set (in GITHUB_ENV) BEFORE the tool-server
+        # starts in the start-tool-server action below.
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends xvfb
           Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
           echo "DISPLAY=:99" >> "$GITHUB_ENV"
 
-      - name: Start tool-server
-        run: |
-          mkdir -p ~/.argent
-          : > ~/.argent/tool-server.log
-          cd packages/tool-server
-          # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
-          # typecheck job already enforces types). Without it a cold start on a
-          # loaded CI runner can take >60s to bind and flakily times out.
-          nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
-            > ~/.argent/tool-server.log 2>&1 &
-          for i in $(seq 1 60); do
-            curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3033/tools | grep -q 200 \
-              && { echo "tool-server up t+${i}s"; exit 0; }
-            sleep 1
-          done
-          echo "tool-server failed to start"; cat ~/.argent/tool-server.log; exit 1
+      - uses: ./.github/actions/start-tool-server
+
+      - name: Vendor the fixture's electron
+        # The fixture brings its own electron (kept out of the root lockfile);
+        # boot-electron resolves ./node_modules/.bin/electron from the app dir.
+        # Standalone project (not a packages/* workspace member), so this ci is
+        # independent of the root install. Electron is only needed at boot time,
+        # so vendoring it after the server starts is fine.
+        run: npm ci
+        working-directory: packages/tool-server/test/fixtures/electron-smoke-app
 
       - name: Boot + drive
         run: bash scripts/e2e/drive-device.sh
@@ -193,36 +158,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
 
-      - name: Install deps + build
-        run: |
-          npm ci
-          npm install @rollup/rollup-darwin-arm64 --no-save
-          npx tsc --build
+      - uses: ./.github/actions/start-tool-server
 
       - name: Vendor the fixture's electron
         run: npm ci
         working-directory: packages/tool-server/test/fixtures/electron-smoke-app
-
-      - name: Start tool-server
-        run: |
-          mkdir -p ~/.argent
-          : > ~/.argent/tool-server.log
-          cd packages/tool-server
-          # TS_NODE_TRANSPILE_ONLY skips ts-node's whole-program type-check (the
-          # typecheck job already enforces types). Without it a cold start on a
-          # loaded CI runner can take >60s to bind and flakily times out.
-          nohup env ARGENT_PORT=3033 TS_NODE_TRANSPILE_ONLY=1 npx ts-node src/index.ts start \
-            > ~/.argent/tool-server.log 2>&1 &
-          for i in $(seq 1 60); do
-            curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3033/tools | grep -q 200 \
-              && { echo "tool-server up t+${i}s"; exit 0; }
-            sleep 1
-          done
-          echo "tool-server failed to start"; cat ~/.argent/tool-server.log; exit 1
 
       - name: Boot + drive
         # macOS runner has a window server and Electron's sandbox is fine there,

--- a/.github/workflows/e2e-device-smoke.yml
+++ b/.github/workflows/e2e-device-smoke.yml
@@ -45,7 +45,7 @@ on:
 jobs:
   # ── iOS simulator on macOS ────────────────────────────────────────────────
   ios-sim-macos:
-    name: Boot + drive iOS simulator (macOS)
+    name: macOS + iOS E2E
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -113,7 +113,7 @@ jobs:
 
   # ── Chromium / Electron on Linux (Xvfb) ───────────────────────────────────
   chromium-linux:
-    name: Boot + drive Electron (Linux/Xvfb)
+    name: Linux + Chromium E2E
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -182,7 +182,7 @@ jobs:
 
   # ── Chromium / Electron on macOS ──────────────────────────────────────────
   chromium-macos:
-    name: Boot + drive Electron (macOS)
+    name: macOS + Chromium E2E
     runs-on: macos-latest
     timeout-minutes: 20
     steps:

--- a/packages/tool-server/test/fixtures/electron-smoke-app/index.html
+++ b/packages/tool-server/test/fixtures/electron-smoke-app/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Argent E2E smoke</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        font-family: -apple-system, system-ui, sans-serif;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+        /* High-frequency diagonal stripes guarantee the captured PNG clears the
+           ~20 KB "real pixels" floor — a flat colour would compress under it. */
+        background: repeating-linear-gradient(
+          45deg,
+          #ff006e 0 24px,
+          #fb5607 24px 48px,
+          #ffbe0b 48px 72px,
+          #8338ec 72px 96px,
+          #3a86ff 96px 120px
+        );
+      }
+      h1 {
+        font-size: 48px;
+        margin: 0 0 16px;
+      }
+      button {
+        font-size: 24px;
+        padding: 16px 40px;
+        border: 0;
+        border-radius: 12px;
+        background: #fff;
+        color: #111;
+        cursor: pointer;
+      }
+      #count {
+        margin-top: 16px;
+        font-size: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Argent E2E smoke</h1>
+    <!-- Centred so a gesture-tap at (0.5, 0.5) lands on it. -->
+    <button id="tap">Tap me</button>
+    <div id="count">taps: 0</div>
+    <script>
+      let n = 0;
+      document.getElementById("tap").addEventListener("click", () => {
+        n += 1;
+        document.getElementById("count").textContent = "taps: " + n;
+      });
+    </script>
+  </body>
+</html>

--- a/packages/tool-server/test/fixtures/electron-smoke-app/main.js
+++ b/packages/tool-server/test/fixtures/electron-smoke-app/main.js
@@ -1,0 +1,25 @@
+// Minimal Electron main process for the Chromium E2E smoke test. Opens a single
+// window onto index.html and quits when it closes. No services, no IPC, no
+// network — the window just has to render so screenshot returns real pixels and
+// gesture-tap has something at (0.5, 0.5) to hit.
+const { app, BrowserWindow } = require("electron");
+const path = require("path");
+
+// Software rendering: CI runners have no usable GPU (and on Linux the window
+// lives inside Xvfb). Deterministic, and avoids GPU-process startup flake. The
+// Chromium jobs also pass --no-sandbox via electronArgs on Linux; this keeps
+// the app launchable by hand on a dev box too.
+app.commandLine.appendSwitch("disable-gpu");
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    show: true,
+    webPreferences: { contextIsolation: true, nodeIntegration: false },
+  });
+  win.loadFile(path.join(__dirname, "index.html"));
+}
+
+app.whenReady().then(createWindow);
+app.on("window-all-closed", () => app.quit());

--- a/packages/tool-server/test/fixtures/electron-smoke-app/package-lock.json
+++ b/packages/tool-server/test/fixtures/electron-smoke-app/package-lock.json
@@ -1,0 +1,871 @@
+{
+  "name": "electron-smoke-app",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "electron-smoke-app",
+      "version": "0.0.0",
+      "devDependencies": {
+        "electron": "^33.2.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron": {
+      "version": "33.4.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/packages/tool-server/test/fixtures/electron-smoke-app/package.json
+++ b/packages/tool-server/test/fixtures/electron-smoke-app/package.json
@@ -2,7 +2,7 @@
   "name": "electron-smoke-app",
   "version": "0.0.0",
   "private": true,
-  "description": "Minimal self-contained Electron app used as the boot target for the Chromium cells of .github/workflows/e2e-device-smoke.yml. Not part of the workspace build: CI runs `npm install` inside this directory so it vendors its OWN electron (keeping electron out of the repo's root lockfile). boot-electron resolves ./node_modules/.bin/electron from here.",
+  "description": "Minimal self-contained Electron app used as the boot target for the Chromium cells of .github/workflows/e2e-device-smoke.yml. Not part of the workspace build: CI runs `npm ci` inside this directory so it vendors its OWN electron (keeping electron out of the repo's root lockfile). boot-electron resolves ./node_modules/.bin/electron from here.",
   "main": "main.js",
   "scripts": {
     "start": "electron ."

--- a/packages/tool-server/test/fixtures/electron-smoke-app/package.json
+++ b/packages/tool-server/test/fixtures/electron-smoke-app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "electron-smoke-app",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Minimal self-contained Electron app used as the boot target for the Chromium cells of .github/workflows/e2e-device-smoke.yml. Not part of the workspace build: CI runs `npm install` inside this directory so it vendors its OWN electron (keeping electron out of the repo's root lockfile). boot-electron resolves ./node_modules/.bin/electron from here.",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^33.2.0"
+  }
+}

--- a/scripts/e2e/drive-device.sh
+++ b/scripts/e2e/drive-device.sh
@@ -100,13 +100,31 @@ test "$SZ" -gt "$MIN_SHOT_BYTES" || {
 }
 
 echo "::group::gesture-tap"
-TAP_RESP=$(curl -sS -m 30 -X POST "${BASE_URL}/gesture-tap" \
-  -H 'Content-Type: application/json' \
-  -d "{\"udid\":\"${DEVICE_ID}\",\"x\":0.5,\"y\":0.5}")
-echo "gesture-tap: $TAP_RESP"
+# Mirror the screenshot retry above: the successful screenshot already proves the
+# device is painted, so a tap race (#391) is unlikely here — but a tiny loop keeps
+# the tap symmetric with the screenshot and avoids an unguarded hard-fail if the
+# same transport race ever surfaces. A non-JSON / error response just retries
+# instead of spewing a raw python traceback.
+TAPPED=""
+for attempt in 1 2 3; do
+  TAP_RESP=$(curl -sS -m 30 -X POST "${BASE_URL}/gesture-tap" \
+    -H 'Content-Type: application/json' \
+    -d "{\"udid\":\"${DEVICE_ID}\",\"x\":0.5,\"y\":0.5}" || true)
+  echo "gesture-tap attempt ${attempt}/3: $TAP_RESP"
+  if printf '%s' "$TAP_RESP" | python3 -c "import json,sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+sys.exit(0 if isinstance(d, dict) and d.get('data', {}).get('tapped') is True else 1)"; then
+    TAPPED=1
+    break
+  fi
+  sleep 2
+done
 echo "::endgroup::"
-echo "$TAP_RESP" | python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin).get('data',{}).get('tapped') is True else 1)" || {
-  echo "::error::gesture-tap did not report tapped:true"
+[ -n "$TAPPED" ] || {
+  echo "::error::gesture-tap did not report tapped:true after 3 attempts"
   exit 1
 }
 

--- a/scripts/e2e/drive-device.sh
+++ b/scripts/e2e/drive-device.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generic tool-server E2E driver shared by every cell of e2e-device-smoke.yml
+# (iOS sim / Android emulator / Chromium-Electron, on macOS or Linux). It boots
+# ONE device through an already-running tool-server, then asserts the core
+# interaction pipeline works headlessly:
+#   1. boot-device reports booted:true
+#   2. screenshot returns real (non-blank) pixels
+#   3. gesture-tap round-trips
+# This mirrors the three assertions inlined in wayland-e2e.yml, but parameterised
+# so each platform job stays a few lines. Every tool takes the device id as
+# `udid` and screenshots come back as the same ArtifactHandle envelope
+# (data.image.hostPath) regardless of platform, so the body is uniform.
+#
+# Inputs (env):
+#   BOOT_JSON          required  JSON body for POST /boot-device
+#   DEVICE_ID          required  id/udid/serial for screenshot + gesture-tap
+#                                (e.g. emulator-5554, an iOS UDID, chromium-cdp-<port>)
+#   BASE_URL           optional  default http://127.0.0.1:3033/tools
+#   MIN_SHOT_BYTES     optional  default 20000 (all-zero framebuffer PNGs are ~3-7 KB)
+#   SLEEP_BEFORE_SHOT  optional  default 0  (Android needs ~15s for SurfaceFlinger)
+#   BOOT_CURL_TIMEOUT  optional  default 900 (curl -m seconds; > the boot budget)
+#   ARTIFACT_DIR       optional  default ${RUNNER_TEMP:-/tmp}; screenshot copied here
+
+: "${BOOT_JSON:?BOOT_JSON is required}"
+: "${DEVICE_ID:?DEVICE_ID is required}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:3033/tools}"
+MIN_SHOT_BYTES="${MIN_SHOT_BYTES:-20000}"
+SLEEP_BEFORE_SHOT="${SLEEP_BEFORE_SHOT:-0}"
+BOOT_CURL_TIMEOUT="${BOOT_CURL_TIMEOUT:-900}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${RUNNER_TEMP:-/tmp}}"
+mkdir -p "$ARTIFACT_DIR"
+
+echo "::group::boot-device ($DEVICE_ID)"
+echo "POST ${BASE_URL}/boot-device  body=${BOOT_JSON}"
+T0=$(date +%s)
+BOOT_RESP=$(curl -sS -m "$BOOT_CURL_TIMEOUT" -X POST "${BASE_URL}/boot-device" \
+  -H 'Content-Type: application/json' -d "$BOOT_JSON")
+T1=$(date +%s)
+echo "boot-device ($((T1 - T0))s): $BOOT_RESP"
+echo "::endgroup::"
+echo "$BOOT_RESP" | grep -q '"booted":true' || {
+  echo "::error::boot-device did not report booted:true"
+  exit 1
+}
+
+if [ "$SLEEP_BEFORE_SHOT" -gt 0 ]; then
+  echo "Waiting ${SLEEP_BEFORE_SHOT}s for the compositor to paint the first frame..."
+  sleep "$SLEEP_BEFORE_SHOT"
+fi
+
+echo "::group::screenshot"
+SHOT_JSON="$ARTIFACT_DIR/smoke-shot.json"
+curl -sS -m 60 -X POST "${BASE_URL}/screenshot" \
+  -H 'Content-Type: application/json' \
+  -d "{\"udid\":\"${DEVICE_ID}\"}" >"$SHOT_JSON"
+# The screenshot tool returns an ArtifactHandle ({ image: { hostPath, ... } });
+# the job runs co-located with the tool-server so hostPath is readable here.
+HOST_PATH=$(python3 -c "import json;print(json.load(open('$SHOT_JSON'))['data']['image']['hostPath'])")
+SHOT_PNG="$ARTIFACT_DIR/smoke-shot.png"
+cp "$HOST_PATH" "$SHOT_PNG"
+# `wc -c` instead of `stat` so the script is identical on macOS and Linux
+# (BSD stat uses -f%z, GNU stat uses -c%s).
+SZ=$(wc -c <"$SHOT_PNG" | tr -d '[:space:]')
+echo "screenshot=${SHOT_PNG} size=${SZ}B (floor ${MIN_SHOT_BYTES}B)"
+echo "::endgroup::"
+# An all-zero / uniform framebuffer PNG-compresses to a few KB; a real painted
+# screen is reliably larger. Guards against the boot "succeeding" but the
+# device never actually rendering.
+test "$SZ" -gt "$MIN_SHOT_BYTES" || {
+  echo "::error::screenshot too small (${SZ}B) — likely a blank/all-zero framebuffer"
+  exit 1
+}
+
+echo "::group::gesture-tap"
+TAP_RESP=$(curl -sS -m 30 -X POST "${BASE_URL}/gesture-tap" \
+  -H 'Content-Type: application/json' \
+  -d "{\"udid\":\"${DEVICE_ID}\",\"x\":0.5,\"y\":0.5}")
+echo "gesture-tap: $TAP_RESP"
+echo "::endgroup::"
+echo "$TAP_RESP" | grep -q '"tapped":true' || {
+  echo "::error::gesture-tap did not report tapped:true"
+  exit 1
+}
+
+echo "✅ smoke OK: booted + screenshot ${SZ}B + tap on ${DEVICE_ID}"

--- a/scripts/e2e/drive-device.sh
+++ b/scripts/e2e/drive-device.sh
@@ -40,7 +40,7 @@ BOOT_RESP=$(curl -sS -m "$BOOT_CURL_TIMEOUT" -X POST "${BASE_URL}/boot-device" \
 T1=$(date +%s)
 echo "boot-device ($((T1 - T0))s): $BOOT_RESP"
 echo "::endgroup::"
-echo "$BOOT_RESP" | grep -q '"booted":true' || {
+echo "$BOOT_RESP" | python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin).get('data',{}).get('booted') is True else 1)" || {
   echo "::error::boot-device did not report booted:true"
   exit 1
 }
@@ -52,12 +52,38 @@ fi
 
 echo "::group::screenshot"
 SHOT_JSON="$ARTIFACT_DIR/smoke-shot.json"
-curl -sS -m 60 -X POST "${BASE_URL}/screenshot" \
-  -H 'Content-Type: application/json' \
-  -d "{\"udid\":\"${DEVICE_ID}\"}" >"$SHOT_JSON"
-# The screenshot tool returns an ArtifactHandle ({ image: { hostPath, ... } });
-# the job runs co-located with the tool-server so hostPath is readable here.
-HOST_PATH=$(python3 -c "import json;print(json.load(open('$SHOT_JSON'))['data']['image']['hostPath'])")
+# Retry a few times: a fresh-spawn streaming-screenshot race (issue #391) can
+# briefly return an error envelope before the first frame is available. A tiny
+# loop is cheap belt-and-suspenders for this one-shot smoke.
+HOST_PATH=""
+for attempt in 1 2 3; do
+  curl -sS -m 60 -X POST "${BASE_URL}/screenshot" \
+    -H 'Content-Type: application/json' \
+    -d "{\"udid\":\"${DEVICE_ID}\"}" >"$SHOT_JSON" || true
+  # Surface a tool-side error as a clean annotation instead of letting the
+  # hostPath extraction blow up with a raw python KeyError traceback.
+  ERR=$(python3 -c "import json,sys;
+try:
+    d=json.load(open('$SHOT_JSON'))
+except Exception as e:
+    print('unparseable screenshot response: %s' % e); sys.exit(0)
+print(d.get('error','') if isinstance(d,dict) else '')")
+  if [ -n "$ERR" ]; then
+    echo "screenshot attempt ${attempt}/3 failed: ${ERR}"
+    sleep 2
+    continue
+  fi
+  # The screenshot tool returns an ArtifactHandle ({ image: { hostPath, ... } });
+  # the job runs co-located with the tool-server so hostPath is readable here.
+  HOST_PATH=$(python3 -c "import json;print(json.load(open('$SHOT_JSON')).get('data',{}).get('image',{}).get('hostPath',''))")
+  [ -n "$HOST_PATH" ] && break
+  echo "screenshot attempt ${attempt}/3 returned no hostPath"
+  sleep 2
+done
+if [ -z "$HOST_PATH" ]; then
+  echo "::error::screenshot did not return a readable hostPath after 3 attempts (last response: $(cat "$SHOT_JSON"))"
+  exit 1
+fi
 SHOT_PNG="$ARTIFACT_DIR/smoke-shot.png"
 cp "$HOST_PATH" "$SHOT_PNG"
 # `wc -c` instead of `stat` so the script is identical on macOS and Linux
@@ -79,7 +105,7 @@ TAP_RESP=$(curl -sS -m 30 -X POST "${BASE_URL}/gesture-tap" \
   -d "{\"udid\":\"${DEVICE_ID}\",\"x\":0.5,\"y\":0.5}")
 echo "gesture-tap: $TAP_RESP"
 echo "::endgroup::"
-echo "$TAP_RESP" | grep -q '"tapped":true' || {
+echo "$TAP_RESP" | python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin).get('data',{}).get('tapped') is True else 1)" || {
   echo "::error::gesture-tap did not report tapped:true"
   exit 1
 }


### PR DESCRIPTION
## What

`wayland-e2e.yml` boots an Android AVD on Linux under headless Weston and asserts the full pipeline works without a display. It guards exactly one cell of the support matrix. This adds the same boot→screenshot→gesture-tap smoke test for every other (target × host) cell that can run on GitHub-hosted runners.

| target | host | job | status |
|---|---|---|---|
| Android emulator | Linux (KVM) | `wayland-e2e.yml` (existing) | ✅ |
| iOS simulator | macOS | `ios-sim-macos` | ✅ |
| Chromium / Electron | Linux (Xvfb) | `chromium-linux` | ✅ |
| Chromium / Electron | macOS | `chromium-macos` | ✅ |

## How

- **`scripts/e2e/drive-device.sh`** — shared driver. Boots one device through the tool-server, then asserts `booted:true` → screenshot has real (non-blank) pixels → `gesture-tap` round-trips. Every tool takes the device id as `udid` and screenshots come back as the same `data.image.hostPath` envelope on all platforms, so the body is uniform; each job just supplies the cell-specific boot JSON + device id.
- **`packages/tool-server/test/fixtures/electron-smoke-app/`** — minimal self-contained Electron app the Chromium jobs point `electronAppPath` at. It vendors its own electron via its own lockfile (kept out of the repo root lockfile); CI `npm ci`s it so `boot-electron` resolves `./node_modules/.bin/electron`.
- **`.github/workflows/e2e-device-smoke.yml`** — three jobs, `workflow_dispatch` + path-filtered `pull_request`. iOS downloads the darwin native binaries (injection must succeed for `bootIos` to report `booted:true`); Chromium-Linux runs under Xvfb with `--no-sandbox`. The tool-server is started with `TS_NODE_TRANSPILE_ONLY=1` so cold ts-node startup doesn't flakily exceed the readiness poll on loaded macOS runners (types are still enforced by the typecheck job).

## Known gaps (supported on real machines, not runnable on hosted runners)

- **Android emulator on macOS** — the arm64 emulator needs HVF (`-enable-hvf`), but hosted macOS runners are themselves VMs with no nested virtualization. Confirmed by running it: qemu dies with `HVF error: HV_UNSUPPORTED` ~18s into boot, regardless of GPU mode or RAM. The Android boot/screenshot/tap path is already regression-guarded on Linux via KVM (`wayland-e2e.yml`), so macOS adds no runnable coverage.
- **Physical devices** — real iOS (CoreDevice HID) and real Android (adb-USB) have no attached hardware on hosted runners.

Both would need self-hosted runners (a Mac exposing HVF / wired-up devices). Documented in the workflow header.

## Verification

- All checks green: the 3 device jobs + ESLint + Prettier + Unit tests.
- Locally (before CI): ran `drive-device.sh` end-to-end against a real tool-server → boot `booted:true`, screenshot **142 KB** (floor 20 KB), tap `tapped:true`, exit 0; and confirmed via the Argent stack that a tap at (0.5, 0.5) lands on the fixture's centered button and increments its counter.