### PR TITLE
fix(vega): stop a VVD the `vega` CLI lost track of via the ps probe

### DIFF
--- a/packages/skills/skills/argent-vega/SKILL.md
+++ b/packages/skills/skills/argent-vega/SKILL.md
@@ -27,7 +27,7 @@ Then `describe` again to confirm. On a miss, run the loop again.
 
 - `list-devices` → Vega devices appear with a `serial` (use as `udid`) and a `vvdImage`. Start here to get both.
 - `boot-device {vvdImage}` — starts the single SDK-managed VVD (e.g. `vvdImage:"tv"`) and returns its `serial`. Skip if `list-devices` already shows a running device.
-- **Stopping the VVD** — run `vega virtual-device stop` in your shell. Caveat: the CLI tracks only VVDs it started in the foreground, so it often reports "virtual device not running" for a VVD that `boot-device` booted and stops nothing. To restart in that case use `boot-device {vvdImage, force:true}`, which stops the running VVD by process before re-booting.
+- **Stopping the VVD** — run `vega virtual-device stop` in your shell. Caveat: the CLI only tracks VVDs it starts in the foreground. As a result, it may report "virtual device not running" for a VVD started with `boot-device`, and won't stop it. To restart that VVD, run `boot-device {vvdImage, force: true}`. This stops the running VVD process before booting it again.
 
 ### App lifecycle
 

--- a/packages/skills/skills/argent-vega/SKILL.md
+++ b/packages/skills/skills/argent-vega/SKILL.md
@@ -27,7 +27,7 @@ Then `describe` again to confirm. On a miss, run the loop again.
 
 - `list-devices` → Vega devices appear with a `serial` (use as `udid`) and a `vvdImage`. Start here to get both.
 - `boot-device {vvdImage}` — starts the single SDK-managed VVD (e.g. `vvdImage:"tv"`) and returns its `serial`. Skip if `list-devices` already shows a running device.
