### PR TITLE
fix(argent-lens): preview-UI serving, variant matcher, and off-screen reveal

### DIFF
--- a/packages/tool-server/src/preview.ts
+++ b/packages/tool-server/src/preview.ts
@@ -34,6 +34,18 @@ function findUiFile(name: string): string | null {
   return null;
 }
 
+// Serve a resolved preview-UI file. We go through `sendFile` with an explicit
+// `root` instead of passing the absolute path directly: Express 5's `send`
+// defaults to `dotfiles: "ignore"`, which 404s any path containing a dot-segment.
+// argent is routinely installed under one (nvm's `~/.nvm/...`, fnm, volta,
+// asdf), so `sendFile(absolutePath)` silently fails there and the Lens preview
+// window can't load. Scoping to `{ root: dir }` makes the request path just the
+// basename — no dot-segment — so the file is served regardless of install path.
+export function serveUiFile(res: Response, filePath: string, contentType: string): void {
+  res.set("Cache-Control", "no-store, must-revalidate");
+  res.type(contentType).sendFile(path.basename(filePath), { root: path.dirname(filePath) });
+}
+
 function wsUrlFromHttp(httpUrl: string): string {
   const u = new URL(httpUrl);
   const scheme = u.protocol === "https:" ? "wss:" : "ws:";
@@ -340,8 +352,7 @@ export function createPreviewRouter(registry: Registry): Router {
       res.status(404).type("text/plain").send("theme.css not found");
       return;
     }
-    res.set("Cache-Control", "no-store, must-revalidate");
-    res.type("text/css").sendFile(p);
+    serveUiFile(res, p, "text/css");
   });
 
   router.get("/", (req: Request, res: Response) => {
@@ -360,10 +371,7 @@ export function createPreviewRouter(registry: Registry): Router {
       res.status(404).type("text/plain").send("Preview UI not found");
       return;
     }
-    // Dev-style no-cache so edits to packages/ui/index.html are picked up on
-    // reload without the user having to hard-refresh.
-    res.set("Cache-Control", "no-store, must-revalidate");
-    res.type("text/html").sendFile(p);
+    serveUiFile(res, p, "text/html");
   });
 
   return router;

