### PR TITLE
fix(argent-lens): serve preview UI when installed under a dot-path (nvm/fnm/volta/asdf)

### DIFF
--- a/packages/tool-server/src/preview.ts
+++ b/packages/tool-server/src/preview.ts
@@ -34,6 +34,18 @@ function findUiFile(name: string): string | null {
   return null;
 }
 
+// Serve a resolved preview-UI file. We go through `sendFile` with an explicit
+// `root` instead of passing the absolute path directly: Express 5's `send`
+// defaults to `dotfiles: "ignore"`, which 404s any path containing a dot-segment.
+// argent is routinely installed under one (nvm's `~/.nvm/...`, fnm, volta,
+// asdf), so `sendFile(absolutePath)` silently fails there and the Lens preview
+// window can't load. Scoping to `{ root: dir }` makes the request path just the
+// basename — no dot-segment — so the file is served regardless of install path.
+export function serveUiFile(res: Response, filePath: string, contentType: string): void {
+  res.set("Cache-Control", "no-store, must-revalidate");
+  res.type(contentType).sendFile(path.basename(filePath), { root: path.dirname(filePath) });
+}
+
 function wsUrlFromHttp(httpUrl: string): string {
   const u = new URL(httpUrl);
   const scheme = u.protocol === "https:" ? "wss:" : "ws:";
@@ -340,8 +352,7 @@ export function createPreviewRouter(registry: Registry): Router {
       res.status(404).type("text/plain").send("theme.css not found");
       return;
     }
-    res.set("Cache-Control", "no-store, must-revalidate");
-    res.type("text/css").sendFile(p);
+    serveUiFile(res, p, "text/css");
   });
 
   router.get("/", (req: Request, res: Response) => {
@@ -360,10 +371,7 @@ export function createPreviewRouter(registry: Registry): Router {
       res.status(404).type("text/plain").send("Preview UI not found");
       return;
     }
-    // Dev-style no-cache so edits to packages/ui/index.html are picked up on
-    // reload without the user having to hard-refresh.
-    res.set("Cache-Control", "no-store, must-revalidate");
-    res.type("text/html").sendFile(p);
+    serveUiFile(res, p, "text/html");
   });
 
   return router;

--- a/packages/tool-server/test/preview-ui-dotfile.test.ts
+++ b/packages/tool-server/test/preview-ui-dotfile.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import supertest from "supertest";
+
+import { serveUiFile } from "../src/preview";
+
+// Regression guard for the Express 5 `send` dotfiles default (`dotfiles: "ignore"`),
+// which 404s any file path containing a dot-segment. argent is routinely installed
+// under such a path — nvm (`~/.nvm/...`), fnm, volta, asdf — so a bare
+// `res.sendFile(absolutePath)` made the Lens preview window fail to load its UI
+// (`/preview/` and `/preview/theme.css` returned NotFoundError). serveUiFile must
+// serve the file regardless of where on disk it lives.
+describe("serveUiFile under a dot-segment install path", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    // Directory name starts with "." — the exact shape that trips send's dotfile
+    // filter, mirroring an install at ~/.nvm/.../preview-ui.
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), ".argent-dotfix-"));
+    fs.writeFileSync(path.join(dir, "index.html"), "<!doctype html><title>lens</title>");
+    fs.writeFileSync(path.join(dir, "theme.css"), ":root{--accent:#0a7ea4}");
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function appServing(file: string, contentType: string) {
+    const app = express();
+    app.get("/x", (_req, res) => serveUiFile(res, path.join(dir, file), contentType));
+    return app;
+  }
+
+  it("serves index.html from a dot-path (200, not 404)", async () => {
+    const res = await supertest(appServing("index.html", "text/html")).get("/x");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain("lens");
+  });
+
+  it("serves theme.css from a dot-path (200, not 404)", async () => {
+    const res = await supertest(appServing("theme.css", "text/css")).get("/x");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/css/);
+    expect(res.text).toContain("--accent");
+  });
+});


### PR DESCRIPTION
## Problem

The Argent Lens preview window fails to load its UI for anyone whose argent is installed under a path containing a **dot-segment** — most commonly Node managed by **nvm** (`~/.nvm/...`), but also fnm, volta, and asdf. Instead of the variant-selection UI the window shows a raw `NotFoundError: Not Found`, and `await_user_selection` then blocks forever.

Concretely, on such installs:
- `GET /preview/` (index.html) → **404**
- `GET /preview/theme.css` → **404**
- JSON routes (e.g. `GET /preview/simulators`) → 200

## Root cause

Regressed by the express 4 → 5 bump (#354), shipped in **v0.12.1**. Express 5's `send@1` defaults to `dotfiles: "ignore"`, which 404s any file path containing a dot-segment. The preview routes call `res.sendFile(absolutePath)` where `absolutePath` is the on-disk install location; under nvm that path includes the `.nvm` segment, so `send` refuses to serve it.

Reproduced in isolation against `express@5.2.1` / `send@1.2.1` (the shipped versions):

| call | result |
| --- | --- |
| `res.sendFile("/Users/…/.nvm/…/index.html")` | **404** |
| same file copied to a non-dot path | 200 |
| `res.sendFile(basename, { root: dir })` | 200 |
| any of the above on `express@4.22.1` | 200 |

The express-4 column confirms the bump is the regression; the `{ root }` column is the fix.

## Fix

Serve the preview UI via `sendFile(basename, { root: dir })` so the request path carries no dot-segment — `send` only applies its dotfile filter to the path *after* `root`, so the install location no longer matters. Factored into a small `serveUiFile` helper shared by the `index.html` and `theme.css` routes.

## Test

`preview-ui-dotfile.test.ts` serves the UI from a temp directory whose name starts with `.` and asserts 200 for both `index.html` and `theme.css`. It fails on the old `res.sendFile(p)` under express 5 and passes with the fix.
