### PR TITLE
fix(describe): surface React Native Web / Expo-web content on Chromium

### DIFF
--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -16,14 +16,16 @@ import type { DescribeNode, DescribeTreeData } from "../contract";
  *    tree stays small.
  *  - Treat anchors, buttons, inputs, [role=button], [onclick], [tabindex]≥0
  *    as `clickable: true` so the agent knows which nodes to tap.
- *  - Prune a node only when it is truly invisible (display:none, visibility:hidden,
- *    opacity:0) or its border box is zero-area AND it clips overflow. A zero-area
- *    box with the default overflow:visible still paints its descendants — so we
- *    traverse it and promote them instead of cutting the subtree. This covers
- *    display:contents wrappers (React Native Web nests content under them), the
- *    zero-height anchor of an absolutely-positioned dropdown/popover/portal, and
- *    float/overflow wrappers that collapse to a zero-height box. A collapsed
- *    overflow:hidden container genuinely hides its content, so it stays pruned.
+ *  - Prune a node only when it is truly invisible (display:none, opacity:0) or its
+ *    border box is zero-area AND it clips overflow. A zero-area box with the default
+ *    overflow:visible still paints its descendants — so we traverse it and promote them
+ *    instead of cutting the subtree. This covers display:contents wrappers (React Native
+ *    Web nests content under them), the zero-height anchor of an absolutely-positioned
+ *    dropdown/popover/portal, and float/overflow wrappers that collapse to a zero-height
+ *    box. A collapsed overflow:hidden container genuinely hides its content, so it stays
+ *    pruned. visibility:hidden is NOT hard-pruned (it inherits, but a descendant can
+ *    override it back to visible): we descend and suppress only the hidden element's own
+ *    paint, so a visibility:visible descendant still surfaces.
  *  - Cap node count at 5000 — that, not depth, bounds the payload a runaway SPA
  *    would otherwise serialize past CDP's single Runtime.evaluate reply limit
  *    (~50MB). Cap depth at 60 purely to bound recursion: modern React DOMs
@@ -49,15 +51,26 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   // walk, the exact crash class this walker must avoid. A prototype accessor is never
   // shadowed by a form's named properties, so EVERY inherited member read on a possibly-
   // clobbered element (methods and getters alike) goes through these via .call(el).
-  const getChildNodes = Object.getOwnPropertyDescriptor(Node.prototype, "childNodes").get;
-  const getTextContent = Object.getOwnPropertyDescriptor(Node.prototype, "textContent").get;
-  const getTagName = Object.getOwnPropertyDescriptor(Element.prototype, "tagName").get;
-  const getChildrenEls = Object.getOwnPropertyDescriptor(Element.prototype, "children").get;
-  const getShadowRoot = Object.getOwnPropertyDescriptor(Element.prototype, "shadowRoot").get;
-  const getScrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, "scrollHeight").get;
-  const getClientHeight = Object.getOwnPropertyDescriptor(Element.prototype, "clientHeight").get;
-  const getScrollWidth = Object.getOwnPropertyDescriptor(Element.prototype, "scrollWidth").get;
-  const getClientWidth = Object.getOwnPropertyDescriptor(Element.prototype, "clientWidth").get;
+  //
+  // protoGetter reads the accessor's getter defensively: if the descriptor is ever
+  // absent (a page can delete/redefine a DOM prototype member), it falls back to a
+  // direct property read so one missing accessor degrades a single node instead of a
+  // \`.get\` on \`undefined\` throwing at script top and aborting the entire describe.
+  function protoGetter(proto, prop) {
+    const d = Object.getOwnPropertyDescriptor(proto, prop);
+    return d && d.get ? d.get : function () { return this[prop]; };
+  }
+  const getChildNodes = protoGetter(Node.prototype, "childNodes");
+  const getNodeType = protoGetter(Node.prototype, "nodeType");
+  const getNodeValue = protoGetter(Node.prototype, "nodeValue");
+  const getTextContent = protoGetter(Node.prototype, "textContent");
+  const getTagName = protoGetter(Element.prototype, "tagName");
+  const getChildrenEls = protoGetter(Element.prototype, "children");
+  const getShadowRoot = protoGetter(Element.prototype, "shadowRoot");
+  const getScrollHeight = protoGetter(Element.prototype, "scrollHeight");
+  const getClientHeight = protoGetter(Element.prototype, "clientHeight");
+  const getScrollWidth = protoGetter(Element.prototype, "scrollWidth");
+  const getClientWidth = protoGetter(Element.prototype, "clientWidth");
   const getAttr = Element.prototype.getAttribute;
   const hasAttr = Element.prototype.hasAttribute;
   const getBCR = Element.prototype.getBoundingClientRect;
@@ -101,7 +114,12 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   function ownText(el) {
     let s = "";
     for (const child of getChildNodes.call(el)) {
-      if (child.nodeType === 3) s += child.nodeValue;
+      // nodeType/nodeValue via the prototype getters, keeping the "every inherited
+      // read goes through a captured getter" invariant whole: a child can be a
+      // clobbering <form> whose named control shadows these to a control element.
+      // (=== 3 already made a clobbered nodeType safe; this removes the lone
+      // directly-read member so no read's safety rests on the comparison semantics.)
+      if (getNodeType.call(child) === 3) s += getNodeValue.call(child);
     }
     return s.replace(/\\s+/g, " ").trim();
   }
@@ -165,11 +183,14 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     return normRect(getBCR.call(el));
   }
 
-  // Painted extent of an element's own inline content. A box-less element
-  // (display:contents, or a zero-width box whose text overflows) has a 0x0 border box
-  // yet its text still paints; a Range measures that. Crucially it returns 0x0 when an
-  // ancestor transform (e.g. scale(0)) collapses the paint, which is how we tell
-  // genuinely-invisible content apart from merely box-less content.
+  // Painted extent of an element's own inline TEXT. A box-less element (display:contents,
+  // or a zero-width box whose text overflows) has a 0x0 border box yet its text still
+  // paints; a Range measures that. It returns 0x0 when an ancestor transform (e.g.
+  // scale(0)) or display:none collapses the paint. It does NOT distinguish a
+  // visibility:hidden / opacity:0 *descendant* — those keep their layout box, so the
+  // Range is non-zero even though nothing paints — which is why walk() consults this only
+  // when the element has its own text, never to resurrect a wrapper whose element
+  // children were all pruned as invisible.
   function contentFrame(el) {
     try {
       const range = document.createRange();
@@ -196,15 +217,17 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   }
 
   function hidden(el, style) {
-    if (style.visibility === "hidden" || style.display === "none") {
-      return true;
-    }
+    if (style.display === "none") return true;
     // display:contents has no box, so box-only properties don't apply — it lays
     // its children out normally. Never prune it for opacity:0 (opacity affects a
     // box, of which there is none, so descendants still paint) or for its 0x0
     // rect; walk() descends and promotes the visible content.
     if (style.display === "contents") return false;
     if (style.opacity === "0") return true;
+    // visibility:hidden is deliberately NOT hard-pruned here: visibility inherits but a
+    // descendant can override it back to visible, so cutting the subtree would drop
+    // painted content. walk() descends and suppresses only this element's own paint
+    // (see \`invisibleSelf\`), pruning it only if no visible descendant survives.
     const r = getBCR.call(el);
     if (r.width > 0 && r.height > 0) return false;
     // Zero-area box: prune it only when it clips its overflow (a collapsed
@@ -282,30 +305,50 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
       }
     }
 
-    const text = ownText(el);
-    const name = accessibleName(el);
-    const clickable = isInteractive(el);
+    // A visibility:hidden element paints nothing itself, but a descendant can override
+    // visibility back to visible, so walk() descended instead of pruning (see hidden()).
+    // Suppress this element's own paint — its text / name / interactivity are invisible —
+    // and treat it as box-less so it contributes no box of its own: it survives only
+    // through, and is framed by, whatever visible descendants it has.
+    const invisibleSelf = style.visibility === "hidden";
+    const text = invisibleSelf ? "" : ownText(el);
+    const name = invisibleSelf ? null : accessibleName(el);
+    const clickable = invisibleSelf ? false : isInteractive(el);
     const role = nodeRole(el);
-    const bl = boxless(el, style);
+    // getAttribute, not el.id: like .title, a named form control can clobber the .id
+    // property to a DOM node, which would then break JSON.stringify of the tree.
+    // Computed here (before promotion) because an id / data-testid is agent-visible
+    // targeting info: a wrapper that carries one is not a pure layer, so neither
+    // promotion path below may drop it.
+    const id =
+      getAttr.call(el, "id") ||
+      getAttr.call(el, "data-testid") ||
+      getAttr.call(el, "data-test-id");
+    const bl = invisibleSelf || boxless(el, style);
 
     // A box-less element has no rect of its own. Its visible extent is whatever its
