### PR TITLE
fix(telemetry): orchestator sub-tools invocations was missing ai_client and platform attributes

### DIFF
--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -71,6 +71,25 @@ export interface InvokeToolOptions {
   fileInputs?: Record<string, ResolvedFileInput>;
   /** Optional caller-provided id used to correlate outer request metadata. */
   toolInvocationId?: string;
+  /**
+   * Registers a freshly-minted invocation id against the outer request's
+   * telemetry attribution, returning a release fn. Set by the tool-server's HTTP
+   * layer (bound to the request's metadata) and forwarded verbatim into
+   * {@link ToolContext}. Orchestrator tools (run-sequence, flow-execute,
+   * flow-add-step) call it for every sub-tool they dispatch through
+   * {@link Registry.invokeTool} so nested invocations inherit attribution
+   * instead of being recorded as anonymous; they also pass it back down here so
+   * propagation survives arbitrary nesting.
+   *
+   * The outer request's AI client is inherited unchanged. The platform is
+   * re-derived from each sub-tool's own `childArgs` (its `udid` / `device_id` /
+   * `avdName`), falling back to the outer request's platform when the sub-tool
+   * carries no device arg — an orchestrator like flow-execute has no platform of
+   * its own and a single flow can target several devices, so the child's device
+   * arg is the only correct platform source. Opaque to the registry — it neither
+   * reads nor validates the recorded metadata.
+   */
+  recordChildInvocation?: (toolInvocationId: string, childArgs?: unknown) => () => void;
 }
 
 /**

--- a/packages/telemetry/src/events.ts
+++ b/packages/telemetry/src/events.ts
@@ -142,10 +142,6 @@ export interface ToolserverStopProps extends FailureTelemetryProps {
   total_tool_calls: number;
 }
 
-// Consent transition events
-
-export type TelemetryOptOutProps = Record<string, never>;
-
 // Discriminated union for typed-track()
 
 export interface EventPropertyMap {
@@ -170,7 +166,6 @@ export interface EventPropertyMap {
   "cli:run_fail": CliRunFailProps;
   "toolserver:start": ToolserverStartProps;
   "toolserver:stop": ToolserverStopProps;
-  "telemetry:opt_out": TelemetryOptOutProps;
 }
 
 export type EventName = keyof EventPropertyMap;
@@ -198,5 +193,4 @@ export const EVENT_NAMES: readonly EventName[] = [
   "cli:run_fail",
   "toolserver:start",
   "toolserver:stop",
-  "telemetry:opt_out",
 ];

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { sanitize } from "./sanitize.js";
 import { getBaseProps, type Runtime } from "./base-props.js";
 import { readOrCreateAnonId, peekAnonId } from "./identity.js";
-import { isEnabled as consentIsEnabled, writeConsentFlag, getConsentState } from "./consent.js";
+import { isEnabled, writeConsentFlag, getConsentState } from "./consent.js";
 import { emitDebugError, emitDebugPayload, isDebugEnabled } from "./debug.js";
 import { forget as forgetImpl, type ForgetOptions, type ForgetResult } from "./erasure.js";
 import type { EventName, EventPropertyMap } from "./events.js";
@@ -25,10 +25,10 @@ export { POSTHOG_HOST, resolveConfig } from "./posthog.js";
 export { _resetConsentCacheForTest } from "./consent.js";
 export { EVENT_NAMES } from "./events.js";
 export { isDebugEnabled } from "./debug.js";
-export { getConsentState } from "./consent.js";
-// Persists the consent flag without emitting a transition event — for recording
-// an initial first-run choice. Use markDisabled() (not this) for a live opt-out
-// that should send a final telemetry:opt_out before the pipe closes.
+export { getConsentState, isEnabled } from "./consent.js";
+// Persists the consent flag — for recording an initial first-run choice. Use
+// markDisabled() (not this) for a live opt-out that should also drain and reset
+// the running client.
 export { writeConsentFlag } from "./consent.js";
 // Applies a first-run choice to the current session only (in-process, not on
 // disk), so an interactive consent prompt can govern this run's events before
@@ -105,7 +105,7 @@ function buildPayload(
  */
 export function track<E extends EventName>(event: E, props: EventPropertyMap[E]): void {
   try {
-    if (!consentIsEnabled()) return;
+    if (!isEnabled()) return;
     // Resolve the client before buildPayload(): buildPayload creates/persists
     // the anon-id file, and there's no reason to provision a persistent
     // identifier on disk for an event that can never be transmitted (no usable
@@ -165,48 +165,19 @@ export async function shutdown(timeoutMs = SHORT_FLUSH_TIMEOUT_MS): Promise<void
   }
 }
 
