### PR TITLE
fix(ios-profiler): set maxBuffer on xctrace export to stop ENOBUFS killing every export

### DIFF
--- a/packages/tool-server/src/utils/ios-profiler/export.ts
+++ b/packages/tool-server/src/utils/ios-profiler/export.ts
@@ -33,7 +33,7 @@ export interface ExportDiagnostics {
  * Run `xctrace export --toc` to discover what tables/schemas exist in the trace.
  * Returns an array of schema names found in the TOC.
  */
-function discoverTraceSchemas(traceFile: string): string[] {
+function discoverTraceSchemas(traceFile: string, diagnostics?: ExportDiagnostics): string[] {
   try {
     const toc = execSyncWithTimeout(`xctrace export --input "${traceFile}" --toc`, {
       encoding: "utf-8",
@@ -46,7 +46,13 @@ function discoverTraceSchemas(traceFile: string): string[] {
       schemas.push(m[1]);
     }
     return schemas;
-  } catch {
+  } catch (err) {
+    // Record rather than swallow: a `--toc` failure (e.g. ENOBUFS, timeout)
+    // leaves us with no schema list, which previously surfaced downstream as a
+    // misleading "schema not found / brute-force failed" message.
+    if (diagnostics) {
+      diagnostics.errors.toc = err instanceof Error ? err.message : String(err);
+    }
     return [];
   }
 }
@@ -56,7 +62,7 @@ function discoverTraceSchemas(traceFile: string): string[] {
  * Falls back to trying known schema candidates if TOC parsing fails.
  */
 function resolveCpuXpath(traceFile: string, diagnostics: ExportDiagnostics): string | null {
-  const tocSchemas = discoverTraceSchemas(traceFile);
+  const tocSchemas = discoverTraceSchemas(traceFile, diagnostics);
   diagnostics.tocSchemas = tocSchemas;
 
   if (tocSchemas.length > 0) {

--- a/packages/tool-server/src/utils/ios-profiler/run-with-timeout.ts
+++ b/packages/tool-server/src/utils/ios-profiler/run-with-timeout.ts
@@ -3,6 +3,15 @@ import { execSync as nodeExecSync, type ExecSyncOptions } from "child_process";
 export const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
 
 /**
+ * `xctrace export` floods stderr with multi-megabyte progress/symbolication
+ * noise (observed ~4.4 MB for a single `--toc` on a 122 MB trace). Node's
+ * default `maxBuffer` is only 1 MiB, so spawnSync throws `ENOBUFS` on every
+ * export command before xctrace ever evaluates the xpath — which previously
+ * masqueraded as a "schema not found" failure. 256 MiB gives ample headroom.
+ */
+export const DEFAULT_EXEC_MAX_BUFFER = 256 * 1024 * 1024;
+
+/**
  * Wrapper around execSync that always supplies a timeout. A misbehaving
  * `xctrace export`, `xctrace version`, or shelled-out helper would otherwise
  * block the Node event loop indefinitely.
@@ -13,6 +22,7 @@ export function execSyncWithTimeout(
 ): Buffer | string {
   return nodeExecSync(command, {
     timeout: DEFAULT_EXEC_TIMEOUT_MS,
+    maxBuffer: DEFAULT_EXEC_MAX_BUFFER,
     ...options,
   });
 }


### PR DESCRIPTION
## Problem

`native-profiler-stop` produces **zero usable data on the iOS simulator**. The export step reports what looks like two unrelated failures:

- `cpu: "Brute-force export also failed for schemas: [time-profile, cpu-profile, time-sample]."`
- `hangs: "spawnSync /bin/sh ENOBUFS"`, `leaks: "spawnSync /bin/sh ENOBUFS"`

These are actually **one root cause**, and the "schema mismatch" is a phantom.

## Root cause

`execSyncWithTimeout` (`run-with-timeout.ts`) wraps `execSync` with a timeout but never sets `maxBuffer`, so Node defaults to **1 MiB**. `xctrace export` floods **stderr** with progress/symbolication noise — measured **~4.4 MB** for a single `--toc` on a 122 MB trace. Node captures stderr into the spawnSync buffer, it overflows, and spawnSync throws `ENOBUFS` on **every** export command before xctrace even evaluates the xpath.

Cascade for the CPU path:
1. `discoverTraceSchemas()` → `--toc` → ENOBUFS → swallowed by a bare `catch {}` → returns `[]`.
2. `resolveCpuXpath()` sees an empty schema list → returns `null` (no diagnostic).
3. `tryCpuExportFallback()` brute-forces all candidate schemas — each ENOBUFS-es on stderr → "failed for all schemas".

But the schema was never wrong: the TOC actually contains `time-profile` and `time-sample` (and `potential-hangs`). It was just invisible because discovery died on the same buffer overflow.

## Fix

Set `maxBuffer` to 256 MiB centrally in `execSyncWithTimeout` (covers all four xctrace call sites). Also record the `--toc` discovery error into `diagnostics` instead of swallowing it, so a future failure surfaces honestly rather than masquerading as a missing schema.

## Verification

Same export command on a real 122 MB trace, only `maxBuffer` differs:

| `maxBuffer` | Result |
|---|---|
| default (1 MiB) | ❌ `ENOBUFS` |
| 256 MiB | ✅ success — 63 MB CPU XML, **81,801** sample rows |

`tsc --noEmit` clean for `tool-server`.

## Scope

iOS-only. Android's Perfetto native-profiler chain (`adb pull` + protobuf, no xctrace stderr firehose) is unaffected and was verified working end-to-end during the same test sweep.

Found while running a full cross-platform sweep of the Argent MCP tool surface (iOS / Android / Chromium).