### PR TITLE
fix(debugger): stop unmatched device_id silently collapsing onto one device

### DIFF
--- a/packages/tool-server/src/utils/debugger/target-selection.ts
+++ b/packages/tool-server/src/utils/debugger/target-selection.ts
@@ -24,8 +24,35 @@ export function selectTarget(
   let candidates = targets;
 
   if (options?.deviceId) {
-    const filtered = candidates.filter((t) => t.reactNative?.logicalDeviceId === options.deviceId);
-    if (filtered.length) candidates = filtered;
+    const deviceId = options.deviceId;
+    const filtered = candidates.filter((t) => t.reactNative?.logicalDeviceId === deviceId);
+    if (filtered.length) {
+      candidates = filtered;
+    } else {
+      // No target matches the requested device. Silently falling back to the
+      // first/priority target here would route EVERY unmatched device_id to the
+      // same device — so two debugger sessions opened with different device_ids
+      // would both land on whichever device Metro happens to list first. Only
+      // fall back when there is a single device to fall back to; with multiple
+      // distinct devices connected, refuse to guess and report the valid ids so
+      // the caller can re-target (the logicalDeviceId is what debugger-connect
+      // returns and what subsequent debugger-* calls must pass).
+      const distinctDeviceIds = [
+        ...new Set(
+          targets
+            .map((t) => t.reactNative?.logicalDeviceId)
+            .filter((id): id is string => id !== undefined && id !== "")
+        ),
+      ];
+      if (distinctDeviceIds.length > 1) {
+        throw new Error(
+          `No debugger target matches device_id "${String(deviceId)}". ` +
+            `${distinctDeviceIds.length} devices are connected to Metro on port ${port}: ` +
+            `${distinctDeviceIds.join(", ")}. Pass one of these as device_id ` +
+            `(the logicalDeviceId returned by debugger-connect).`
+        );
+      }
+    }
   }
   if (options?.deviceName) {
     const filtered = candidates.filter((t) => t.deviceName === options.deviceName);

--- a/packages/tool-server/src/utils/debugger/target-selection.ts
+++ b/packages/tool-server/src/utils/debugger/target-selection.ts
@@ -37,19 +37,22 @@ export function selectTarget(
       // distinct devices connected, refuse to guess and report the valid ids so
       // the caller can re-target (the logicalDeviceId is what debugger-connect
       // returns and what subsequent debugger-* calls must pass).
-      const distinctDeviceIds = [
-        ...new Set(
-          targets
-            .map((t) => t.reactNative?.logicalDeviceId)
-            .filter((id): id is string => id !== undefined && id !== "")
-        ),
-      ];
-      if (distinctDeviceIds.length > 1) {
+      const distinctDevices = new Map<string, string | undefined>();
+      for (const t of targets) {
+        const id = t.reactNative?.logicalDeviceId;
+        if (id !== undefined && id !== "" && !distinctDevices.has(id)) {
+          distinctDevices.set(id, t.deviceName);
+        }
+      }
+      if (distinctDevices.size > 1) {
+        const listed = [...distinctDevices.entries()]
+          .map(([id, name]) => (name ? `${name} (${id})` : id))
+          .join(", ");
         throw new Error(
           `No debugger target matches device_id "${deviceId}". ` +
-            `${distinctDeviceIds.length} devices are connected to Metro on port ${port}: ` +
-            `${distinctDeviceIds.join(", ")}. Pass one of these as device_id ` +
-            `(the logicalDeviceId returned by debugger-connect).`
+            `${distinctDevices.size} devices are connected to Metro on port ${port}: ` +
+            `${listed}. Pass the logicalDeviceId (in parentheses) of the desired ` +
+            `device as device_id (the logicalDeviceId returned by debugger-connect).`
         );
       }
     }

--- a/packages/tool-server/src/utils/debugger/target-selection.ts
+++ b/packages/tool-server/src/utils/debugger/target-selection.ts
@@ -23,7 +23,7 @@ export function selectTarget(
 ): SelectedTarget {
   let candidates = targets;
 
-  if (options?.deviceId) {
+  if (typeof options?.deviceId === "string" && options.deviceId) {
     const deviceId = options.deviceId;
     const filtered = candidates.filter((t) => t.reactNative?.logicalDeviceId === deviceId);
     if (filtered.length) {
@@ -46,7 +46,7 @@ export function selectTarget(
       ];
       if (distinctDeviceIds.length > 1) {
         throw new Error(
-          `No debugger target matches device_id "${String(deviceId)}". ` +
+          `No debugger target matches device_id "${deviceId}". ` +
             `${distinctDeviceIds.length} devices are connected to Metro on port ${port}: ` +
             `${distinctDeviceIds.join(", ")}. Pass one of these as device_id ` +
             `(the logicalDeviceId returned by debugger-connect).`

--- a/packages/tool-server/test/metro/multi-device.test.ts
+++ b/packages/tool-server/test/metro/multi-device.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { WebSocketServer, WebSocket } from "ws";
+import * as http from "node:http";
+import { Registry } from "@argent/registry";
+import { jsRuntimeDebuggerBlueprint } from "../../src/blueprints/js-runtime-debugger";
+import { debuggerConnectTool } from "../../src/tools/debugger/debugger-connect";
+
+/**
+ * End-to-end regression for the "multiple debuggers all resolve to the same
+ * device despite being passed different device_id" bug.
+ *
+ * Stands up a mock Metro whose /json/list reports TWO distinct devices (each
+ * with its own logicalDeviceId + deviceName) on a single port, then drives the
+ * real Registry → JsRuntimeDebugger blueprint → debugger-connect path.
+ */
+
+let mockServer: http.Server;
+let wss: WebSocketServer;
+let mockPort: number;
+let registry: Registry;
+
+const DEVICES = [
+  { logicalDeviceId: "logical-aaa", deviceName: "iPhone 16 Pro Max" },
+  { logicalDeviceId: "logical-bbb", deviceName: "Pixel 9" },
+];
+
+function handleCDPMessage(ws: WebSocket, raw: string) {
+  const { id, method } = JSON.parse(raw) as { id: number; method: string };
+  switch (method) {
+    case "Debugger.enable":
+      ws.send(JSON.stringify({ id, result: { debuggerId: "mock" } }));
+      ws.send(
+        JSON.stringify({
+          method: "Debugger.scriptParsed",
+          params: {
+            scriptId: "1",
+            url: "http://localhost/index.bundle?platform=ios&dev=true",
+            startLine: 0,
+            endLine: 1,
+            sourceMapURL: "index.bundle.map",
+          },
+        })
+      );
+      break;
+    default:
+      ws.send(JSON.stringify({ id, result: {} }));
+  }
+}
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    mockServer = http.createServer((req, res) => {
+      if (req.url === "/status") {
+        res.setHeader("X-React-Native-Project-Root", "/mock/project");
+        res.end("packager-status:running");
+        return;
+      }
+      if (req.url === "/json/list") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify(
+            DEVICES.map((d, i) => ({
+              id: `page-${i}`,
+              title: `app (${d.deviceName})`,
+              description: "[C++ connection]",
+              webSocketDebuggerUrl: `ws://localhost:${mockPort}/inspector/debug?device=${d.logicalDeviceId}&page=1`,
+              deviceName: d.deviceName,
+              reactNative: {
+                logicalDeviceId: d.logicalDeviceId,
+                capabilities: { prefersFuseboxFrontend: true },
+              },
+            }))
+          )
+        );
+        return;
+      }
+      res.statusCode = 404;
+      res.end("Not found");
+    });
+
+    wss = new WebSocketServer({ server: mockServer });
+    wss.on("connection", (ws) => ws.on("message", (raw) => handleCDPMessage(ws, raw.toString())));
+
+    mockServer.listen(0, () => {
+      mockPort = (mockServer.address() as { port: number }).port;
+      resolve();
+    });
+  });
+
+  registry = new Registry();
+  registry.registerBlueprint(jsRuntimeDebuggerBlueprint);
+  registry.registerTool(debuggerConnectTool);
+});
+
+afterAll(async () => {
+  await registry.dispose();
+  await new Promise<void>((resolve) => wss.close(() => mockServer.close(() => resolve())));
+});
+
+describe("multi-device debugger routing (mock Metro, two devices)", () => {
+  it("routes each device_id to its own device", async () => {
+    const a = (await registry.invokeTool("debugger-connect", {
+      port: mockPort,
+      device_id: "logical-aaa",
+    })) as Record<string, unknown>;
+    const b = (await registry.invokeTool("debugger-connect", {
+      port: mockPort,
+      device_id: "logical-bbb",
+    })) as Record<string, unknown>;
+
+    expect(a.deviceName).toBe("iPhone 16 Pro Max");
+    expect(b.deviceName).toBe("Pixel 9");
+    // The two connections must NOT collapse onto the same device.
+    expect(a.logicalDeviceId).not.toBe(b.logicalDeviceId);
+  });
+
+  it("rejects an unmatched device_id instead of silently picking the first device", async () => {
+    await expect(
+      registry.invokeTool("debugger-connect", { port: mockPort, device_id: "not-a-real-device" })
+    ).rejects.toThrow(/No debugger target matches device_id "not-a-real-device"/);
+  });
+});

--- a/packages/tool-server/test/metro/target-selection.test.ts
+++ b/packages/tool-server/test/metro/target-selection.test.ts
@@ -120,6 +120,37 @@ describe("selectTarget", () => {
     expect(() => selectTarget([dev1, dev2], 8081, { deviceId: "unmatched" })).toThrow(/aaa.*bbb/);
   });
 
+  it("surfaces deviceName alongside logicalDeviceId so the caller can map ids to devices", () => {
+    const ipad = makeTarget({
+      id: "dev1",
+      deviceName: "iPad Pro",
+      reactNative: { logicalDeviceId: "9e7844f7" },
+    });
+    const iphone = makeTarget({
+      id: "dev2",
+      deviceName: "iPhone 16",
+      reactNative: { logicalDeviceId: "8a44101d" },
+    });
+
+    // Each listed device shows its human-readable name next to the hash.
+    expect(() => selectTarget([ipad, iphone], 8081, { deviceId: "some-udid" })).toThrow(
+      /iPad Pro \(9e7844f7\).*iPhone 16 \(8a44101d\)/
+    );
+  });
+
+  it("falls back to the bare logicalDeviceId when a device has no deviceName", () => {
+    const named = makeTarget({
+      id: "dev1",
+      deviceName: "iPhone 16",
+      reactNative: { logicalDeviceId: "aaa" },
+    });
+    const unnamed = makeTarget({ id: "dev2", reactNative: { logicalDeviceId: "bbb" } });
+
+    expect(() => selectTarget([named, unnamed], 8081, { deviceId: "unmatched" })).toThrow(
+      /iPhone 16 \(aaa\).*bbb/
+    );
+  });
+
   it("still falls back to the only device when a single device is connected", () => {
     // Single-device convenience: callers may pass an id Metro never echoes (e.g.
     // an iOS simulator UDID, which is not the logicalDeviceId). With one device

--- a/packages/tool-server/test/metro/target-selection.test.ts
+++ b/packages/tool-server/test/metro/target-selection.test.ts
@@ -92,4 +92,63 @@ describe("selectTarget", () => {
     const result = selectTarget([dev1, dev2], 8081, { deviceId: "bbb" });
     expect(result.target.id).toBe("dev2");
   });
+
+  it("routes distinct deviceIds to distinct devices (no collapse)", () => {
+    const dev1 = makeTarget({
+      id: "dev1",
+      reactNative: { logicalDeviceId: "aaa", capabilities: { prefersFuseboxFrontend: true } },
+    });
+    const dev2 = makeTarget({
+      id: "dev2",
+      reactNative: { logicalDeviceId: "bbb", capabilities: { prefersFuseboxFrontend: true } },
+    });
+
+    expect(selectTarget([dev1, dev2], 8081, { deviceId: "aaa" }).target.id).toBe("dev1");
+    expect(selectTarget([dev1, dev2], 8081, { deviceId: "bbb" }).target.id).toBe("dev2");
+  });
+
+  it("throws instead of silently collapsing when an unmatched deviceId is ambiguous", () => {
+    const dev1 = makeTarget({ id: "dev1", reactNative: { logicalDeviceId: "aaa" } });
+    const dev2 = makeTarget({ id: "dev2", reactNative: { logicalDeviceId: "bbb" } });
+
+    // An id that matches neither device must NOT resolve to the first target —
+    // that is the "all debuggers resolve to the same device" bug.
+    expect(() => selectTarget([dev1, dev2], 8081, { deviceId: "unmatched" })).toThrow(
+      /No debugger target matches device_id "unmatched"/
+    );
+    // The error must surface the valid ids so the caller can re-target.
+    expect(() => selectTarget([dev1, dev2], 8081, { deviceId: "unmatched" })).toThrow(/aaa.*bbb/);
+  });
+
+  it("still falls back to the only device when a single device is connected", () => {
+    // Single-device convenience: callers may pass an id Metro never echoes (e.g.
+    // an iOS simulator UDID, which is not the logicalDeviceId). With one device
+    // there is no ambiguity, so selection must succeed via fallback.
+    const fusebox = makeTarget({
+      id: "only",
+      reactNative: {
+        logicalDeviceId: "real-logical-id",
+        capabilities: { prefersFuseboxFrontend: true },
+      },
+    });
+    const uiPage = makeTarget({
+      id: "only-ui",
+      reactNative: { logicalDeviceId: "real-logical-id" },
+    });
+
+    const result = selectTarget([fusebox, uiPage], 8081, { deviceId: "some-ios-udid" });
+    expect(result.target.id).toBe("only");
+  });
+
+  it("falls back when no target exposes a logicalDeviceId at all", () => {
+    // Old-arch / pre-Fusebox targets omit reactNative.logicalDeviceId entirely.
+    const t1 = makeTarget({ id: "first" });
+    const t2 = makeTarget({
+      id: "second",
+      reactNative: { capabilities: { prefersFuseboxFrontend: true } },
+    });
+
+    const result = selectTarget([t1, t2], 8081, { deviceId: "anything" });
+    expect(result.target.id).toBe("second");
+  });
 });


### PR DESCRIPTION
## Problem

Opening debugger sessions with **different** `device_id`s could all resolve to the **same** physical device.

`selectTarget` filters Metro's `/json/list` CDP targets by `reactNative.logicalDeviceId === device_id`, but when the provided `device_id` matched **no** target it kept *all* candidates and fell through to the first/priority target:

```ts
const filtered = candidates.filter((t) => t.reactNative?.logicalDeviceId === options.deviceId);
if (filtered.length) candidates = filtered; // unmatched id → silently ignored
```

This silently no-ops surprisingly often: Metro's `logicalDeviceId` is an internal hash, **not** the iOS simulator UDID. Verified live against a real device:

- simulator UDID: `6DBF83B4-F341-4F8D-B48D-CD8FF312CCFB`
- Metro `logicalDeviceId`: `a1956f6bd1e3a3ac3dbb505e24d79687a5ea60b1`

With one device the fallback is harmless (it picks the only device). With **several** devices on one Metro, every unmatched `device_id` collapses onto whichever device Metro lists first — so two debugger sessions opened with different `device_id`s drive the same device.

## Fix

In `selectTarget`, only fall back to the priority target when there is **at most one distinct device** to fall back to. When multiple distinct devices are connected and the `device_id` matches none, throw an error that lists the valid `logicalDeviceId`s so the caller can re-target instead of being silently misrouted. The single-device convenience path (pass any id — including a UDID — and get the one connected device) is preserved.

## Verification

- `selectTarget` unit tests: distinct ids → distinct devices; ambiguous unmatched id throws and surfaces the valid ids; single-device and no-`logicalDeviceId` fallbacks still work.
- Full-stack multi-device test driving `Registry → JsRuntimeDebugger → debugger-connect` against a two-device mock Metro: distinct `device_id`s route to distinct devices; unmatched id is rejected.
- Full `tool-server` suite: **1203 passed**.
- Confirmed the real contract on a live iOS sim: `debugger-connect` with the UDID still connects (single-device fallback) and returns `logicalDeviceId a1956f…`.

## Notes

The three RN-only debugger tools (`debugger-component-tree`, `debugger-inspect-element`, `debugger-reload-metro`) build their Metro service ref via a raw template literal instead of `debuggerServiceRef()`. For the Metro path the resulting URN is byte-identical, so it's not part of this bug; left untouched to keep the fix scoped.