--- a/packages/tool-server/src/utils/match-element-frame.ts
+++ b/packages/tool-server/src/utils/match-element-frame.ts
@@ -28,34 +28,52 @@ function normLabel(s: string | undefined): string {
 // mirrors the UI's `spotMaxFrameArea` guard.
 const MAX_FRAME_AREA = 0.85;
 
-function nodeMatches(n: DescribeNode, match: VariantMatch, needle: string): boolean {
-  if (!needle) return false;
+// Whether a node matches, and whether that match is EXACT (the whole normalized
+// label/identifier/value equals the needle) rather than a looser substring.
+// Exact hits win: a propose for "Favourites" should anchor the header
+// (label === needle), not the "Favourites (5)" tab (a same-text distractor).
+function matchNode(
+  n: DescribeNode,
+  match: VariantMatch,
+  needle: string
+): { exact: boolean } | null {
   const label = normLabel(n.label);
   const ident = normLabel(n.identifier);
   const value = normLabel(n.value);
   const role = (n.role || "").toLowerCase();
   switch (match.by) {
     case "label":
-      return label === needle || label.includes(needle);
+      if (label === needle) return { exact: true };
+      return label.includes(needle) ? { exact: false } : null;
     case "identifier":
-      return ident === needle;
+      return ident === needle ? { exact: true } : null;
     case "role":
-      return role === needle;
-    default: // "text" — fuzzy contains across label / identifier / value
-      return label.includes(needle) || ident.includes(needle) || value.includes(needle);
+      return role === needle ? { exact: true } : null;
+    default: // "text" — exact across label/identifier/value, else substring
+      if (label === needle || ident === needle || value === needle) return { exact: true };
+      if (label.includes(needle) || ident.includes(needle) || value.includes(needle)) {
+        return { exact: false };
+      }
+      return null;
   }
 }
 
-// Walk the accessibility tree and return the smallest on-screen element whose
-// frame is a sane, centered box — the same selection the preview UI's
-// `vpMatchNode` makes. Returns null when nothing matches.
-export function matchFrameInTree(tree: DescribeNode, match: VariantMatch): NormalizedFrame | null {
+// Walk the accessibility tree for the on-screen element matching `match`. An
+// exact hit always beats a substring one; within a tier the smallest sane,
+// centered box wins (the same selection the preview UI's `vpMatchNode` makes).
+// `exact` is reported so the caller can hold out for the intended element while
+// the screen is still rendering. Returns null when nothing matches.
+export function findElementMatch(
+  tree: DescribeNode,
+  match: VariantMatch
+): { frame: NormalizedFrame; exact: boolean } | null {
   const needle = normLabel(match.value);
-  let best: NormalizedFrame | null = null;
-  let bestArea = Infinity;
+  if (!needle) return null;
+  const candidates: { frame: NormalizedFrame; area: number; exact: boolean }[] = [];
   const walk = (n: DescribeNode | null | undefined): void => {
     if (!n || typeof n !== "object") return;
-    if (nodeMatches(n, match, needle) && n.frame) {
+    const m = matchNode(n, match, needle);
+    if (m && n.frame) {
       const f = n.frame;
       const cx = f.x + f.width / 2;
       const cy = f.y + f.height / 2;
@@ -67,39 +85,80 @@ export function matchFrameInTree(tree: DescribeNode, match: VariantMatch): Norma
         cx <= 1 &&
         cy >= 0 &&
         cy <= 1 &&
-        area <= MAX_FRAME_AREA &&
-        area < bestArea
+        area <= MAX_FRAME_AREA
       ) {
-        bestArea = area;
-        best = { x: f.x, y: f.y, width: f.width, height: f.height };
+        candidates.push({
+          frame: { x: f.x, y: f.y, width: f.width, height: f.height },
+          area,
+          exact: m.exact,
+        });
       }
     }
     if (Array.isArray(n.children)) n.children.forEach(walk);
   };
   walk(tree);
-  return best;
+  if (candidates.length === 0) return null;
+  // Exact beats substring; within a tier, the smallest sane box wins.
+  candidates.sort((a, b) => (a.exact !== b.exact ? (a.exact ? -1 : 1) : a.area - b.area));
+  return { frame: candidates[0].frame, exact: candidates[0].exact };
 }
+
+// Frame-only convenience (exact-preferred). Returns null when nothing matches.
+export function matchFrameInTree(tree: DescribeNode, match: VariantMatch): NormalizedFrame | null {
+  return findElementMatch(tree, match)?.frame ?? null;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Retry budget for the warm-up window. For the first ~1s+ after a screen appears
+// — navigate → screenshot → propose, exactly the Lens workflow — iOS' AX tree
+// comes back empty and, a beat later, half-built (nav chrome before screen
+// content), so a single describe matches nothing or only a distractor. 8 ×
+// ~300ms comfortably spans that window.
+const CAPTURE_ATTEMPTS = 8;
+const CAPTURE_RETRY_MS = 300;
 
 // Resolve the on-screen frame of the matched element for the device the agent
 // proposed against, by describing it RIGHT NOW (the variant is on screen at
-// propose time) and matching. Best-effort: any failure returns null so
+// propose time) and matching. The accessibility tree lands incrementally after a
+// screen appears — empty for ~1s+, then nav chrome (e.g. the "Favourites" tab)
+// before the screen's own content (the "Favourites" header). So we retry across
+// the warm-up window and HOLD OUT for an exact hit (the intended element), only
+// falling back to a substring match once the budget is spent — otherwise a
+// propose that closely follows navigation either captures no frame or anchors to
+// a same-text distractor. Best-effort: any failure returns null so
 // `propose_variant` never fails just because a frame couldn't be auto-captured.
 export async function captureElementFrame(
   registry: Registry,
   udid: string,
-  match: VariantMatch
+  match: VariantMatch,
+  opts: { attempts?: number; retryMs?: number } = {}
 ): Promise<NormalizedFrame | null> {
+  const attempts = Math.max(1, opts.attempts ?? CAPTURE_ATTEMPTS);
+  const retryMs = opts.retryMs ?? CAPTURE_RETRY_MS;
   try {
     const device = resolveDevice(udid);
     // Chromium (CDP) devices have no adb/sim-server describe path; skip frame
     // auto-capture rather than shelling adb against a non-existent serial.
     if (device.platform === "chromium") return null;
-    const data =
-      device.platform === "ios"
-        ? await describeIos(registry, device, {})
-        : await describeAndroid(registry, udid);
-    if (!data?.tree) return null;
-    return matchFrameInTree(data.tree, match);
+    let bestPartial: NormalizedFrame | null = null;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const data =
+        device.platform === "ios"
+          ? await describeIos(registry, device, {})
+          : await describeAndroid(registry, udid);
+      const tree = data?.tree ?? null;
+      const hit = tree ? findElementMatch(tree, match) : null;
+      // An exact hit is the intended element — take it at once. This is what
+      // skips a half-built tree where only a same-text distractor exists yet.
+      if (hit?.exact) return hit.frame;
+      if (hit) bestPartial = hit.frame;
+      if (attempt < attempts - 1) await delay(retryMs);
+    }
+    // No exact hit within the budget → best-effort substring match (or null).
+    return bestPartial;
   } catch {
     return null;
   }

--- a/packages/tool-server/src/utils/match-element-frame.ts
+++ b/packages/tool-server/src/utils/match-element-frame.ts
@@ -119,6 +119,17 @@ function delay(ms: number): Promise<void> {
 // ~300ms comfortably spans that window.
 const CAPTURE_ATTEMPTS = 8;
 const CAPTURE_RETRY_MS = 300;
+// Hard wall-clock ceiling on the whole retry loop. `attempts × retryMs` only
+// bounds the loop when each describe is near-instant — true on iOS (~tens of ms)
+// but NOT on Android, where a describe can be a multi-second `uiautomator` dump.
+// Without this cap, 8 attempts on the Android `uiautomator` fallback path block
+// for ~8 × that (measured 18–23s) on a tool meant to return promptly. Capping
+// total elapsed time bounds the loop regardless of per-describe cost WITHOUT any
+// platform branching: a fast describe still samples many times across the
+// warm-up; a slow describe stops after roughly one call — and a describe slow
+// enough to blow the budget in one shot has itself already outlasted the warm-up,
+// so the tree it returns is settled and one sample is the right answer anyway.
+const CAPTURE_BUDGET_MS = 2_000;
 
 // Resolve the on-screen frame of the matched element for the device the agent
 // proposed against, by describing it RIGHT NOW (the variant is on screen at
@@ -134,16 +145,18 @@ export async function captureElementFrame(
   registry: Registry,
   udid: string,
   match: VariantMatch,
-  opts: { attempts?: number; retryMs?: number } = {}
+  opts: { attempts?: number; retryMs?: number; budgetMs?: number } = {}
 ): Promise<NormalizedFrame | null> {
   const attempts = Math.max(1, opts.attempts ?? CAPTURE_ATTEMPTS);
   const retryMs = opts.retryMs ?? CAPTURE_RETRY_MS;
+  const budgetMs = opts.budgetMs ?? CAPTURE_BUDGET_MS;
   try {
     const device = resolveDevice(udid);
     // Chromium (CDP) devices have no adb/sim-server describe path; skip frame
     // auto-capture rather than shelling adb against a non-existent serial.
     if (device.platform === "chromium") return null;
     let bestPartial: NormalizedFrame | null = null;
+    const startedAt = Date.now();
     for (let attempt = 0; attempt < attempts; attempt++) {
       const data =
         device.platform === "ios"
@@ -155,7 +168,11 @@ export async function captureElementFrame(
       // skips a half-built tree where only a same-text distractor exists yet.
       if (hit?.exact) return hit.frame;
       if (hit) bestPartial = hit.frame;
-      if (attempt < attempts - 1) await delay(retryMs);
+      if (attempt >= attempts - 1) break;
+      // Stop before another describe+delay once the time budget is spent — this
+      // is what bounds the slow-describe (Android `uiautomator`) worst case.
+      if (Date.now() - startedAt >= budgetMs) break;
+      await delay(retryMs);
     }
     // No exact hit within the budget → best-effort substring match (or null).
     return bestPartial;

--- a/packages/tool-server/test/match-element-frame-chromium.test.ts
+++ b/packages/tool-server/test/match-element-frame-chromium.test.ts
@@ -44,7 +44,9 @@ describe("captureElementFrame — chromium guard", () => {
 
   it("still dispatches the Android adapter for a genuine Android serial", async () => {
     describeAndroidMock.mockResolvedValue({ tree: null });
-    const out = await captureElementFrame(fakeRegistry, "emulator-5554", match);
+    // attempts: 1 — this asserts the adapter is dispatched (vs the chromium
+    // guard); the warm-up retry would otherwise re-describe across the budget.
+    const out = await captureElementFrame(fakeRegistry, "emulator-5554", match, { attempts: 1 });
     expect(out).toBeNull(); // null tree → no match, but the adapter WAS consulted
     expect(describeAndroidMock).toHaveBeenCalledTimes(1);
     expect(describeIosMock).not.toHaveBeenCalled();

--- a/packages/tool-server/test/match-element-frame-cold-describe.test.ts
+++ b/packages/tool-server/test/match-element-frame-cold-describe.test.ts
@@ -129,6 +129,24 @@ describe("captureElementFrame — holds out for the exact element through warm-u
     expect(frame).toBeNull();
     expect(describeIosMock.mock.calls.length).toBe(3);
   });
+
+  it("keeps a substring partial when a LATER attempt re-empties (tree regressed mid-warm-up)", async () => {
+    // A substring hit lands first, then the AX tree re-empties (a transient the
+    // device can return while still settling). The held partial must survive —
+    // an "if the latest attempt is empty, return null" refactor would drop it.
+    describeIosMock
+      .mockResolvedValueOnce(ROW)
+      .mockResolvedValueOnce(COLD)
+      .mockResolvedValueOnce(COLD);
+    const frame = await captureElementFrame(
+      registry,
+      "TEST-UDID",
+      { by: "text", value: "simisear" },
+      { attempts: 3, retryMs: 0 }
+    );
+    expect(frame).toEqual(rowFrame); // the attempt-1 partial, not null
+    expect(describeIosMock.mock.calls.length).toBe(3); // no exact hit → full budget
+  });
 });
 
 describe("findElementMatch — exact beats substring", () => {

--- a/packages/tool-server/test/match-element-frame-cold-describe.test.ts
+++ b/packages/tool-server/test/match-element-frame-cold-describe.test.ts
@@ -147,6 +147,27 @@ describe("captureElementFrame — holds out for the exact element through warm-u
     expect(frame).toEqual(rowFrame); // the attempt-1 partial, not null
     expect(describeIosMock.mock.calls.length).toBe(3); // no exact hit → full budget
   });
+
+  it("stops well before the full attempt count once the wall-clock budget is spent (slow describe)", async () => {
+    // Each describe is slow, like an Android `uiautomator` dump. An instant
+    // describe would run all 8 attempts (see the absent-element test above); the
+    // time budget must cut the loop short so propose_variant can't block for
+    // 8 × a multi-second describe (the measured 18–23s Android stall).
+    describeIosMock.mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 40));
+      return WARM_OTHER; // no "Favourites" → never an exact hit
+    });
+    const frame = await captureElementFrame(registry, "TEST-UDID", match, {
+      attempts: 8,
+      retryMs: 0,
+      budgetMs: 100,
+    });
+    expect(frame).toBeNull(); // absent → still best-effort null
+    // ~40ms/describe under a 100ms budget → a couple of calls, and crucially far
+    // fewer than the 8 attempts an instant describe would have run.
+    expect(describeIosMock.mock.calls.length).toBeLessThan(8);
+    expect(describeIosMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
 });
 
 describe("findElementMatch — exact beats substring", () => {

--- a/packages/tool-server/test/match-element-frame-cold-describe.test.ts
+++ b/packages/tool-server/test/match-element-frame-cold-describe.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Registry } from "@argent/registry";
+import type { DescribeNode } from "../src/tools/describe/contract";
+
+vi.mock("../src/utils/device-info", () => ({
+  resolveDevice: vi.fn(() => ({
+    platform: "ios",
+    udid: "TEST-UDID",
+    name: "iPhone",
+    state: "Booted",
+  })),
+}));
+vi.mock("../src/tools/describe/platforms/ios", () => ({ describeIos: vi.fn() }));
+vi.mock("../src/tools/describe/platforms/android", () => ({ describeAndroid: vi.fn() }));
+
+import { captureElementFrame, findElementMatch } from "../src/utils/match-element-frame";
+import { describeIos } from "../src/tools/describe/platforms/ios";
+
+const describeIosMock = vi.mocked(describeIos);
+const registry = {} as Registry;
+
+const headerFrame = { x: 0.068, y: 0.092, width: 0.294, height: 0.033 };
+const tabFrame = { x: 0, y: 0.923, width: 0.25, height: 0.077 };
+const rowFrame = { x: 0, y: 0.215, width: 1, height: 0.13 };
+const ROOT_FRAME = { x: 0, y: 0, width: 1, height: 1 };
+const match = { by: "text" as const, value: "Favourites" };
+// Zero retry delay so the warm-up loop runs instantly in tests.
+const FAST = { attempts: 8, retryMs: 0 };
+
+function node(
+  role: string,
+  label: string | undefined,
+  frame: { x: number; y: number; width: number; height: number },
+  children: DescribeNode[] = []
+): DescribeNode {
+  return { role, label, frame, children };
+}
+
+// The empty/cold tree iOS returns for the first ~1s+ after a screen appears.
+const COLD = { source: "ax-service" as const, tree: node("AXGroup", undefined, ROOT_FRAME, []) };
+
+// A half-built tree: the persistent bottom tab ("Favourites (5)") has landed but
+// the screen's own header has NOT yet rendered. Its label is a SUBSTRING of
+// "Favourites" — the distractor that must not win.
+const HALF_BUILT_TAB = {
+  source: "ax-service" as const,
+  tree: node("AXGroup", undefined, ROOT_FRAME, [
+    node("AXButton", ", , Favourites (5)", tabFrame),
+    node("AXButton", ", , Browse", { x: 0.25, y: 0.923, width: 0.25, height: 0.077 }),
+    node("AXButton", ", , Map", { x: 0.5, y: 0.923, width: 0.25, height: 0.077 }),
+  ]),
+};
+
+// A fully-rendered Favourites screen: BOTH the header (exact "Favourites") and
+// the tab ("Favourites (5)", substring) match — the exact header must win.
+const WARM = {
+  source: "ax-service" as const,
+  tree: node("AXGroup", undefined, ROOT_FRAME, [
+    node("AXStaticText", "Favourites", headerFrame),
+    node("AXStaticText", "5 saved · 0 total stats", {
+      x: 0.068,
+      y: 0.127,
+      width: 0.294,
+      height: 0.015,
+    }),
+    node("AXButton", ", , Favourites (5)", tabFrame),
+    node("AXButton", ", , Browse", { x: 0.25, y: 0.923, width: 0.25, height: 0.077 }),
+  ]),
+};
+
+// A fully-rendered DIFFERENT screen — no "Favourites" anywhere.
+const WARM_OTHER = {
+  source: "ax-service" as const,
+  tree: node("AXGroup", undefined, ROOT_FRAME, [
+    node("AXStaticText", "Browse", { x: 0.068, y: 0.092, width: 0.2, height: 0.033 }),
+    node("AXButton", ", , Browse", { x: 0.25, y: 0.923, width: 0.25, height: 0.077 }),
+    node("AXButton", ", , Map", { x: 0.5, y: 0.923, width: 0.25, height: 0.077 }),
+    node("AXButton", ", , Compare", { x: 0.75, y: 0.923, width: 0.25, height: 0.077 }),
+  ]),
+};
+
+// A list row whose label only CONTAINS the query — no exact hit possible.
+const ROW = {
+  source: "ax-service" as const,
+  tree: node("AXGroup", undefined, ROOT_FRAME, [
+    node("AXGroup", "simisear, gluttony, blaze, ", rowFrame),
+  ]),
+};
+
+describe("captureElementFrame — holds out for the exact element through warm-up", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("skips the half-built same-text tab and resolves the exact header once it renders", async () => {
+    describeIosMock
+      .mockResolvedValueOnce(COLD)
+      .mockResolvedValueOnce(HALF_BUILT_TAB)
+      .mockResolvedValueOnce(WARM);
+    const frame = await captureElementFrame(registry, "TEST-UDID", match, FAST);
+    expect(frame).toEqual(headerFrame); // header, NOT the bottom tab
+    expect(frame).not.toEqual(tabFrame);
+    expect(describeIosMock.mock.calls.length).toBe(3);
+  });
+
+  it("returns the exact header immediately when the screen is already warm", async () => {
+    describeIosMock.mockResolvedValue(WARM);
+    const frame = await captureElementFrame(registry, "TEST-UDID", match, FAST);
+    expect(frame).toEqual(headerFrame);
+    expect(describeIosMock.mock.calls.length).toBe(1);
+  });
+
+  it("falls back to a substring match after the budget when no exact hit exists", async () => {
+    describeIosMock.mockResolvedValue(ROW);
+    const frame = await captureElementFrame(
+      registry,
+      "TEST-UDID",
+      { by: "text", value: "simisear" },
+      { attempts: 3, retryMs: 0 }
+    );
+    expect(frame).toEqual(rowFrame);
+    expect(describeIosMock.mock.calls.length).toBe(3);
+  });
+
+  it("returns null when the element is absent within the budget", async () => {
+    describeIosMock.mockResolvedValue(WARM_OTHER);
+    const frame = await captureElementFrame(registry, "TEST-UDID", match, {
+      attempts: 3,
+      retryMs: 0,
+    });
+    expect(frame).toBeNull();
+    expect(describeIosMock.mock.calls.length).toBe(3);
+  });
+});
+
+describe("findElementMatch — exact beats substring", () => {
+  it("prefers the exact 'Favourites' header over the 'Favourites (5)' tab", () => {
+    expect(findElementMatch(WARM.tree, match)).toEqual({ frame: headerFrame, exact: true });
+  });
+
+  it("reports a substring-only hit as inexact", () => {
+    const hit = findElementMatch(ROW.tree, { by: "text", value: "simisear" });
+    expect(hit?.exact).toBe(false);
+    expect(hit?.frame).toEqual(rowFrame);
+  });
+});

--- a/packages/tool-server/test/match-element-frame.test.ts
+++ b/packages/tool-server/test/match-element-frame.test.ts
@@ -103,7 +103,14 @@ describe("captureElementFrame", () => {
       tree: { role: "AXGroup", frame: { x: 0, y: 0, width: 1, height: 1 }, children: [] },
       source: "ax-service",
     });
-    const f = await captureElementFrame(registry, "UDID-1", { by: "text", value: "Favourites" });
+    // attempts: 1 — skip the warm-up retry budget; here we only assert that a
+    // single describe with no match yields null.
+    const f = await captureElementFrame(
+      registry,
+      "UDID-1",
+      { by: "text", value: "Favourites" },
+      { attempts: 1 }
+    );
     expect(f).toBeNull();
   });
 });

--- a/packages/tool-server/test/preview-describe-route.test.ts
+++ b/packages/tool-server/test/preview-describe-route.test.ts
@@ -142,3 +142,40 @@ describe("GET /preview/describe/:udid (describe-based; post-#197 text-contract r
     expect(mockedAndroid).not.toHaveBeenCalled();
   });
 });
