### PR TITLE
fix(ios-profiler): make xctrace export async so native-profiler-stop can't trip the tool-server health check

### DIFF
--- a/packages/tool-server/src/tools/profiler/native-profiler/platforms/ios.ts
+++ b/packages/tool-server/src/tools/profiler/native-profiler/platforms/ios.ts
@@ -462,7 +462,7 @@ export async function stopNativeProfilerIos(api: NativeProfilerSessionApi): Prom
     api.recordingExitedUnexpectedly = false;
     api.lastExitInfo = null;
 
-    const { files: exportedFiles, diagnostics } = exportIosTraceData(traceFile);
+    const { files: exportedFiles, diagnostics } = await exportIosTraceData(traceFile);
     api.exportedFiles = exportedFiles;
 
     const warning = wasTimeout
@@ -514,7 +514,7 @@ export async function stopNativeProfilerIos(api: NativeProfilerSessionApi): Prom
   api.recordingExitedUnexpectedly = false;
   api.lastExitInfo = null;
 
-  const { files: exportedFiles, diagnostics } = exportIosTraceData(api.traceFile);
+  const { files: exportedFiles, diagnostics } = await exportIosTraceData(api.traceFile);
   api.exportedFiles = exportedFiles;
 
   const stopResult: IosStopResult = {

--- a/packages/tool-server/src/utils/ios-profiler/export.ts
+++ b/packages/tool-server/src/utils/ios-profiler/export.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { execSyncWithTimeout } from "./run-with-timeout";
+import { execAsyncWithTimeout } from "./run-with-timeout";
 
 /**
  * Known xctrace schema names that contain CPU time-profile data.
@@ -33,12 +33,14 @@ export interface ExportDiagnostics {
  * Run `xctrace export --toc` to discover what tables/schemas exist in the trace.
  * Returns an array of schema names found in the TOC.
  */
-function discoverTraceSchemas(traceFile: string, diagnostics?: ExportDiagnostics): string[] {
+async function discoverTraceSchemas(
+  traceFile: string,
+  diagnostics?: ExportDiagnostics
+): Promise<string[]> {
   try {
-    const toc = execSyncWithTimeout(`xctrace export --input "${traceFile}" --toc`, {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    }) as string;
+    const { stdout: toc } = await execAsyncWithTimeout(
+      `xctrace export --input "${traceFile}" --toc`
+    );
     const schemas: string[] = [];
     const schemaRe = /schema="([^"]+)"/g;
     let m;
@@ -61,8 +63,11 @@ function discoverTraceSchemas(traceFile: string, diagnostics?: ExportDiagnostics
  * Find the correct CPU schema xpath by checking the trace TOC.
  * Falls back to trying known schema candidates if TOC parsing fails.
  */
-function resolveCpuXpath(traceFile: string, diagnostics: ExportDiagnostics): string | null {
-  const tocSchemas = discoverTraceSchemas(traceFile, diagnostics);
+async function resolveCpuXpath(
+  traceFile: string,
+  diagnostics: ExportDiagnostics
+): Promise<string | null> {
+  const tocSchemas = await discoverTraceSchemas(traceFile, diagnostics);
   diagnostics.tocSchemas = tocSchemas;
 
   if (tocSchemas.length > 0) {
@@ -85,20 +90,17 @@ function resolveCpuXpath(traceFile: string, diagnostics: ExportDiagnostics): str
  * Try exporting CPU data with each known schema name until one succeeds.
  * Used as a fallback when TOC discovery doesn't find a match or fails.
  */
-function tryCpuExportFallback(
+async function tryCpuExportFallback(
   traceFile: string,
   outPath: string,
   diagnostics: ExportDiagnostics
-): boolean {
+): Promise<boolean> {
   const triedSchemas: string[] = [];
   for (const candidate of CPU_SCHEMA_CANDIDATES) {
     const xpath = `/trace-toc/run[@number="1"]/data/table[@schema="${candidate}"]`;
     try {
-      execSyncWithTimeout(
-        `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${xpath}'`,
-        {
-          stdio: "pipe",
-        }
+      await execAsyncWithTimeout(
+        `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${xpath}'`
       );
       diagnostics.cpuSchemaUsed = candidate;
       return true;
@@ -112,10 +114,10 @@ function tryCpuExportFallback(
   return false;
 }
 
-export function exportIosTraceData(traceFile: string): {
+export async function exportIosTraceData(traceFile: string): Promise<{
   files: Record<string, string | null>;
   diagnostics: ExportDiagnostics;
-} {
+}> {
   const exportedFiles: Record<string, string | null> = {};
   const diagnostics: ExportDiagnostics = {
     tocSchemas: [],
@@ -130,13 +132,12 @@ export function exportIosTraceData(traceFile: string): {
 
     if (key === "cpu") {
       // Dynamic CPU schema resolution
-      const resolvedXpath = resolveCpuXpath(traceFile, diagnostics);
+      const resolvedXpath = await resolveCpuXpath(traceFile, diagnostics);
 
       if (resolvedXpath) {
         try {
-          execSyncWithTimeout(
-            `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${resolvedXpath}'`,
-            { stdio: "pipe" }
+          await execAsyncWithTimeout(
+            `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${resolvedXpath}'`
           );
           exportedFiles[key] = outPath;
           continue;
@@ -148,7 +149,7 @@ export function exportIosTraceData(traceFile: string): {
       }
 
       // Fallback: brute-force try all known CPU schemas
-      if (tryCpuExportFallback(traceFile, outPath, diagnostics)) {
+      if (await tryCpuExportFallback(traceFile, outPath, diagnostics)) {
         exportedFiles[key] = outPath;
       } else {
         exportedFiles[key] = null;
@@ -167,9 +168,8 @@ export function exportIosTraceData(traceFile: string): {
     // export` does not accept; the first attempt always failed and fell back to
     // this same plain export, so it has been removed.)
     try {
-      execSyncWithTimeout(
-        `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${config.xpath}'`,
-        { stdio: "pipe" }
+      await execAsyncWithTimeout(
+        `xctrace export --input "${traceFile}" --output "${outPath}" --xpath '${config.xpath}'`
       );
       exportedFiles[key] = outPath;
     } catch (err) {

--- a/packages/tool-server/src/utils/ios-profiler/run-with-timeout.ts
+++ b/packages/tool-server/src/utils/ios-profiler/run-with-timeout.ts
@@ -1,28 +1,49 @@
-import { execSync as nodeExecSync, type ExecSyncOptions } from "child_process";
+import { exec as nodeExec, type ExecOptions } from "child_process";
+import { promisify } from "util";
 
 export const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
 
 /**
  * `xctrace export` floods stderr with multi-megabyte progress/symbolication
- * noise (observed ~4.4 MB for a single `--toc` on a 122 MB trace). Node's
- * default `maxBuffer` is only 1 MiB, so spawnSync throws `ENOBUFS` on every
- * export command before xctrace ever evaluates the xpath — which previously
- * masqueraded as a "schema not found" failure. 256 MiB gives ample headroom.
+ * noise (observed ~4.4 MB for a single `--toc` on a 122 MB trace, and far more
+ * for a host-wide `--all-processes` capture). Node's default `maxBuffer` is
+ * only 1 MiB, so the export command throws `ENOBUFS` before xctrace ever
+ * evaluates the xpath — which previously masqueraded as a "schema not found"
+ * failure. 256 MiB gives ample headroom.
  */
 export const DEFAULT_EXEC_MAX_BUFFER = 256 * 1024 * 1024;
 
 /**
- * Wrapper around execSync that always supplies a timeout. A misbehaving
- * `xctrace export`, `xctrace version`, or shelled-out helper would otherwise
- * block the Node event loop indefinitely.
+ * Async wrapper around `exec` that always supplies a timeout and a generous
+ * `maxBuffer`.
+ *
+ * This MUST stay async (`exec` + `await`), never `execSync`. A single
+ * `native-profiler-stop` runs four `xctrace export` passes (TOC discovery, CPU,
+ * hangs, leaks); under the host-wide `--all-processes` capture each pass exports
+ * tens of MB and the whole stop takes ~30s+. With `execSync` that work freezes
+ * the tool-server's event loop for the full duration, so its `/tools` health
+ * endpoint stops answering. The MCP client treats a health check that misses
+ * its 2s window as a dead server, respawns a replacement tool-server, and
+ * rotates the auth token — which 401s the very stop request that was about to
+ * succeed. Keeping the export non-blocking leaves the event loop free to answer
+ * health checks while xctrace runs.
+ *
+ * The `timeout` still caps a genuinely-stuck `xctrace` so it cannot hang the
+ * stop forever; with async exec that timeout no longer also pins the event loop.
  */
-export function execSyncWithTimeout(
+export async function execAsyncWithTimeout(
   command: string,
-  options: ExecSyncOptions & { timeout?: number } = {}
-): Buffer | string {
-  return nodeExecSync(command, {
+  options: ExecOptions = {}
+): Promise<{ stdout: string; stderr: string }> {
+  // `promisify` is resolved per-call (not at module load) so that test suites
+  // which `vi.doMock("child_process", …)` without an `exec` export can still
+  // import this module — matching the original lazy `execSync` usage.
+  const execAsync = promisify(nodeExec);
+  const { stdout, stderr } = await execAsync(command, {
     timeout: DEFAULT_EXEC_TIMEOUT_MS,
     maxBuffer: DEFAULT_EXEC_MAX_BUFFER,
+    encoding: "utf-8",
     ...options,
   });
+  return { stdout: stdout as string, stderr: stderr as string };
 }

--- a/packages/tool-server/test/ios-instruments/stop-recovery.test.ts
+++ b/packages/tool-server/test/ios-instruments/stop-recovery.test.ts
@@ -114,7 +114,7 @@ describe("handleXctraceExit", () => {
 describe("native-profiler-stop recovery branch", () => {
   beforeEach(() => {
     mockedExport.mockReset();
-    mockedExport.mockReturnValue(FAKE_EXPORT_RESULT);
+    mockedExport.mockResolvedValue(FAKE_EXPORT_RESULT);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Problem

On the newest main (0.12.1), `native-profiler-stop` on an iOS 26.5 sim returns:

```
Missing or invalid Authorization header. Tool-server requires `Authorization: Bearer <token>`…
```

…even though the trace export actually completes and the XML lands on disk. Reproduced profiling Settings on a 26.5 sim.

## Root cause — event-loop starvation, not a profiler bug

1. `native-profiler-stop` runs **four** `xctrace export` passes (TOC discovery, CPU, hangs, leaks) through `execSyncWithTimeout` → `child_process.execSync`, which **blocks the Node event loop** for the entire export.
2. iOS 26.5 forces the host-wide `--all-processes` capture fallback (the `xctrace --device` deadlock workaround, #380). That export is ~44 MB and the whole stop takes **~34 s** (`durationMs: 34083` in `mcp-calls.log`).
3. While the loop is frozen, the tool-server's `GET /tools` health endpoint can't answer. The MCP client's `ensureToolsServer()` gates every call on `isToolsServerHealthy()` with a **hard 2 s timeout**:
   ```js
   const healthy = await isToolsServerHealthy(state.port, host, 2e3, state.token); // 2s
   if (healthy) return {…reuse…};
   await clearState();
   const token = generateToken();   // ← respawn + NEW token
   ```
4. The busy-but-alive server fails the 2 s check → the client declares it dead, **spawns a second tool-server and rotates the auth token** in `~/.argent/tool-server.json` → the in-flight stop is 401'd. Confirmed live: one MCP client, *two* `tool-server.cjs` processes.

The recording **start** path already uses async `spawn` + `await`, which is why it never trips this; only the export path was synchronous.

## Fix

Convert the four export passes to async (`exec` + `await`) so the event loop stays free to answer health checks while `xctrace` runs. Carried over verbatim onto the async wrapper:
- `timeout: 60_000` — still caps a genuinely-stuck `xctrace`.
- `maxBuffer: 256 MiB` — the ENOBUFS fix (#382); `exec` honors it.

`promisify(exec)` is resolved per-call (not at module load) so test suites that `vi.doMock("child_process", …)` without an `exec` export still import the module — matching the original lazy `execSync` usage.

This does **not** change stop latency (the export is genuinely slow) — it makes it **non-blocking**, which is the actual bug. Concurrent calls (health checks, screenshots) now work during a long stop.

## Not addressed here (follow-ups)

- **MCP respawn hardening:** `ensureToolsServer()` still rotates the token / abandons in-flight requests against a *still-alive* PID the moment a health check misses. Async export removes this trigger; the brittle respawn behaviour is a separate fix.
- **Analyze path:** if `native-profiler-analyze` parses the 44 MB XML synchronously it can block the loop similarly — worth checking next.

## Testing

- `tsc --noEmit` clean
- `eslint` clean on changed files
- Full tool-server suite: **1314 tests pass** (incl. `test/ios-instruments/`, 34 tests). Updated the `exportIosTraceData` mock from `mockReturnValue` → `mockResolvedValue`.