### PR TITLE
fix(skills): degrade argent rule gracefully without argent installed

### DIFF
--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -32,7 +32,7 @@ If argent IS available, ignore the rest of this block and follow this rule norma
 
 If argent is ABSENT, treat it as an expected state, not an error to retry. Do not call `mcp__argent__*` tools, do not run `argent` commands, and do not attempt any argent workflow. Tell the user once, and ask if you should continue without argent:
 
-> Argent isn't installed in this environment. To enable the mobile/Chromium tooling this repo is configured for, run `npx @swmansion/argent init` (or `npm i -g @swmansion/argent && argent init`).
+> Argent isn't installed in this environment. To enable the mobile/Chromium tooling this repo is configured for, run `npx @swmansion/argent init -y` (or `npm i -g @swmansion/argent && argent init -y`).
 > </availability_check>
 
 <tapping_rule>

--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -4,7 +4,7 @@ alwaysApply: true
 ---
 
 <description>
-Argent MCP tools are available in this project for iOS simulator, Android emulator, and Chromium (CDP) app control. Argent MCP tools are the preferred form of interaction with the application. A "Chromium (CDP) app" is any Chromium runtime exposing a Chrome DevTools Protocol endpoint — an Electron app, or any Chromium-family browser (Chrome/Brave/Edge) launched with `--remote-debugging-port`; all are driven through the same tool surface and tagged `platform: "chromium"`.
+If argent is installed and configured in this environment, its MCP tools are the preferred form of interaction with the application for iOS simulator, Android emulator, and Chromium (CDP) app control; otherwise see `<availability_check>` below before attempting any argent workflow. A "Chromium (CDP) app" is any Chromium runtime exposing a Chrome DevTools Protocol endpoint — an Electron app, or any Chromium-family browser (Chrome/Brave/Edge) launched with `--remote-debugging-port`; all are driven through the same tool surface and tagged `platform: "chromium"`.
 Running MCP server and managing the Argent toolkit utilises `argent` command - if asked use `argent --help` for reference.
 To check current version of MCP server run `argent --version` command.
 
@@ -19,6 +19,21 @@ Use cases:
 - Profiling performance or diagnosing re-renders in a React Native app (iOS or Android)
 - Running, debugging, or testing a Chromium (CDP) app — an Electron app (boot with `boot-device` + `electronAppPath`) or a Chromium browser exposing CDP (auto-discovered on port `9222` / `ARGENT_CHROMIUM_PORTS`); on Chromium scroll with `gesture-scroll` and drag with `gesture-drag` — `gesture-swipe` is touch-only
   </description>
+
+<availability_check>
+<important>Run this check once per session, before the first argent tool call or `argent` command. Do not re-probe before later calls.</important>
+
+Confirm argent is available:
+
+1. Are `mcp__argent__*` tools in your tool list? If none are present, argent is not available.
+2. If still unsure, run `command -v argent`. A non-zero exit means the CLI is not on PATH.
+
+If argent IS available, ignore the rest of this block and follow this rule normally.
+
+If argent is ABSENT, treat it as an expected state, not an error to retry. Do not call `mcp__argent__*` tools, do not run `argent` commands, and do not attempt any argent workflow. Tell the user once, and ask if you should continue without argent:
+
+> Argent isn't installed in this environment. To enable the mobile/Chromium tooling this repo is configured for, run `npx @swmansion/argent init` (or `npm i -g @swmansion/argent && argent init`).
+> </availability_check>
 
 <tapping_rule>
 <important>**Never** derive tap coordinates from a screenshot</important>


### PR DESCRIPTION
## Problem

Teams want to commit argent's `.claude/` content (the always-on rule + skills +
agents) into their repos so teammates share the same workflow. Today that
**breaks the agent for anyone who clones the repo without argent installed**.

The always-on rule (`packages/skills/rules/argent.md`) unconditionally asserted
*"Argent MCP tools are available in this project"* and routed the agent into
argent skills and the `argent` CLI. For a teammate with no argent install:
- the committed `.mcp.json` server (`command: "argent"`) can't launch, so no
  `mcp__argent__*` tools appear;
- the `argent` CLI isn't on PATH;
- but the rule still names argent the *preferred* way to work → the agent
  confidently calls missing tools and a missing binary → confusing failures.

## Change

- **Soften the opening claim** from an unconditional assertion to conditional
  phrasing ("If argent is installed and configured… otherwise see
  `<availability_check>`").
- **Add an `<availability_check>` block** that runs **once per session** before
  the first argent tool call / `argent` command:
  1. primary signal — are `mcp__argent__*` tools in the tool list?
  2. secondary probe — `command -v argent`.
  - If present: follow the rule normally (no-op).
  - If absent: treat it as an expected state (not an error to retry), don't
    attempt any argent workflow, and surface a one-time install hint
    (`npx @swmansion/argent init`).

## Scope

- Only `packages/skills/rules/argent.md` (16 insertions, 1 deletion).
- Later steps (an `argent doctor` command for version skew and global-vs-local
  install conflicts) are tracked separately and **not** in this PR.

## Verification

- No-argent path: in a checkout with the committed `.claude/` but argent not on
  PATH, an argent-triggering task ("take a screenshot of the app") makes the
  agent recognize argent is absent, print the install hint, and skip
  `mcp__argent__*` calls.
- Regression check: with argent installed, the "present" path is a no-op and
  normal argent behavior is unchanged.