-- **Stopping the VVD** — run `vega virtual-device stop` in your shell.
+- **Stopping the VVD** — run `vega virtual-device stop` in your shell. Caveat: the CLI tracks only VVDs it started in the foreground, so it often reports "virtual device not running" for a VVD that `boot-device` booted and stops nothing. To restart in that case use `boot-device {vvdImage, force:true}`, which stops the running VVD by process before re-booting.
 
 ### App lifecycle
 

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -1155,8 +1155,9 @@ async function bootVegaImpl(params: {
       const which = runningImage ? `("${runningImage}")` : "(its image could not be confirmed)";
       throw new Error(
         `A Vega VVD ${which} is already running; argent v1 supports a single running VVD. ` +
-          `To boot "${params.vvdImage}", re-run boot-device with force:true (stops the current ` +
-          "VVD first) or stop it via `vega virtual-device stop`."
+          `To boot "${params.vvdImage}", re-run boot-device with force:true, which stops the ` +
+          "current VVD first (by process, since the `vega` CLI does not reliably stop a VVD " +
+          "argent booted) and then boots the requested image."
       );
     }
     return {

--- a/packages/tool-server/src/utils/vega-process.ts
+++ b/packages/tool-server/src/utils/vega-process.ts
@@ -15,6 +15,12 @@ const execFileAsync = promisify(execFile);
 // (alias of `args` on procps) prints the full argv with no header.
 export const PS_ARGS = ["-A", "-ww", "-o", "command="] as const;
 
+// Same probe, with a leading PID column, for the stop/kill path: the `vega` CLI
+// can lose track of a running VVD and refuse to stop it (see `stopVvd`), so we
+// terminate the process directly. `pid=,command=` prints `<pid> <argv>` per line
+// with no header on both macOS/BSD `ps` and Linux procps.
+export const PS_ARGS_WITH_PID = ["-A", "-ww", "-o", "pid=,command="] as const;
+
 // The VVD's emulator binary, anchored to a path boundary + a following arg/EOL so
 // it can't match a substring like `…/vega-virtual-device-wrapper`.
 const VVD_PROCESS_RE = /(?:^|\/)(?:vega|kepler)-virtual-device(?:\s|$)/;
@@ -43,6 +49,29 @@ function consolePortFromVvdArgs(line: string): number | null {
 }
 
 /**
+ * PIDs of running VVD emulator processes from `ps -o pid=,command=` output
+ * (pure; unit-tested). Same VVD identity as `parseVvdConsolePorts` — only the
+ * pid (not the console port) is read, since the stop path kills by pid.
+ */
+export function parseVvdPids(psOutput: string): number[] {
+  const pids: number[] = [];
+  for (const line of psOutput.split("\n")) {
+    // `<leading spaces><pid> <argv...>`; split the pid off, then identity-match argv.
+    const m = line.match(/^\s*(\d+)\s+(.*)$/);
+    if (!m) continue;
+    const argv = m[2]!;
+    // Require BOTH the VVD binary name AND an emulator console-port signal
+    // (`-ports`/`-qmp`). The pid feeds SIGTERM/SIGKILL, so demand a positive
+    // emulator identity — otherwise a process that merely mentions a
+    // `…/vega-virtual-device` path in its argv (e.g. a git command on a branch
+    // of that name) could be mistaken for the device and signalled.
+    if (!VVD_PROCESS_RE.test(argv) || consolePortFromVvdArgs(argv) === null) continue;
+    pids.push(parseInt(m[1]!, 10));
+  }
+  return pids;
+}
+
+/**
  * Console ports of all running VVDs (empty if none / `ps` unavailable). `>1` ⇒
  * multiple VVDs — callers that target one surface `MultipleVegaDevicesError`.
  */
@@ -60,5 +89,21 @@ export async function listRunningVvdConsolePorts(): Promise<Set<number>> {
       `[vega-process] ps probe failed; assuming no running VVD: ${String(err)}\n`
     );
     return new Set();
+  }
+}
+
+/** PIDs of all running VVD emulator processes (empty if none / `ps` unavailable). */
+export async function listRunningVvdPids(): Promise<number[]> {
+  try {
+    const { stdout } = await execFileAsync("ps", [...PS_ARGS_WITH_PID], {
+      timeout: 5_000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return parseVvdPids(stdout);
+  } catch (err) {
+    process.stderr.write(
+      `[vega-process] ps (pid) probe failed; cannot enumerate VVD pids: ${String(err)}\n`
+    );
+    return [];
   }
 }

--- a/packages/tool-server/src/utils/vega-vvd.ts
+++ b/packages/tool-server/src/utils/vega-vvd.ts
@@ -108,7 +108,11 @@ export async function stopVvd(
   // in this state, so a throwing stop must not abort the caller (e.g. a force reboot
   // in boot-device, which would otherwise fail outright and leave the VVD running).
   await runVega(["virtual-device", "stop"], { timeoutMs: options.timeoutMs ?? 60_000 }).catch(
-    () => {}
+    (err) => {
+      // Tolerated (the ps probe below tears the device down regardless), but logged so a
+      // genuine stop failure for a VVD the CLI *was* tracking is diagnosable, not silent.
+      process.stderr.write(`[vega-vvd] \`vega virtual-device stop\` failed: ${String(err)}\n`);
+    }
   );
   // Detection already trusts the OS process table over the CLI (see `isVvdRunning`);
   // make stop symmetric. Terminate any VVD emulator process the ps probe still
@@ -125,20 +129,34 @@ async function terminateStrayVvdProcesses(graceMs: number, pollMs: number): Prom
   if (pids.length === 0) return;
   for (const pid of pids) signalQuietly(pid, "SIGTERM");
   // Give SIGTERM a chance to bring the emulator down cleanly, then escalate.
+  if (await waitForVvdGone(graceMs, pollMs)) return;
+  for (const pid of await listRunningVvdPids()) signalQuietly(pid, "SIGKILL");
+  // Mirror the post-SIGTERM grace poll: don't return while a just-killed qemu could still
+  // be in the ps probe, or the next force-reboot's start would read it as a second VVD and
+  // trip `MultipleVegaDevicesError`. (Orphaned qemu reparents to launchd and reaps fast.)
+  await waitForVvdGone(graceMs, pollMs);
+}
+
+// Poll the ps probe until no VVD process is left, up to `graceMs`. Returns whether the VVD
+// went away within the window.
+async function waitForVvdGone(graceMs: number, pollMs: number): Promise<boolean> {
   const deadline = Date.now() + graceMs;
   while (Date.now() < deadline) {
-    if (!(await isVvdRunning())) return;
+    if (!(await isVvdRunning())) return true;
     await new Promise((r) => setTimeout(r, pollMs));
   }
-  for (const pid of await listRunningVvdPids()) signalQuietly(pid, "SIGKILL");
+  return !(await isVvdRunning());
 }
 
 // `process.kill` throws ESRCH if the pid already exited and EPERM if it isn't ours;
-// either way there's nothing left to do for that pid, so swallow it.
+// either way there's nothing left to do for that pid, so swallow just those. Anything
+// else (e.g. EINVAL from a bad signal) is a real bug — let it surface.
 function signalQuietly(pid: number, signal: NodeJS.Signals): void {
   try {
     process.kill(pid, signal);
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ESRCH" && code !== "EPERM") throw err;
     /* already gone or not ours */
   }
 }

--- a/packages/tool-server/src/utils/vega-vvd.ts
+++ b/packages/tool-server/src/utils/vega-vvd.ts
@@ -1,6 +1,6 @@
 import { runVega } from "./vega-cli";
 import { runAdb, parseAdbDevices } from "./adb";
-import { listRunningVvdConsolePorts } from "./vega-process";
+import { listRunningVvdConsolePorts, listRunningVvdPids } from "./vega-process";
 
 /**
  * VVD lifecycle — start / stop / liveness. Running-VVD console-port discovery lives
@@ -94,8 +94,53 @@ export async function startVvd(params: {
   });
 }
 
-export async function stopVvd(options: { timeoutMs?: number } = {}): Promise<void> {
-  await runVega(["virtual-device", "stop"], { timeoutMs: options.timeoutMs ?? 60_000 });
+const STOP_KILL_GRACE_MS = 4_000;
+const STOP_VERIFY_POLL_MS = 300;
+
+export async function stopVvd(
+  options: { timeoutMs?: number; killGraceMs?: number; verifyPollMs?: number } = {}
+): Promise<void> {
+  // Graceful first — ask the CLI to stop the VVD it tracks — but best-effort: when
+  // the CLI has lost track of a running VVD it exits non-zero with "virtual device
+  // not running" (the same staleness that makes `vega virtual-device status`
+  // misreport). An argent-booted VVD — started via `vega virtual-device start -t N`,
+  // which returns once boot completes rather than staying foreground — is routinely
+  // in this state, so a throwing stop must not abort the caller (e.g. a force reboot
+  // in boot-device, which would otherwise fail outright and leave the VVD running).
+  await runVega(["virtual-device", "stop"], { timeoutMs: options.timeoutMs ?? 60_000 }).catch(
+    () => {}
+  );
+  // Detection already trusts the OS process table over the CLI (see `isVvdRunning`);
+  // make stop symmetric. Terminate any VVD emulator process the ps probe still
+  // finds — SIGTERM, then SIGKILL the stragglers — so a stop the CLI no-oped (or
+  // refused) still tears the device down instead of leaking the qemu process.
+  await terminateStrayVvdProcesses(
+    options.killGraceMs ?? STOP_KILL_GRACE_MS,
+    options.verifyPollMs ?? STOP_VERIFY_POLL_MS
+  );
+}
+
+async function terminateStrayVvdProcesses(graceMs: number, pollMs: number): Promise<void> {
+  const pids = await listRunningVvdPids();
+  if (pids.length === 0) return;
+  for (const pid of pids) signalQuietly(pid, "SIGTERM");
+  // Give SIGTERM a chance to bring the emulator down cleanly, then escalate.
+  const deadline = Date.now() + graceMs;
+  while (Date.now() < deadline) {
+    if (!(await isVvdRunning())) return;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  for (const pid of await listRunningVvdPids()) signalQuietly(pid, "SIGKILL");
+}
+
+// `process.kill` throws ESRCH if the pid already exited and EPERM if it isn't ours;
+// either way there's nothing left to do for that pid, so swallow it.
+function signalQuietly(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal);
+  } catch {
+    /* already gone or not ours */
+  }
 }
 
 const VVD_RUNNING_POLL_INTERVAL_MS = 1_000;

