### PR TITLE
fix(screenshot): wait for first frame so multi-sim captures don't fail (#391)

### DIFF
--- a/packages/tool-server/src/utils/simulator-client.ts
+++ b/packages/tool-server/src/utils/simulator-client.ts
@@ -2,8 +2,20 @@ import WebSocket from "ws";
 import { FAILURE_CODES, FailureError } from "@argent/registry";
 import type { SimulatorServerApi } from "../blueprints/simulator-server";
 import { toSimulatorNetworkError } from "./format-error";
+import { sleep } from "./timing";
 
 const DEFAULT_SCREENSHOT_SCALE = 0.3;
+
+// A simulator-server captures screenshots from its live frame stream, so the
+// first frame must have arrived before a capture can succeed. Right after the
+// server starts streaming it replies HTTP 200 `{ error: "no image to export" }`
+// until that first frame lands — typically ~0.5-1s, and reliably so for a
+// backgrounded simulator when more than one is booted (the regression in
+// https://github.com/software-mansion/argent/issues/391). Poll past that
+// transient instead of surfacing it as a hard failure.
+const NO_IMAGE_ERROR = /no image to export/i;
+const FIRST_FRAME_WAIT_MS = 6_000;
+const FIRST_FRAME_POLL_MS = 250;
 
 const connections = new Map<string, WebSocket>();
 let cmdId = 0;
@@ -106,33 +118,51 @@ export async function httpScreenshot(
   if (rotation) body.rotation = rotation;
   if (resolvedScale !== 1.0) body.scale = resolvedScale;
 
-  const { res, body: resBody } = await simulatorPost<{
-    url?: string;
-    path?: string;
-    error?: string;
-  }>("Screenshot", api, "/api/screenshot", body, signal);
+  const deadline = Date.now() + FIRST_FRAME_WAIT_MS;
+  for (;;) {
+    const { res, body: resBody } = await simulatorPost<{
+      url?: string;
+      path?: string;
+      error?: string;
+    }>("Screenshot", api, "/api/screenshot", body, signal);
 
-  if (!res.ok) {
-    const serverMsg = resBody.error ?? `HTTP ${res.status}`;
-    throw new FailureError(
-      `Screenshot failed: ${serverMsg}. ` +
-        `Ensure the simulator is booted and the simulator-server is running.`,
-      {
-        error_code: FAILURE_CODES.SIMULATOR_HTTP_ERROR_RESPONSE,
-        failure_stage: "simulator_screenshot_http_response",
-        failure_area: "tool_server",
-        error_kind: "network",
-        network_failure: "invalid_response",
-      }
-    );
-  }
-  if (resBody.url == null || resBody.path == null) {
-    // Some capture failures come back as HTTP 200 with an `error` field rather
-    // than a non-2xx status (e.g. Android full-resolution requests that exceed
-    // what the emulator framebuffer can stream: "wrong data size, expected X
-    // got Y"). Surface that message instead of the misleading generic hint so
-    // the real cause is visible rather than sending callers to restart a
-    // perfectly healthy server.
+    if (!res.ok) {
+      const serverMsg = resBody.error ?? `HTTP ${res.status}`;
+      throw new FailureError(
+        `Screenshot failed: ${serverMsg}. ` +
+          `Ensure the simulator is booted and the simulator-server is running.`,
+        {
+          error_code: FAILURE_CODES.SIMULATOR_HTTP_ERROR_RESPONSE,
+          failure_stage: "simulator_screenshot_http_response",
+          failure_area: "tool_server",
+          error_kind: "network",
+          network_failure: "invalid_response",
+        }
+      );
+    }
+    if (resBody.url != null && resBody.path != null) {
+      return { url: resBody.url, path: resBody.path };
+    }
+
+    // HTTP 200 with no url/path. A "no image to export" means the frame stream
+    // hasn't produced its first frame yet; poll until it does (or the deadline
+    // passes) rather than failing a freshly-spawned or backgrounded simulator.
+    if (
+      resBody.error &&
+      NO_IMAGE_ERROR.test(resBody.error) &&
+      !signal?.aborted &&
+      Date.now() + FIRST_FRAME_POLL_MS < deadline
+    ) {
+      await sleep(FIRST_FRAME_POLL_MS);
+      continue;
+    }
+
+    // Other HTTP-200 capture failures carry an `error` field rather than a
+    // non-2xx status (e.g. Android full-resolution requests that exceed what
+    // the emulator framebuffer can stream: "wrong data size, expected X got
+    // Y"). Surface that message instead of the misleading generic hint so the
+    // real cause is visible rather than sending callers to restart a perfectly
+    // healthy server.
     if (resBody.error) {
       throw new Error(`Screenshot failed: ${resBody.error}.`);
     }
@@ -148,5 +178,4 @@ export async function httpScreenshot(
       }
     );
   }
-  return { url: resBody.url, path: resBody.path };
 }