-    // children span; with no surviving child, fall back to the painted extent of its
-    // own inline content. If that is still zero-area it paints nothing — e.g. a
-    // transform: scale(0) subtree, whose descendants all collapse — so it is invisible
-    // and dropped. A box-less wrapper with one child and nothing of its own is just a
-    // layer, so promote the child. (Clickable / named box-less nodes fall through and
-    // are emitted with this child- or content-spanning frame.)
+    // children span; with no surviving child, fall back to the painted extent of its own
+    // inline TEXT — but only when it has its own text. A Range over a wrapper whose
+    // element children were all pruned as invisible still measures their
+    // visibility:hidden / opacity:0 layout boxes (non-zero though nothing paints), which
+    // would resurrect an empty wrapper with a real frame; own text is the only inline
+    // content not already represented by childResults. If the frame is still zero-area it
+    // paints nothing — e.g. a transform: scale(0) subtree, whose descendants all collapse
+    // — so it is invisible and dropped. A box-less wrapper with one child and nothing of
+    // its own (no clickable / name / text / identifier) is just a layer, so promote the
+    // child. (Clickable / named / identified box-less nodes fall through and are emitted
+    // with this child- or content-spanning frame.)
     let selfFrame;
     if (bl) {
       selfFrame = unionFrame(childResults);
-      if (selfFrame.width <= 0 && selfFrame.height <= 0) {
+      if (text && selfFrame.width <= 0 && selfFrame.height <= 0) {
         const cf = contentFrame(el);
         if (cf) selfFrame = cf;
       }
       if (childResults.length === 0 && selfFrame.width <= 0 && selfFrame.height <= 0) {
         return null;
       }
-      if (!clickable && !name && !text && childResults.length === 1) {
+      if (!clickable && !name && !text && !id && childResults.length === 1) {
         return childResults[0];
       }
     } else {
@@ -313,13 +356,14 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     }
 
     // Prune structural wrappers with no info that just add a layer.
-    // Keep them if they're roots/clickable/named/have text.
+    // Keep them if they're roots/clickable/named/identified/have text.
     if (
       depth > 0 &&
       childResults.length === 1 &&
       !clickable &&
       !name &&
       !text &&
+      !id &&
       role === "div"
     ) {
       return childResults[0];
@@ -331,12 +375,6 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     };
     if (name) node.label = name;
     if (text && text !== name) node.value = text.slice(0, 200);
-    // getAttribute, not el.id: like .title, a named form control can clobber the .id
-    // property to a DOM node, which would then break JSON.stringify of the tree.
-    const id =
-      getAttr.call(el, "id") ||
-      getAttr.call(el, "data-testid") ||
-      getAttr.call(el, "data-test-id");
     if (id) node.identifier = id;
     if (clickable) node.clickable = true;
     if (isDisabled(el)) node.disabled = true;
@@ -389,13 +427,17 @@ export async function describeChromium(api: ChromiumCdpApi): Promise<DescribeTre
   if (!parsed.tree) {
     throw new Error("Chromium describe: empty tree");
   }
+  const data: DescribeTreeData = { tree: parsed.tree, source: "cdp-dom" };
   if (parsed.truncated) {
     // Surface a server-side warning so a partial tree is visible to ops.
-    // A flag in DescribeTreeData would be cleaner but the contract is shared
-    // with iOS/Android and we don't want to widen it just for Chromium.
     process.stderr.write(
       `[chromium-describe] tree truncated at MAX_NODES — page exceeds the walker's budget; consider scoping the inspection.\n`
     );
+    // And tell the agent via the existing `hint` channel (iOS/Vega already use it) so a
+    // partial tree isn't silently consumed as if it were the whole page — no need to
+    // widen the shared contract just for Chromium.
+    data.hint =
+      "describe hit the node budget (MAX_NODES) and returned a PARTIAL tree — some on-screen content is missing. Scope the inspection to a smaller region (scroll to or focus the relevant view) and describe again.";
   }
-  return { tree: parsed.tree, source: "cdp-dom" };
+  return data;
 }

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -42,27 +42,36 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   const h = window.innerHeight;
   if (!w || !h) return JSON.stringify({ tree: null, error: "viewport is zero" });
 
-  // Native prototype accessors, captured once. HTMLFormElement is [LegacyOverrideBuiltins]:
-  // a control named "children"/"childNodes"/"tagName" shadows the matching inherited
-  // property on the <form>, so el.children there returns the control element (not iterable)
-  // and the throw aborts the whole walk — the exact crash class this walker must avoid.
-  // The prototype getter is never shadowed by a form's named properties, so route every
-  // read of these three through it via .call(el).
+  // Native prototype accessors, captured once. HTMLFormElement (and HTMLObject/Embed)
+  // is [LegacyOverrideBuiltins]: a control named the same as an inherited member shadows
+  // it on the <form>, so el.children returns the control element (not iterable) and
+  // el.getAttribute returns an element (not a function) — both throw and abort the whole
+  // walk, the exact crash class this walker must avoid. A prototype accessor is never
+  // shadowed by a form's named properties, so EVERY inherited member read on a possibly-
+  // clobbered element (methods and getters alike) goes through these via .call(el).
   const getChildNodes = Object.getOwnPropertyDescriptor(Node.prototype, "childNodes").get;
   const getTagName = Object.getOwnPropertyDescriptor(Element.prototype, "tagName").get;
   const getChildrenEls = Object.getOwnPropertyDescriptor(Element.prototype, "children").get;
+  const getShadowRoot = Object.getOwnPropertyDescriptor(Element.prototype, "shadowRoot").get;
+  const getScrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, "scrollHeight").get;
+  const getClientHeight = Object.getOwnPropertyDescriptor(Element.prototype, "clientHeight").get;
+  const getScrollWidth = Object.getOwnPropertyDescriptor(Element.prototype, "scrollWidth").get;
+  const getClientWidth = Object.getOwnPropertyDescriptor(Element.prototype, "clientWidth").get;
+  const getAttr = Element.prototype.getAttribute;
+  const hasAttr = Element.prototype.hasAttribute;
+  const getBCR = Element.prototype.getBoundingClientRect;
 
   function nodeRole(el) {
-    const r = el.getAttribute("role");
+    const r = getAttr.call(el, "role");
     if (r) return r;
     const t = getTagName.call(el).toLowerCase();
     return t;
   }
 
   function accessibleName(el) {
-    const aria = el.getAttribute("aria-label");
+    const aria = getAttr.call(el, "aria-label");
     if (aria) return aria.trim().slice(0, 200);
-    const labelledBy = el.getAttribute("aria-labelledby");
+    const labelledBy = getAttr.call(el, "aria-labelledby");
     if (labelledBy) {
       const ids = labelledBy.split(/\\s+/);
       const parts = [];
@@ -80,7 +89,7 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     // getAttribute, not el.title: a <form> with a control named "title" clobbers the
     // .title property to return that element (not a string), and .slice() then throws,
     // aborting the whole describe. getAttribute always yields string | null.
-    const t = el.getAttribute("title");
+    const t = getAttr.call(el, "title");
     if (t) return t.slice(0, 200);
     return null;
   }
@@ -99,17 +108,17 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     if (tag === "button") return true;
     if (tag === "input" || tag === "textarea" || tag === "select") return true;
     if (tag === "summary" || tag === "details") return true;
-    if (el.hasAttribute("onclick")) return true;
-    const role = el.getAttribute("role");
+    if (hasAttr.call(el, "onclick")) return true;
+    const role = getAttr.call(el, "role");
     if (role && /^(button|link|tab|menuitem|checkbox|radio|switch|option)$/i.test(role)) return true;
-    const tabIndex = el.getAttribute("tabindex");
+    const tabIndex = getAttr.call(el, "tabindex");
     if (tabIndex !== null && tabIndex !== "-1") return true;
     return false;
   }
 
   function isDisabled(el) {
-    if (el.hasAttribute("disabled")) return true;
-    if (el.getAttribute("aria-disabled") === "true") return true;
+    if (hasAttr.call(el, "disabled")) return true;
+    if (getAttr.call(el, "aria-disabled") === "true") return true;
     return false;
   }
 
@@ -117,7 +126,7 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     if (el instanceof HTMLInputElement && (el.type === "checkbox" || el.type === "radio")) {
       return el.checked;
     }
-    const v = el.getAttribute("aria-checked");
+    const v = getAttr.call(el, "aria-checked");
     if (v === "true") return true;
     return false;
   }
@@ -131,7 +140,11 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     const oy = style.overflowY;
     const ox = style.overflowX;
     if (oy === "auto" || oy === "scroll" || ox === "auto" || ox === "scroll") {
-      if (el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth) return true;
+      if (
+        getScrollHeight.call(el) > getClientHeight.call(el) ||
+        getScrollWidth.call(el) > getClientWidth.call(el)
+      )
+        return true;
     }
     return false;
   }
@@ -145,7 +158,7 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   }
 
   function frame(el) {
-    return normRect(el.getBoundingClientRect());
+    return normRect(getBCR.call(el));
   }
 
   // Painted extent of an element's own inline content. A box-less element
@@ -174,7 +187,7 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   // frame spanning their children rather than their own 0x0 rect.
   function boxless(el, style) {
     if (style.display === "contents") return true;
-    const r = el.getBoundingClientRect();
+    const r = getBCR.call(el);
     return r.width <= 0 || r.height <= 0;
   }
 
@@ -184,7 +197,7 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     }
     // display:contents has no box but lays its children out normally — never prune it.
     if (style.display === "contents") return false;
-    const r = el.getBoundingClientRect();
+    const r = getBCR.call(el);
     if (r.width > 0 && r.height > 0) return false;
     // Zero-area box: prune it only when it clips its overflow (a collapsed
     // overflow:hidden container genuinely hides its content). With the default
@@ -234,8 +247,13 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     // Web-components-heavy apps (VS Code, every Lit/Polymer SPA) put their
     // interactive content under .shadowRoot, so without this descent describe
     // returns an empty body.
