### PR TITLE
fix(skills): remove deprecated or non-existent things from skills/rules

### DIFF
--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -28,7 +28,7 @@ Use `list-devices` to get a target id. Results are tagged with `platform` (`ios`
 1. **Always refer to tapping_rule** from your argent.md rule before tapping.
 2. Before performing interactions, consider whether they can be **dispatched sequentially** - more on that in `run-sequence`.
 3. **Use `gesture-swipe` for lists/scrolling**, not `gesture-custom`, unless you need non-linear movement. On Chromium use `gesture-scroll` instead — `gesture-swipe` is touch-only. Consider whether you need multiple swipes, if yes - use `run-sequence`.
-4. **Tap a text field before typing** — on iOS try `paste` first then fall back to `keyboard`; on Android use `keyboard` directly (`paste` is iOS-only).
+4. **Tap a text field before typing**, then use `keyboard` to enter text.
 5. **Coordinates are normalized** — always 0.0–1.0, not pixels.
 6. **For app navigation, prefer `describe` first.** It works on any screen without app restart. Do not navigate from screenshots on regular in-app screens unless `describe` failed to expose a reliable target. Use `native-describe-screen` only when you need app-scoped UIKit properties.
 
@@ -54,25 +54,24 @@ Common schemes: `messages://`, `settings://`, `maps://?q=<query>`, `tel://<numbe
 
 ## 4. Choosing the Right Tool
 
-| Action            | Tool             | Notes                                                                  |
-| ----------------- | ---------------- | ---------------------------------------------------------------------- |
-| Multiple actions  | `run-sequence`   | Batch steps in one call (no intermediate screenshots)                  |
-| Open an app       | `launch-app`     | **Always — never tap home-screen icons**                               |
-| Restart an app    | `restart-app`    | Terminate and relaunch by bundle ID                                    |
-| Open URL/scheme   | `open-url`       | Web pages, deep links, URL schemes                                     |
-| Single tap        | `gesture-tap`    | Buttons, links, checkboxes                                             |
-| Scroll/swipe      | `gesture-swipe`  | Straight-line scroll or swipe                                          |
-| Scroll (Chromium) | `gesture-scroll` | Wheel-based; deltas are window fractions, positive deltaY = down       |
-| Drag (Chromium)   | `gesture-drag`   | Sliders, drag-and-drop, text selection                                 |
-| Long press        | `gesture-custom` | Context menus, drag start                                              |
-| Drag & drop       | `gesture-custom` | Complex drag interactions                                              |
-| Pinch/zoom        | `gesture-pinch`  | Two-finger pinch with auto-interpolation                               |
-| Rotation          | `gesture-rotate` | Two-finger rotation with auto-interpolation                            |
-| Custom gesture    | `gesture-custom` | Arbitrary touch sequences, optional interpolation                      |
-| Hardware key      | `button`         | Home, back, power, volume, appSwitch, actionButton                     |
-| Type text (fast)  | `paste`          | iOS only. Form fields — uses clipboard                                 |
-| Type text         | `keyboard`       | iOS+Android. Fallback when paste fails; supports Enter, Escape, arrows |
-| Rotate device     | `rotate`         | Orientation changes                                                    |
+| Action            | Tool             | Notes                                                            |
+| ----------------- | ---------------- | ---------------------------------------------------------------- |
+| Multiple actions  | `run-sequence`   | Batch steps in one call (no intermediate screenshots)            |
+| Open an app       | `launch-app`     | **Always — never tap home-screen icons**                         |
+| Restart an app    | `restart-app`    | Terminate and relaunch by bundle ID                              |
+| Open URL/scheme   | `open-url`       | Web pages, deep links, URL schemes                               |
+| Single tap        | `gesture-tap`    | Buttons, links, checkboxes                                       |
+| Scroll/swipe      | `gesture-swipe`  | Straight-line scroll or swipe                                    |
+| Scroll (Chromium) | `gesture-scroll` | Wheel-based; deltas are window fractions, positive deltaY = down |
+| Drag (Chromium)   | `gesture-drag`   | Sliders, drag-and-drop, text selection                           |
+| Long press        | `gesture-custom` | Context menus, drag start                                        |
+| Drag & drop       | `gesture-custom` | Complex drag interactions                                        |
+| Pinch/zoom        | `gesture-pinch`  | Two-finger pinch with auto-interpolation                         |
+| Rotation          | `gesture-rotate` | Two-finger rotation with auto-interpolation                      |
+| Custom gesture    | `gesture-custom` | Arbitrary touch sequences, optional interpolation                |
+| Hardware key      | `button`         | Home, back, power, volume, appSwitch, actionButton               |
+| Type text         | `keyboard`       | iOS+Android. Supports Enter, Escape, arrows                      |
+| Rotate device     | `rotate`         | Orientation changes                                              |
 
 ## 5. Finding Tap Targets
 
@@ -161,14 +160,6 @@ For long-press, drag-and-drop, and other complex sequences, see `references/gest
 
 Values: `home`, `back`, `power`, `volumeUp`, `volumeDown`, `appSwitch`, `actionButton`
 
-### paste — Type text into focused field (iOS only)
-
-```json
-{ "udid": "<UDID>", "text": "Hello, world!" }
-```
-
-Tap the field first, then paste. Fall back to `keyboard` if it doesn't work. On Android the call is rejected by the capability gate ("Tool 'paste' is not supported on android") — use `keyboard` directly.
-
 ### keyboard — Type text or press special keys
 
 ```json
@@ -246,7 +237,7 @@ Use the sequencing when:
 
 ### Allowed tools inside `run-sequence`
 
-`gesture-tap`, `gesture-swipe`, `gesture-custom`, `gesture-pinch`, `gesture-rotate`, `button`, `keyboard`, `rotate`
+`gesture-tap`, `gesture-swipe`, `gesture-scroll`, `gesture-drag`, `gesture-custom`, `gesture-pinch`, `gesture-rotate`, `button`, `keyboard`, `rotate`
 
 The `udid` is shared — do **not** include it in each step's `args`. Optional `delayMs` per step (default 100ms).
 

--- a/packages/skills/skills/argent-native-profiler/SKILL.md
+++ b/packages/skills/skills/argent-native-profiler/SKILL.md
@@ -87,7 +87,7 @@ To revisit a previous trace:
 Bottlenecks are categorized by severity:
 
 - **RED**: CPU functions taking >15% of total time, all UI hangs, and **attributed** memory leaks (those with a resolved responsible frame). These require immediate attention.
-- **YELLOW**: CPU functions taking 5-15% of total time, and **unattributed** memory leaks (`<Call stack limit reached>`, no library — see the memory-leaks caveat below). Worth investigating but may be acceptable.
+- **YELLOW**: CPU functions taking 3-15% of total time, and **unattributed** memory leaks (`<Call stack limit reached>`, no library — see the memory-leaks caveat below). Worth investigating but may be acceptable.
 
 Each bottleneck type indicates a different class of problem:
 

--- a/packages/skills/skills/argent-test-ui-flow/SKILL.md
+++ b/packages/skills/skills/argent-test-ui-flow/SKILL.md
@@ -58,9 +58,9 @@ Steps:
 ```
 1. screenshot → see login screen
 2. gesture-tap { x: 0.5, y: 0.4 }  → tap email field
-3. paste { text: "user@example.com" }
+3. keyboard { text: "user@example.com" }
 4. gesture-tap { x: 0.5, y: 0.55 } → tap password field
-5. paste { text: "password123" }
+5. keyboard { text: "password123" }
 6. gesture-tap { x: 0.5, y: 0.7 }  → tap Login button
 7. screenshot → verify home screen appeared
 ```
@@ -101,7 +101,6 @@ Steps:
 
 ## Tips
 
-- **Use `paste` for text entry on iOS** — faster and more reliable than key-by-key `keyboard`. `paste` is iOS-only; on Android use `keyboard` instead.
 - **Use `gesture-custom` for long-press** context menus (800ms hold).
 - **Report clearly**: state what you expected, what you saw, and the verdict.
 - **Permission modals**: try `describe` first. Use `screenshot` only as fallback, tap one visible button at a time, and verify with the returned screenshot before continuing.

--- a/packages/tool-server/src/tools/devices/list-devices.ts
+++ b/packages/tool-server/src/tools/devices/list-devices.ts
@@ -86,7 +86,7 @@ export const listDevicesTool: ToolDefinition<Record<string, never>, ListDevicesR
 Use at the start of a session to pick a target id ('udid' for iOS entries, 'serial' for Android/Vega entries, 'id' for Chromium) to pass to interaction tools, and to see which targets are already running.
 Returns { devices, avds } where each device carries a 'platform' discriminator ('ios', 'android', 'chromium', or 'vega'); 'avds' lists Android AVDs bootable via boot-device. A Vega VVD is listed under 'devices' whether running or stopped (state 'running'/'stopped'); start a stopped one with boot-device using its 'vvdImage'.
 Android entries also carry a 'kind' ('emulator' for a local AVD, 'device' for a physical phone connected over USB / wireless adb) — physical phones are detected from \`adb devices\` (any serial that is not an \`emulator-*\` one) and are driven through the same interaction tools as emulators; they do not need boot-device (just connect the phone with USB debugging authorised).
-Chromium apps are discovered by probing CDP debugging ports (default 9222; extend via the ARGENT_CHROMIUM_PORTS=<comma-separated-ports> env var). They must already be running with --remote-debugging-port=<port> — use boot-device with chromiumAppPath to launch one.
+Chromium apps are discovered by probing CDP debugging ports (default 9222; extend via the ARGENT_CHROMIUM_PORTS=<comma-separated-ports> env var). They must already be running with --remote-debugging-port=<port> — use boot-device with electronAppPath to launch one.
 Booted/ready devices are listed first. Platforms whose CLI is unavailable are silently omitted — an empty result usually means xcode-select, Android platform-tools, or the Vega SDK is not installed.`,
   alwaysLoad: true,
   searchHint:

--- a/packages/tool-server/src/tools/keyboard/index.ts
+++ b/packages/tool-server/src/tools/keyboard/index.ts
@@ -19,9 +19,7 @@ const zodSchema = z.object({
   text: z
     .string()
     .optional()
-    .describe(
-      "Text to type character by character. Handles uppercase and common punctuation. Use when paste is unreliable."
-    ),
+    .describe("Text to type character by character. Handles uppercase and common punctuation."),
   key: z
     .string()
     .optional()
@@ -183,7 +181,7 @@ Use when you need to enter text or trigger a named key such as enter, escape, or
 Returns { typed: string, keys: number }. Fails if an unsupported key name is provided or the backend is not reachable for the given device.
 - text: types a string character by character (supports uppercase, digits, common punctuation)
 - key: presses a single named key (enter, escape, backspace, tab, arrow-up/down/left/right, f1–f12)
-Provide text, key, or both. Use instead of paste when paste is unreliable or unsupported by the focused field.`,
+Provide text, key, or both.`,
   zodSchema,
   capability,
   services: (params): Record<string, ServiceRef> => {

--- a/packages/tool-server/src/utils/ios-profiler/IOS_PROFILER_REFERENCE.md
+++ b/packages/tool-server/src/utils/ios-profiler/IOS_PROFILER_REFERENCE.md
@@ -205,8 +205,6 @@ For each iOS hang the tool maps `[hangStart, hangEnd]` → wall-clock and looks 
 | Memory leak | attributed (resolved responsible frame)                      | RED          |
 | Memory leak | unattributed (`<Call stack limit reached>` under `--attach`) | YELLOW       |
 
-> Note: `argent-native-profiler/SKILL.md` currently documents the YELLOW band as 5–15 %. The implementation uses 3–15 % (`MIN_WEIGHT_PERCENTAGE = 3` in `02-aggregate.ts`). The code is the source of truth.
-
 ---
 
 ## 11. Caveats worth keeping in mind


### PR DESCRIPTION
## Summary
Audited the shipped skills, rules, and tool descriptions for references to things that no longer exist or no longer match the implementation, and corrected them. No behavior changes — these are documentation/description fixes that keep agent-facing guidance in sync with the actual tool surface and code.

## Changes

**Text entry → standardize on `keyboard`**
- `argent-device-interact`: best-practice step and the "Choosing the Right Tool" table now point text entry at the cross-platform `keyboard` tool; dropped the standalone text-entry subsection that referenced `paste`.
- `argent-test-ui-flow`: login-flow example and the Tips section now use `keyboard`.
- `keyboard` tool (`keyboard/index.ts`): removed the `paste` cross-references from the `text` param and tool descriptions.
- *(The `paste` tool source is left untouched.)*

**`run-sequence` allowed-tools list (`argent-device-interact`)**
- Added the Chromium gesture tools `gesture-scroll` and `gesture-drag`, which were missing from the documented allow-list.

**`boot-device` parameter name (`list-devices.ts`)**
- Tool description referenced a non-existent `chromiumAppPath`; corrected to the real parameter `electronAppPath`.

**Native-profiler YELLOW band (`argent-native-profiler` + `IOS_PROFILER_REFERENCE.md`)**
- Corrected the documented YELLOW severity range from `5–15%` to `3–15%` to match the implementation (`MIN_WEIGHT_PERCENTAGE = 3` in `02-aggregate.ts`).
- Removed the now-obsolete reconciliation note in `IOS_PROFILER_REFERENCE.md` that flagged the doc/code mismatch.