--- a/packages/tool-server/test/simulator-client.test.ts
+++ b/packages/tool-server/test/simulator-client.test.ts
@@ -48,4 +48,59 @@ describe("httpScreenshot", () => {
       path: "/tmp/x.png",
     });
   });
+
+  it("retries 'no image to export' until the first frame lands, then resolves", async () => {
+    // A freshly-spawned simulator-server has not captured its first frame yet,
+    // so the streaming screenshot endpoint replies 200 { error: "no image to
+    // export" } for ~0.5-1s. The capture must poll past that rather than fail
+    // (regression #391: reliably hit with >1 booted simulator).
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          calls += 1;
+          const json =
+            calls < 3
+              ? { error: "no image to export" }
+              : { url: "http://127.0.0.1:4949/media/x.png", path: "/tmp/x.png" };
+          return { ok: true, status: 200, json: async () => json } as unknown as Response;
+        })
+      );
+      const pending = httpScreenshot(api);
+      await vi.advanceTimersByTimeAsync(600);
+      await expect(pending).resolves.toEqual({
+        url: "http://127.0.0.1:4949/media/x.png",
+        path: "/tmp/x.png",
+      });
+      expect(calls).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives up with the 'no image to export' message once the first-frame deadline passes", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            json: async () => ({ error: "no image to export" }),
+          }) as unknown as Response
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const pending = httpScreenshot(api);
+      const expectation = expect(pending).rejects.toThrow("Screenshot failed: no image to export.");
+      await vi.advanceTimersByTimeAsync(7_000);
+      await expectation;
+      // Polling is bounded (~6s / 250ms ≈ 24 attempts), never an infinite loop.
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+      expect(fetchMock.mock.calls.length).toBeLessThan(40);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
After more investigation i've found a much better fix for #391. 
I'm merging this either way, because it blocks 0.13.0 release and we already have this fix tested and approved.
By the next release, I want to revert this patch in favour of fixing core of the issue in simserver.

Regression introduced by https://github.com/software-mansion/radon/pull/101 adding the streaming feature to the argent simulator-server build, which made `/api/screenshot` serve the last streamed frame async instead of capturing on demand. 

<details>

## Summary

Fixes #391 — `screenshot` failing with `no image to export` when more than one simulator is booted, even with an explicit `--udid`. Regression in 0.12.x.

## Root cause

The simulator-server captures screenshots from its **live frame stream**, so a capture only succeeds once the first frame has arrived. Immediately after the server starts streaming, `POST /api/screenshot` replies `HTTP 200 { error: "no image to export" }` until that first frame lands (~0.5–1s). The tool-server requested the capture right after the server became ready, **losing that race**.

- With a single, foreground simulator the first frame arrives fast enough that the race is usually won — hiding the bug.
- With more than one simulator booted, the target is often backgrounded and its first frame is delayed, so the race is lost **reliably** → `no image to export`.

This became reachable when streaming was enabled for the argent simulator-server build in 0.12.x (radon [#101](https://github.com/software-mansion/radon/pull/101)); the 0.11.0 non-streaming build captured frames on demand, so it was immune. Device selection itself is correct — each device's stream captures the right device (verified: Pro Max → 1320×2868, iPhone 15 → 1179×2556).

## Fix

`httpScreenshot` now polls past that specific transient (every 250ms, up to 6s) instead of failing immediately, while still surfacing every other error (non-2xx, Android `wrong data size`, missing url/path) right away.

## Verification

End-to-end against the **shipped** simulator-server binary with **three** booted simulators, forcing a fresh sim-server spawn before each capture:

| | result |
|---|---|
| **unfixed** (current `dist`) | `no image to export` ~2/3 of fresh-spawn attempts |
| **fixed** | 7/7 success (~800ms), returns a correct PNG (1320×2868) |

- `npm test` (tool-server): **1199 passed**, including new retry / give-up cases for `httpScreenshot`
- `npx tsc --build`, `prettier --check`, `typecheck:tests`: clean

</details>