-export function isEnabled(): boolean {
-  return consentIsEnabled();
-}
-
 /** Persist `enabled=true`. */
 export function markEnabled(): void {
   writeConsentFlag(true);
 }
 
-// Disable records one final opt-out event, persists the flag, then drains.
+// Disable persists the opt-out flag, then drains any already-queued events and
+// resets the running client.
 export async function markDisabled(): Promise<void> {
   try {
-    const wasEnabled = consentIsEnabled();
-    let client = getConstructedClient();
-    // Only announce the opt-out when a persistent id already exists on disk.
-    // buildPayload() goes through readOrCreateAnonId(), so emitting the event on
-    // a machine that has never sent anything would mint a durable identifier
-    // purely to transmit the opt-out — provisioning identity at the exact moment
-    // the user is opting out. peekAnonId() reads without creating.
-    if (wasEnabled && peekAnonId() !== null) {
-      const built = buildPayload("telemetry:opt_out", {});
-      if (built && isDebugEnabled()) {
-        emitDebugPayload({
-          event: "telemetry:opt_out",
-          distinctId: built.distinctId,
-          properties: built.properties,
-          ts: new Date().toISOString(),
-        });
-      }
-      client = getClient();
-      if (built && client) {
-        try {
-          client.capture({
-            distinctId: built.distinctId,
-            event: "telemetry:opt_out",
-            properties: built.properties,
-          });
-        } catch (err) {
-          emitDebugError("markDisabled: capture(telemetry:opt_out) failed", err);
-        }
-      }
-    }
+    // Drain only a client that already exists; opting out must never construct
+    // one (and thereby mint a durable anon-id) on a machine that has never sent
+    // anything.
+    const client = getConstructedClient();
     writeConsentFlag(false);
     if (client) {
       try {

--- a/packages/telemetry/src/sanitize.ts
+++ b/packages/telemetry/src/sanitize.ts
@@ -211,7 +211,6 @@ export const ALLOWED: ValidatorMap = {
     total_tool_calls: COUNT,
     ...FAILURE_SIGNAL,
   },
-  "telemetry:opt_out": {},
 };
 
 /** Strip keys and values that are not allowed for this event. */

--- a/packages/telemetry/test/index.test.ts
+++ b/packages/telemetry/test/index.test.ts
@@ -63,7 +63,7 @@ describe("telemetry public surface", () => {
     vi.restoreAllMocks();
   });
 
-  it("markDisabled queues opt-out, persists disabled state, and drains prior events", async () => {
+  it("markDisabled persists disabled state and drains prior events without emitting an opt-out event", async () => {
     track("toolserver:start", {});
     const client = posthogMock.instances[0]!;
 
@@ -74,10 +74,11 @@ describe("telemetry public surface", () => {
     await markDisabled();
 
     expect(posthogMock.instances).toHaveLength(1);
+    expect(client.capture).toHaveBeenCalledTimes(1);
     expect(client.capture).toHaveBeenCalledWith(
       expect.objectContaining({ event: "toolserver:start" })
     );
-    expect(client.capture).toHaveBeenCalledWith(
+    expect(client.capture).not.toHaveBeenCalledWith(
       expect.objectContaining({ event: "telemetry:opt_out" })
     );
     expect(client.flush).not.toHaveBeenCalled();

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -136,15 +136,31 @@ function extractInvocationMeta(
 ): InvocationMeta | null {
   const meta: InvocationMeta = { ...aiMeta };
   if (hasCapability && data && typeof data === "object") {
-    const record = data as Record<string, unknown>;
-    const deviceArg = extractDeviceArg(record);
-    if (deviceArg) {
-      meta.platform = resolveDevice(deviceArg).platform;
-    } else if (typeof record.avdName === "string") {
-      meta.platform = "android";
-    }
+    const platform = platformFromArgs(data);
+    if (platform) meta.platform = platform;
   }
   return Object.keys(meta).length > 0 ? meta : null;
+}
+
+/** Coarse platform from a tool call's device arg (`udid` / `device_id` / `avdName`), or null. */
+function platformFromArgs(data: unknown): Platform | null {
+  if (!data || typeof data !== "object") return null;
+  const deviceArg = extractDeviceArg(data);
+  if (deviceArg) return inferPlatform(deviceArg) ?? null;
+  if (typeof (data as Record<string, unknown>).avdName === "string") return "android";
+  return null;
+}
+
+/**
+ * Attribution for a sub-tool an orchestrator dispatches: the outer request's AI
+ * client is inherited unchanged, but the platform is re-derived from the child's
+ * OWN device arg. Orchestrators like flow-execute carry no platform (and a flow
+ * can span several devices), so the child's `udid` is the only correct source;
+ * the parent's platform is the fallback when the child has no device arg.
+ */
+function deriveChildInvocationMeta(parentMeta: InvocationMeta, childArgs: unknown): InvocationMeta {
+  const childPlatform = platformFromArgs(childArgs);
+  return childPlatform ? { ...parentMeta, platform: childPlatform } : parentMeta;
 }
 
 // ── HTTP app ────────────────────────────────────────────────────────
@@ -587,10 +603,21 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
       // Hashing happens in the telemetry listener, not in the HTTP layer.
       const toolInvocationId = randomUUID();
       let releaseInvocationMeta: (() => void) | undefined;
-      if (options?.recordInvocation) {
+      // A recorder bound to THIS request's attribution, handed to orchestrator
+      // tools (run-sequence, flow-execute) so the sub-tools they dispatch
+      // directly through the registry inherit the same ai_client / platform
+      // instead of being recorded as anonymous. Only present when there is
+      // attribution worth propagating.
+      let recordChildInvocation:
+        | ((childInvocationId: string, childArgs?: unknown) => () => void)
+        | undefined;
+      const recordInvocation = options?.recordInvocation;
+      if (recordInvocation) {
         const invocationMeta = extractInvocationMeta(Boolean(def.capability), parsedData, aiMeta);
         if (invocationMeta) {
-          releaseInvocationMeta = options.recordInvocation(toolInvocationId, invocationMeta);
+          releaseInvocationMeta = recordInvocation(toolInvocationId, invocationMeta);
+          recordChildInvocation = (childInvocationId, childArgs) =>
+            recordInvocation(childInvocationId, deriveChildInvocationMeta(invocationMeta, childArgs));
         }
       }
 
@@ -599,6 +626,7 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
           signal: controller.signal,
           ...(resolvedFileInputs ? { fileInputs: resolvedFileInputs } : {}),
           toolInvocationId,
+          ...(recordChildInvocation ? { recordChildInvocation } : {}),
         });
         // Gate on `updateInstallable` (not `updateAvailable`) and advertise the
         // version the resolver would install — both account for the release-age policy.

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -617,7 +617,10 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
         if (invocationMeta) {
           releaseInvocationMeta = recordInvocation(toolInvocationId, invocationMeta);
           recordChildInvocation = (childInvocationId, childArgs) =>
-            recordInvocation(childInvocationId, deriveChildInvocationMeta(invocationMeta, childArgs));
+            recordInvocation(
+              childInvocationId,
+              deriveChildInvocationMeta(invocationMeta, childArgs)
+            );
         }
       }
 

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { Registry, ToolDefinition } from "@argent/registry";
 import { getActiveFlow, appendStepToActiveFlow, type FlowSavedTo } from "./flow-utils";
+import { invokeSubTool } from "../../utils/sub-invoke";
 
 const zodSchema = z.object({
   command: z.string().describe('MCP tool name (e.g. "tap", "screenshot", "launch-app")'),
@@ -29,11 +30,11 @@ export function createFlowAddStepTool(
     description: `Execute a tool call and record it as a step in the active flow. Use when recording a flow with flow-start-recording and you want to run and capture each action. Returns { message, toolResult, flowFile } on success. If it fails an error is returned and nothing is recorded. Error if the tool name is not found in the registry or arguments are invalid JSON.\nIf a step was recorded by mistake, edit the .yaml file directly to remove it.`,
     zodSchema,
     services: () => ({}),
-    async execute(_services, params) {
+    async execute(_services, params, ctx) {
       const flowName = getActiveFlow();
       const args: Record<string, unknown> = params.args ? JSON.parse(params.args) : {};
 
-      const toolResult = await registry.invokeTool(params.command, args);
+      const toolResult = await invokeSubTool(registry, ctx, params.command, args);
 
       const { flowFile, savedTo } = await appendStepToActiveFlow({
         kind: "tool",

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -9,6 +9,7 @@ import {
   type FlowStep,
 } from "./flow-utils";
 import { sleep } from "../../utils/timing";
+import { invokeSubTool } from "../../utils/sub-invoke";
 
 const zodSchema = z.object({
   name: z.string().describe('Name of the flow to run (e.g. "settings-explore")'),
@@ -77,7 +78,7 @@ Use flow-read-prerequisite to inspect the prerequisite beforehand.`,
     zodSchema,
     fileInputs,
     services: () => ({}),
-    async execute(_services, params) {
+    async execute(_services, params, ctx) {
       const filePath = resolveFlowFilePath(params);
       const fileContent = await fs.readFile(filePath, "utf8");
       const flow = parseFlow(fileContent);
@@ -107,7 +108,7 @@ Use flow-read-prerequisite to inspect the prerequisite beforehand.`,
         const toolDef = registry.getTool(step.name);
 
         try {
-          const result = await registry.invokeTool(step.name, step.args);
+          const result = await invokeSubTool(registry, ctx, step.name, step.args);
           steps.push({
             kind: "tool",
             tool: step.name,

--- a/packages/tool-server/src/tools/run-sequence/index.ts
+++ b/packages/tool-server/src/tools/run-sequence/index.ts
@@ -6,6 +6,7 @@ import { chromiumCdpRef } from "../../blueprints/chromium-cdp";
 import { resolveDevice } from "../../utils/device-info";
 import { assertSupported, UnsupportedOperationError } from "../../utils/capability";
 import { sleep, DEFAULT_INTER_STEP_DELAY_MS } from "../../utils/timing";
+import { invokeSubTool } from "../../utils/sub-invoke";
 
 const ALLOWED_TOOLS = new Set([
   "gesture-tap",
@@ -127,7 +128,7 @@ Stops on the first error and returns partial results.`,
       }
       return { simulatorServer: simulatorServerRef(device) };
     },
-    async execute(_services, params) {
+    async execute(_services, params, ctx) {
       const { udid, steps } = params;
       const device = resolveDevice(udid);
       const results: StepResult[] = [];
@@ -161,7 +162,7 @@ Stops on the first error and returns partial results.`,
 
         try {
           const toolArgs = { ...step.args, udid };
-          const result = await registry.invokeTool(step.tool, toolArgs);
+          const result = await invokeSubTool(registry, ctx, step.tool, toolArgs);
           results.push({ tool: step.tool, result });
         } catch (err) {
           results.push({

--- a/packages/tool-server/src/utils/sub-invoke.ts
+++ b/packages/tool-server/src/utils/sub-invoke.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from "node:crypto";
+import type { Registry, ToolContext } from "@argent/registry";
+
+/**
+ * Dispatch a tool as a child of the current orchestrator invocation.
+ *
+ * run-sequence / flow-execute / flow-add-step run their steps by calling
+ * `registry.invokeTool` directly. Each such call would otherwise emit its
+ * lifecycle events under a fresh, unrecorded invocation id — so the AI-client /
+ * platform attribution the HTTP layer captured for the outer request never
+ * reaches the nested gestures, and they're recorded as anonymous.
+ *
+ * When the outer request carried attribution, `ctx.recordChildInvocation` is
+ * present: mint an id, register it (inheriting the outer AI client, with the
+ * platform re-derived from this sub-tool's own `args`), invoke with that id, and
+ * release afterwards. We also forward the recorder so propagation survives
+ * further nesting (e.g. flow-execute → run-sequence → gesture-tap).
+ *
+ * When there is nothing to propagate (direct invocations, unit tests, or a
+ * request with no AI-client / platform context), this is a thin pass-through
+ * that invokes exactly as before.
+ */
+export async function invokeSubTool<T = unknown>(
+  registry: Registry,
+  ctx: ToolContext | undefined,
+  toolId: string,
+  args: unknown
+): Promise<T> {
+  const recordChildInvocation = ctx?.recordChildInvocation;
+  if (!recordChildInvocation) {
+    return registry.invokeTool<T>(toolId, args);
+  }
+
+  const toolInvocationId = randomUUID();
+  const release = recordChildInvocation(toolInvocationId, args);
+  try {
+    return await registry.invokeTool<T>(toolId, args, {
+      toolInvocationId,
+      recordChildInvocation,
+    });
+  } finally {
+    release();
+  }
+}

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Registry } from "@argent/registry";
+import type { Registry, ToolContext } from "@argent/registry";
 
 import { flowStartRecordingTool } from "../../src/tools/flows/flow-start-recording";
 import { flowInsertEchoTool } from "../../src/tools/flows/flow-insert-echo";
@@ -248,6 +248,31 @@ describe("flow-add-step", () => {
     });
   });
 
+  it("propagates the request's telemetry attribution to the recorded sub-tool", async () => {
+    const registry = createMockRegistry({ tap: { result: { ok: true } } });
+    const tool = createFlowAddStepTool(registry);
+    const release = vi.fn();
+    const recordChildInvocation = vi.fn((_id: string, _args?: unknown) => release);
+    const ctx = { artifacts: {}, recordChildInvocation } as unknown as ToolContext;
+
+    await flowStartRecordingTool.execute(
+      {},
+      { name: "tele-step", project_root: tmpDir, executionPrerequisite: PREREQ }
+    );
+    await tool.execute({}, { command: "tap", args: '{"x":0.5}' }, ctx);
+
+    expect(recordChildInvocation).toHaveBeenCalledOnce();
+    const childId = recordChildInvocation.mock.calls[0]![0];
+    // The sub-tool's own args reach the recorder so it can derive the platform.
+    expect(recordChildInvocation).toHaveBeenCalledWith(childId, { x: 0.5 });
+    expect(registry.invokeTool).toHaveBeenCalledWith(
+      "tap",
+      { x: 0.5 },
+      expect.objectContaining({ toolInvocationId: childId, recordChildInvocation })
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("does not record when tool fails", async () => {
     const registry = createMockRegistry({
       tap: { result: null, throws: true },
@@ -476,6 +501,55 @@ describe("flow-execute", () => {
     });
 
     expect(registry.invokeTool).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates the request's telemetry attribution to each tool step", async () => {
+    const registry = createMockRegistry({
+      tap: { result: { ok: true } },
+      swipe: { result: { ok: true } },
+    });
+    const runFlow = createRunFlowTool(registry);
+
+    const dir = path.join(tmpDir, ".argent", "flows");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "tele-run.yaml"),
+      serializeFlow({
+        executionPrerequisite: "",
+        steps: [
+          { kind: "tool", name: "tap", args: { x: 0.5 } },
+          { kind: "echo", message: "between" },
+          { kind: "tool", name: "swipe", args: { direction: "up" } },
+        ],
+      })
+    );
+
+    const release = vi.fn();
+    const recordChildInvocation = vi.fn((_id: string, _args?: unknown) => release);
+    const ctx = { artifacts: {}, recordChildInvocation } as unknown as ToolContext;
+
+    await runFlow.execute({}, { name: "tele-run", project_root: tmpDir }, ctx);
+
+    // Only the two tool steps dispatch; the echo step records nothing.
+    expect(recordChildInvocation).toHaveBeenCalledTimes(2);
+    const ids = recordChildInvocation.mock.calls.map((c) => c[0]);
+    expect(new Set(ids).size).toBe(2);
+    // Each step's own args reach the recorder so per-step platform can be derived.
+    expect(recordChildInvocation).toHaveBeenNthCalledWith(1, ids[0], { x: 0.5 });
+    expect(recordChildInvocation).toHaveBeenNthCalledWith(2, ids[1], { direction: "up" });
+    expect(registry.invokeTool).toHaveBeenNthCalledWith(
+      1,
+      "tap",
+      { x: 0.5 },
+      expect.objectContaining({ toolInvocationId: ids[0], recordChildInvocation })
+    );
+    expect(registry.invokeTool).toHaveBeenNthCalledWith(
+      2,
+      "swipe",
+      { direction: "up" },
+      expect.objectContaining({ toolInvocationId: ids[1], recordChildInvocation })
+    );
+    expect(release).toHaveBeenCalledTimes(2);
   });
 
   it("stops on first error", async () => {

--- a/packages/tool-server/test/http-tools-meta.test.ts
+++ b/packages/tool-server/test/http-tools-meta.test.ts
@@ -187,6 +187,90 @@ describe("GET /tools progressive-loading metadata", () => {
     expect(seenMeta).toEqual({ platform: "ios", ai_client: "codex" });
   });
 
+  it("forwards a child-invocation recorder bound to the request's attribution", async () => {
+    const release = vi.fn();
+    const recordInvocation = vi.fn((_id: string, _meta: Record<string, unknown>) => release);
+    const registry = stubRegistry();
+    handle.dispose();
+    handle = createHttpApp(registry, { recordInvocation });
+
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .set("X-Argent-AI-Client", "codex")
+      .send({ udid: "11111111-1111-1111-1111-111111111111" })
+      .expect(200);
+
+    // The parent invocation is recorded with the resolved attribution.
+    expect(recordInvocation).toHaveBeenCalledTimes(1);
+    expect(recordInvocation.mock.calls[0]![1]).toEqual({ platform: "ios", ai_client: "codex" });
+
+    // A recorder is threaded into the tool context so orchestrator tools can
+    // attribute the sub-tools they dispatch. The AI client is inherited; a child
+    // with no device arg of its own falls back to the request's platform.
+    const opts = vi.mocked(registry.invokeTool).mock.calls[0]![2] as {
+      recordChildInvocation?: (id: string, childArgs?: unknown) => () => void;
+    };
+    expect(opts.recordChildInvocation).toBeTypeOf("function");
+
+    const childRelease = opts.recordChildInvocation!("child-id");
+    expect(recordInvocation).toHaveBeenCalledWith("child-id", {
+      platform: "ios",
+      ai_client: "codex",
+    });
+    expect(childRelease).toBe(release);
+  });
+
+  it("re-derives each child's platform from its own device arg", async () => {
+    const recordInvocation = vi.fn((_id: string, _meta: Record<string, unknown>) => vi.fn());
+    const registry = stubRegistry();
+    handle.dispose();
+    handle = createHttpApp(registry, { recordInvocation });
+
+    // Parent request targets iOS.
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .set("X-Argent-AI-Client", "codex")
+      .send({ udid: "11111111-1111-1111-1111-111111111111" })
+      .expect(200);
+
+    const { recordChildInvocation } = vi.mocked(registry.invokeTool).mock.calls[0]![2] as {
+      recordChildInvocation: (id: string, childArgs?: unknown) => () => void;
+    };
+
+    // A sub-tool that targets an Android device keeps the inherited ai_client but
+    // is attributed to ITS OWN platform — not the parent's iOS. This is what lets
+    // a flow-execute (no platform of its own) attribute each gesture correctly.
+    recordChildInvocation("android-child", { udid: "emulator-5554" });
+    expect(recordInvocation).toHaveBeenCalledWith("android-child", {
+      ai_client: "codex",
+      platform: "android",
+    });
+
+    // A child with no device arg falls back to the parent's platform.
+    recordChildInvocation("no-device-child", { message: "hi" });
+    expect(recordInvocation).toHaveBeenCalledWith("no-device-child", {
+      ai_client: "codex",
+      platform: "ios",
+    });
+  });
+
+  it("does not forward a child recorder when there is no attribution to propagate", async () => {
+    const recordInvocation = vi.fn(() => vi.fn());
+    const registry = stubRegistry();
+    handle.dispose();
+    handle = createHttpApp(registry, { recordInvocation });
+
+    // plain-tool has no capability and no AI-client header → no metadata at all,
+    // so nothing is recorded and no child recorder is handed downstream.
+    await request(handle.app).post("/tools/plain-tool").send({}).expect(200);
+
+    expect(recordInvocation).not.toHaveBeenCalled();
+    const opts = vi.mocked(registry.invokeTool).mock.calls[0]![2] as {
+      recordChildInvocation?: unknown;
+    };
+    expect(opts.recordChildInvocation).toBeUndefined();
+  });
+
   it("records the coarse `other` bucket for an unknown tool, never its name", async () => {
     let seenMeta: Record<string, unknown> | undefined;
     const recordInvocation = vi.fn((_id: string, meta: Record<string, unknown>) => {

--- a/packages/tool-server/test/run-sequence.test.ts
+++ b/packages/tool-server/test/run-sequence.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Registry, ToolContext } from "@argent/registry";
+import { createRunSequenceTool } from "../src/tools/run-sequence";
+
+// iOS-shaped udid so `resolveDevice` classifies it as an iOS simulator without
+// touching a real device (classification is purely shape-based).
+const IOS = "11111111-1111-1111-1111-111111111111";
+
+function mockRegistry(invokeImpl?: (id: string, args: unknown) => unknown): Registry {
+  return {
+    // No capability declared → run-sequence skips the per-step assertSupported.
+    getTool: vi.fn(() => undefined),
+    invokeTool: vi.fn(async (id: string, args: unknown) => invokeImpl?.(id, args) ?? { ok: true }),
+  } as unknown as Registry;
+}
+
+describe("run-sequence", () => {
+  it("runs each step in order, injecting the shared udid", async () => {
+    const registry = mockRegistry();
+    const tool = createRunSequenceTool(registry);
+
+    const result = await tool.execute(
+      {},
+      {
+        udid: IOS,
+        steps: [
+          { tool: "gesture-tap", args: { x: 0.5, y: 0.3 }, delayMs: 0 },
+          { tool: "keyboard", args: { text: "hi" }, delayMs: 0 },
+        ],
+      }
+    );
+
+    expect(result).toMatchObject({ completed: 2, total: 2 });
+    expect(registry.invokeTool).toHaveBeenNthCalledWith(1, "gesture-tap", {
+      x: 0.5,
+      y: 0.3,
+      udid: IOS,
+    });
+    expect(registry.invokeTool).toHaveBeenNthCalledWith(2, "keyboard", { text: "hi", udid: IOS });
+  });
+
+  it("stops at an unrecognized tool without invoking it", async () => {
+    const registry = mockRegistry();
+    const tool = createRunSequenceTool(registry);
+
+    const result = await tool.execute(
+      {},
+      { udid: IOS, steps: [{ tool: "not-a-tool", args: {}, delayMs: 0 }] }
+    );
+
+    expect(result.completed).toBe(0);
+    expect(result.steps[0]).toMatchObject({
+      tool: "not-a-tool",
+      error: expect.stringContaining("not allowed"),
+    });
+    expect(registry.invokeTool).not.toHaveBeenCalled();
+  });
+
+  it("propagates the request's telemetry attribution to every sub-tool", async () => {
+    const registry = mockRegistry();
+    const tool = createRunSequenceTool(registry);
+
+    const release = vi.fn();
+    const recordChildInvocation = vi.fn((_id: string, _args?: unknown) => release);
+    const ctx = { artifacts: {}, recordChildInvocation } as unknown as ToolContext;
+
+    await tool.execute(
+      {},
+      {
+        udid: IOS,
+        steps: [
+          { tool: "gesture-tap", args: { x: 0.5, y: 0.3 }, delayMs: 0 },
+          { tool: "gesture-swipe", args: { fromX: 0.5 }, delayMs: 0 },
+        ],
+      },
+      ctx
+    );
+
+    // One recorded child invocation per step, each with its own id.
+    expect(recordChildInvocation).toHaveBeenCalledTimes(2);
+    const ids = recordChildInvocation.mock.calls.map((c) => c[0]);
+    expect(new Set(ids).size).toBe(2);
+
+    // Each step's own args (with the injected udid) reach the recorder so it can
+    // attribute the gesture to the right platform.
+    expect(recordChildInvocation).toHaveBeenNthCalledWith(
+      1,
+      ids[0],
+      expect.objectContaining({ x: 0.5, y: 0.3, udid: IOS })
+    );
+    expect(recordChildInvocation).toHaveBeenNthCalledWith(
+      2,
+      ids[1],
+      expect.objectContaining({ fromX: 0.5, udid: IOS })
+    );
+
+    // Each sub-tool is dispatched under its minted id, with the recorder
+    // forwarded so deeper nesting keeps the attribution.
+    expect(registry.invokeTool).toHaveBeenNthCalledWith(
+      1,
+      "gesture-tap",
+      expect.objectContaining({ x: 0.5, y: 0.3, udid: IOS }),
+      expect.objectContaining({ toolInvocationId: ids[0], recordChildInvocation })
+    );
+    expect(registry.invokeTool).toHaveBeenNthCalledWith(
+      2,
+      "gesture-swipe",
+      expect.objectContaining({ fromX: 0.5, udid: IOS }),
+      expect.objectContaining({ toolInvocationId: ids[1], recordChildInvocation })
+    );
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/tool-server/test/sub-invoke.test.ts
+++ b/packages/tool-server/test/sub-invoke.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Registry, ToolContext } from "@argent/registry";
+import { invokeSubTool } from "../src/utils/sub-invoke";
+
+function mockRegistry(impl?: (id: string, args: unknown) => unknown): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string, args: unknown) => impl?.(id, args)),
+  } as unknown as Registry;
+}
+
+describe("invokeSubTool", () => {
+  it("invokes directly (no third arg) when there is no telemetry context", async () => {
+    const registry = mockRegistry(() => ({ ok: true }));
+
+    const result = await invokeSubTool(registry, undefined, "gesture-tap", { x: 0.5, y: 0.3 });
+
+    expect(result).toEqual({ ok: true });
+    // No options object — preserves the pre-fix call shape for direct invokes.
+    expect(registry.invokeTool).toHaveBeenCalledWith("gesture-tap", { x: 0.5, y: 0.3 });
+  });
+
+  it("invokes directly when the context carries no recorder", async () => {
+    const registry = mockRegistry();
+    const ctx = { artifacts: {} } as unknown as ToolContext;
+
+    await invokeSubTool(registry, ctx, "gesture-tap", { x: 0.1 });
+
+    expect(registry.invokeTool).toHaveBeenCalledWith("gesture-tap", { x: 0.1 });
+  });
+
+  it("records a child invocation and forwards the id + recorder when attribution is present", async () => {
+    const registry = mockRegistry(() => ({ done: true }));
+    const release = vi.fn();
+    const recordChildInvocation = vi.fn((_id: string, _args?: unknown) => release);
+    const ctx = { artifacts: {}, recordChildInvocation } as unknown as ToolContext;
+
+    await invokeSubTool(registry, ctx, "gesture-swipe", { fromX: 0.5 });
+
+    expect(recordChildInvocation).toHaveBeenCalledOnce();
+    const childId = recordChildInvocation.mock.calls[0]![0];
+    expect(childId).toEqual(expect.any(String));
+
+    // The child's own args are handed to the recorder so it can re-derive this
+    // sub-tool's platform instead of inheriting the orchestrator's.
+    expect(recordChildInvocation).toHaveBeenCalledWith(childId, { fromX: 0.5 });
+
+    // The sub-tool is invoked under the freshly-minted id, and the recorder is
+    // forwarded so propagation survives further nesting.
+    expect(registry.invokeTool).toHaveBeenCalledWith(
+      "gesture-swipe",
+      { fromX: 0.5 },
+      {
+        toolInvocationId: childId,
+        recordChildInvocation,
+      }
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("mints a distinct id per call", async () => {
+    const registry = mockRegistry();
+    const recordChildInvocation = vi.fn((_id: string) => vi.fn());
+    const ctx = { artifacts: {}, recordChildInvocation } as unknown as ToolContext;
+
+    await invokeSubTool(registry, ctx, "gesture-tap", {});
+    await invokeSubTool(registry, ctx, "gesture-tap", {});
+
+    const idA = recordChildInvocation.mock.calls[0]![0];
+    const idB = recordChildInvocation.mock.calls[1]![0];
+    expect(idA).not.toEqual(idB);
+  });
+
+  it("releases the recorded metadata even when the sub-tool throws", async () => {
+    const registry = {
+      invokeTool: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    } as unknown as Registry;
+    const release = vi.fn();
+    const recordChildInvocation = vi.fn((_id: string) => release);
+    const ctx = { artifacts: {}, recordChildInvocation } as unknown as ToolContext;
+
+    await expect(invokeSubTool(registry, ctx, "gesture-tap", {})).rejects.toThrow("boom");
+    expect(release).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes telemetry attribution for tools dispatched by orchestrators. `run-sequence`,
`flow-execute`, and `flow-add-step` run their steps via `registry.invokeTool()`
directly, which minted a fresh, unregistered invocation id per nested call — so the
`ai_client` / `platform` the HTTP layer captured for the outer request never reached
the nested gestures, and they were recorded as **anonymous** in telemetry.
Remove `opt_out` event that is a leftover.

## Changes

- Add an optional `recordChildInvocation` recorder to `InvokeToolOptions` /
  `ToolContext`, bound by the HTTP layer to the outer request's attribution.
- New `invokeSubTool` helper: registers each sub-tool under a minted id inheriting
  the request's AI client, with the platform re-derived from the sub-tool's **own**
  device arg (`udid` / `device_id` / `avdName`); forwards the recorder so propagation
  survives arbitrary nesting (e.g. `flow-execute → run-sequence → gesture-tap`).
- Route the three orchestrators' sub-dispatch through
- Refactor platform inference in the HTTP layer into a shared `platformFromArgs`
  helper (also hardened to not throw on a malformed device arg).
- Remove opt_out event leftover

Why re-derive platform per child: an orchestrator like `flow-execute` has no platform
of its own and a single flow can target several devices, so the child's device arg is
the only correct platform source; the parent's platform is the fallback.