-    if (el.shadowRoot) {
-      for (const child of el.shadowRoot.children) {
+    // getShadowRoot via the prototype: a <form> with a control named "shadowRoot"
+    // would otherwise return that control, and we'd re-walk its light-DOM children as
+    // shadow content and duplicate the subtree. A real ShadowRoot is a DocumentFragment
+    // (never a form), so its own .children read is safe.
+    const shadow = getShadowRoot.call(el);
+    if (shadow) {
+      for (const child of shadow.children) {
         const c = walk(child, depth + 1);
         if (c) childResults.push(c);
       }
@@ -308,9 +326,9 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     // getAttribute, not el.id: like .title, a named form control can clobber the .id
     // property to a DOM node, which would then break JSON.stringify of the tree.
     const id =
-      el.getAttribute("id") ||
-      el.getAttribute("data-testid") ||
-      el.getAttribute("data-test-id");
+      getAttr.call(el, "id") ||
+      getAttr.call(el, "data-testid") ||
+      getAttr.call(el, "data-test-id");
     if (id) node.identifier = id;
     if (clickable) node.clickable = true;
     if (isDisabled(el)) node.disabled = true;

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -42,10 +42,20 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   const h = window.innerHeight;
   if (!w || !h) return JSON.stringify({ tree: null, error: "viewport is zero" });
 
+  // Native prototype accessors, captured once. HTMLFormElement is [LegacyOverrideBuiltins]:
+  // a control named "children"/"childNodes"/"tagName" shadows the matching inherited
+  // property on the <form>, so el.children there returns the control element (not iterable)
+  // and the throw aborts the whole walk — the exact crash class this walker must avoid.
+  // The prototype getter is never shadowed by a form's named properties, so route every
+  // read of these three through it via .call(el).
+  const getChildNodes = Object.getOwnPropertyDescriptor(Node.prototype, "childNodes").get;
+  const getTagName = Object.getOwnPropertyDescriptor(Element.prototype, "tagName").get;
+  const getChildrenEls = Object.getOwnPropertyDescriptor(Element.prototype, "children").get;
+
   function nodeRole(el) {
     const r = el.getAttribute("role");
     if (r) return r;
-    const t = el.tagName.toLowerCase();
+    const t = getTagName.call(el).toLowerCase();
     return t;
   }
 
@@ -77,14 +87,14 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
 
   function ownText(el) {
     let s = "";
-    for (const child of el.childNodes) {
+    for (const child of getChildNodes.call(el)) {
       if (child.nodeType === 3) s += child.nodeValue;
     }
     return s.replace(/\\s+/g, " ").trim();
   }
 
   function isInteractive(el) {
-    const tag = el.tagName.toLowerCase();
+    const tag = getTagName.call(el).toLowerCase();
     if (tag === "a" && el.href) return true;
     if (tag === "button") return true;
     if (tag === "input" || tag === "textarea" || tag === "select") return true;
@@ -215,7 +225,7 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     nodeBudget--;
 
     const childResults = [];
-    for (const child of el.children) {
+    for (const child of getChildrenEls.call(el)) {
       const c = walk(child, depth + 1);
       if (c) childResults.push(c);
     }
@@ -234,7 +244,7 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     // Same-origin iframes: pierce contentDocument if accessible. Cross-origin
     // contentDocument access throws SecurityError — swallowed silently so the
     // walker doesn't abort the whole tree.
-    if (el.tagName === "IFRAME") {
+    if (getTagName.call(el) === "IFRAME") {
       try {
         const doc = el.contentDocument;
         if (doc && doc.documentElement) {

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -185,19 +185,33 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
 
   // Painted extent of an element's own inline TEXT. A box-less element (display:contents,
   // or a zero-width box whose text overflows) has a 0x0 border box yet its text still
-  // paints; a Range measures that. It returns 0x0 when an ancestor transform (e.g.
-  // scale(0)) or display:none collapses the paint. It does NOT distinguish a
-  // visibility:hidden / opacity:0 *descendant* — those keep their layout box, so the
-  // Range is non-zero even though nothing paints — which is why walk() consults this only
-  // when the element has its own text, never to resurrect a wrapper whose element
-  // children were all pruned as invisible.
+  // paints; a Range over its own text measures that. Measure ONLY the element's direct
+  // text-node children — NOT selectNodeContents(el) over the whole subtree, which also
+  // spans the still-laid-out boxes of visibility:hidden / opacity:0 element descendants
+  // (they keep a layout box but paint nothing), oversizing the frame and mis-placing the
+  // tap point. Returns 0x0 when an ancestor transform (e.g. scale(0)) or display:none
+  // collapses the paint. walk() consults this only when the element has its own text.
   function contentFrame(el) {
     try {
-      const range = document.createRange();
-      range.selectNodeContents(el);
-      const r = range.getBoundingClientRect();
-      if (r.width <= 0 || r.height <= 0) return null;
-      return normRect(r);
+      let box = null;
+      for (const child of getChildNodes.call(el)) {
+        // nodeType via the prototype getter (clobber-safe, like ownText); own text only.
+        if (getNodeType.call(child) !== 3) continue;
+        const range = document.createRange();
+        range.selectNodeContents(child);
+        const r = range.getBoundingClientRect();
+        if (r.width <= 0 || r.height <= 0) continue;
+        if (!box) {
+          box = { left: r.left, top: r.top, right: r.right, bottom: r.bottom };
+        } else {
+          if (r.left < box.left) box.left = r.left;
+          if (r.top < box.top) box.top = r.top;
+          if (r.right > box.right) box.right = r.right;
+          if (r.bottom > box.bottom) box.bottom = r.bottom;
+        }
+      }
+      if (!box || box.right <= box.left || box.bottom <= box.top) return null;
+      return normRect(box);
     } catch (e) {
       return null;
     }
@@ -262,11 +276,20 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
     if (!(el instanceof Element)) return null;
     const style = window.getComputedStyle(el);
     if (hidden(el, style)) return null;
-    if (nodeBudget <= 0) {
-      truncated = true;
-      return null;
+    // Charge the node budget only for elements that can actually EMIT. A
+    // visibility:hidden element paints nothing itself and is descended into
+    // purely to catch a descendant that overrides visibility back to visible
+    // (see hidden()); it is otherwise promoted/dropped. Counting it would let a
+    // large fully-hidden subtree (a closed drawer/modal) exhaust the budget and
+    // truncate genuinely visible content elsewhere in the tree. Its visible
+    // descendants, if any, still consume the budget themselves.
+    if (style.visibility !== "hidden") {
+      if (nodeBudget <= 0) {
+        truncated = true;
+        return null;
+      }
+      nodeBudget--;
     }
-    nodeBudget--;
 
     const childResults = [];
     for (const child of getChildrenEls.call(el)) {
@@ -348,7 +371,20 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
       if (childResults.length === 0 && selfFrame.width <= 0 && selfFrame.height <= 0) {
         return null;
       }
-      if (!clickable && !name && !text && !id && childResults.length === 1) {
+      if (
+        !clickable &&
+        !name &&
+        !text &&
+        !id &&
+        childResults.length === 1 &&
+        (role === "div" || invisibleSelf)
+      ) {
+        // Only a pure layout wrapper (a plain div, e.g. a display:contents RNW
+        // wrapper) or a visibility:hidden element with no meaningful paint of
+        // its own is promoted away. A box-less element with a SEMANTIC role
+        // (list, nav, section, listitem, ...) is kept so its role isn't lost —
+        // mirroring the role === "div" gate on the boxed structural collapse
+        // below.
         return childResults[0];
       }
     } else {

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -16,11 +16,14 @@ import type { DescribeNode, DescribeTreeData } from "../contract";
  *    tree stays small.
  *  - Treat anchors, buttons, inputs, [role=button], [onclick], [tabindex]≥0
  *    as `clickable: true` so the agent knows which nodes to tap.
- *  - Use rect.width/rect.height === 0 to prune invisible nodes (display:none
- *    yields a zero-sized rect; visibility:hidden does not, so we also
- *    short-circuit on computed `visibility: hidden`). display:contents is the
- *    exception — it reports a zero-sized rect but still renders its children, so
- *    we traverse it and promote its content (React Native Web nests under it).
+ *  - Prune a node only when it is truly invisible (display:none, visibility:hidden,
+ *    opacity:0) or its border box is zero-area AND it clips overflow. A zero-area
+ *    box with the default overflow:visible still paints its descendants — so we
+ *    traverse it and promote them instead of cutting the subtree. This covers
+ *    display:contents wrappers (React Native Web nests content under them), the
+ *    zero-height anchor of an absolutely-positioned dropdown/popover/portal, and
+ *    float/overflow wrappers that collapse to a zero-height box. A collapsed
+ *    overflow:hidden container genuinely hides its content, so it stays pruned.
  *  - Cap node count at 5000 — that, not depth, bounds the payload a runaway SPA
  *    would otherwise serialize past CDP's single Runtime.evaluate reply limit
  *    (~50MB). Cap depth at 60 purely to bound recursion: modern React DOMs
@@ -126,29 +129,36 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     return { x, y, width: Math.max(0, right - x), height: Math.max(0, bottom - y) };
   }
 
-  // display:contents elements render their children but generate no box of their
-  // own, so getBoundingClientRect() reports 0x0. React Native Web (and CSS
-  // grid/subgrid layouts) nest real content under such wrappers, so they must be
-  // traversed rather than pruned as zero-sized.
-  function isContents(el) {
-    return window.getComputedStyle(el).display === "contents";
+  function overflowClips(style) {
+    return style.overflowX !== "visible" || style.overflowY !== "visible";
   }
 
-  function hidden(el) {
-    const style = window.getComputedStyle(el);
-    if (style.visibility === "hidden" || style.display === "none" || style.opacity === "0") {
-      return true;
-    }
-    // A zero-area box with nothing in it is an empty spacer worth pruning — but a
-    // display:contents wrapper is zero-area by design while its children render, so
-    // never prune those here; walk() descends and promotes their content.
-    if (isContents(el)) return false;
+  // An element has no box of its own when it is display:contents (renders children
+  // but generates no box) or its border box is zero-area. We give such elements a
+  // frame spanning their children rather than their own 0x0 rect.
+  function boxless(el, style) {
+    if (style.display === "contents") return true;
     const r = el.getBoundingClientRect();
     return r.width <= 0 || r.height <= 0;
   }
 
+  function hidden(el, style) {
+    if (style.visibility === "hidden" || style.display === "none" || style.opacity === "0") {
+      return true;
+    }
+    // display:contents has no box but lays its children out normally — never prune it.
+    if (style.display === "contents") return false;
+    const r = el.getBoundingClientRect();
+    if (r.width > 0 && r.height > 0) return false;
+    // Zero-area box: prune it only when it clips its overflow (a collapsed
+    // overflow:hidden container genuinely hides its content). With the default
+    // overflow:visible, abs-positioned / overflowing / floated descendants still
+    // paint, so walk() must descend and promote them instead of cutting the subtree.
+    return overflowClips(style);
+  }
+
   // Smallest normalized box covering every surviving child frame — the frame we give
-  // a display:contents wrapper we still emit, since it has no rect of its own.
+  // a box-less wrapper we still emit, since it has no rect of its own.
   function unionFrame(children) {
     let minX = 1;
     let minY = 1;
@@ -170,7 +180,8 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     if (truncated) return null;
     if (depth > MAX_DEPTH) return null;
     if (!(el instanceof Element)) return null;
-    if (hidden(el)) return null;
+    const style = window.getComputedStyle(el);
+    if (hidden(el, style)) return null;
     if (nodeBudget <= 0) {
       truncated = true;
       return null;
@@ -213,12 +224,12 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     const name = accessibleName(el);
     const clickable = isInteractive(el);
     const role = nodeRole(el);
-    const contents = isContents(el);
-    // A box-less display:contents wrapper carries no information of its own: promote
-    // its single child or drop it when empty, so the tree mirrors what renders rather
-    // than emitting a 0x0 placeholder. (A display:contents node that is itself
-    // clickable or named falls through and is emitted with a child-spanning frame.)
-    if (contents && !clickable && !name && !text) {
+    const bl = boxless(el, style);
+    // A box-less wrapper carries no information of its own: promote its single child
+    // or drop it when empty, so the tree mirrors what renders rather than emitting a
+    // 0x0 placeholder. (A box-less node that is itself clickable or named falls
+    // through and is emitted with a child-spanning frame.)
+    if (bl && !clickable && !name && !text) {
       if (childResults.length === 0) return null;
       if (childResults.length === 1) return childResults[0];
     }
@@ -236,7 +247,7 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     }
     const node = {
       role,
-      frame: contents ? unionFrame(childResults) : frame(el),
+      frame: bl ? unionFrame(childResults) : frame(el),
       children: childResults,
     };
     if (name) node.label = name;

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -50,6 +50,7 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   // shadowed by a form's named properties, so EVERY inherited member read on a possibly-
   // clobbered element (methods and getters alike) goes through these via .call(el).
   const getChildNodes = Object.getOwnPropertyDescriptor(Node.prototype, "childNodes").get;
+  const getTextContent = Object.getOwnPropertyDescriptor(Node.prototype, "textContent").get;
   const getTagName = Object.getOwnPropertyDescriptor(Element.prototype, "tagName").get;
   const getChildrenEls = Object.getOwnPropertyDescriptor(Element.prototype, "children").get;
   const getShadowRoot = Object.getOwnPropertyDescriptor(Element.prototype, "shadowRoot").get;
@@ -77,7 +78,10 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
       const parts = [];
       for (const id of ids) {
         const ref = document.getElementById(id);
-        if (ref) parts.push((ref.textContent || "").trim());
+        // getTextContent via the prototype: an aria-labelledby target can be a <form>
+        // with a control named "textContent", which would shadow the inherited getter
+        // to a control element and crash (.trim() on a non-string).
+        if (ref) parts.push((getTextContent.call(ref) || "").trim());
       }
       if (parts.length) return parts.join(" ").slice(0, 200);
     }

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -18,13 +18,17 @@ import type { DescribeNode, DescribeTreeData } from "../contract";
  *    as `clickable: true` so the agent knows which nodes to tap.
  *  - Use rect.width/rect.height === 0 to prune invisible nodes (display:none
  *    yields a zero-sized rect; visibility:hidden does not, so we also
- *    short-circuit on computed `visibility: hidden` for the root walk).
- *  - Cap depth at 24 and node count at 5000 — a runaway SPA otherwise
- *    serializes a payload too large for CDP to deliver in a single
- *    Runtime.evaluate reply (~50MB practical limit).
+ *    short-circuit on computed `visibility: hidden`). display:contents is the
+ *    exception — it reports a zero-sized rect but still renders its children, so
+ *    we traverse it and promote its content (React Native Web nests under it).
+ *  - Cap node count at 5000 — that, not depth, bounds the payload a runaway SPA
+ *    would otherwise serialize past CDP's single Runtime.evaluate reply limit
+ *    (~50MB). Cap depth at 60 purely to bound recursion: modern React DOMs
+ *    (React Native Web, navigator/provider stacks) routinely nest 25+ levels
+ *    before reaching leaf text, so a shallower cap silently clips real content.
  */
 const DESCRIBE_DOM_SCRIPT = `(() => {
-  const MAX_DEPTH = 24;
+  const MAX_DEPTH = 60;
   const MAX_NODES = 5000;
   let nodeBudget = MAX_NODES;
   let truncated = false;
@@ -122,21 +126,51 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     return { x, y, width: Math.max(0, right - x), height: Math.max(0, bottom - y) };
   }
 
-  function visible(el) {
-    const r = el.getBoundingClientRect();
-    if (r.width <= 0 || r.height <= 0) return false;
+  // display:contents elements render their children but generate no box of their
+  // own, so getBoundingClientRect() reports 0x0. React Native Web (and CSS
+  // grid/subgrid layouts) nest real content under such wrappers, so they must be
+  // traversed rather than pruned as zero-sized.
+  function isContents(el) {
+    return window.getComputedStyle(el).display === "contents";
+  }
+
+  function hidden(el) {
     const style = window.getComputedStyle(el);
     if (style.visibility === "hidden" || style.display === "none" || style.opacity === "0") {
-      return false;
+      return true;
     }
-    return true;
+    // A zero-area box with nothing in it is an empty spacer worth pruning — but a
+    // display:contents wrapper is zero-area by design while its children render, so
+    // never prune those here; walk() descends and promotes their content.
+    if (isContents(el)) return false;
+    const r = el.getBoundingClientRect();
+    return r.width <= 0 || r.height <= 0;
+  }
+
+  // Smallest normalized box covering every surviving child frame — the frame we give
+  // a display:contents wrapper we still emit, since it has no rect of its own.
+  function unionFrame(children) {
+    let minX = 1;
+    let minY = 1;
+    let maxRight = 0;
+    let maxBottom = 0;
+    for (const c of children) {
+      minX = Math.min(minX, c.frame.x);
+      minY = Math.min(minY, c.frame.y);
+      maxRight = Math.max(maxRight, c.frame.x + c.frame.width);
+      maxBottom = Math.max(maxBottom, c.frame.y + c.frame.height);
+    }
+    if (maxRight <= minX || maxBottom <= minY) {
+      return { x: 0, y: 0, width: 0, height: 0 };
+    }
+    return { x: minX, y: minY, width: maxRight - minX, height: maxBottom - minY };
   }
 
   function walk(el, depth) {
     if (truncated) return null;
     if (depth > MAX_DEPTH) return null;
     if (!(el instanceof Element)) return null;
-    if (!visible(el)) return null;
+    if (hidden(el)) return null;
     if (nodeBudget <= 0) {
       truncated = true;
       return null;
@@ -179,6 +213,15 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     const name = accessibleName(el);
     const clickable = isInteractive(el);
     const role = nodeRole(el);
+    const contents = isContents(el);
+    // A box-less display:contents wrapper carries no information of its own: promote
+    // its single child or drop it when empty, so the tree mirrors what renders rather
+    // than emitting a 0x0 placeholder. (A display:contents node that is itself
+    // clickable or named falls through and is emitted with a child-spanning frame.)
+    if (contents && !clickable && !name && !text) {
+      if (childResults.length === 0) return null;
+      if (childResults.length === 1) return childResults[0];
+    }
     // Prune structural wrappers with no info that just add a layer.
     // Keep them if they're roots/clickable/named/have text.
     if (
@@ -193,7 +236,7 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     }
     const node = {
       role,
-      frame: frame(el),
+      frame: contents ? unionFrame(childResults) : frame(el),
       children: childResults,
     };
     if (name) node.label = name;

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -196,11 +196,15 @@ export const DESCRIBE_DOM_SCRIPT = `(() => {
   }
 
   function hidden(el, style) {
-    if (style.visibility === "hidden" || style.display === "none" || style.opacity === "0") {
+    if (style.visibility === "hidden" || style.display === "none") {
       return true;
     }
-    // display:contents has no box but lays its children out normally — never prune it.
+    // display:contents has no box, so box-only properties don't apply — it lays
+    // its children out normally. Never prune it for opacity:0 (opacity affects a
+    // box, of which there is none, so descendants still paint) or for its 0x0
+    // rect; walk() descends and promotes the visible content.
     if (style.display === "contents") return false;
+    if (style.opacity === "0") return true;
     const r = getBCR.call(el);
     if (r.width > 0 && r.height > 0) return false;
     // Zero-area box: prune it only when it clips its overflow (a collapsed

--- a/packages/tool-server/src/tools/describe/platforms/chromium.ts
+++ b/packages/tool-server/src/tools/describe/platforms/chromium.ts
@@ -30,7 +30,10 @@ import type { DescribeNode, DescribeTreeData } from "../contract";
  *    (React Native Web, navigator/provider stacks) routinely nest 25+ levels
  *    before reaching leaf text, so a shallower cap silently clips real content.
  */
-const DESCRIBE_DOM_SCRIPT = `(() => {
+// Exported for test/describe-chromium-script.test.ts, which evals it against a mock
+// DOM to lock in the visibility/pruning rules (the script runs in the renderer, so
+// the rest of the suite can only mock its CDP response).
+export const DESCRIBE_DOM_SCRIPT = `(() => {
   const MAX_DEPTH = 60;
   const MAX_NODES = 5000;
   let nodeBudget = MAX_NODES;
@@ -64,7 +67,10 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
       if (el.value) return el.value.slice(0, 200);
     }
     if (el instanceof HTMLImageElement && el.alt) return el.alt.slice(0, 200);
-    const t = el.title;
+    // getAttribute, not el.title: a <form> with a control named "title" clobbers the
+    // .title property to return that element (not a string), and .slice() then throws,
+    // aborting the whole describe. getAttribute always yields string | null.
+    const t = el.getAttribute("title");
     if (t) return t.slice(0, 200);
     return null;
   }
@@ -120,13 +126,33 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     return false;
   }
 
-  function frame(el) {
-    const r = el.getBoundingClientRect();
+  function normRect(r) {
     const x = Math.max(0, Math.min(1, r.left / w));
     const y = Math.max(0, Math.min(1, r.top / h));
     const right = Math.max(0, Math.min(1, r.right / w));
     const bottom = Math.max(0, Math.min(1, r.bottom / h));
     return { x, y, width: Math.max(0, right - x), height: Math.max(0, bottom - y) };
+  }
+
+  function frame(el) {
+    return normRect(el.getBoundingClientRect());
+  }
+
+  // Painted extent of an element's own inline content. A box-less element
+  // (display:contents, or a zero-width box whose text overflows) has a 0x0 border box
+  // yet its text still paints; a Range measures that. Crucially it returns 0x0 when an
+  // ancestor transform (e.g. scale(0)) collapses the paint, which is how we tell
+  // genuinely-invisible content apart from merely box-less content.
+  function contentFrame(el) {
+    try {
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const r = range.getBoundingClientRect();
+      if (r.width <= 0 || r.height <= 0) return null;
+      return normRect(r);
+    } catch (e) {
+      return null;
+    }
   }
 
   function overflowClips(style) {
@@ -225,14 +251,31 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     const clickable = isInteractive(el);
     const role = nodeRole(el);
     const bl = boxless(el, style);
-    // A box-less wrapper carries no information of its own: promote its single child
-    // or drop it when empty, so the tree mirrors what renders rather than emitting a
-    // 0x0 placeholder. (A box-less node that is itself clickable or named falls
-    // through and is emitted with a child-spanning frame.)
-    if (bl && !clickable && !name && !text) {
-      if (childResults.length === 0) return null;
-      if (childResults.length === 1) return childResults[0];
+
+    // A box-less element has no rect of its own. Its visible extent is whatever its
+    // children span; with no surviving child, fall back to the painted extent of its
+    // own inline content. If that is still zero-area it paints nothing — e.g. a
+    // transform: scale(0) subtree, whose descendants all collapse — so it is invisible
+    // and dropped. A box-less wrapper with one child and nothing of its own is just a
+    // layer, so promote the child. (Clickable / named box-less nodes fall through and
+    // are emitted with this child- or content-spanning frame.)
+    let selfFrame;
+    if (bl) {
+      selfFrame = unionFrame(childResults);
+      if (selfFrame.width <= 0 && selfFrame.height <= 0) {
+        const cf = contentFrame(el);
+        if (cf) selfFrame = cf;
+      }
+      if (childResults.length === 0 && selfFrame.width <= 0 && selfFrame.height <= 0) {
+        return null;
+      }
+      if (!clickable && !name && !text && childResults.length === 1) {
+        return childResults[0];
+      }
+    } else {
+      selfFrame = frame(el);
     }
+
     // Prune structural wrappers with no info that just add a layer.
     // Keep them if they're roots/clickable/named/have text.
     if (
@@ -247,12 +290,17 @@ const DESCRIBE_DOM_SCRIPT = `(() => {
     }
     const node = {
       role,
-      frame: bl ? unionFrame(childResults) : frame(el),
+      frame: selfFrame,
       children: childResults,
     };
     if (name) node.label = name;
     if (text && text !== name) node.value = text.slice(0, 200);
-    const id = el.id || el.getAttribute("data-testid") || el.getAttribute("data-test-id");
+    // getAttribute, not el.id: like .title, a named form control can clobber the .id
+    // property to a DOM node, which would then break JSON.stringify of the tree.
+    const id =
+      el.getAttribute("id") ||
+      el.getAttribute("data-testid") ||
+      el.getAttribute("data-test-id");
     if (id) node.identifier = id;
     if (clickable) node.clickable = true;
     if (isDisabled(el)) node.disabled = true;

--- a/packages/tool-server/test/describe-chromium-script.test.ts
+++ b/packages/tool-server/test/describe-chromium-script.test.ts
@@ -99,7 +99,12 @@ function el(opts: Opts = {}): MockElement {
   node.__attrs = opts.attrs ?? {};
   node.__rect = rect;
   node.children = opts.children ?? [];
-  node.childNodes = opts.text ? [{ nodeType: 3, nodeValue: opts.text }] : [];
+  // The text node carries the element's own painted-text rect (`content`) so a Range
+  // over just this text node measures the own-text extent — matching the real browser,
+  // where selectNodeContents(textNode) spans the text and NOT sibling element boxes.
+  node.childNodes = opts.text
+    ? [{ nodeType: 3, nodeValue: opts.text, __content: opts.content ?? null }]
+    : [];
   // An open shadow root is a DocumentFragment exposing `.children`; the walker reads
   // `getShadowRoot.call(el)` then iterates `shadow.children`. null unless a fixture sets it.
   node.shadowRoot = opts.shadow ? ({ children: opts.shadow } as unknown) : null;
@@ -272,6 +277,16 @@ function identifiersOf(tree: unknown): string[] {
   (function rec(n: Record<string, unknown> | null) {
     if (!n) return;
     if (typeof n.identifier === "string") out.push(n.identifier);
+    for (const c of (n.children as Record<string, unknown>[]) ?? []) rec(c);
+  })(tree as Record<string, unknown>);
+  return out;
+}
+
+function rolesOf(tree: unknown): string[] {
+  const out: string[] = [];
+  (function rec(n: Record<string, unknown> | null) {
+    if (!n) return;
+    if (typeof n.role === "string") out.push(n.role);
     for (const c of (n.children as Record<string, unknown>[]) ?? []) rec(c);
   })(tree as Record<string, unknown>);
   return out;
@@ -534,6 +549,63 @@ describe("DESCRIBE_DOM_SCRIPT visibility rules", () => {
     ]);
     expect(valuesOf(tree)).toContain("REALTEXT");
     expect(valuesOf(tree)).not.toContain("HIDDENKID2");
+    // The wrapper's frame is its OWN text rect ({0,40,60,12} → 0.06 x 0.012),
+    // NOT the union with the invisible child's still-laid-out box (BOX reaches
+    // y=130, which would have made the frame ~0.09 tall and mis-placed the tap
+    // point). selectNodeContents over the element would have picked up BOX; the
+    // own-text-only measurement does not.
+    const findByValue = (
+      n: Record<string, unknown> | null,
+      v: string
+    ): Record<string, unknown> | null => {
+      if (!n) return null;
+      if (n.value === v) return n;
+      for (const c of (n.children as Record<string, unknown>[]) ?? []) {
+        const r = findByValue(c, v);
+        if (r) return r;
+      }
+      return null;
+    };
+    const real = findByValue(tree as Record<string, unknown>, "REALTEXT");
+    const f = real!.frame as { y: number; width: number; height: number };
+    expect(f.width).toBeCloseTo(0.06, 5);
+    expect(f.height).toBeCloseTo(0.012, 5);
+  });
+
+  it("keeps a box-less wrapper's SEMANTIC role instead of promoting it away", () => {
+    // A display:contents <nav> (semantic role) with a single child and no
+    // clickable/name/text/id of its own must NOT be promoted to its child —
+    // that would silently drop the "nav" role. Only a plain <div> layer is
+    // promoted (see "still promotes an anonymous box-less wrapper" above).
+    const { tree } = run([
+      el({
+        tag: "nav",
+        style: { display: "contents" },
+        rect: ZERO,
+        children: [el({ text: "NAVITEM", rect: BOX })],
+      }),
+    ]);
+    expect(rolesOf(tree)).toContain("nav");
+    expect(valuesOf(tree)).toContain("NAVITEM");
+  });
+
+  it("a large fully visibility:hidden subtree does not starve the node budget", () => {
+    // A closed drawer/modal can be a large visibility:hidden subtree. Descending
+    // into it (to catch a visibility:visible override) must not spend the node
+    // budget on nodes that emit nothing, or genuinely visible content elsewhere
+    // gets truncated. MAX_NODES is 5000; 5100 hidden nodes before a visible one
+    // used to exhaust it.
+    const hiddenKids: MockElement[] = [];
+    for (let i = 0; i < 5100; i++) {
+      hiddenKids.push(el({ text: "HK" + i, style: { visibility: "hidden" }, rect: BOX }));
+    }
+    const { tree, truncated } = run([
+      el({ style: { display: "contents" }, rect: ZERO, children: hiddenKids }),
+      el({ text: "VISIBLE_AFTER", rect: BOX }),
+    ]);
+    expect(truncated).toBe(false);
+    expect(valuesOf(tree)).toContain("VISIBLE_AFTER");
+    expect(valuesOf(tree)).not.toContain("HK0");
   });
 
   // ---- visibility:hidden inherits but a descendant can override it back to visible ----

--- a/packages/tool-server/test/describe-chromium-script.test.ts
+++ b/packages/tool-server/test/describe-chromium-script.test.ts
@@ -11,8 +11,11 @@ import { DESCRIBE_DOM_SCRIPT } from "../src/tools/describe/platforms/chromium";
  *
  * The mock implements only the DOM surface the script reads: getBoundingClientRect,
  * getComputedStyle (display / visibility / opacity / overflow{,X,Y}), children,
- * childNodes (text), getAttribute/hasAttribute, shadowRoot, and a Range whose rect is
- * the element's "painted" content extent (zero when an ancestor transform collapses it).
+ * childNodes (text), getAttribute/hasAttribute, open shadowRoot, iframe contentDocument,
+ * and a Range whose rect unions the element's own painted content with the still-laid-out
+ * boxes of its descendants (everything but display:none) — so it reproduces the real
+ * behaviour where a box-less wrapper's Range is non-zero purely from a visibility:hidden /
+ * opacity:0 child, and returns zero only when an ancestor transform collapses the paint.
  */
 
 const W = 1000;
@@ -80,6 +83,8 @@ type Opts = {
   style?: Record<string, string>;
   attrs?: Record<string, string>;
   children?: MockElement[];
+  shadow?: MockElement[]; // open shadow root children (walker pierces these)
+  iframeDoc?: MockElement; // <iframe> contentDocument.documentElement (same-origin pierce)
   clobber?: boolean; // set .title/.id to non-string objects (DOM-clobbering)
   clobberStructural?: boolean; // shadow .children/.childNodes/.tagName with named controls (LegacyOverrideBuiltins)
   clobberAccessors?: boolean; // shadow getAttribute/hasAttribute/getBoundingClientRect/shadowRoot with a control element
@@ -95,7 +100,14 @@ function el(opts: Opts = {}): MockElement {
   node.__rect = rect;
   node.children = opts.children ?? [];
   node.childNodes = opts.text ? [{ nodeType: 3, nodeValue: opts.text }] : [];
-  node.shadowRoot = null;
+  // An open shadow root is a DocumentFragment exposing `.children`; the walker reads
+  // `getShadowRoot.call(el)` then iterates `shadow.children`. null unless a fixture sets it.
+  node.shadowRoot = opts.shadow ? ({ children: opts.shadow } as unknown) : null;
+  // A same-origin <iframe> exposes contentDocument.documentElement (read directly, not via
+  // a prototype getter). Only meaningful when tag === "iframe".
+  if (opts.iframeDoc) {
+    (node as Record<string, unknown>).contentDocument = { documentElement: opts.iframeDoc };
+  }
   (node as Record<string, unknown>).__content = opts.content ?? null;
   if (opts.clobber) {
     // simulate a <form> whose named control shadows the .title / .id properties
@@ -186,16 +198,44 @@ function run(rootChildren: MockElement[]): { tree: unknown; truncated: boolean }
         selectNodeContents: (e: Record<string, unknown>) => {
           target = e;
         },
+        // Model a real Range over selectNodeContents(el): the union of the element's own
+        // painted inline content (__content) AND the layout boxes of its descendants that
+        // still occupy layout — i.e. everything except display:none (visibility:hidden and
+        // opacity:0 keep their box). This lets a fixture reproduce the real-browser case a
+        // plain "return __content" mock could not: a box-less wrapper whose Range is
+        // non-zero purely because an invisible child still lays out.
         getBoundingClientRect: () => {
-          const c = target?.__content as Rect | null | undefined;
-          if (!c) return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+          let box: { x: number; y: number; r: number; b: number } | null = null;
+          const add = (r: Rect | null | undefined) => {
+            if (!r || r.w <= 0 || r.h <= 0) return;
+            box = box
+              ? {
+                  x: Math.min(box.x, r.x),
+                  y: Math.min(box.y, r.y),
+                  r: Math.max(box.r, r.x + r.w),
+                  b: Math.max(box.b, r.y + r.h),
+                }
+              : { x: r.x, y: r.y, r: r.x + r.w, b: r.y + r.h };
+          };
+          add(target?.__content as Rect | null | undefined);
+          const walkRects = (n: Record<string, unknown> | null | undefined) => {
+            for (const c of (n?.__children as Record<string, unknown>[]) ?? []) {
+              const st = (c.__style as Record<string, string>) ?? {};
+              if (st.display === "none") continue; // display:none collapses layout
+              add(c.__rect as Rect);
+              walkRects(c);
+            }
+          };
+          walkRects(target);
+          if (!box) return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+          const b = box as { x: number; y: number; r: number; b: number };
           return {
-            left: c.x,
-            top: c.y,
-            right: c.x + c.w,
-            bottom: c.y + c.h,
-            width: c.w,
-            height: c.h,
+            left: b.x,
+            top: b.y,
+            right: b.r,
+            bottom: b.b,
+            width: b.r - b.x,
+            height: b.b - b.y,
           };
         },
       };
@@ -225,6 +265,39 @@ function valuesOf(tree: unknown): string[] {
     for (const c of (n.children as Record<string, unknown>[]) ?? []) rec(c);
   })(tree as Record<string, unknown>);
   return out;
+}
+
+function identifiersOf(tree: unknown): string[] {
+  const out: string[] = [];
+  (function rec(n: Record<string, unknown> | null) {
+    if (!n) return;
+    if (typeof n.identifier === "string") out.push(n.identifier);
+    for (const c of (n.children as Record<string, unknown>[]) ?? []) rec(c);
+  })(tree as Record<string, unknown>);
+  return out;
+}
+
+function findById(tree: unknown, id: string): Record<string, unknown> | null {
+  let found: Record<string, unknown> | null = null;
+  (function rec(n: Record<string, unknown> | null) {
+    if (!n || found) return;
+    if (n.identifier === id) {
+      found = n;
+      return;
+    }
+    for (const c of (n.children as Record<string, unknown>[]) ?? []) rec(c);
+  })(tree as Record<string, unknown>);
+  return found;
+}
+
+function countNodes(tree: unknown): number {
+  let n = 0;
+  (function rec(node: Record<string, unknown> | null) {
+    if (!node) return;
+    n++;
+    for (const c of (node.children as Record<string, unknown>[]) ?? []) rec(c);
+  })(tree as Record<string, unknown>);
+  return n;
 }
 
 const ZERO = { x: 0, y: 0, w: 0, h: 0 };
@@ -428,5 +501,215 @@ describe("DESCRIBE_DOM_SCRIPT visibility rules", () => {
   it("leaves an ordinary visible element unchanged", () => {
     const { tree } = run([el({ text: "NORMAL", rect: BOX })]);
     expect(valuesOf(tree)).toContain("NORMAL");
+  });
+
+  // ---- box-less wrapper over invisible-only content must not become a phantom node ----
+  it("drops a box-less wrapper whose non-zero content frame comes only from an invisible child", () => {
+    // The wrapper has no own text; its single element child is visibility:hidden (pruned).
+    // A real Range over the wrapper is non-zero because the child still lays out (the mock
+    // Range now models that), but that must NOT resurrect the wrapper as an empty node with
+    // a real frame — it paints nothing.
+    const { tree } = run([
+      el({
+        attrs: { id: "phantom-wrap" },
+        style: { display: "contents" },
+        rect: ZERO,
+        children: [el({ text: "HIDDENKID", style: { visibility: "hidden" }, rect: BOX })],
+      }),
+    ]);
+    expect(identifiersOf(tree)).not.toContain("phantom-wrap");
+    expect(valuesOf(tree)).not.toContain("HIDDENKID");
+  });
+
+  it("keeps a box-less wrapper with own painting text even when it also has an invisible child", () => {
+    // Own text paints, so the wrapper is real; the invisible child is just pruned.
+    const { tree } = run([
+      el({
+        text: "REALTEXT",
+        content: { x: 0, y: 40, w: 60, h: 12 },
+        style: { display: "contents" },
+        rect: ZERO,
+        children: [el({ text: "HIDDENKID2", style: { visibility: "hidden" }, rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).toContain("REALTEXT");
+    expect(valuesOf(tree)).not.toContain("HIDDENKID2");
+  });
+
+  // ---- visibility:hidden inherits but a descendant can override it back to visible ----
+  it("surfaces a visibility:visible descendant nested under a visibility:hidden ancestor", () => {
+    const { tree } = run([
+      el({
+        style: { visibility: "hidden" },
+        rect: { x: 0, y: 100, w: 200, h: 200 },
+        children: [el({ text: "OVERRIDE", style: { visibility: "visible" }, rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).toContain("OVERRIDE");
+  });
+
+  it("suppresses a visibility:hidden element's own text but keeps its visible child", () => {
+    const { tree } = run([
+      el({
+        text: "HIDDENOWN",
+        style: { visibility: "hidden" },
+        rect: { x: 0, y: 100, w: 200, h: 200 },
+        children: [el({ text: "VISIBLECHILD", style: { visibility: "visible" }, rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).toContain("VISIBLECHILD");
+    expect(valuesOf(tree)).not.toContain("HIDDENOWN");
+  });
+
+  it("prunes a fully visibility:hidden subtree with no visible descendant (no phantom)", () => {
+    const { tree } = run([
+      el({
+        style: { visibility: "hidden" },
+        rect: { x: 0, y: 100, w: 200, h: 200 },
+        children: [el({ text: "ALLHIDDEN", style: { visibility: "hidden" }, rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).not.toContain("ALLHIDDEN");
+    // Only the html/body scaffold survives — no phantom node for the hidden subtree.
+    expect(identifiersOf(tree)).toEqual([]);
+  });
+
+  // ---- promotion must not discard an identifier ----
+  it("keeps a box-less wrapper's identifier instead of promoting it away", () => {
+    const { tree } = run([
+      el({
+        attrs: { id: "keepme" },
+        style: { display: "contents" },
+        rect: ZERO,
+        children: [el({ text: "INNER5", rect: BOX })],
+      }),
+    ]);
+    expect(identifiersOf(tree)).toContain("keepme");
+    expect(valuesOf(tree)).toContain("INNER5");
+  });
+
+  it("keeps a boxed structural div's identifier instead of collapsing it away", () => {
+    const { tree } = run([
+      el({
+        attrs: { "data-testid": "structural" },
+        rect: { x: 0, y: 100, w: 200, h: 200 },
+        children: [el({ text: "INNER5C", rect: BOX })],
+      }),
+    ]);
+    expect(identifiersOf(tree)).toContain("structural");
+    expect(valuesOf(tree)).toContain("INNER5C");
+  });
+
+  it("still promotes an anonymous box-less wrapper (no identifier) to its single child", () => {
+    const withWrap = run([
+      el({
+        style: { display: "contents" },
+        rect: ZERO,
+        children: [el({ text: "SOLO", rect: BOX })],
+      }),
+    ]);
+    const withoutWrap = run([el({ text: "SOLO", rect: BOX })]);
+    expect(valuesOf(withWrap.tree)).toContain("SOLO");
+    // The wrapper adds no node — identical node count to the bare child.
+    expect(countNodes(withWrap.tree)).toBe(countNodes(withoutWrap.tree));
+    expect(identifiersOf(withWrap.tree)).toEqual([]);
+  });
+
+  // ---- box-less node framing: unionFrame across multiple children (emitted, not promoted) ----
+  it("frames an emitted box-less multi-child wrapper by the union of its children (unionFrame)", () => {
+    const { tree } = run([
+      el({
+        attrs: { role: "button", id: "unioned" }, // clickable + named -> emitted, not promoted
+        style: { display: "contents" },
+        rect: ZERO,
+        children: [
+          el({ text: "A", rect: { x: 100, y: 100, w: 100, h: 20 } }),
+          el({ text: "B", rect: { x: 300, y: 400, w: 100, h: 20 } }),
+        ],
+      }),
+    ]);
+    const node = findById(tree, "unioned");
+    expect(node).toBeTruthy();
+    expect((node!.children as unknown[]).length).toBe(2);
+    const f = node!.frame as { x: number; y: number; width: number; height: number };
+    // union of (100,100,100,20) and (300,400,100,20): x=100 y=100 right=400 bottom=420
+    expect(f.x).toBeCloseTo(0.1, 6);
+    expect(f.y).toBeCloseTo(0.1, 6);
+    expect(f.width).toBeCloseTo(0.3, 6); // (400-100)/1000
+    expect(f.height).toBeCloseTo(0.32, 6); // (420-100)/1000
+  });
+
+  it("frames a promoted box-less single-child node by the child's own rect", () => {
+    const { tree } = run([
+      el({
+        style: { display: "contents" },
+        rect: ZERO,
+        children: [el({ text: "SOLO2", rect: BOX })],
+      }),
+    ]);
+    const node = findById(tree, "");
+    // The promoted node is the child itself; find it by value and check its frame == BOX.
+    const child = (function find(
+      n: Record<string, unknown> | null
+    ): Record<string, unknown> | null {
+      if (!n) return null;
+      if (n.value === "SOLO2") return n;
+      for (const c of (n.children as Record<string, unknown>[]) ?? []) {
+        const r = find(c);
+        if (r) return r;
+      }
+      return null;
+    })(tree as Record<string, unknown>);
+    expect(child).toBeTruthy();
+    const f = child!.frame as { x: number; y: number; width: number; height: number };
+    expect(f.x).toBeCloseTo(BOX.x / W, 6);
+    expect(f.y).toBeCloseTo(BOX.y / H, 6);
+    expect(f.width).toBeCloseTo(BOX.w / W, 6);
+    expect(f.height).toBeCloseTo(BOX.h / H, 6);
+    expect(node).toBeNull(); // sanity: no node literally identified by "" exists
+  });
+
+  // ---- shadow DOM + iframe piercing (previously uncovered) ----
+  it("pierces an open shadow root and surfaces its content", () => {
+    const { tree } = run([
+      el({ tag: "my-widget", rect: BOX, shadow: [el({ text: "SHADOWTEXT", rect: BOX })] }),
+    ]);
+    expect(valuesOf(tree)).toContain("SHADOWTEXT");
+  });
+
+  it("pierces a same-origin iframe's contentDocument", () => {
+    const innerDoc = el({
+      tag: "html",
+      rect: { x: 0, y: 0, w: W, h: H },
+      children: [
+        el({
+          tag: "body",
+          rect: { x: 0, y: 0, w: W, h: H },
+          children: [el({ text: "IFRAMETEXT", rect: BOX })],
+        }),
+      ],
+    });
+    const { tree } = run([
+      el({ tag: "iframe", rect: { x: 0, y: 0, w: 500, h: 500 }, iframeDoc: innerDoc }),
+    ]);
+    expect(valuesOf(tree)).toContain("IFRAMETEXT");
+  });
+
+  // ---- a missing captured accessor must degrade, not abort the whole describe ----
+  it("degrades instead of aborting when a captured prototype accessor is absent", () => {
+    // scrollHeight is read only for overflow:auto/scroll nodes. Removing its prototype
+    // accessor made the old `getOwnPropertyDescriptor(...).get` throw at script top and
+    // abort the entire describe; protoGetter now falls back to a direct read.
+    const saved = Object.getOwnPropertyDescriptor(MockElement.prototype, "scrollHeight");
+    delete (MockElement.prototype as unknown as Record<string, unknown>).scrollHeight;
+    try {
+      let out: { tree: unknown } | undefined;
+      expect(() => {
+        out = run([el({ text: "STILLHERE", rect: BOX, style: { overflow: "auto" } })]);
+      }).not.toThrow();
+      expect(valuesOf(out!.tree)).toContain("STILLHERE");
+    } finally {
+      Object.defineProperty(MockElement.prototype, "scrollHeight", saved!);
+    }
   });
 });

--- a/packages/tool-server/test/describe-chromium-script.test.ts
+++ b/packages/tool-server/test/describe-chromium-script.test.ts
@@ -43,6 +43,7 @@ function defineNative(proto: object, prop: string, field: string): void {
   });
 }
 defineNative(MockNode.prototype, "childNodes", "__childNodes");
+defineNative(MockNode.prototype, "textContent", "__textContent");
 defineNative(MockElement.prototype, "tagName", "__tagName");
 defineNative(MockElement.prototype, "children", "__children");
 defineNative(MockElement.prototype, "shadowRoot", "__shadowRoot");
@@ -118,7 +119,13 @@ function el(opts: Opts = {}): MockElement {
     // read would re-walk the control's children (duplicating the subtree). The script must
     // route every one of these through the captured Element.prototype accessor.
     const ctrl = (opts.children ?? [])[0];
-    for (const m of ["getAttribute", "hasAttribute", "getBoundingClientRect", "shadowRoot"]) {
+    for (const m of [
+      "getAttribute",
+      "hasAttribute",
+      "getBoundingClientRect",
+      "shadowRoot",
+      "textContent",
+    ]) {
       Object.defineProperty(node, m, { value: ctrl, configurable: true });
     }
   }
@@ -159,7 +166,20 @@ function run(rootChildren: MockElement[]): { tree: unknown; truncated: boolean }
   };
   g.document = {
     documentElement: root,
-    getElementById: () => null,
+    // Resolve aria-labelledby targets by walking the mock tree's backing __children
+    // (the real children, unaffected by any structural clobber) for a matching id.
+    getElementById: (id: string) => {
+      const find = (n: Record<string, unknown>): Record<string, unknown> | null => {
+        const attrs = (n.__attrs as Record<string, string>) ?? {};
+        if (attrs.id === id) return n;
+        for (const k of (n.__children as Record<string, unknown>[]) ?? []) {
+          const f = find(k);
+          if (f) return f;
+        }
+        return null;
+      };
+      return find(root);
+    },
     createRange: () => {
       let target: Record<string, unknown> | null = null;
       return {
@@ -348,6 +368,39 @@ describe("DESCRIBE_DOM_SCRIPT visibility rules", () => {
     // The child still surfaces — exactly once (the shadowRoot clobber must not re-walk it).
     expect(serialized).toContain("deep-inner");
     expect((serialized.match(/deep-inner/g) || []).length).toBe(1);
+  });
+
+  it("does not crash on an aria-labelledby target whose form clobbers textContent", () => {
+    // accessibleName resolves aria-labelledby via getElementById, then reads textContent.
+    // A <form id="lbl"> with a control named "textContent" shadows the inherited getter,
+    // so a direct read returns the control and crashes (.trim on a non-string). The fix
+    // routes through Node.prototype.textContent.
+    const labelForm = el({
+      tag: "form",
+      attrs: { id: "lbl" },
+      rect: { x: 0, y: 200, w: 200, h: 20 },
+      children: [
+        el({
+          tag: "input",
+          attrs: { id: "tc", name: "textContent" },
+          rect: { x: 0, y: 200, w: 100, h: 20 },
+        }),
+      ],
+      clobberAccessors: true,
+    }) as MockElement & Record<string, unknown>;
+    labelForm.__textContent = "Real Label";
+    const labelled = el({
+      tag: "div",
+      attrs: { "aria-labelledby": "lbl" },
+      rect: BOX,
+      children: [el({ text: "BODY", rect: BOX })],
+    });
+    let result: { tree: unknown } | undefined;
+    expect(() => {
+      result = run([labelled, labelForm]);
+    }).not.toThrow();
+    // The label resolves via the prototype textContent despite the clobber.
+    expect(JSON.stringify(result!.tree)).toContain("Real Label");
   });
 
   it("leaves an ordinary visible element unchanged", () => {

--- a/packages/tool-server/test/describe-chromium-script.test.ts
+++ b/packages/tool-server/test/describe-chromium-script.test.ts
@@ -55,15 +55,17 @@ defineNative(MockElement.prototype, "clientWidth", "__clientWidth");
 // getAttribute / hasAttribute / getBoundingClientRect are methods on Element.prototype.
 // The script invokes them via the captured `Element.prototype.X` so a [LegacyOverrideBuiltins]
 // form can't shadow them to a control element (which would crash with "not a function").
-// Back them with per-element fields, mirroring the real DOM.
-MockElement.prototype.getAttribute = function (this: Record<string, unknown>, n: string) {
+// Back them with per-element fields, mirroring the real DOM. Assigned through a cast
+// because the bare mock classes declare no DOM members.
+const elementProto = MockElement.prototype as unknown as Record<string, unknown>;
+elementProto.getAttribute = function (this: Record<string, unknown>, n: string) {
   const a = (this.__attrs as Record<string, string>) ?? {};
   return n in a ? a[n] : null;
 };
-MockElement.prototype.hasAttribute = function (this: Record<string, unknown>, n: string) {
+elementProto.hasAttribute = function (this: Record<string, unknown>, n: string) {
   return n in ((this.__attrs as Record<string, string>) ?? {});
 };
-MockElement.prototype.getBoundingClientRect = function (this: Record<string, unknown>) {
+elementProto.getBoundingClientRect = function (this: Record<string, unknown>) {
   const r = this.__rect as Rect;
   return { left: r.x, top: r.y, right: r.x + r.w, bottom: r.y + r.h, width: r.w, height: r.h };
 };

--- a/packages/tool-server/test/describe-chromium-script.test.ts
+++ b/packages/tool-server/test/describe-chromium-script.test.ts
@@ -18,10 +18,33 @@ import { DESCRIBE_DOM_SCRIPT } from "../src/tools/describe/platforms/chromium";
 const W = 1000;
 const H = 1000;
 
-class MockElement {}
+class MockNode {}
+class MockElement extends MockNode {}
 class MockHTMLInputElement extends MockElement {}
 class MockHTMLTextAreaElement extends MockElement {}
 class MockHTMLImageElement extends MockElement {}
+
+// The script reads childNodes / tagName / children through the native prototype getter
+// (Object.getOwnPropertyDescriptor(proto, prop).get.call(el)) so a DOM-clobbering <form>
+// can't shadow them. Mirror that here: expose each as a prototype accessor backed by a
+// field, so a test can shadow the *public* property (see `clobberStructural`) while the
+// prototype getter still returns the real value — exactly the real [LegacyOverrideBuiltins]
+// behaviour the fix relies on. childNodes lives on Node.prototype, tagName/children on
+// Element.prototype, matching where the script captures each getter.
+function defineNative(proto: object, prop: string, field: string): void {
+  Object.defineProperty(proto, prop, {
+    get(this: Record<string, unknown>) {
+      return this[field];
+    },
+    set(this: Record<string, unknown>, v: unknown) {
+      this[field] = v;
+    },
+    configurable: true,
+  });
+}
+defineNative(MockNode.prototype, "childNodes", "__childNodes");
+defineNative(MockElement.prototype, "tagName", "__tagName");
+defineNative(MockElement.prototype, "children", "__children");
 
 type Rect = { x: number; y: number; w: number; h: number };
 type Opts = {
@@ -33,6 +56,7 @@ type Opts = {
   attrs?: Record<string, string>;
   children?: MockElement[];
   clobber?: boolean; // set .title/.id to non-string objects (DOM-clobbering)
+  clobberStructural?: boolean; // shadow .children/.childNodes/.tagName with named controls (LegacyOverrideBuiltins)
 };
 
 function el(opts: Opts = {}): MockElement {
@@ -59,6 +83,16 @@ function el(opts: Opts = {}): MockElement {
     node.title = node;
     node.id = node;
   }
+  if (opts.clobberStructural) {
+    // simulate a <form> with [LegacyOverrideBuiltins] whose controls are named
+    // children / childNodes / tagName: the public property returns the control element
+    // (not iterable / not a string), while the native prototype getter still returns the
+    // real DOM value (preserved in the backing fields set above).
+    const kids = opts.children ?? [];
+    Object.defineProperty(node, "children", { value: kids[0], configurable: true });
+    Object.defineProperty(node, "childNodes", { value: kids[1], configurable: true });
+    Object.defineProperty(node, "tagName", { value: kids[2], configurable: true });
+  }
   const baseStyle: Record<string, string> = {
     display: "block",
     visibility: "visible",
@@ -83,6 +117,7 @@ function run(rootChildren: MockElement[]): { tree: unknown; truncated: boolean }
   const saved = {
     window: g.window,
     document: g.document,
+    Node: g.Node,
     Element: g.Element,
     HTMLInputElement: g.HTMLInputElement,
     HTMLTextAreaElement: g.HTMLTextAreaElement,
@@ -117,6 +152,7 @@ function run(rootChildren: MockElement[]): { tree: unknown; truncated: boolean }
       };
     },
   };
+  g.Node = MockNode;
   g.Element = MockElement;
   g.HTMLInputElement = MockHTMLInputElement;
   g.HTMLTextAreaElement = MockHTMLTextAreaElement;
@@ -209,6 +245,43 @@ describe("DESCRIBE_DOM_SCRIPT visibility rules", () => {
     const tree = JSON.stringify(result!.tree);
     expect(tree).toContain("realid");
     expect(valuesOf(result!.tree)).toContain("CLOBBER");
+  });
+
+  it("does not crash on a <form> whose controls clobber children/childNodes/tagName (LegacyOverrideBuiltins)", () => {
+    // Named controls shadow the form's inherited DOM properties: el.children returns a
+    // single control (not iterable), el.childNodes / el.tagName likewise return elements.
+    // Reading any of them directly aborts the whole walk; the fix routes through the
+    // native prototype getter, so the form and its controls still surface.
+    const fieldChildren = el({
+      tag: "input",
+      attrs: { name: "children", id: "field-children" },
+      rect: { x: 0, y: 100, w: 200, h: 20 },
+    });
+    const fieldChildNodes = el({
+      tag: "input",
+      attrs: { name: "childNodes", id: "field-childnodes" },
+      rect: { x: 0, y: 130, w: 200, h: 20 },
+    });
+    const fieldTagName = el({
+      tag: "input",
+      attrs: { name: "tagName", id: "field-tagname" },
+      rect: { x: 0, y: 160, w: 200, h: 20 },
+    });
+    let result: { tree: unknown } | undefined;
+    expect(() => {
+      result = run([
+        el({
+          tag: "form",
+          rect: { x: 0, y: 100, w: 200, h: 100 },
+          children: [fieldChildren, fieldChildNodes, fieldTagName],
+          clobberStructural: true,
+        }),
+      ]);
+    }).not.toThrow();
+    const serialized = JSON.stringify(result!.tree);
+    expect(serialized).toContain("field-children");
+    expect(serialized).toContain("field-childnodes");
+    expect(serialized).toContain("field-tagname");
   });
 
   it("leaves an ordinary visible element unchanged", () => {

--- a/packages/tool-server/test/describe-chromium-script.test.ts
+++ b/packages/tool-server/test/describe-chromium-script.test.ts
@@ -45,6 +45,28 @@ function defineNative(proto: object, prop: string, field: string): void {
 defineNative(MockNode.prototype, "childNodes", "__childNodes");
 defineNative(MockElement.prototype, "tagName", "__tagName");
 defineNative(MockElement.prototype, "children", "__children");
+defineNative(MockElement.prototype, "shadowRoot", "__shadowRoot");
+// Scroll-dimension getters live on Element.prototype too; the script captures their
+// descriptor up front (so they must exist) and only reads them for overflow:auto/scroll.
+defineNative(MockElement.prototype, "scrollHeight", "__scrollHeight");
+defineNative(MockElement.prototype, "clientHeight", "__clientHeight");
+defineNative(MockElement.prototype, "scrollWidth", "__scrollWidth");
+defineNative(MockElement.prototype, "clientWidth", "__clientWidth");
+// getAttribute / hasAttribute / getBoundingClientRect are methods on Element.prototype.
+// The script invokes them via the captured `Element.prototype.X` so a [LegacyOverrideBuiltins]
+// form can't shadow them to a control element (which would crash with "not a function").
+// Back them with per-element fields, mirroring the real DOM.
+MockElement.prototype.getAttribute = function (this: Record<string, unknown>, n: string) {
+  const a = (this.__attrs as Record<string, string>) ?? {};
+  return n in a ? a[n] : null;
+};
+MockElement.prototype.hasAttribute = function (this: Record<string, unknown>, n: string) {
+  return n in ((this.__attrs as Record<string, string>) ?? {});
+};
+MockElement.prototype.getBoundingClientRect = function (this: Record<string, unknown>) {
+  const r = this.__rect as Rect;
+  return { left: r.x, top: r.y, right: r.x + r.w, bottom: r.y + r.h, width: r.w, height: r.h };
+};
 
 type Rect = { x: number; y: number; w: number; h: number };
 type Opts = {
@@ -57,23 +79,17 @@ type Opts = {
   children?: MockElement[];
   clobber?: boolean; // set .title/.id to non-string objects (DOM-clobbering)
   clobberStructural?: boolean; // shadow .children/.childNodes/.tagName with named controls (LegacyOverrideBuiltins)
+  clobberAccessors?: boolean; // shadow getAttribute/hasAttribute/getBoundingClientRect/shadowRoot with a control element
 };
 
 function el(opts: Opts = {}): MockElement {
   const node = new MockElement() as MockElement & Record<string, unknown>;
   const rect = opts.rect ?? { x: 0, y: 0, w: 100, h: 20 };
   node.tagName = (opts.tag ?? "div").toUpperCase();
-  const attrs = opts.attrs ?? {};
-  node.getAttribute = (n: string) => (n in attrs ? attrs[n] : null);
-  node.hasAttribute = (n: string) => n in attrs;
-  node.getBoundingClientRect = () => ({
-    left: rect.x,
-    top: rect.y,
-    right: rect.x + rect.w,
-    bottom: rect.y + rect.h,
-    width: rect.w,
-    height: rect.h,
-  });
+  // Backing fields read by the Element.prototype getAttribute/hasAttribute/
+  // getBoundingClientRect methods defined above (the script reads them via the prototype).
+  node.__attrs = opts.attrs ?? {};
+  node.__rect = rect;
   node.children = opts.children ?? [];
   node.childNodes = opts.text ? [{ nodeType: 3, nodeValue: opts.text }] : [];
   node.shadowRoot = null;
@@ -92,6 +108,17 @@ function el(opts: Opts = {}): MockElement {
     Object.defineProperty(node, "children", { value: kids[0], configurable: true });
     Object.defineProperty(node, "childNodes", { value: kids[1], configurable: true });
     Object.defineProperty(node, "tagName", { value: kids[2], configurable: true });
+  }
+  if (opts.clobberAccessors) {
+    // simulate a <form> whose controls are named getAttribute / hasAttribute /
+    // getBoundingClientRect / shadowRoot: each public member returns a control element,
+    // so a direct el.getAttribute(...) throws "not a function" and a direct el.shadowRoot
+    // read would re-walk the control's children (duplicating the subtree). The script must
+    // route every one of these through the captured Element.prototype accessor.
+    const ctrl = (opts.children ?? [])[0];
+    for (const m of ["getAttribute", "hasAttribute", "getBoundingClientRect", "shadowRoot"]) {
+      Object.defineProperty(node, m, { value: ctrl, configurable: true });
+    }
   }
   const baseStyle: Record<string, string> = {
     display: "block",
@@ -282,6 +309,43 @@ describe("DESCRIBE_DOM_SCRIPT visibility rules", () => {
     expect(serialized).toContain("field-children");
     expect(serialized).toContain("field-childnodes");
     expect(serialized).toContain("field-tagname");
+  });
+
+  it("does not crash (or duplicate) on a <form> clobbering getAttribute/getBoundingClientRect/hasAttribute/shadowRoot", () => {
+    // A <form> whose controls are named getAttribute / getBoundingClientRect /
+    // hasAttribute reproduced "TypeError: el.X is not a function" on real Chrome (each
+    // shadows the inherited method to a control element); a control named shadowRoot made
+    // the walker re-walk the control's children and duplicate the subtree. The fix routes
+    // all of these through the captured Element.prototype accessor.
+    const inner = el({
+      tag: "input",
+      attrs: { id: "deep-inner" },
+      rect: { x: 0, y: 130, w: 200, h: 20 },
+    });
+    const fieldset = el({
+      tag: "fieldset",
+      attrs: { id: "fs", name: "shadowRoot" },
+      rect: { x: 0, y: 110, w: 200, h: 40 },
+      children: [inner],
+    });
+    let result: { tree: unknown } | undefined;
+    expect(() => {
+      result = run([
+        el({
+          tag: "form",
+          attrs: { id: "clobber-form" },
+          rect: { x: 0, y: 100, w: 200, h: 60 },
+          children: [fieldset],
+          clobberAccessors: true,
+        }),
+      ]);
+    }).not.toThrow();
+    const serialized = JSON.stringify(result!.tree);
+    // The form's own id is read via the prototype getAttribute despite the clobber.
+    expect(serialized).toContain("clobber-form");
+    // The child still surfaces — exactly once (the shadowRoot clobber must not re-walk it).
+    expect(serialized).toContain("deep-inner");
+    expect((serialized.match(/deep-inner/g) || []).length).toBe(1);
   });
 
   it("leaves an ordinary visible element unchanged", () => {

--- a/packages/tool-server/test/describe-chromium-script.test.ts
+++ b/packages/tool-server/test/describe-chromium-script.test.ts
@@ -246,6 +246,28 @@ describe("DESCRIBE_DOM_SCRIPT visibility rules", () => {
     expect(valuesOf(tree)).toContain("CONTENTS");
   });
 
+  it("surfaces content under a display:contents wrapper even at opacity:0 (opacity affects no box)", () => {
+    const { tree } = run([
+      el({
+        style: { display: "contents", opacity: "0" },
+        rect: ZERO,
+        children: [el({ text: "CONTENTS0", rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).toContain("CONTENTS0");
+  });
+
+  it("still prunes a normal (boxed) opacity:0 subtree", () => {
+    const { tree } = run([
+      el({
+        style: { opacity: "0" },
+        rect: { x: 0, y: 0, w: 200, h: 200 },
+        children: [el({ text: "INVISIBLE", rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).not.toContain("INVISIBLE");
+  });
+
   it("surfaces an absolutely-positioned child of a zero-height overflow:visible wrapper", () => {
     const { tree } = run([
       el({

--- a/packages/tool-server/test/describe-chromium-script.test.ts
+++ b/packages/tool-server/test/describe-chromium-script.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DESCRIBE_DOM_SCRIPT } from "../src/tools/describe/platforms/chromium";
+
+/**
+ * `DESCRIBE_DOM_SCRIPT` is an IIFE injected via Runtime.evaluate that walks the live
+ * renderer DOM. The rest of the suite can only mock its CDP *response*, so this test
+ * evals the real script against a hand-built mock DOM to lock in the visibility /
+ * pruning rules — the part that broke describe on React Native Web (everything nested
+ * under a zero-area display:contents box was pruned) and crashed it on pages with
+ * DOM-clobbering forms. Mirrors test/debugger/component-tree-script.test.ts.
+ *
+ * The mock implements only the DOM surface the script reads: getBoundingClientRect,
+ * getComputedStyle (display / visibility / opacity / overflow{,X,Y}), children,
+ * childNodes (text), getAttribute/hasAttribute, shadowRoot, and a Range whose rect is
+ * the element's "painted" content extent (zero when an ancestor transform collapses it).
+ */
+
+const W = 1000;
+const H = 1000;
+
+class MockElement {}
+class MockHTMLInputElement extends MockElement {}
+class MockHTMLTextAreaElement extends MockElement {}
+class MockHTMLImageElement extends MockElement {}
+
+type Rect = { x: number; y: number; w: number; h: number };
+type Opts = {
+  tag?: string;
+  text?: string;
+  rect?: Rect;
+  content?: Rect | null; // painted extent of own inline content (Range)
+  style?: Record<string, string>;
+  attrs?: Record<string, string>;
+  children?: MockElement[];
+  clobber?: boolean; // set .title/.id to non-string objects (DOM-clobbering)
+};
+
+function el(opts: Opts = {}): MockElement {
+  const node = new MockElement() as MockElement & Record<string, unknown>;
+  const rect = opts.rect ?? { x: 0, y: 0, w: 100, h: 20 };
+  node.tagName = (opts.tag ?? "div").toUpperCase();
+  const attrs = opts.attrs ?? {};
+  node.getAttribute = (n: string) => (n in attrs ? attrs[n] : null);
+  node.hasAttribute = (n: string) => n in attrs;
+  node.getBoundingClientRect = () => ({
+    left: rect.x,
+    top: rect.y,
+    right: rect.x + rect.w,
+    bottom: rect.y + rect.h,
+    width: rect.w,
+    height: rect.h,
+  });
+  node.children = opts.children ?? [];
+  node.childNodes = opts.text ? [{ nodeType: 3, nodeValue: opts.text }] : [];
+  node.shadowRoot = null;
+  (node as Record<string, unknown>).__content = opts.content ?? null;
+  if (opts.clobber) {
+    // simulate a <form> whose named control shadows the .title / .id properties
+    node.title = node;
+    node.id = node;
+  }
+  const baseStyle: Record<string, string> = {
+    display: "block",
+    visibility: "visible",
+    opacity: "1",
+    overflow: "visible",
+    overflowX: "visible",
+    overflowY: "visible",
+  };
+  const s = { ...baseStyle, ...(opts.style ?? {}) };
+  if (opts.style?.overflow && !opts.style.overflowX) s.overflowX = opts.style.overflow;
+  if (opts.style?.overflow && !opts.style.overflowY) s.overflowY = opts.style.overflow;
+  (node as Record<string, unknown>).__style = s;
+  return node;
+}
+
+function run(rootChildren: MockElement[]): { tree: unknown; truncated: boolean } {
+  const root = el({ tag: "html", rect: { x: 0, y: 0, w: W, h: H } }) as MockElement &
+    Record<string, unknown>;
+  root.children = [el({ tag: "body", rect: { x: 0, y: 0, w: W, h: H }, children: rootChildren })];
+
+  const g = globalThis as Record<string, unknown>;
+  const saved = {
+    window: g.window,
+    document: g.document,
+    Element: g.Element,
+    HTMLInputElement: g.HTMLInputElement,
+    HTMLTextAreaElement: g.HTMLTextAreaElement,
+    HTMLImageElement: g.HTMLImageElement,
+  };
+  g.window = {
+    innerWidth: W,
+    innerHeight: H,
+    getComputedStyle: (e: Record<string, unknown>) => e.__style,
+  };
+  g.document = {
+    documentElement: root,
+    getElementById: () => null,
+    createRange: () => {
+      let target: Record<string, unknown> | null = null;
+      return {
+        selectNodeContents: (e: Record<string, unknown>) => {
+          target = e;
+        },
+        getBoundingClientRect: () => {
+          const c = target?.__content as Rect | null | undefined;
+          if (!c) return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+          return {
+            left: c.x,
+            top: c.y,
+            right: c.x + c.w,
+            bottom: c.y + c.h,
+            width: c.w,
+            height: c.h,
+          };
+        },
+      };
+    },
+  };
+  g.Element = MockElement;
+  g.HTMLInputElement = MockHTMLInputElement;
+  g.HTMLTextAreaElement = MockHTMLTextAreaElement;
+  g.HTMLImageElement = MockHTMLImageElement;
+  try {
+    const payload = (0, eval)(DESCRIBE_DOM_SCRIPT) as string;
+    return JSON.parse(payload);
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete g[k];
+      else g[k] = v;
+    }
+  }
+}
+
+function valuesOf(tree: unknown): string[] {
+  const out: string[] = [];
+  (function rec(n: Record<string, unknown> | null) {
+    if (!n) return;
+    if (typeof n.value === "string") out.push(n.value);
+    for (const c of (n.children as Record<string, unknown>[]) ?? []) rec(c);
+  })(tree as Record<string, unknown>);
+  return out;
+}
+
+const ZERO = { x: 0, y: 0, w: 0, h: 0 };
+const BOX = { x: 0, y: 100, w: 200, h: 30 };
+
+afterEach(() => {
+  // run() restores globals in its finally, nothing else to clean up.
+});
+
+describe("DESCRIBE_DOM_SCRIPT visibility rules", () => {
+  it("surfaces content nested under a display:contents wrapper (the RNW bug)", () => {
+    const { tree } = run([
+      el({
+        style: { display: "contents" },
+        rect: ZERO,
+        children: [el({ text: "CONTENTS", rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).toContain("CONTENTS");
+  });
+
+  it("surfaces an absolutely-positioned child of a zero-height overflow:visible wrapper", () => {
+    const { tree } = run([
+      el({
+        rect: { x: 0, y: 100, w: 1000, h: 0 },
+        children: [el({ text: "DROPDOWN", rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).toContain("DROPDOWN");
+  });
+
+  it("keeps pruning a zero-area box that clips its overflow (collapsed content)", () => {
+    const { tree } = run([
+      el({
+        rect: ZERO,
+        style: { overflow: "hidden" },
+        children: [el({ text: "CLIPPED", rect: BOX })],
+      }),
+    ]);
+    expect(valuesOf(tree)).not.toContain("CLIPPED");
+  });
+
+  it("prunes a box-less leaf whose painted content is also zero-area (transform: scale(0))", () => {
+    const { tree } = run([el({ text: "SCALE0", rect: ZERO, content: null })]);
+    expect(valuesOf(tree)).not.toContain("SCALE0");
+  });
+
+  it("surfaces a box-less leaf whose text actually paints (overflowing / contents text)", () => {
+    const { tree } = run([
+      el({ text: "OVERFLOWTEXT", rect: ZERO, content: { x: 0, y: 50, w: 80, h: 15 } }),
+    ]);
+    expect(valuesOf(tree)).toContain("OVERFLOWTEXT");
+  });
+
+  it("does not crash and ignores DOM-clobbered .title / .id (uses getAttribute)", () => {
+    let result: { tree: unknown } | undefined;
+    expect(() => {
+      result = run([
+        el({
+          text: "CLOBBER",
+          rect: BOX,
+          clobber: true,
+          attrs: { title: "realtitle", id: "realid" },
+        }),
+      ]);
+    }).not.toThrow();
+    const tree = JSON.stringify(result!.tree);
+    expect(tree).toContain("realid");
+    expect(valuesOf(result!.tree)).toContain("CLOBBER");
+  });
+
+  it("leaves an ordinary visible element unchanged", () => {
+    const { tree } = run([el({ text: "NORMAL", rect: BOX })]);
+    expect(valuesOf(tree)).toContain("NORMAL");
+  });
+});


### PR DESCRIPTION
## Problem

`describe` on a Chromium device (the `cdp-dom` walker) returned an essentially **empty tree** for React Native Web / Expo-web apps — just `html > body > div > div` — even though the page was fully rendered and interactive.

## Root cause

The walker pruned any element whose `getBoundingClientRect()` is **zero-area**, cutting its **entire subtree**. That is wrong whenever a zero-area element still paints visible descendants. Verified against `react-native-gesture-handler`'s `expo-example` on web (488 elements, depth 28):

1. **`display:contents` wrappers.** RNW nests content under `<div style="display:contents">` → no box → `0×0` rect → pruned (first one ~16 levels deep, above all content). Not the depth cap alone (disproven) and not the node budget (`truncated:false`).
2. **`MAX_DEPTH = 24`** — RNW leaf text sits ~25 levels deep; `MAX_NODES` (5000), not depth, bounds the CDP payload.
3. **Other `0×0`-but-visible cases** — zero-height wrapper of an `position:absolute` dropdown/popover/portal, `width:0;height:0;overflow:visible` wrapper, float-collapsed wrapper. Discriminator vs. a *correctly* pruned box (collapsed `overflow:hidden`): **does it clip overflow**.
4. **Invisible box-less content** — a box-less element whose content paints nothing (e.g. a `transform: scale(0)` subtree) must still be dropped.
5. **Crash on DOM-clobbering pages** — a `<form>` control named `title`/`id` shadows `el.title`/`el.id` to a DOM node; `el.title.slice(...)` threw (Wikipedia) and a clobbered `el.id` would break `JSON.stringify`. Pre-existing; describe failed entirely on such pages.

## Fix

- Prune a node only when truly invisible (`display:none`/`visibility:hidden`/`opacity:0`) **or** its border box is zero-area **and it clips overflow**. Otherwise traverse and promote its content.
- A box-less element's frame is its child-spanning union; with no surviving child, fall back to the **painted extent of its own inline content via a `Range`**. Still zero-area ⇒ invisible ⇒ dropped (handles `scale(0)`; also gives box-less text leaves a real frame instead of `0×0`).
- `MAX_DEPTH` 24 → 60 (pure recursion bound; `MAX_NODES` is the payload guard).
- Read `title`/`id` via `getAttribute` (clobber-proof, always `string | null`).
- `getComputedStyle` read once per node.

All other behavior (hidden-subtree pruning, structural single-`div` collapse, interactivity, shadow-DOM / iframe piercing) unchanged.

## Verification

Driven through the **actual built tool-server's** `describe` over HTTP, plus the real injected script against live pages.

**RNGH `expo-example` (web):** `7 → 295` nodes; `html>body>div>div` → full gesture list with `[clickable]` buttons + labels (Fling/Tap/Pinch/…) + normalized frames.

**Adversarial fixture — 15/15 correct:**

| case | result |
|---|---|
| display:contents / nested contents / contents-link | ✓ shown (link gets a real frame) |
| abs-positioned child in `height:0` wrapper | ✓ shown |
| overflowing child of `0×0` box / float-collapsed wrapper | ✓ shown |
| `position:fixed` child / sr-only (`1×1`) / `display:contents` button | ✓ shown |
| `0×0; overflow:hidden` (clipped) / `overflow:clip` / `display:none` child / mixed-overflow | ✓ stays pruned |
| `transform: scale(0)` content | ✓ pruned (invisible) |

**Real pages (old vs new script):**

| page | old | new | regression |
|---|---|---|---|
| github.com | 150 nodes | 961 nodes, not truncated | none — 0 dropped texts |
| example.com | 7 | 7 (identical) | none |
| en.wikipedia.org | **crash** (`el.title.slice`) | 761-node tree | **fixed** |

**New automated guard:** `test/describe-chromium-script.test.ts` evals the real `DESCRIBE_DOM_SCRIPT` against a mock DOM, locking in: contents traversal, zero-height-dropdown, clipped-stays-pruned, `scale(0)` invisibility, box-less painted-text, and the clobbering crash. (The script runs in the renderer; the rest of the suite can only mock the CDP response, and the repo has no headless-browser test infra.)

`npm run build` ✓ · `typecheck:tests` ✓ · prettier ✓ · eslint ✓ · **full suite 1580 tests pass**.