### PR TITLE
feat(installer): add Kiro CLI MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,17 +117,18 @@ argent init
 
 `argent init` auto-detects and configures MCP for:
 
-| Editor      | Config location                                                          |
-| ----------- | ------------------------------------------------------------------------ |
-| Claude Code | `.mcp.json` (project) or `~/.claude.json` (global)                       |
-| Cursor      | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global)            |
-| VS Code     | `.vscode/mcp.json`                                                       |
-| Windsurf    | `~/.codeium/windsurf/mcp_config.json` (global)                           |
-| Zed         | `.zed/settings.json`                                                     |
-| Gemini CLI  | `.gemini/settings.json`                                                  |
-| Codex CLI   | `.codex/config.toml` (project) or `~/.codex/config.toml` (global)        |
-| Hermes      | `~/.hermes/config.yaml` (global)                                         |
-| opencode    | `opencode.json` (project) or `~/.config/opencode/opencode.json` (global) |
+| Editor      | Config location                                                             |
+| ----------- | --------------------------------------------------------------------------- |
+| Claude Code | `.mcp.json` (project) or `~/.claude.json` (global)                          |
+| Cursor      | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global)               |
+| VS Code     | `.vscode/mcp.json`                                                          |
+| Windsurf    | `~/.codeium/windsurf/mcp_config.json` (global)                              |
+| Zed         | `.zed/settings.json`                                                        |
+| Gemini CLI  | `.gemini/settings.json`                                                     |
+| Codex CLI   | `.codex/config.toml` (project) or `~/.codex/config.toml` (global)           |
+| Hermes      | `~/.hermes/config.yaml` (global)                                            |
+| opencode    | `opencode.json` (project) or `~/.config/opencode/opencode.json` (global)    |
+| Kiro        | `.kiro/settings/mcp.json` (project) or `~/.kiro/settings/mcp.json` (global) |
 
 ## Privacy
 

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -827,6 +827,82 @@ const openCodeAdapter: McpConfigAdapter = {
   },
 };
 
+// ── Kiro adapter ─────────────────────────────────────────────────────────────
+// MARK: Kiro
+// Format: { mcpServers: { argent: { command, args, env } } }
+// Project: <root>/.kiro/settings/mcp.json   Global: ~/.kiro/settings/mcp.json
+// Allowlist: autoApprove: ["*"] on the argent entry (Kiro's documented
+// auto-approve-all syntax). See https://kiro.dev/docs/mcp/configuration/
+
+const KIRO_AUTO_APPROVE_ALL = ["*"];
+
+const kiroAdapter: McpConfigAdapter = {
+  name: "Kiro",
+
+  detect(): boolean {
+    return dirExists(path.join(homedir(), ".kiro")) || dirExists(path.join(process.cwd(), ".kiro"));
+  },
+
+  projectPath(root: string): string | null {
+    return path.join(root, ".kiro", "settings", "mcp.json");
+  },
+
+  globalPath(): string | null {
+    return path.join(homedir(), ".kiro", "settings", "mcp.json");
+  },
+
+  write(configPath: string, entry: McpServerEntry): void {
+    const config = readJson(configPath);
+    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+    servers[MCP_SERVER_KEY] = {
+      command: entry.command,
+      args: entry.args,
+      ...(hasEnv(entry) ? { env: entry.env } : {}),
+    };
+    config.mcpServers = servers;
+    writeJson(configPath, config);
+  },
+
+  remove(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const config = readJson(configPath);
+    const servers = config.mcpServers as Record<string, unknown> | undefined;
+    if (!servers?.[MCP_SERVER_KEY]) return false;
+    delete servers[MCP_SERVER_KEY];
+    writeJsonOrRemove(configPath, config);
+    return true;
+  },
+
+  hasArgentEntry(configPath: string): boolean {
+    if (!fs.existsSync(configPath)) return false;
+    const config = readJson(configPath);
+    const servers = config.mcpServers as Record<string, unknown> | undefined;
+    return Boolean(servers?.[MCP_SERVER_KEY]);
+  },
+
+  addAllowlist(root: string, scope: "local" | "global"): void {
+    const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
+    if (!configPath) return;
+    const config = readJson(configPath);
+    const servers = (config.mcpServers ?? {}) as Record<string, Record<string, unknown>>;
+    const entry = servers[MCP_SERVER_KEY];
+    if (!entry) return;
+    entry.autoApprove = [...KIRO_AUTO_APPROVE_ALL];
+    writeJson(configPath, config);
+  },
+
+  removeAllowlist(root: string, scope: "local" | "global"): void {
+    const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
+    if (!configPath || !fs.existsSync(configPath)) return;
+    const config = readJson(configPath);
+    const servers = config.mcpServers as Record<string, Record<string, unknown>> | undefined;
+    const entry = servers?.[MCP_SERVER_KEY];
+    if (!entry?.autoApprove) return;
+    delete entry.autoApprove;
+    writeJsonOrRemove(configPath, config);
+  },
+};
+
 // ── Registry ──────────────────────────────────────────────────────────────────
 // MARK: Registry
 