+
+// Integration coverage for the two preview-UI route handlers PR #394 changed to
+// go through `serveUiFile` (the dot-path fix). preview-ui-dotfile.test.ts tests
+// the helper in isolation under a dot dir; this mounts the REAL router (as
+// http.ts does, at "/preview") and serves the actual packages/ui files, so the
+// route wiring — findUiFile resolution, content-type, no-store, the "/" → "/"
+// trailing-slash redirect, and the missing-file 404 branch — is guarded too.
+describe("preview UI routes (real router, real packages/ui)", () => {
+  function previewApp() {
+    const registry = { invokeTool: vi.fn() } as unknown as Registry;
+    const app = express();
+    app.use("/preview", createPreviewRouter(registry));
+    return app;
+  }
+
+  it("GET /preview/theme.css -> 200 text/css, no-store, real stylesheet", async () => {
+    const res = await request(previewApp()).get("/preview/theme.css");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/css/);
+    expect(res.headers["cache-control"]).toBe("no-store, must-revalidate");
+    expect(res.text).toContain("Argent Preview");
+  });
+
+  it("GET /preview/ -> 200 text/html, the real index.html", async () => {
+    const res = await request(previewApp()).get("/preview/");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.headers["cache-control"]).toBe("no-store, must-revalidate");
+    expect(res.text).toContain("<!doctype html>");
+  });
+
+  it("GET /preview (no trailing slash) -> 301 to /preview/ so relative theme.css resolves", async () => {
+    const res = await request(previewApp()).get("/preview");
+    expect(res.status).toBe(301);
+    expect(res.headers["location"]).toBe("/preview/");
+  });
+});

