### PR TITLE
fix(release): readable error when 'next' dist-tag sync fails (follow-up to #357)

### DIFF
--- a/scripts/sync-next-dist-tag.mjs
+++ b/scripts/sync-next-dist-tag.mjs
@@ -162,5 +162,17 @@ function main() {
 
 // Run only when invoked directly, not when imported by the test.
 if (processArgv[1] && import.meta.url === pathToFileURL(processArgv[1]).href) {
-  main();
+  try {
+    main();
+  } catch (err) {
+    // A registry read (`npm view`) or `npm dist-tag add` can fail (404 on a
+    // mistyped package, a transient registry blip, non-JSON output). Surface a
+    // concise diagnostic instead of an opaque execFileSync stack dump. The
+    // publish workflows mark this step continue-on-error (the publish already
+    // succeeded and is irreversible), so this never fails a release; the manual
+    // Sync workflow has no continue-on-error, so it still exits non-zero here —
+    // just with a readable reason rather than a Node crash dump.
+    console.error(`Failed to sync '${TAG}' dist-tag: ${err.message}`);
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Follow-up to #357 (swarm review finding)

#357 added the auto-sync `scripts/sync-next-dist-tag.mjs`. A full review of the merged change surfaced one real robustness gap; everything else (SemVer comparator, workflow expressions, `continue-on-error` placement, permissions, secret handling, CI wiring) reviewed clean.

## Problem

The script reads the registry via `execFileSync("npm", ["view", …])` and `JSON.parse`s the output. `getDistTags` wraps that in try/catch; `getVersions` did not. So a failed read — a 404 from a mistyped package in the **manual `Sync 'next' dist-tag`** workflow, a transient registry blip, or non-JSON stdout — propagated the raw error and the script exited with a multi-screen Node stack trace **plus** the serialized `execFileSync` object instead of a one-line reason.

This is hidden in the two **publish** workflows (their sync step is `continue-on-error`), but the **manual** workflow deliberately has no `continue-on-error` (so operator-facing failures stay visible) — which is exactly where the crash dump is worst.

### Repro (before)
```
$ node scripts/sync-next-dist-tag.mjs mistyped-pkg-name --dry-run
… npm's 404 …
node:internal/errors:985
  const err = new Error(message);
Error: Command failed: npm view mistyped-pkg-name versions --json
    at genericNodeError (node:internal/errors:985:15)
    … 8 more stack frames + { status, signal, output, stdout, stderr, pid } …
```

## Fix

Wrap the direct-invocation entry point so any failure prints one concise diagnostic and exits non-zero. Happy path unchanged.

### After
```
$ node scripts/sync-next-dist-tag.mjs mistyped-pkg-name --dry-run
… npm's own 404 (inherited stderr) …
Failed to sync 'next' dist-tag: Command failed: npm view mistyped-pkg-name versions --json   # exit 1
```

The publish workflows keep `continue-on-error` (an already-successful, irreversible publish must not go red over a sync blip); the manual workflow still fails visibly — now with a readable reason.

## Verification

- Reproduced the crash and the clean post-fix output for both the 404 path and a non-JSON-stdout stub (exit 1 preserved in both).
- Happy-path live dry-run against the real registry still resolves `next` → `0.12.1`.
- `npm run test:scripts` (4/4), `prettier --check`, `typecheck:scripts`, and `eslint` all pass.