### PR TITLE
docs(readme): correct Node version floor and editor config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npx @swmansion/argent init
 
 #### Prerequisites
 
-- **Node.js 18** or later
+- **Node.js 20.11** or later
 - For iOS: macOS with **Xcode** installed
 - For Android: **Android SDK Platform Tools** (`adb`) on `PATH`, and the **Android Emulator** package if you want to boot AVDs from Argent. Create AVDs via Android Studio or `avdmanager`.
 
@@ -121,10 +121,11 @@ argent init
 | Claude Code | `.mcp.json` (project) or `~/.claude.json` (global)                       |
 | Cursor      | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global)            |
 | VS Code     | `.vscode/mcp.json`                                                       |
-| Windsurf    | `.windsurf/mcp.json`                                                     |
+| Windsurf    | `~/.codeium/windsurf/mcp_config.json` (global)                           |
 | Zed         | `.zed/settings.json`                                                     |
 | Gemini CLI  | `.gemini/settings.json`                                                  |
-| Codex CLI   | `.codex/config.yaml`                                                     |
+| Codex CLI   | `.codex/config.toml` (project) or `~/.codex/config.toml` (global)        |
+| Hermes      | `~/.hermes/config.yaml` (global)                                         |
 | opencode    | `opencode.json` (project) or `~/.config/opencode/opencode.json` (global) |
 
 ## Privacy


### PR DESCRIPTION
While verifying the README's setup instructions against the actual code, I found a few factual inaccuracies. All changes are README-only.

### Fixes

- **Node version floor: 18 → 20.11.** The README's prerequisites claim "Node.js 18 or later", but the CLI relies on `import.meta.dirname` (added in Node 20.11) in its very entry path — `packages/argent/src/cli.ts`, `packages/argent/src/bundled-paths.ts`, `packages/argent-installer/src/utils.ts`. On Node 18 that property is `undefined`, so `argent` throws at startup before any command runs. CI only exercises Node 20 and 24, and there is no `engines` field.

- **Windsurf config path.** Was `.windsurf/mcp.json`; the adapter actually writes `~/.codeium/windsurf/mcp_config.json` (global only) — `packages/argent-installer/src/mcp-configs.ts:342-355`.

- **Codex config path.** Was `.codex/config.yaml`; it is `.codex/config.toml` (project) or `~/.codex/config.toml` (global) — `packages/argent-installer/src/mcp-configs.ts:577-592`.

- **Hermes adapter was missing** from the Supported Editors table. It writes `~/.hermes/config.yaml` (global only) and is part of `ALL_ADAPTERS` — `packages/argent-installer/src/mcp-configs.ts:682-695`.

### Scope notes

- Left the "auto-detects your editor" wording as-is — detection is real; the user only confirms the detected set.
- Did not expand the iOS-Simulator/Android-Emulator positioning to mention physical devices / Chromium support — that's a scoping choice, not an inaccuracy.

Opened as draft.