--- a/packages/tool-server/test/preview-ui-dotfile.test.ts
+++ b/packages/tool-server/test/preview-ui-dotfile.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import supertest from "supertest";
+
+import { serveUiFile } from "../src/preview";
+
+// Regression guard for the Express 5 `send` dotfiles default (`dotfiles: "ignore"`),
+// which 404s any file path containing a dot-segment. argent is routinely installed
+// under such a path — nvm (`~/.nvm/...`), fnm, volta, asdf — so a bare
+// `res.sendFile(absolutePath)` made the Lens preview window fail to load its UI
+// (`/preview/` and `/preview/theme.css` returned NotFoundError). serveUiFile must
+// serve the file regardless of where on disk it lives.
+describe("serveUiFile under a dot-segment install path", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    // Directory name starts with "." — the exact shape that trips send's dotfile
+    // filter, mirroring an install at ~/.nvm/.../preview-ui.
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), ".argent-dotfix-"));
+    fs.writeFileSync(path.join(dir, "index.html"), "<!doctype html><title>lens</title>");
+    fs.writeFileSync(path.join(dir, "theme.css"), ":root{--accent:#0a7ea4}");
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function appServing(file: string, contentType: string) {
+    const app = express();
+    app.get("/x", (_req, res) => serveUiFile(res, path.join(dir, file), contentType));
+    return app;
+  }
+
+  it("serves index.html from a dot-path (200, not 404)", async () => {
+    const res = await supertest(appServing("index.html", "text/html")).get("/x");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+    expect(res.text).toContain("lens");
+  });
+
+  it("serves theme.css from a dot-path (200, not 404)", async () => {
+    const res = await supertest(appServing("theme.css", "text/css")).get("/x");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/css/);
+    expect(res.text).toContain("--accent");
+  });
+});

