### PR TITLE
fix(argent-lens): native window controls, comment cursor, card layout polish

### DIFF
--- a/packages/preview-window/src/main.ts
+++ b/packages/preview-window/src/main.ts
@@ -1,6 +1,16 @@
 import { app, BrowserWindow } from "electron";
 import * as readline from "node:readline";
 
+// Name the app so app.getName() and the default menu items ("Quit Argent
+// Lens", the About panel) report "Argent Lens" instead of "Electron". Set
+// before `app` is ready so the default menu picks it up. NOTE: this does NOT
+// change the bold macOS menu-bar / app-switcher title — that's the unpackaged
+// Electron.app bundle's CFBundleName, which no runtime call can override (only
+// shipping the helper as its own .app bundle would). The window's OWN title is
+// set to "Argent Lens" below, which is what shows in Mission Control / the
+// Window menu / screen-share window pickers.
+app.setName("Argent Lens");
+
 // One-window-at-a-time host for the Argent Lens preview UI. The
 // tool-server spawns this process when `await_user_selection` parks, then
 // pipes single-line JSON commands ({cmd:"foreground"|"close",url?}) over
@@ -127,7 +137,17 @@ async function createWindow(): Promise<void> {
   win = new BrowserWindow({
     width: TARGET_WIDTH,
     height: TARGET_HEIGHT,
-    frame: false,
+    title: "Argent Lens",
+    // Native window controls (the macOS traffic lights) instead of a
+    // handcrafted close button: `titleBarStyle: "hidden"` keeps the real OS
+    // buttons in the top-left while hiding the rest of the title bar, so the
+    // window still reads as frameless. (`frame: false` would suppress the
+    // buttons entirely — that's what we used to do.)
+    titleBarStyle: "hidden",
+    // Inset the traffic lights to share the same 14px padding the in-window
+    // corner panels use (theme toggle, status pill), so the native buttons and
+    // the handcrafted chrome read as one consistent margin.
+    trafficLightPosition: { x: 14, y: 18 },
     show: false,
     // Transparent + no native shadow: the OS window is just a passthrough
     // for the renderer. The visible "card" is whatever <html> + <body>
@@ -141,6 +161,11 @@ async function createWindow(): Promise<void> {
       sandbox: true,
     },
   });
+  // Belt-and-suspenders for the traffic lights on a transparent window:
+  // some macOS/Electron combinations hide the buttons when `transparent` is
+  // set, so force them visible. No-op / undefined off macOS.
+  win.setWindowButtonVisibility?.(true);
+  win.setTitle("Argent Lens");
   win.on("closed", () => {
     win = null;
     app.quit();

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -181,15 +181,8 @@ export function start(): void {
       previewWindow.requestClose();
     }, PREVIEW_CLOSE_DELAY_MS);
   };
-  // User clicked "Close" in the preview window — dismiss it immediately (the
-  // animated close), leaving any parked await still waiting.
-  const onCloseRequested = (): void => {
-    cancelPendingClose();
-    previewWindow.requestClose();
-  };
   variantProposalStore.events.on("awaitParked", onAwaitParked);
   variantProposalStore.events.on("selectionSubmitted", onSelectionSubmitted);
-  variantProposalStore.events.on("closeRequested", onCloseRequested);
 
   // `shutdown` closes over `server` by reference — reads the current value when
   // called, so it works correctly whether server has started yet or not.
@@ -202,7 +195,6 @@ export function start(): void {
 
     variantProposalStore.events.off("awaitParked", onAwaitParked);
     variantProposalStore.events.off("selectionSubmitted", onSelectionSubmitted);
-    variantProposalStore.events.off("closeRequested", onCloseRequested);
     cancelPendingClose();
     previewWindow.dispose();
     updateChecker.dispose();

--- a/packages/tool-server/src/preview.ts
+++ b/packages/tool-server/src/preview.ts
@@ -173,14 +173,6 @@ export function createPreviewRouter(registry: Registry): Router {
     res.json(variantProposalStore.snapshot());
   });
 
-  // Human pressed "Close" in the preview window — dismiss it. The tool-server
-  // owns the Electron window lifecycle (index.ts listens for `closeRequested`),
-  // so the UI just signals intent here. Does not affect any parked await.
-  router.post("/close", (_req: Request, res: Response) => {
-    variantProposalStore.requestWindowClose();
-    res.json({ ok: true });
-  });
-
   // Human pressed "Complete selection" in the UI — unblocks await_user_selection.
   router.post("/variants/selection", (req: Request, res: Response) => {
     const body = req.body ?? {};

--- a/packages/tool-server/src/utils/preview-window.ts
+++ b/packages/tool-server/src/utils/preview-window.ts
@@ -1,6 +1,80 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
+
+/**
+ * macOS only. Build (and cache) a thin `.app` wrapper around the installed
+ * Electron.app whose Info.plist `CFBundleName` is "Argent Lens", so the OS names
+ * the window — menu bar, Cmd-Tab, Dock — "Argent Lens" instead of "Electron"
+ * (the framework default, which `app.setName()` at runtime cannot override).
+ *
+ * The wrapper SYMLINKS Electron's heavy Frameworks/Resources — there is no
+ * ~270MB copy — and supplies only its own Info.plist + a symlinked executable.
+ * The catch: a symlinked bundle with a modified Info.plist no longer matches the
+ * signed Helper apps inside Frameworks, so the OS sandbox cannot initialise and
+ * the helper processes crash unless the app is launched with `--no-sandbox`
+ * (the caller adds it). That is an acceptable trade-off for THIS window: it only
+ * ever loads the tool-server's own localhost preview UI — never untrusted or
+ * remote content — and the renderer still runs with contextIsolation +
+ * sandbox:true at the Electron level. The full alternative (a renamed, deeply
+ * re-signed copy of Electron.app, à la @electron/packager) is what avoids
+ * `--no-sandbox`, at the cost of that ~270MB copy.
+ *
+ * Returns the wrapper's executable path, or null to fall back to plain Electron
+ * (non-macOS, or any failure — the window still opens, just named "Electron").
+ */
+function ensureLensAppBundle(electronBin: string): string | null {
+  if (process.platform !== "darwin") return null;
+  try {
+    const realApp = electronBin.replace(/\/Contents\/MacOS\/[^/]+$/, "");
+    if (!realApp.endsWith(".app")) return null;
+    const realContents = path.join(realApp, "Contents");
+    const wrapperContents = path.join(
+      os.tmpdir(),
+      "argent-lens-app",
+      "Argent Lens.app",
+      "Contents"
+    );
+    const wrapperExec = path.join(wrapperContents, "MacOS", "Electron");
+    // Reuse the cached wrapper unless it's missing or points at a different
+    // Electron install (e.g. an upgrade moved the binary).
+    try {
+      if (fs.realpathSync(wrapperExec) === fs.realpathSync(electronBin)) return wrapperExec;
+    } catch {
+      /* not built yet — fall through and build it */
+    }
+    fs.rmSync(path.dirname(wrapperContents), { recursive: true, force: true });
+    fs.mkdirSync(path.join(wrapperContents, "MacOS"), { recursive: true });
+    fs.symlinkSync(path.join(realContents, "Frameworks"), path.join(wrapperContents, "Frameworks"));
+    fs.symlinkSync(path.join(realContents, "Resources"), path.join(wrapperContents, "Resources"));
+    fs.symlinkSync(electronBin, wrapperExec);
+    const pkgInfo = path.join(realContents, "PkgInfo");
+    if (fs.existsSync(pkgInfo)) fs.copyFileSync(pkgInfo, path.join(wrapperContents, "PkgInfo"));
+    // Custom Info.plist: copy Electron's, rename the display fields. PlistBuddy
+    // is a macOS system tool (handles binary or XML plists), so no new dep. Keep
+    // CFBundleExecutable = "Electron" so the signed Helper apps still resolve.
+    const plist = path.join(wrapperContents, "Info.plist");
+    fs.copyFileSync(path.join(realContents, "Info.plist"), plist);
+    const setPlist = (entry: string, value: string): void => {
+      try {
+        execFileSync("/usr/libexec/PlistBuddy", ["-c", `Set :${entry} ${value}`, plist]);
+      } catch {
+        try {
+          execFileSync("/usr/libexec/PlistBuddy", ["-c", `Add :${entry} string ${value}`, plist]);
+        } catch {
+          /* leave the original value if PlistBuddy can't set it */
+        }
+      }
+    };
+    setPlist("CFBundleName", "Argent Lens");
+    setPlist("CFBundleDisplayName", "Argent Lens");
+    setPlist("CFBundleIdentifier", "com.swmansion.argent.lens");
+    return wrapperExec;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Tool-server side of the Electron preview window. A single Electron child
@@ -110,7 +184,14 @@ export function createPreviewWindowManager(
       opts.onLaunchFailure?.(e);
       return;
     }
-    const next = spawn(electronBin, [mainScript], {
+    // On macOS, launch through the "Argent Lens" wrapper bundle so the OS names
+    // the window correctly. The wrapper needs `--no-sandbox` (see
+    // ensureLensAppBundle); both fall back to plain Electron when the wrapper
+    // can't be built, so the window always opens.
+    const wrapperBin = ensureLensAppBundle(electronBin);
+    const launchBin = wrapperBin ?? electronBin;
+    const launchArgs = wrapperBin ? ["--no-sandbox", mainScript] : [mainScript];
+    const next = spawn(launchBin, launchArgs, {
       env: { ...process.env, ARGENT_PREVIEW_URL: url },
       stdio: ["pipe", "ignore", "pipe"],
     });

--- a/packages/tool-server/src/utils/variant-proposals.ts
+++ b/packages/tool-server/src/utils/variant-proposals.ts
@@ -147,13 +147,6 @@ type StoreEvents = {
   awaitParked: () => void;
   /** Emitted after a successful `submitSelection` — the round is done. */
   selectionSubmitted: () => void;
-  /**
-   * Emitted when the user clicks "Close" in the preview window — a request to
-   * dismiss the window (the tool-server owns its lifecycle). Does NOT settle
-   * any parked await; the agent keeps waiting and the window re-opens on the
-   * next round.
-   */
-  closeRequested: () => void;
 };
 
 /** A parked `await_user_selection` call, bound to the round it is waiting on. */
@@ -235,11 +228,6 @@ export class VariantProposalStore {
   findVariant(elementId: string, variantId: string): Variant | null {
     const p = this.proposals.find((x) => x.id === elementId);
     return p?.variants.find((v) => v.id === variantId) ?? null;
-  }
-
-  /** Preview UI's "Close" button — ask listeners to dismiss the window. */
-  requestWindowClose(): void {
-    this.events.emit("closeRequested");
   }
 
   /**

--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -64,6 +64,7 @@
       .stage,
       .vcard,
       .float-controls,
+      .float-toolbelt,
       .float-status,
       .footbar,
       .comment-pop,
@@ -82,6 +83,13 @@
         align-items: center;
         gap: var(--gap-list);
         z-index: var(--z-overlay);
+      }
+      /* macOS traffic lights (native window controls) occupy the top-left in
+         Electron. Shift the status pill clear of them so a "Connecting…" or
+         error message never lands under the buttons. A browser tab has no
+         buttons, so .native-frame is absent and the pill keeps its corner. */
+      .native-frame .float-status {
+        left: var(--traffic-light-gutter);
       }
       .status {
         background: var(--color-surface);
@@ -297,12 +305,26 @@
         font-weight: var(--fw-semibold);
         box-shadow: var(--shadow-card);
       }
-      /* Floating top-right controls (theme, comment, close): a row of square
-         icon buttons that sit over the stream, away from the slim drag toolbar. */
+      /* Floating top-right controls (just the theme toggle now — comment moved
+         to the bottom toolbelt, close is a native traffic light): square icon
+         buttons that sit over the stream, away from the slim drag toolbar. */
       .float-controls {
         position: absolute;
         top: var(--footbar-bottom);
         right: var(--footbar-right);
+        display: flex;
+        gap: var(--gap-list);
+        z-index: var(--z-overlay);
+        -webkit-app-region: no-drag;
+      }
+      /* Bottom-centre toolbelt — floats below the stream. Today it carries the
+         comment toggle; it's shaped to grow into a Figma-style bottom tool tab,
+         so it's a horizontal row centred on the window. */
+      .float-toolbelt {
+        position: absolute;
+        bottom: var(--footbar-bottom);
+        left: 50%;
+        transform: translateX(-50%);
         display: flex;
         gap: var(--gap-list);
         z-index: var(--z-overlay);
@@ -726,14 +748,14 @@
       }
       .spot-hit {
         position: absolute;
-        cursor: crosshair;
+        cursor: var(--cursor-comment);
         z-index: var(--z-spot-hit);
         /* The spotlight root sets pointer-events:none; this capture layer must
            opt back in or hover/click never reaches it and nothing un-blurs. */
         pointer-events: auto;
       }
       .inspecting .stage img {
-        cursor: crosshair;
+        cursor: var(--cursor-comment);
       }
 
       /* Comment box bubble anchored next to the inspected element. */
@@ -1209,6 +1231,18 @@
         </div>
         <div class="float-controls" id="float-controls">
           <button
+            id="theme-btn"
+            class="float-btn"
+            type="button"
+            aria-label="Theme"
+            title="Theme"></button>
+        </div>
+        <!-- Bottom-centre toolbelt that floats below the stream. Holds the
+             comment toggle for now; this is the seed of a Figma-style bottom
+             tool tab we'll grow later. Window close/minimise live in the native
+             traffic lights, not a handcrafted button. -->
+        <div class="float-toolbelt" id="float-toolbelt">
+          <button
             id="comment-btn"
             class="float-btn"
             type="button"
@@ -1225,28 +1259,6 @@
               aria-hidden="true">
               <path
                 d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
-            </svg>
-          </button>
-          <button
-            id="theme-btn"
-            class="float-btn"
-            type="button"
-            aria-label="Theme"
-            title="Theme"></button>
-          <button
-            id="close-btn"
-            class="float-btn"
-            type="button"
-            aria-label="Close preview window"
-            title="Close preview window">
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              aria-hidden="true">
-              <path d="M6 6 18 18M18 6 6 18" />
             </svg>
           </button>
         </div>
@@ -2023,15 +2035,15 @@
       }
 
       // ── Events ──────────────────────────────────────────────────────────
-      // Close button: ask the tool-server to dismiss the Electron window (it
-      // owns the window lifecycle over stdin, so it plays the close animation
-      // and quits the host cleanly — more reliable than renderer window.close()
-      // under the sandboxed BrowserWindow).
-      const closeBtn = document.getElementById("close-btn");
-      closeBtn.addEventListener("click", () => {
-        closeBtn.blur();
-        fetch(`${TOOL_SERVER}/preview/close`, { method: "POST" }).catch(() => {});
-      });
+      // Window close/minimise are the native macOS traffic lights now (the host
+      // window uses titleBarStyle:"hidden"), so there's no handcrafted close
+      // button to wire up. Closing the native window quits the host; the
+      // tool-server re-opens it on the next round, exactly as the old button's
+      // dismiss did. In Electron, flag the document so the top-left chrome can
+      // sidestep the traffic lights (a browser tab has none).
+      if (/Electron/i.test(navigator.userAgent)) {
+        document.documentElement.classList.add("native-frame");
+      }
 
       // ── Theme (light / dark) ────────────────────────────────────────────
       // Colours are light-dark(LIGHT, DARK) tokens in theme.css; forcing
@@ -3192,6 +3204,37 @@
         else return home;
         return { x: nx, y: home.y };
       }
+      // Deterministic de-overlap of the spring HOMES (targets), run once per
+      // layoutCards pass — i.e. per describe poll, NOT per animation frame. That
+      // is the whole point: the damped bubble springs then glide to homes that
+      // already don't overlap, so there is no live correction force and thus
+      // none of the micro-jitter / wedge-wiggle a per-frame position fix causes.
+      // Stable top-down sweep: walking cards in y order, each one is dropped to
+      // sit just below every card above it that shares its vertical lane. Moving
+      // only ever downward makes it monotonic — it cannot oscillate. Pinned
+      // (user-dropped) cards are fixed anchors the others flow past.
+      function deOverlapHomes(items, cardW, gap, top, bottom) {
+        const sorted = items.slice().sort((a, b) => a.rec.home.y - b.rec.home.y);
+        for (let i = 1; i < sorted.length; i++) {
+          const cur = sorted[i];
+          if (cur.rec.pinned) continue;
+          let floor = top;
+          for (let j = 0; j < i; j++) {
+            const prev = sorted[j];
+            // Same vertical lane? (cards in different columns never constrain.)
+            const oX =
+              Math.min(cur.rec.home.x, prev.rec.home.x) +
+              cardW -
+              Math.max(cur.rec.home.x, prev.rec.home.x);
+            if (oX <= 0) continue;
+            const prevBottom = prev.rec.home.y + prev.ch + gap;
+            if (prevBottom > floor) floor = prevBottom;
+          }
+          // Drop to clear the cards above; clamp so it can't leave the window
+          // (true overflow piles at the bottom rather than vanishing off-screen).
+          if (cur.rec.home.y < floor) cur.rec.home.y = Math.min(floor, bottom - cur.ch);
+        }
+      }
       function layoutCards() {
         const now = Date.now();
         const mr = mainEl.getBoundingClientRect();
@@ -3305,7 +3348,7 @@
         //        • The final maxHeight write is diffed against the inline
         //          value so unchanged frames are no-ops — keeps scrollTop.
         const COL_PAD = 8;
-        const GAP = 12;
+        const GAP = 8;
         const want = vis.map((rec, i) => {
           const body = rec.el.querySelector(".vcard-body");
           if (body && rec.chromeH == null) {
@@ -3371,11 +3414,19 @@
         // the "ready" pop. offsetTop ignores the transform (offsetParent is the
         // position:relative #main), keeping the column height stable.
         const footTop = footEl && !footEl.hidden ? footEl.offsetTop - COL_PAD : mh;
-        const colBottom = Math.min(mh - COL_PAD, footTop);
-        const colH = colBottom - colTop;
+        // The footbar is anchored bottom-RIGHT, so only the column(s) that
+        // actually sit above it should surrender height for it. A column clear
+        // of the footbar's x-range gets the full window height — otherwise the
+        // left column was needlessly squeezed (and its cards clipped) by a
+        // footbar that only overlaps the right column.
+        const footLeft = footEl && !footEl.hidden ? footEl.offsetLeft : mw;
         for (const col of ["L", "R"]) {
           const cwant = want.filter((w) => w.side === col);
           if (cwant.length === 0) continue;
+          const colX = col === "L" ? leftX : rightX;
+          const colBottom =
+            colX + cardW > footLeft ? Math.min(mh - COL_PAD, footTop) : mh - COL_PAD;
+          const colH = colBottom - colTop;
           const naturalSum = cwant.reduce((s, w) => s + w.natural, 0) + (cwant.length - 1) * GAP;
           if (naturalSum <= colH) {
             cwant.sort((a, b) => a.anchor - b.anchor);
@@ -3468,6 +3519,9 @@
             w.rec.vel.y += Math.random() * 18 - 9;
           }
         }
+        // Guarantee no two resting homes overlap. Deterministic + once per pass,
+        // so the springs simply glide to clear targets (no live force, no jitter).
+        deOverlapHomes(want, cardW, GAP, COL_PAD, mh - COL_PAD);
       }
 
       // Reuses SVG nodes (no per-frame teardown) and draws to the *eased*

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -131,7 +131,7 @@
   --pad-code: 2px 6px;
   --pad-pill: 3px 11px;
   --pad-card-head: 7px 10px;
-  --pad-row: 8px 10px;
+  --pad-row: 5px 10px; /* tighter vertical so a 2-variant card fits its column without clipping */
   --pad-cmt: 6px 10px; /* in-card comment box */
   --pad-input: 6px 8px; /* popover textareas */
   --pad-pop: 10px; /* comment / annotation popover */
@@ -168,6 +168,7 @@
   --footbar-bottom: 14px;
   --footbar-right: 14px;
   --resize-edge: 6px; /* drag-layer inset so the frameless window's edges still resize */
+  --traffic-light-gutter: 84px; /* left inset for top-left chrome to clear the native macOS window buttons (Electron only) */
   --footbar-max-width: 70%;
   --select-min-width: 240px;
   --debug-min-width: 220px;
@@ -180,6 +181,18 @@
   --pad-modal: 18px;
   --stream-max-h: 80dvh; /* dvh, not vh: in a browser tab `vh` is the toolbar-retracted (large) viewport, so the centered stream overflowed the %-height container and got clipped at the bottom. `dvh` tracks the visible viewport. In the frameless Electron window (no toolbar) dvh == vh, so production is unchanged. */
   --backdrop-blur: 1.67px; /* light haze over the dimmed stream (3× softer than the former 5px) */
+
+  /* ── Cursors ─────────────────────────────────────────────────────────── */
+  /* Comment-mode cursor — a Figma-style speech bubble that makes "you are
+     placing a comment" unmistakable (replaces the generic crosshair). Accent
+     fill + white outline & dots so it reads on the bright stream AND on the
+     dark spotlight scrim. "7 24" is the hotspot: the tail tip, where the click
+     actually lands. Baked as a data-URI because a cursor image can't reference
+     CSS vars — so the colours live here, in the theme, like every other value. */
+  --cursor-comment:
+    url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2228%22%20height%3D%2228%22%20viewBox%3D%220%200%2028%2028%22%3E%3Cpath%20d%3D%22M6%203h16a3%203%200%200%201%203%203v10a3%203%200%200%201-3%203h-9l-6%205v-5h-1a3%203%200%200%201-3-3V6a3%203%200%200%201%203-3z%22%20fill%3D%22%232f6fd0%22%20stroke%3D%22%23ffffff%22%20stroke-width%3D%221.5%22%20stroke-linejoin%3D%22round%22%2F%3E%3Ccircle%20cx%3D%229%22%20cy%3D%2211%22%20r%3D%221.4%22%20fill%3D%22%23ffffff%22%2F%3E%3Ccircle%20cx%3D%2214%22%20cy%3D%2211%22%20r%3D%221.4%22%20fill%3D%22%23ffffff%22%2F%3E%3Ccircle%20cx%3D%2219%22%20cy%3D%2211%22%20r%3D%221.4%22%20fill%3D%22%23ffffff%22%2F%3E%3C%2Fsvg%3E")
+      7 24,
+    crosshair;
 
   /* ── Opacities ───────────────────────────────────────────────────────── */
   --opacity-disabled: 0.45;


### PR DESCRIPTION
Part 1 out of N reworks for Argent Lens

Polish pass on the Argent Lens preview window.

## Changes
- **Native window controls.** `titleBarStyle: "hidden"` (+ `setWindowButtonVisibility`) shows the real macOS traffic lights on the transparent window instead of the handcrafted close button. `trafficLightPosition` insets them to share the corner panels' 14px padding.
- **Comment-mode cursor.** Entering comment mode swaps the crosshair for a Figma-style speech-bubble cursor over the stream, so "you are placing a comment" is unmistakable. Defined as a `--cursor-comment` data-URI token in `theme.css`.
- **Bottom toolbelt.** The "Add comment" button moved out of the top-right cluster into a new bottom-centre floating toolbelt — the seed of a Figma-style bottom tool tab. Same button look, placement only.
- **Cards show all variants.** Two fixes so short cards no longer clip a variant: the left column is no longer height-limited by the bottom-right footbar (per-column bound), and tighter variant-row padding lets a 2-variant card fit its column.
- **Cards repel / never overlap.** A deterministic per-poll de-overlap of the spring **home** targets (a stable top-down sweep), not a per-frame force. The damped springs glide to non-overlapping rests: no micro-jitter, no rubber-banding, and a card wedged between two settles instead of wiggling forever.
- **App named "Argent Lens".** The window title was already set, but the macOS menu bar / Cmd-Tab / Dock showed "Electron" (the unpackaged `Electron.app` bundle's `CFBundleName`, which `app.setName` can't override). On macOS the tool-server now launches the window through a thin **wrapper `.app`** whose `Info.plist` `CFBundleName` is "Argent Lens" — it symlinks Electron's Frameworks/Resources (no ~270MB copy) and is launched with `--no-sandbox` (the modified/symlinked bundle no longer matches the signed Helper apps). Acceptable for this window: it only loads the tool-server's localhost UI, and the renderer keeps `contextIsolation` + `sandbox:true`. Falls back to plain Electron on non-macOS or any failure.

## Verification
Driven live against the iOS simulator via a dev tool-server + the Electron window over CDP:
- Native traffic lights render on the transparent window; handcrafted close button removed.
- Comment-mode `.stage img` computed cursor is the speech-bubble data-URI.
- "Add comment" is in `#float-toolbelt`, horizontally centred at the window mid-line, 14px above the bottom.
- All demo cards report `bodyScrollHeight === clientHeight` (zero clip); both variants visible.
- 5- and 9-card layouts: zero overlaps, positions identical across 2s (no jitter), and pinning a card between two settles with no overlap and no wiggle.
- Menu bar / Cmd-Tab read "Argent Lens"; `ps` confirms the window launches via `…/argent-lens-app/Argent Lens.app/Contents/MacOS/Electron --no-sandbox`.
- `tsc --build`, `eslint`, `prettier --check`, and the preview/variant test files all pass.