--- a/packages/tool-server/test/vega-process.test.ts
+++ b/packages/tool-server/test/vega-process.test.ts
@@ -3,8 +3,11 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import {
   parseVvdConsolePorts,
+  parseVvdPids,
   listRunningVvdConsolePorts,
+  listRunningVvdPids,
   PS_ARGS,
+  PS_ARGS_WITH_PID,
 } from "../src/utils/vega-process";
 
 const execFileAsync = promisify(execFile);
@@ -67,6 +70,50 @@ describe("parseVvdConsolePorts", () => {
   });
 });
 
+// A `ps -o pid=,command=` line: a leading pid column, then the same argv.
+function vvdPidLine(pid: number, consolePort: number): string {
+  return `  ${pid} ${vvdLine(consolePort)}`;
+}
+
+describe("parseVvdPids", () => {
+  it("reads the pid of a running VVD emulator process", () => {
+    expect(parseVvdPids(vvdPidLine(75137, 5554))).toEqual([75137]);
+  });
+
+  it("ignores a co-running Android emulator, a crashpad sibling, and a branch ref", () => {
+    const ps = [
+      `  4242 ${ANDROID_EMULATOR}`,
+      `  4243 ${CRASHPAD}`,
+      `  4244 ${GIT_REF}`,
+      vvdPidLine(75137, 5556),
+    ].join("\n");
+    expect(parseVvdPids(ps)).toEqual([75137]);
+  });
+
+  it("returns empty when no VVD process is present", () => {
+    const ps = [`  1 /sbin/launchd`, `  4242 ${ANDROID_EMULATOR}`].join("\n");
+    expect(parseVvdPids(ps)).toEqual([]);
+  });
+
+  it("reports every pid when multiple VVDs run", () => {
+    const ps = [vvdPidLine(75137, 5554), vvdPidLine(80001, 5556)].join("\n");
+    expect(parseVvdPids(ps).sort((a, b) => a - b)).toEqual([75137, 80001]);
+  });
+
+  it("matches the legacy kepler-virtual-device process name", () => {
+    const line = vvdPidLine(75137, 5554).replace("vega-virtual-device", "kepler-virtual-device");
+    expect(parseVvdPids(line)).toEqual([75137]);
+  });
+
+  it("does not match a `…-virtual-device-wrapper` substring", () => {
+    const line = vvdPidLine(75137, 5554).replace(
+      "vega-virtual-device",
+      "vega-virtual-device-wrapper"
+    );
+    expect(parseVvdPids(line)).toEqual([]);
+  });
+});
+
 // Exercises the REAL `ps` invocation (not mocked) so a flag invalid on the host —
 // e.g. the BSD-only `-x` on the Linux CI runner — fails here, fast, instead of only
 // surfacing in the slow Vega e2e (where the catch would otherwise hide it).