@@ -840,6 +916,7 @@ export const ALL_ADAPTERS: McpConfigAdapter[] = [
   codexAdapter,
   hermesAdapter,
   openCodeAdapter,
+  kiroAdapter,
 ];
 
 export function detectAdapters(): McpConfigAdapter[] {

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -831,8 +831,16 @@ const openCodeAdapter: McpConfigAdapter = {
 // MARK: Kiro
 // Format: { mcpServers: { argent: { command, args, env } } }
 // Project: <root>/.kiro/settings/mcp.json   Global: ~/.kiro/settings/mcp.json
-// Allowlist: autoApprove: ["*"] on the argent entry (Kiro's documented
-// auto-approve-all syntax). See https://kiro.dev/docs/mcp/configuration/
+//
+// The same .kiro/settings/mcp.json is read by both the Kiro IDE and the Kiro
+// CLI (the rebranded Amazon Q Developer CLI), so one entry serves both.
+//
+// Allowlist: autoApprove: ["*"] on the argent entry — the Kiro IDE's documented
+// "approve every tool" syntax. The Kiro CLI's server-config struct has no
+// autoApprove field and is NOT deny_unknown_fields, so the CLI silently ignores
+// the key (verified against kiro-cli 2.9.0 / upstream CustomToolConfig). Net:
+// honored by the IDE, harmless to the CLI, which carries its own trust model.
+// IDE: https://kiro.dev/docs/mcp/configuration/  CLI: https://kiro.dev/docs/cli/mcp/
 
 const KIRO_AUTO_APPROVE_ALL = ["*"];
 

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -127,6 +127,7 @@ const PROJECT_ROOT_MARKERS = [
   ".codex",
   ".agents",
   ".zed",
+  ".kiro",
   ".opencode",
   "opencode.json",
   "opencode.jsonc",

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -94,7 +94,7 @@ describe("getMcpEntry", () => {
 // ── Adapter registry ──────────────────────────────────────────────────────────
 
 describe("ALL_ADAPTERS", () => {
-  it("contains all nine adapters", () => {
+  it("contains all ten adapters", () => {
     const names = ALL_ADAPTERS.map((a) => a.name);
     expect(names).toEqual([
       "Cursor",
@@ -106,6 +106,7 @@ describe("ALL_ADAPTERS", () => {
       "Codex",
       "Hermes",
       "opencode",
+      "Kiro",
     ]);
   });
 });
@@ -1032,6 +1033,119 @@ describe("opencode adapter", () => {
     const servers = parsed.mcp as Record<string, unknown>;
     expect(servers).toHaveProperty("argent");
     expect((servers.argent as Record<string, unknown>).type).toBe("local");
+  });
+});
+
+// ── Kiro adapter ─────────────────────────────────────────────────────────────
+
+describe("Kiro adapter", () => {
+  const adapter = ALL_ADAPTERS.find((a) => a.name === "Kiro")!;
+
+  afterEach(() => {
+    homedirOverride = undefined;
+  });
+
+  it("writes { mcpServers: { argent: ... } } without type", () => {
+    const configPath = path.join(tmpDir, ".kiro", "settings", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("argent");
+    const argent = servers.argent as Record<string, unknown>;
+    expect(argent.command).toBe("argent");
+    expect(argent.args).toEqual(["mcp"]);
+    expect(argent).not.toHaveProperty("type");
+  });
+
+  it("removes argent entry and returns true", () => {
+    const configPath = path.join(tmpDir, ".kiro", "settings", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+
+    expect(adapter.remove(configPath)).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it("returns false when removing from non-existent file", () => {
+    expect(adapter.remove(path.join(tmpDir, "nope.json"))).toBe(false);
+  });
+
+  it("returns false when removing from file without argent entry", () => {
+    const configPath = path.join(tmpDir, ".kiro", "settings", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: {} }));
+    expect(adapter.remove(configPath)).toBe(false);
+  });
+
+  it("preserves other servers when writing", () => {
+    const configPath = path.join(tmpDir, ".kiro", "settings", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: { other: { command: "other" } } }));
+
+    adapter.write(configPath, getMcpEntry());
+
+    const config = readJsonFile(configPath);
+    const servers = config.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("other");
+    expect(servers).toHaveProperty("argent");
+  });
+
+  it("projectPath returns .kiro/settings/mcp.json under project root", () => {
+    expect(adapter.projectPath("/foo")).toBe(path.join("/foo", ".kiro", "settings", "mcp.json"));
+  });
+
+  it("globalPath returns ~/.kiro/settings/mcp.json", () => {
+    expect(adapter.globalPath()).toBe(path.join(os.homedir(), ".kiro", "settings", "mcp.json"));
+  });
+
+  it("detect() returns true when local .kiro dir exists", () => {
+    const localKiro = path.join(process.cwd(), ".kiro");
+    const existed = fs.existsSync(localKiro);
+    if (!existed) fs.mkdirSync(localKiro, { recursive: true });
+    try {
+      expect(adapter.detect()).toBe(true);
+    } finally {
+      if (!existed) fs.rmdirSync(localKiro);
+    }
+  });
+
+  it("addAllowlist sets autoApprove: ['*'] on the argent entry (local)", () => {
+    const configPath = path.join(tmpDir, ".kiro", "settings", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+
+    adapter.addAllowlist!(tmpDir, "local");
+
+    const config = readJsonFile(configPath);
+    const entry = (config.mcpServers as Record<string, unknown>).argent as Record<string, unknown>;
+    expect(entry.autoApprove).toEqual(["*"]);
+  });
+
+  it("addAllowlist sets autoApprove: ['*'] on the argent entry (global)", () => {
+    homedirOverride = path.join(tmpDir, "home");
+    const configPath = path.join(homedirOverride, ".kiro", "settings", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+
+    adapter.addAllowlist!(tmpDir, "global");
+
+    const config = readJsonFile(configPath);
+    const entry = (config.mcpServers as Record<string, unknown>).argent as Record<string, unknown>;
+    expect(entry.autoApprove).toEqual(["*"]);
+  });
+
+  it("removeAllowlist deletes autoApprove from the argent entry", () => {
+    const configPath = path.join(tmpDir, ".kiro", "settings", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+
+    adapter.removeAllowlist!(tmpDir, "local");
+
+    const config = readJsonFile(configPath);
+    const entry = (config.mcpServers as Record<string, unknown>).argent as Record<string, unknown>;
+    expect(entry).not.toHaveProperty("autoApprove");
+  });
+
+  it("removeAllowlist is a no-op when file does not exist", () => {
+    expect(() => adapter.removeAllowlist!(tmpDir, "local")).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Fixes #408

## Summary

Adds first-class support for the [Kiro CLI](https://kiro.dev/cli/) to `argent init` / `update` / `uninstall`, so the Argent MCP server is registered for Kiro alongside the other supported editors.

The new `kiroAdapter` follows the same `McpConfigAdapter` contract as every other editor, so it automatically flows through the existing init wizard, the `update` re-sync (only for users who opted Kiro in), and the uninstall sweep.

## What it does

Per Kiro's [MCP configuration docs](https://kiro.dev/docs/mcp/configuration/):

- **Config paths** — `.kiro/settings/mcp.json` (workspace) and `~/.kiro/settings/mcp.json` (user/global).
- **Format** — writes the documented `mcpServers` shape:
  ```json
  {
    "mcpServers": {
      "argent": { "command": "argent", "args": ["mcp"] }
    }
  }
  ```
- **Auto-approve** — opting into the allowlist sets `"autoApprove": ["*"]` on the `argent` entry (Kiro's documented "approve all tools" syntax), scope-aware for project vs. global.
- **Detection** — `detect()` is true when a `.kiro` dir exists in the project or home dir; `.kiro` is also added to the project-root markers so `resolveProjectRoot` treats a Kiro workspace as a project root.

## Scope

MCP-only, matching editors like Windsurf/Zed/Hermes that don't get rules/agents copied. Kiro's steering files are a separate mechanism and out of scope for this MCP-config request.

## Testing

- `vitest run` for `@argent/installer` — **299 passed** (12 new Kiro adapter tests: write/remove/detect/allowlist round-trips, scope handling, server preservation). The generic `ALL_ADAPTERS` portability/env/uninstall sweeps now also cover Kiro.
- Typecheck (`tsc --noEmit`) on src + tests, ESLint (`--max-warnings 0`), and Prettier all clean.
- End-to-end against the **compiled** `dist` artifact: drove `init.ts`'s exact `getMcpEntry → write → addAllowlist` sequence into a temp project and confirmed `.kiro/settings/mcp.json` is produced with the format above (including `autoApprove: ["*"]`), and that `remove()` prunes it.

---

## End-to-end verification against the real Kiro CLI

The docs were not taken on faith — the actual `kiro-cli` was installed and the integration validated against the real binary and the open-source upstream.

**Reconciled a real risk first:** the **Kiro CLI** (kiro.dev/cli/) is the rebranded **Amazon Q Developer CLI**, documented separately from the Kiro IDE. Confirmed both read the **same** config paths this adapter targets — `<root>/.kiro/settings/mcp.json` (workspace) and `~/.kiro/settings/mcp.json` (global) — via the CLI-specific docs, multiple web sources, the CLI's own `mcp --scope {workspace,global}` flags, and the pre-existing `~/.kiro/settings/mcp.json` on the test machine.

**Verified, autonomously:**
- **`argent mcp` is a working MCP stdio server** — completed an `initialize` + `tools/list` handshake: `serverInfo {name: "argent", version: "0.12.1"}`, **69 tools** (incl. `screenshot`, `list-devices`). This is exactly the `command`/`args` the adapter writes.
- **Installed the real Kiro CLI** (`kiro-cli 2.9.0`) via the official installer and wrote the workspace config through the **compiled adapter** (`dist/`), producing the expected `{ mcpServers: { argent: { command, args, autoApprove } } }`.
- **Config-schema compatibility, proven authoritatively.** The CLI's server-config struct (`CustomToolConfig`, upstream + confirmed in the 2.9.0 binary) recognizes `command/args/env/timeout/disabled` — our `command`/`args`/`env` map exactly. It has **no `deny_unknown_fields`** (that serde attribute lives only on the *agent* config), so the extra **`autoApprove` is silently ignored by the CLI** — it cannot break loading. Since the file is shared with the Kiro IDE, `autoApprove: ["*"]` is honored there and harmless here.

**Could not exercise (no credentials):** every `kiro-cli mcp` subcommand and `chat` is gated behind `kiro-cli login` (Kiro/AWS auth). So the final authenticated leg — `kiro-cli chat` spawning `argent mcp` and listing/invoking a tool live — was **not** run. Every link up to that boundary is verified; the remaining step is mechanical given a logged-in session.