--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -4296,24 +4296,14 @@
         const allChosen = vp.proposals.length > 0 && vp.proposals.every((p) => vp.staged[p.id]);
         footEl.classList.toggle("ready", allChosen && !vp.submitting);
 
-        // Off-screen proposals stay folded away (the "N hidden" badge) until the
-        // user opts in. Once every ON-screen choice is staged, offer to reveal
-        // the rest via a prompt above the footbar. Dismissing it collapses to a
-        // persistent pill — the hidden choices are always one click from visible.
+        // Whenever ANY proposal's element is off-screen, surface the reveal
+        // prompt above the footbar so the user can always bring the hidden
+        // choices into view. (Previously this was gated on every on-screen
+        // choice already being staged, which stranded the user with a "N hidden"
+        // count and no affordance to act on it.) `offscreenPromptCollapsed` only
+        // selects between the full card and the collapsed pill (see below).
         const offScreenCount = vp.proposals.filter((p) => !p._node).length;
-        // Every currently-on-screen choice is staged. `every` is vacuously true
-        // when NONE are on screen (e.g. all proposals target another screen), so
-        // the reveal prompt still appears in that case instead of stranding the
-        // user with inert "N hidden" cards and no way to surface them.
-        const onScreenStaged = vp.proposals.every((p) => !p._node || vp.staged[p.id]);
-        // Latch on `offscreenPromptCollapsed`: once dismissed to the pill, keep it
-        // shown even if an on-screen pick is later un-staged — the hidden choices
-        // must ALWAYS stay one click from visible (the pill never disappears).
-        const showPrompt =
-          offScreenCount > 0 &&
-          !vp.revealOffscreen &&
-          !vp.submitting &&
-          (onScreenStaged || vp.offscreenPromptCollapsed);
+        const showPrompt = offScreenCount > 0 && !vp.revealOffscreen && !vp.submitting;
         offscreenPrompt.hidden = !showPrompt;
         if (showPrompt) {
           offscreenPrompt.classList.toggle("collapsed", !!vp.offscreenPromptCollapsed);


### PR DESCRIPTION
Three independent reliability fixes for **Argent Lens** (the `propose_variant` / `await_user_selection` variant-review flow and its preview window). They touch disjoint files and were validated separately; combined here into one PR.

---

### 1. Preview window 404s on dot-path installs (nvm/fnm/volta/asdf)

The Lens window showed a raw `NotFoundError` instead of the variant UI whenever argent was installed under a path containing a dot-segment (most commonly nvm, `~/.nvm/...`). `GET /preview/` and `/preview/theme.css` returned 404 while JSON routes worked.

Cause: the express 4 → 5 bump (#354, shipped in v0.12.1). Express 5's `send@1` defaults to `dotfiles: "ignore"`, which 404s any file path containing a dot-segment, and the preview routes pass the absolute install path to `res.sendFile`. Proven in isolation: express 5.2.1 `sendFile` of the file → 404; express 4.22.1 → 200; `sendFile(basename, { root: dir })` → 200.

Fix: serve the preview UI via `sendFile(basename, { root: dir })` (a `serveUiFile` helper) so the request path carries no dot-segment. Regression test serves the UI from a temp dir whose name starts with `.`.

> Note: the underlying `send@1` dot-path behaviour is a property of the express-5 migration, not of Lens — these two routes are simply the only `sendFile` calls in the tool-server today.

### 2. Variant fails to anchor right after navigation

A `propose_variant` made immediately after navigating to a screen (exactly the navigate → screenshot → propose workflow) often failed to anchor: the card floated/hid ("didn't register"), or latched onto a same-text distractor (e.g. a bottom-bar tab instead of a header).

Cause: `captureElementFrame` describes the device **once** at propose time, but iOS' accessibility tree is empty for ~1.25 s after a screen appears and then fills incrementally (nav chrome before screen content) — measured on a real device.

Fix: `captureElementFrame` now retries across the warm-up window and **holds out for an exact label/identifier hit** (the intended element), falling back to a substring match only after the budget. `findElementMatch` / `matchFrameInTree` rank exact matches above substring ones. Adds `match-element-frame-cold-describe.test.ts`; two existing tests updated for the new retry signature.

### 3. Off-screen choices were unreachable

In the preview window, the off-screen reveal prompt (the "Show them" card and the "N hidden — show" pill) was hidden unless **every on-screen choice was already staged** (`onScreenStaged`). So a proposal whose element was off-screen showed a hidden-choice count with no affordance to surface it.

Fix: show the prompt whenever any element is off-screen (`offScreenCount > 0 && !revealOffscreen && !submitting`), dropping the `onScreenStaged` gate.

---

Supersedes #390, #392, #393 (same commits, combined).