@@ -80,5 +127,18 @@ describe("listRunningVvdConsolePorts (real ps)", () => {
     const ports = await listRunningVvdConsolePorts();
     expect(ports).toBeInstanceOf(Set);
     for (const p of ports) expect(Number.isInteger(p) && p > 0).toBe(true);
+  });
+
+  it("PS_ARGS_WITH_PID is accepted by the host `ps` (exit 0, non-empty output)", async () => {
+    const { stdout } = await execFileAsync("ps", [...PS_ARGS_WITH_PID], {
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    expect(stdout.split("\n").filter(Boolean).length).toBeGreaterThan(0);
+  });
+
+  it("resolves to positive integer pids without throwing", async () => {
+    const pids = await listRunningVvdPids();
+    expect(Array.isArray(pids)).toBe(true);
+    for (const p of pids) expect(Number.isInteger(p) && p > 0).toBe(true);
   });
 });

--- a/packages/tool-server/test/vega-vvd.test.ts
+++ b/packages/tool-server/test/vega-vvd.test.ts
@@ -107,4 +107,19 @@ describe("stopVvd", () => {
     expect(kill).toHaveBeenCalledWith(75137, "SIGTERM");
     expect(kill).toHaveBeenCalledWith(75137, "SIGKILL");
   });
+
+  it("swallows a throwing process.kill (ESRCH/EPERM) and still signals every pid", async () => {
+    // signalQuietly must absorb a kill that races the process exiting (ESRCH) or
+    // hits a pid we don't own (EPERM) — stopVvd must still resolve and must keep
+    // signalling the remaining pids rather than aborting on the first throw.
+    runVega.mockResolvedValue({ stdout: "", stderr: "" });
+    listRunningVvdPids.mockResolvedValue([75137, 80001]);
+    listRunningVvdConsolePorts.mockResolvedValue(new Set()); // gone after SIGTERM → no SIGKILL pass
+    kill.mockImplementation(() => {
+      throw Object.assign(new Error("kill ESRCH"), { code: "ESRCH" });
+    });
+    await expect(stopVvd({ killGraceMs: 50, verifyPollMs: 5 })).resolves.toBeUndefined();
+    expect(kill).toHaveBeenCalledWith(75137, "SIGTERM");
+    expect(kill).toHaveBeenCalledWith(80001, "SIGTERM");
+  });
 });

