### PR TITLE
ci(wayland-e2e): poll for a warm screenshot instead of a single fixed sleep

### DIFF
--- a/.github/workflows/wayland-e2e.yml
+++ b/.github/workflows/wayland-e2e.yml
@@ -222,26 +222,44 @@ jobs:
 
       - name: Screenshot returns real pixels (not all-zero framebuffer)
         run: |
-          set -e
-          # After boot_completed=1 the SurfaceFlinger compositor needs a few
-          # more seconds to paint the lockscreen UI. On fast cold boots (~40s)
-          # screencap can still return an all-zero framebuffer if taken
-          # immediately. 15s is enough headroom without meaningfully extending
-          # the overall job time.
-          sleep 15
-          curl -sS -m 60 -X POST http://127.0.0.1:3033/tools/screenshot \
-            -H 'Content-Type: application/json' \
-            -d '{"udid":"emulator-5554"}' > /tmp/shot.json
-          # The screenshot tool returns an ArtifactHandle ({ image: { hostPath, ... } })
-          # since the remote-artifacts change; the job runs co-located with the
-          # tool-server so hostPath is directly readable.
-          PATH_PNG=$(python3 -c "import json,sys;print(json.load(open('/tmp/shot.json'))['data']['image']['hostPath'])")
-          cp "$PATH_PNG" /tmp/wayland-cold-boot.png
-          SZ=$(stat -c%s /tmp/wayland-cold-boot.png)
-          echo "size=${SZ}B"
-          # All-zero framebuffer PNG-compresses to ~3-7 KB. Lockscreen UI
-          # (clock + battery + nav pill) is reliably > 20 KB.
-          test "$SZ" -gt 20000 || { echo "screenshot too small"; exit 1; }
+          set -u
+          # After boot_completed=1 two things still need to settle before a
+          # screenshot carries real pixels: SurfaceFlinger has to paint the
+          # lockscreen UI, and the simulator-server's screenshot stream only
+          # starts warming on the first capture request. An immediate screencap
+          # can therefore return either a "no image to export" error (cold stream,
+          # response has no .data envelope) or an all-zero framebuffer that
+          # PNG-compresses to a few KB. A single fixed sleep races both of these,
+          # which is flaky on slow/contended runners. Poll instead: each request
+          # also warms the stream, so we retry until we get a real frame or time
+          # out. All-zero framebuffer compresses to ~3-7 KB; the real lockscreen
+          # UI (clock + battery + nav pill) is reliably > 20 KB.
+          attempts=15
+          for i in $(seq 1 "$attempts"); do
+            curl -sS -m 60 -X POST http://127.0.0.1:3033/tools/screenshot \
+              -H 'Content-Type: application/json' \
+              -d '{"udid":"emulator-5554"}' > /tmp/shot.json || true
+            # The screenshot tool returns an ArtifactHandle ({ data: { image:
+            # { hostPath, ... } } }); the job runs co-located with the tool-server
+            # so hostPath is directly readable. A cold stream returns
+            # { error: "...no image to export" } with no .data — tolerate that and
+            # retry rather than aborting the step.
+            PATH_PNG=$(python3 -c "import json;print(json.load(open('/tmp/shot.json'))['data']['image']['hostPath'])" 2>/dev/null || true)
+            if [ -n "$PATH_PNG" ] && [ -f "$PATH_PNG" ]; then
+              cp "$PATH_PNG" /tmp/wayland-cold-boot.png
+              SZ=$(stat -c%s /tmp/wayland-cold-boot.png)
+              echo "attempt ${i}/${attempts}: size=${SZ}B"
+              if [ "$SZ" -gt 20000 ]; then
+                echo "got a real frame after ${i} attempt(s)"
+                exit 0
+              fi
+            else
+              echo "attempt ${i}/${attempts}: no image yet ($(head -c 160 /tmp/shot.json))"
+            fi
+            sleep 4
+          done
+          echo "screenshot never returned a real frame after ${attempts} attempts"
+          exit 1
 
       - name: gesture-tap round-trips
         run: |

--- a/.github/workflows/wayland-e2e.yml
+++ b/.github/workflows/wayland-e2e.yml
@@ -222,7 +222,7 @@ jobs:
 
       - name: Screenshot returns real pixels (not all-zero framebuffer)
         run: |
-          set -u
+          set -euo pipefail
           # After boot_completed=1 two things still need to settle before a
           # screenshot carries real pixels: SurfaceFlinger has to paint the
           # lockscreen UI, and the simulator-server's screenshot stream only
@@ -234,9 +234,13 @@ jobs:
           # also warms the stream, so we retry until we get a real frame or time
           # out. All-zero framebuffer compresses to ~3-7 KB; the real lockscreen
           # UI (clock + battery + nav pill) is reliably > 20 KB.
+          # A healthy capture returns sub-second (and a cold stream errors
+          # immediately), so a tight per-attempt timeout keeps the cadence near
+          # the 4s interval and bounds the worst case (~6 min if the tool-server
+          # wedges) instead of 15x60s.
           attempts=15
           for i in $(seq 1 "$attempts"); do
-            curl -sS -m 60 -X POST http://127.0.0.1:3033/tools/screenshot \
+            curl -sS -m 20 -X POST http://127.0.0.1:3033/tools/screenshot \
               -H 'Content-Type: application/json' \
               -d '{"udid":"emulator-5554"}' > /tmp/shot.json || true
             # The screenshot tool returns an ArtifactHandle ({ data: { image:
@@ -256,7 +260,8 @@ jobs:
             else
               echo "attempt ${i}/${attempts}: no image yet ($(head -c 160 /tmp/shot.json))"
             fi
-            sleep 4
+            # No need to wait after the final attempt before failing.
+            if [ "$i" -lt "$attempts" ]; then sleep 4; fi
           done
           echo "screenshot never returned a real frame after ${attempts} attempts"
           exit 1


### PR DESCRIPTION
## Problem

The **Boot + drive AVD on headless Weston** job's *"Screenshot returns real pixels"* step takes a single screenshot 15s after `boot_completed` and asserts it is > 20 KB. That single shot races **two** independent warm-up delays:

1. SurfaceFlinger painting the lockscreen UI, and
2. the simulator-server's screenshot stream, which only starts warming on the **first capture request**.

On slow/contended runners the one-and-only capture comes back as either:
- `{"error":"...no image to export"}` — a cold stream, response has no `.data` envelope, so the step's `json.load(...)['data']` raises `KeyError: 'data'`; or
- an all-zero framebuffer that PNG-compresses to ~3–7 KB and fails the `> 20 KB` check.

Either way the step fails even though the boot was healthy. This is intermittent — the same commit passes most runs and fails some.

## Fix

Replace the single fixed `sleep 15` + one capture with a **bounded poll** (15 attempts, 4s apart). Each request also warms the stream, and the loop exits as soon as a frame exceeds 20 KB. A cold-stream error response is tolerated and retried rather than aborting the step. Genuinely broken framebuffers still fail, now with per-attempt diagnostics in the log.

- Healthy boots pass in the first attempt or two (no slower than before in the common case).
- Worst-case added headroom is ~60s, only spent when the framebuffer never warms — which is a real failure worth surfacing.

## Verification

The workflow file is unchanged elsewhere; only this step's `run:` script changed.

- `prettier --check` passes on the workflow file.
- Extracted the exact `run:` script and ran it against a mock `curl` covering: cold-error → all-zero frame → real frame (exits 0 on the real frame); always-cold (exits 1 after 15 attempts); always all-zero framebuffer (exits 1). Exit codes confirmed 0 / 1 respectively.