### PR TITLE
fix(argent-lens): anchor variants reliably right after navigation (warm-up retry + exact-match)

### DIFF
--- a/packages/tool-server/src/utils/match-element-frame.ts
+++ b/packages/tool-server/src/utils/match-element-frame.ts
@@ -28,34 +28,52 @@ function normLabel(s: string | undefined): string {
 // mirrors the UI's `spotMaxFrameArea` guard.
 const MAX_FRAME_AREA = 0.85;
 
-function nodeMatches(n: DescribeNode, match: VariantMatch, needle: string): boolean {
-  if (!needle) return false;
+// Whether a node matches, and whether that match is EXACT (the whole normalized
+// label/identifier/value equals the needle) rather than a looser substring.
+// Exact hits win: a propose for "Favourites" should anchor the header
+// (label === needle), not the "Favourites (5)" tab (a same-text distractor).
+function matchNode(
+  n: DescribeNode,
+  match: VariantMatch,
+  needle: string
+): { exact: boolean } | null {
   const label = normLabel(n.label);
   const ident = normLabel(n.identifier);
   const value = normLabel(n.value);
   const role = (n.role || "").toLowerCase();
   switch (match.by) {
     case "label":
-      return label === needle || label.includes(needle);
+      if (label === needle) return { exact: true };
+      return label.includes(needle) ? { exact: false } : null;
     case "identifier":
-      return ident === needle;
+      return ident === needle ? { exact: true } : null;
     case "role":
-      return role === needle;
-    default: // "text" — fuzzy contains across label / identifier / value
-      return label.includes(needle) || ident.includes(needle) || value.includes(needle);
+      return role === needle ? { exact: true } : null;
+    default: // "text" — exact across label/identifier/value, else substring
+      if (label === needle || ident === needle || value === needle) return { exact: true };
+      if (label.includes(needle) || ident.includes(needle) || value.includes(needle)) {
+        return { exact: false };
+      }
+      return null;
   }
 }
 
-// Walk the accessibility tree and return the smallest on-screen element whose
-// frame is a sane, centered box — the same selection the preview UI's
-// `vpMatchNode` makes. Returns null when nothing matches.
-export function matchFrameInTree(tree: DescribeNode, match: VariantMatch): NormalizedFrame | null {
+// Walk the accessibility tree for the on-screen element matching `match`. An
+// exact hit always beats a substring one; within a tier the smallest sane,
+// centered box wins (the same selection the preview UI's `vpMatchNode` makes).
+// `exact` is reported so the caller can hold out for the intended element while
+// the screen is still rendering. Returns null when nothing matches.
+export function findElementMatch(
+  tree: DescribeNode,
+  match: VariantMatch
+): { frame: NormalizedFrame; exact: boolean } | null {
   const needle = normLabel(match.value);
-  let best: NormalizedFrame | null = null;
-  let bestArea = Infinity;
+  if (!needle) return null;
+  const candidates: { frame: NormalizedFrame; area: number; exact: boolean }[] = [];
   const walk = (n: DescribeNode | null | undefined): void => {
     if (!n || typeof n !== "object") return;
-    if (nodeMatches(n, match, needle) && n.frame) {
+    const m = matchNode(n, match, needle);
+    if (m && n.frame) {
       const f = n.frame;
       const cx = f.x + f.width / 2;
       const cy = f.y + f.height / 2;
@@ -67,39 +85,80 @@ export function matchFrameInTree(tree: DescribeNode, match: VariantMatch): Norma
         cx <= 1 &&
         cy >= 0 &&
         cy <= 1 &&
-        area <= MAX_FRAME_AREA &&
-        area < bestArea
+        area <= MAX_FRAME_AREA
       ) {
-        bestArea = area;
-        best = { x: f.x, y: f.y, width: f.width, height: f.height };
+        candidates.push({
+          frame: { x: f.x, y: f.y, width: f.width, height: f.height },
+          area,
+          exact: m.exact,
+        });
       }
     }
     if (Array.isArray(n.children)) n.children.forEach(walk);
   };
   walk(tree);
-  return best;
+  if (candidates.length === 0) return null;
+  // Exact beats substring; within a tier, the smallest sane box wins.
+  candidates.sort((a, b) => (a.exact !== b.exact ? (a.exact ? -1 : 1) : a.area - b.area));
+  return { frame: candidates[0].frame, exact: candidates[0].exact };
 }
+
+// Frame-only convenience (exact-preferred). Returns null when nothing matches.
+export function matchFrameInTree(tree: DescribeNode, match: VariantMatch): NormalizedFrame | null {
+  return findElementMatch(tree, match)?.frame ?? null;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Retry budget for the warm-up window. For the first ~1s+ after a screen appears
+// — navigate → screenshot → propose, exactly the Lens workflow — iOS' AX tree
+// comes back empty and, a beat later, half-built (nav chrome before screen
+// content), so a single describe matches nothing or only a distractor. 8 ×
+// ~300ms comfortably spans that window.
+const CAPTURE_ATTEMPTS = 8;
+const CAPTURE_RETRY_MS = 300;
 
 // Resolve the on-screen frame of the matched element for the device the agent
 // proposed against, by describing it RIGHT NOW (the variant is on screen at
-// propose time) and matching. Best-effort: any failure returns null so
+// propose time) and matching. The accessibility tree lands incrementally after a
+// screen appears — empty for ~1s+, then nav chrome (e.g. the "Favourites" tab)
+// before the screen's own content (the "Favourites" header). So we retry across
+// the warm-up window and HOLD OUT for an exact hit (the intended element), only
+// falling back to a substring match once the budget is spent — otherwise a
+// propose that closely follows navigation either captures no frame or anchors to
+// a same-text distractor. Best-effort: any failure returns null so
 // `propose_variant` never fails just because a frame couldn't be auto-captured.
 export async function captureElementFrame(
   registry: Registry,
   udid: string,
-  match: VariantMatch
+  match: VariantMatch,
+  opts: { attempts?: number; retryMs?: number } = {}
 ): Promise<NormalizedFrame | null> {
+  const attempts = Math.max(1, opts.attempts ?? CAPTURE_ATTEMPTS);
+  const retryMs = opts.retryMs ?? CAPTURE_RETRY_MS;
   try {
     const device = resolveDevice(udid);
     // Chromium (CDP) devices have no adb/sim-server describe path; skip frame
     // auto-capture rather than shelling adb against a non-existent serial.
     if (device.platform === "chromium") return null;
-    const data =
-      device.platform === "ios"
-        ? await describeIos(registry, device, {})
-        : await describeAndroid(registry, udid);
-    if (!data?.tree) return null;
-    return matchFrameInTree(data.tree, match);
+    let bestPartial: NormalizedFrame | null = null;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const data =
+        device.platform === "ios"
+          ? await describeIos(registry, device, {})
+          : await describeAndroid(registry, udid);
+      const tree = data?.tree ?? null;
+      const hit = tree ? findElementMatch(tree, match) : null;
+      // An exact hit is the intended element — take it at once. This is what
+      // skips a half-built tree where only a same-text distractor exists yet.
+      if (hit?.exact) return hit.frame;
+      if (hit) bestPartial = hit.frame;
+      if (attempt < attempts - 1) await delay(retryMs);
+    }
+    // No exact hit within the budget → best-effort substring match (or null).
+    return bestPartial;
   } catch {
     return null;
   }

--- a/packages/tool-server/test/match-element-frame-chromium.test.ts
+++ b/packages/tool-server/test/match-element-frame-chromium.test.ts
@@ -44,7 +44,9 @@ describe("captureElementFrame — chromium guard", () => {
 
   it("still dispatches the Android adapter for a genuine Android serial", async () => {
     describeAndroidMock.mockResolvedValue({ tree: null });
-    const out = await captureElementFrame(fakeRegistry, "emulator-5554", match);
+    // attempts: 1 — this asserts the adapter is dispatched (vs the chromium
+    // guard); the warm-up retry would otherwise re-describe across the budget.
+    const out = await captureElementFrame(fakeRegistry, "emulator-5554", match, { attempts: 1 });
     expect(out).toBeNull(); // null tree → no match, but the adapter WAS consulted
     expect(describeAndroidMock).toHaveBeenCalledTimes(1);
     expect(describeIosMock).not.toHaveBeenCalled();

--- a/packages/tool-server/test/match-element-frame-cold-describe.test.ts
+++ b/packages/tool-server/test/match-element-frame-cold-describe.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Registry } from "@argent/registry";
+import type { DescribeNode } from "../src/tools/describe/contract";
+
+vi.mock("../src/utils/device-info", () => ({
+  resolveDevice: vi.fn(() => ({
+    platform: "ios",
+    udid: "TEST-UDID",
+    name: "iPhone",
+    state: "Booted",
+  })),
+}));
+vi.mock("../src/tools/describe/platforms/ios", () => ({ describeIos: vi.fn() }));
+vi.mock("../src/tools/describe/platforms/android", () => ({ describeAndroid: vi.fn() }));
+
+import { captureElementFrame, findElementMatch } from "../src/utils/match-element-frame";
+import { describeIos } from "../src/tools/describe/platforms/ios";
+
+const describeIosMock = vi.mocked(describeIos);
+const registry = {} as Registry;
+
+const headerFrame = { x: 0.068, y: 0.092, width: 0.294, height: 0.033 };
+const tabFrame = { x: 0, y: 0.923, width: 0.25, height: 0.077 };
+const rowFrame = { x: 0, y: 0.215, width: 1, height: 0.13 };
+const ROOT_FRAME = { x: 0, y: 0, width: 1, height: 1 };
+const match = { by: "text" as const, value: "Favourites" };
+// Zero retry delay so the warm-up loop runs instantly in tests.
+const FAST = { attempts: 8, retryMs: 0 };
+
+function node(
+  role: string,
+  label: string | undefined,
+  frame: { x: number; y: number; width: number; height: number },
+  children: DescribeNode[] = []
+): DescribeNode {
+  return { role, label, frame, children };
+}
+
+// The empty/cold tree iOS returns for the first ~1s+ after a screen appears.
+const COLD = { source: "ax-service" as const, tree: node("AXGroup", undefined, ROOT_FRAME, []) };
+
+// A half-built tree: the persistent bottom tab ("Favourites (5)") has landed but
+// the screen's own header has NOT yet rendered. Its label is a SUBSTRING of
+// "Favourites" — the distractor that must not win.
+const HALF_BUILT_TAB = {
+  source: "ax-service" as const,
+  tree: node("AXGroup", undefined, ROOT_FRAME, [
+    node("AXButton", ", , Favourites (5)", tabFrame),
+    node("AXButton", ", , Browse", { x: 0.25, y: 0.923, width: 0.25, height: 0.077 }),
+    node("AXButton", ", , Map", { x: 0.5, y: 0.923, width: 0.25, height: 0.077 }),
+  ]),
+};
+
+// A fully-rendered Favourites screen: BOTH the header (exact "Favourites") and
+// the tab ("Favourites (5)", substring) match — the exact header must win.
+const WARM = {
+  source: "ax-service" as const,
+  tree: node("AXGroup", undefined, ROOT_FRAME, [
+    node("AXStaticText", "Favourites", headerFrame),
+    node("AXStaticText", "5 saved · 0 total stats", {
+      x: 0.068,
+      y: 0.127,
+      width: 0.294,
+      height: 0.015,
+    }),
+    node("AXButton", ", , Favourites (5)", tabFrame),
+    node("AXButton", ", , Browse", { x: 0.25, y: 0.923, width: 0.25, height: 0.077 }),
+  ]),
+};
+
+// A fully-rendered DIFFERENT screen — no "Favourites" anywhere.
+const WARM_OTHER = {
+  source: "ax-service" as const,
+  tree: node("AXGroup", undefined, ROOT_FRAME, [
+    node("AXStaticText", "Browse", { x: 0.068, y: 0.092, width: 0.2, height: 0.033 }),
+    node("AXButton", ", , Browse", { x: 0.25, y: 0.923, width: 0.25, height: 0.077 }),
+    node("AXButton", ", , Map", { x: 0.5, y: 0.923, width: 0.25, height: 0.077 }),
+    node("AXButton", ", , Compare", { x: 0.75, y: 0.923, width: 0.25, height: 0.077 }),
+  ]),
+};
+
+// A list row whose label only CONTAINS the query — no exact hit possible.
+const ROW = {
+  source: "ax-service" as const,
+  tree: node("AXGroup", undefined, ROOT_FRAME, [
+    node("AXGroup", "simisear, gluttony, blaze, ", rowFrame),
+  ]),
+};
+
+describe("captureElementFrame — holds out for the exact element through warm-up", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("skips the half-built same-text tab and resolves the exact header once it renders", async () => {
+    describeIosMock
+      .mockResolvedValueOnce(COLD)
+      .mockResolvedValueOnce(HALF_BUILT_TAB)
+      .mockResolvedValueOnce(WARM);
+    const frame = await captureElementFrame(registry, "TEST-UDID", match, FAST);
+    expect(frame).toEqual(headerFrame); // header, NOT the bottom tab
+    expect(frame).not.toEqual(tabFrame);
+    expect(describeIosMock.mock.calls.length).toBe(3);
+  });
+
+  it("returns the exact header immediately when the screen is already warm", async () => {
+    describeIosMock.mockResolvedValue(WARM);
+    const frame = await captureElementFrame(registry, "TEST-UDID", match, FAST);
+    expect(frame).toEqual(headerFrame);
+    expect(describeIosMock.mock.calls.length).toBe(1);
+  });
+
+  it("falls back to a substring match after the budget when no exact hit exists", async () => {
+    describeIosMock.mockResolvedValue(ROW);
+    const frame = await captureElementFrame(
+      registry,
+      "TEST-UDID",
+      { by: "text", value: "simisear" },
+      { attempts: 3, retryMs: 0 }
+    );
+    expect(frame).toEqual(rowFrame);
+    expect(describeIosMock.mock.calls.length).toBe(3);
+  });
+
+  it("returns null when the element is absent within the budget", async () => {
+    describeIosMock.mockResolvedValue(WARM_OTHER);
+    const frame = await captureElementFrame(registry, "TEST-UDID", match, {
+      attempts: 3,
+      retryMs: 0,
+    });
+    expect(frame).toBeNull();
+    expect(describeIosMock.mock.calls.length).toBe(3);
+  });
+});
+
+describe("findElementMatch — exact beats substring", () => {
+  it("prefers the exact 'Favourites' header over the 'Favourites (5)' tab", () => {
+    expect(findElementMatch(WARM.tree, match)).toEqual({ frame: headerFrame, exact: true });
+  });
+
+  it("reports a substring-only hit as inexact", () => {
+    const hit = findElementMatch(ROW.tree, { by: "text", value: "simisear" });
+    expect(hit?.exact).toBe(false);
+    expect(hit?.frame).toEqual(rowFrame);
+  });
+});

--- a/packages/tool-server/test/match-element-frame.test.ts
+++ b/packages/tool-server/test/match-element-frame.test.ts
@@ -103,7 +103,14 @@ describe("captureElementFrame", () => {
       tree: { role: "AXGroup", frame: { x: 0, y: 0, width: 1, height: 1 }, children: [] },
       source: "ax-service",
     });
-    const f = await captureElementFrame(registry, "UDID-1", { by: "text", value: "Favourites" });
+    // attempts: 1 — skip the warm-up retry budget; here we only assert that a
+    // single describe with no match yields null.
+    const f = await captureElementFrame(
+      registry,
+      "UDID-1",
+      { by: "text", value: "Favourites" },
+      { attempts: 1 }
+    );
     expect(f).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

A `propose_variant` made right after navigating to a screen — exactly what the Lens workflow does (navigate → screenshot → propose) — often fails to anchor the floating card to the element. The card shows up unanchored / in the "hidden" bucket ("didn't register against anything"), or it latches onto a same-text **distractor** (e.g. the bottom **"Favourites" tab** instead of the **"Favourites" header**).

## Root cause

`propose_variant` auto-captures the matched element's frame via `captureElementFrame`, which describes the device **once** and matches. But iOS' accessibility tree is **not ready** at propose time — measured against a real device:

- For the first **~1.25 s** after a screen appears, describe returns an essentially empty tree (`nodes=1–2`). A single describe there matches nothing → `null` frame → no anchor.
- The tree then lands **incrementally**: persistent nav chrome (the `"Favourites (5)"` tab) shows up *before* the screen's own content (the `"Favourites"` header). A single describe in that window matches the **tab**, not the header.

So the one-shot capture either gets nothing or the wrong (same-text) element.

## Fix

`captureElementFrame` now:
- **Retries across the warm-up window** instead of giving up on the first (empty) describe.
- **Holds out for an exact label/identifier hit** — the intended element — and only falls back to a substring match once the retry budget is spent. This skips the half-built tree where only a same-text distractor exists yet.

`findElementMatch` / `matchFrameInTree` now **tier exact matches above substring matches** (within a tier, smallest sane box still wins), so the exact `"Favourites"` header beats the `"Favourites (5)"` tab once both are present.

## Verification

- New `match-element-frame-cold-describe.test.ts` (6 cases): holds out through the cold + half-built-tab window to the exact header; returns immediately when warm; falls back to a substring match after the budget; returns null when absent; `findElementMatch` exact-beats-substring ranking.
- Updated two existing tests that asserted the old single-describe behavior (`{ attempts: 1 }`).
- All matcher tests green; monorepo `tsc --build` + `typecheck:tests` green.
- **Real device (pokemon app, iPhone 16 Pro Max):** reproduced the ~1.25 s empty-tree window by polling describe across a relaunch; confirmed the old single-shot returns `null` in that window; confirmed the new logic resolves the **exact header** (`y≈0.092`), not the tab (`y≈0.923`), on the Favourites screen.

## Note

A substring-only match (e.g. a list row matched by a partial name) now waits the full retry budget before falling back, since there is no way to tell "the exact element hasn't rendered yet" from "there is no exact element" without risking the distractor bug. Propose is not latency-critical; correctness is preferred. Agents are still best served by `identifier`/`label` matchers (already recommended in the skill).