--- a/packages/tool-server/test/vega-vvd.test.ts
+++ b/packages/tool-server/test/vega-vvd.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// The running VVD's console port comes from the process table; mock that source.
+// The running VVD's console port / pids come from the process table; mock that source.
 const listRunningVvdConsolePorts = vi.fn();
+const listRunningVvdPids = vi.fn();
 vi.mock("../src/utils/vega-process", () => ({
   listRunningVvdConsolePorts: (...a: unknown[]) => listRunningVvdConsolePorts(...a),
+  listRunningVvdPids: (...a: unknown[]) => listRunningVvdPids(...a),
+}));
+
+// stopVvd asks the CLI to stop first; mock it so we can make it succeed or throw.
+const runVega = vi.fn();
+vi.mock("../src/utils/vega-cli", () => ({
+  runVega: (...a: unknown[]) => runVega(...a),
 }));
 
 // discoverVegaConsolePort also confirms the VVD's `emulator-<port>` is adb-ready;
@@ -14,7 +22,7 @@ vi.mock("../src/utils/adb", async () => {
   return { ...actual, runAdb: (...a: unknown[]) => runAdb(...a) };
 });
 
-import { discoverVegaConsolePort, MultipleVegaDevicesError } from "../src/utils/vega-vvd";
+import { discoverVegaConsolePort, MultipleVegaDevicesError, stopVvd } from "../src/utils/vega-vvd";
 
 function adbDevices(...serials: string[]): { stdout: string; stderr: string } {
   return {
@@ -25,6 +33,8 @@ function adbDevices(...serials: string[]): { stdout: string; stderr: string } {
 
 beforeEach(() => {
   listRunningVvdConsolePorts.mockReset();
+  listRunningVvdPids.mockReset();
+  runVega.mockReset();
   runAdb.mockReset();
   runAdb.mockResolvedValue(adbDevices("emulator-5556")); // adb-ready by default
 });
@@ -54,5 +64,47 @@ describe("discoverVegaConsolePort", () => {
     await expect(discoverVegaConsolePort({ adbReadyTimeoutMs: 0 })).rejects.toThrow(
       /has not registered with adb/
     );
+  });
+});
+
+describe("stopVvd", () => {
+  let kill: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Don't actually signal real processes from the test runner.
+    kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+  });
+  afterEach(() => kill.mockRestore());
+
+  it("does not signal anything when the CLI stop succeeds and no VVD process remains", async () => {
+    runVega.mockResolvedValue({ stdout: "", stderr: "" });
+    listRunningVvdPids.mockResolvedValue([]);
+    await stopVvd();
+    expect(runVega).toHaveBeenCalledWith(
+      ["virtual-device", "stop"],
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    );
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("kills a VVD the CLI refused to stop, and does not rethrow the CLI failure", async () => {
+    // The CLI exits non-zero ("virtual device not running") for a VVD it lost track of.
+    runVega.mockRejectedValue(
+      new Error("vega virtual-device stop failed: virtual device not running")
+    );
+    listRunningVvdPids.mockResolvedValue([75137]);
+    listRunningVvdConsolePorts.mockResolvedValue(new Set()); // isVvdRunning → gone after SIGTERM
+    await expect(stopVvd({ killGraceMs: 50, verifyPollMs: 5 })).resolves.toBeUndefined();
+    expect(kill).toHaveBeenCalledWith(75137, "SIGTERM");
+    expect(kill).not.toHaveBeenCalledWith(75137, "SIGKILL");
+  });
+
+  it("escalates to SIGKILL when SIGTERM leaves the VVD running", async () => {
+    runVega.mockResolvedValue({ stdout: "", stderr: "" });
+    listRunningVvdPids.mockResolvedValue([75137]);
+    listRunningVvdConsolePorts.mockResolvedValue(new Set([5554])); // still running through the grace window
+    await stopVvd({ killGraceMs: 20, verifyPollMs: 5 });
+    expect(kill).toHaveBeenCalledWith(75137, "SIGTERM");
+    expect(kill).toHaveBeenCalledWith(75137, "SIGKILL");
   });
 });


### PR DESCRIPTION
## Problem

`vega virtual-device stop` exits non-zero with **"virtual device not running"** for any VVD the `vega` CLI is not tracking — and that is **every VVD argent boots**. `boot-device` starts a VVD via `vega virtual-device start -t N`, which returns once boot completes (rather than staying foreground), so the CLI never registers the device. `vega virtual-device status` then reports `running:false` and `stop` is a no-op-that-throws.

That error threw straight out of `stopVvd`, so **`boot-device {force:true}` failed outright and left the VVD running** — even though argent's *detection* (`isVvdRunning` / `listRunningVvdConsolePorts`) already deliberately trusts the OS process table over the flaky CLI.

Repro (against a VVD argent booted):
```
boot-device {vvdImage:"tv", force:true}
→ [Tool:boot-device] vega virtual-device stop failed: virtual device not running
     at stopVvd (vega-vvd.ts) → bootVegaImpl (boot-device.ts)
```

## Fix

Make **stop** symmetric with **detection**:
- Tolerate the CLI's stale failure (`vega virtual-device stop` is now best-effort).
- Terminate any VVD emulator process the `ps` probe still finds — SIGTERM, then SIGKILL the stragglers, verifying via `isVvdRunning` between.
- Killing by pid demands a **positive** emulator identity — the VVD binary name **and** a `-ports`/`-qmp` signal — so a process that merely mentions a `…/vega-virtual-device` path in its argv (e.g. a git command on a branch of that name) is never signalled.

Also stopped pointing users at `vega virtual-device stop` for an argent-booted VVD (the boot-device error message + the `argent-vega` skill); the reliable restart is `boot-device {force:true}`.

## Verification

- `npx vitest run --root packages/tool-server` → **1430 passed**. New unit tests cover `parseVvdPids` (identity/safety incl. the git-ref guard) and `stopVvd` (no-kill on clean stop; kill-without-rethrow when the CLI refuses; SIGTERM→SIGKILL escalation).
- **Live on a VVD**: reproduced the orphan state (argent boot → `status:false` while pid alive), then `boot-device force:true` — old pid gone, a fresh single VVD running, `booted:true`. Previously it threw.