### PR TITLE
fix(argent-lens): cache device-list validation in the preview routes

### DIFF
--- a/packages/tool-server/src/preview.ts
+++ b/packages/tool-server/src/preview.ts
@@ -55,6 +55,69 @@ function wsUrlFromHttp(httpUrl: string): string {
 export function createPreviewRouter(registry: Registry): Router {
   const router = express.Router();
 
+  // ── Known-device cache ────────────────────────────────────────────────
+  // Both /describe/:udid and /simulator-server/:udid validate the :udid against
+  // the live device list before dispatching, so this auth-exempt route can't
+  // amplify forged ids into unbounded `xcrun`/`adb` subprocess spawns. But the
+  // preview UI polls /describe ~3×/s while variants are on screen, and `argent
+  // lens` holds the window open across rounds — so invoking `list-devices`
+  // (which itself shells `xcrun`/`adb`/`ps` + probes Chromium CDP) per request
+  // turns the guard into a spawn storm. Cache the known-id set for a short
+  // window: the guard stays O(1) on the hot path and `list-devices` runs at most
+  // ~once per window. This also tightens the guard — a flood of forged ids now
+  // shares one refresh instead of triggering a `list-devices` spawn each.
+  // /simulators refreshes the cache as a side effect, so a device the UI just
+  // listed is immediately connectable without waiting out the TTL.
+  const KNOWN_DEVICES_TTL_MS = 5_000;
+  let knownDevices: { ids: Set<string>; at: number } | null = null;
+  let knownDevicesInFlight: Promise<Set<string>> | null = null;
+
+  // Mirror the original `.some()` guard exactly: an iOS device is keyed by its
+  // udid, every other platform by its serial (a chromium entry has neither, so
+  // it's skipped — it was never a valid preview target anyway).
+  function deviceIdSet(
+    devices: ReadonlyArray<{ platform: string; udid?: string; serial?: string }>
+  ): Set<string> {
+    const ids = new Set<string>();
+    for (const d of devices) {
+      const id = d.platform === "ios" ? d.udid : d.serial;
+      if (typeof id === "string") ids.add(id);
+    }
+    return ids;
+  }
+
+  // Record a freshly-resolved device list into the cache (used by both the
+  // dedicated refresh below and the /simulators handler, which already fetches
+  // the full list for its dropdown).
+  function rememberDevices(
+    devices: ReadonlyArray<{ platform: string; udid?: string; serial?: string }>
+  ): void {
+    knownDevices = { ids: deviceIdSet(devices), at: Date.now() };
+  }
+
+  // Resolve the set of known device ids, refreshing via `list-devices` only when
+  // the cache is cold or stale. Concurrent callers within one refresh share a
+  // single in-flight invocation. Rejections propagate (the routes 500 on them,
+  // as they did when calling `list-devices` inline).
+  async function knownDeviceIds(): Promise<Set<string>> {
+    if (knownDevices && Date.now() - knownDevices.at < KNOWN_DEVICES_TTL_MS) {
+      return knownDevices.ids;
+    }
+    if (knownDevicesInFlight) return knownDevicesInFlight;
+    knownDevicesInFlight = registry
+      .invokeTool<{
+        devices: Array<{ platform: string; udid?: string; serial?: string }>;
+      }>(listDevicesTool.id)
+      .then((data) => {
+        rememberDevices(data.devices);
+        return knownDevices!.ids;
+      })
+      .finally(() => {
+        knownDevicesInFlight = null;
+      });
+    return knownDevicesInFlight;
+  }
+
   router.get("/simulators", async (_req: Request, res: Response) => {
     try {
       const data = await registry.invokeTool<{
@@ -116,6 +179,11 @@ export function createPreviewRouter(registry: Registry): Router {
         }
         return [];
       });
+      // This is the authoritative fresh device list — prime the validation
+      // cache so the immediately-following connect (/simulator-server/:udid)
+      // and the describe poll loop hit a warm, correct set instead of each
+      // re-running `list-devices`.
+      rememberDevices(data.devices);
       res.json({ simulators });
     } catch (err) {
       res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
@@ -142,11 +210,10 @@ export function createPreviewRouter(registry: Registry): Router {
       // number of simulator-server processes with arbitrary distinct ids
       // (DoS), nor (b) inject argv into the binary via a crafted id. The UI
       // only ever requests ids returned by /preview/simulators — no
-      // regression.
-      const data = await registry.invokeTool<{
-        devices: Array<{ platform: "ios"; udid: string } | { platform: "android"; serial: string }>;
-      }>(listDevicesTool.id);
-      const known = data.devices.some((d) => (d.platform === "ios" ? d.udid : d.serial) === udid);
+      // regression. Validation goes through the short-lived known-device cache
+      // (see top of createPreviewRouter) so the describe poll loop doesn't
+      // re-run `list-devices` on every tick.
+      const known = (await knownDeviceIds()).has(udid);
       if (!known) {
         res
           .status(400)
@@ -319,13 +386,11 @@ export function createPreviewRouter(registry: Registry): Router {
       // bind the dispatch to an actually-present device — otherwise an
       // unauthenticated caller could flood distinct ids and amplify into
       // unbounded subprocess spawns. The UI only ever requests ids returned by
-      // /preview/simulators — no regression.
-      const deviceList = await registry.invokeTool<{
-        devices: Array<{ platform: "ios"; udid: string } | { platform: "android"; serial: string }>;
-      }>(listDevicesTool.id);
-      const known = deviceList.devices.some(
-        (d) => (d.platform === "ios" ? d.udid : d.serial) === udid
-      );
+      // /preview/simulators — no regression. Validation goes through the
+      // short-lived known-device cache (see top of createPreviewRouter): this
+      // route is polled ~3×/s, so re-running `list-devices` per tick would
+      // storm `xcrun`/`adb`/`ps`.
+      const known = (await knownDeviceIds()).has(udid);
       if (!known) {
         res
           .status(400)

--- a/packages/tool-server/test/preview-describe-route.test.ts
+++ b/packages/tool-server/test/preview-describe-route.test.ts
@@ -179,3 +179,112 @@ describe("preview UI routes (real router, real packages/ui)", () => {
     expect(res.headers["location"]).toBe("/preview/");
   });
 });
+
+// Both /describe/:udid and /simulator-server/:udid validate the :udid against
+// the live device list to keep these auth-exempt routes from amplifying forged
+// ids into subprocess spawns. The preview UI polls /describe ~3×/s while
+// variants are on screen, and `argent lens` holds the window open across rounds
+// — so validating by re-invoking `list-devices` (itself a storm of
+// `xcrun`/`adb`/`ps` spawns) per request was the "spamming list-devices" bug.
+// These guard the short-lived known-device cache that fixes it.
+describe("known-device validation cache (preview /describe + /simulator-server)", () => {
+  // Harness that exposes the registry mock so call counts are assertable.
+  // resolveService is stubbed so the /simulator-server happy path resolves.
+  function harness(
+    devices: unknown[] = [
+      { platform: "ios", udid: IOS_UDID },
+      { platform: "android", serial: ANDROID_SERIAL },
+    ]
+  ) {
+    const invokeTool = vi.fn(async () => ({ devices }));
+    const resolveService = vi.fn(async () => ({
+      apiUrl: "http://127.0.0.1:65000/",
+      streamUrl: "http://127.0.0.1:65000/stream",
+    }));
+    const registry = { invokeTool, resolveService } as unknown as Registry;
+    const app = express();
+    app.use(createPreviewRouter(registry));
+    return { app, invokeTool };
+  }
+
+  it("polling /describe repeatedly invokes list-devices ONCE, not per request", async () => {
+    mockedIos.mockResolvedValue({ tree: TREE, source: "ax-service" });
+    const { app, invokeTool } = harness();
+
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app).get(`/describe/${IOS_UDID}`);
+      expect(res.status).toBe(200);
+    }
+
+    // The fix: validation is served from the cache after the first refresh, so
+    // 5 describe polls cost ONE list-devices call (was 5 — the spam).
+    expect(invokeTool).toHaveBeenCalledTimes(1);
+    // Every poll still describes — only the device-list validation is cached.
+    expect(mockedIos).toHaveBeenCalledTimes(5);
+  });
+
+  it("/simulators primes the cache so a following /describe doesn't re-list", async () => {
+    mockedIos.mockResolvedValue({ tree: TREE, source: "ax-service" });
+    const { app, invokeTool } = harness();
+
+    const sims = await request(app).get(`/simulators`);
+    expect(sims.status).toBe(200);
+    expect(invokeTool).toHaveBeenCalledTimes(1);
+
+    const desc = await request(app).get(`/describe/${IOS_UDID}`);
+    expect(desc.status).toBe(200);
+    // No extra list-devices: the connect/poll path rides the list /simulators
+    // already fetched for its dropdown.
+    expect(invokeTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("/simulator-server validation is cached too (connect path doesn't re-list)", async () => {
+    const { app, invokeTool } = harness();
+
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app).get(`/simulator-server/${ANDROID_SERIAL}`);
+      expect(res.status).toBe(200);
+    }
+    expect(invokeTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("an unknown id is still rejected from cache without re-listing per request", async () => {
+    const { app, invokeTool } = harness([{ platform: "ios", udid: IOS_UDID }]);
+
+    for (let i = 0; i < 4; i++) {
+      const res = await request(app).get(`/describe/${"11111111-1111-1111-1111-111111111111"}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("Unknown device");
+    }
+    // A flood of forged ids shares one refresh instead of one list-devices each
+    // — the cache tightens the DoS guard rather than weakening it.
+    expect(invokeTool).toHaveBeenCalledTimes(1);
+    expect(mockedIos).not.toHaveBeenCalled();
+  });
+
+  it("re-lists once the cache goes stale (a disappeared/new device is eventually seen)", async () => {
+    // Fake only the clock (Date), not setTimeout — supertest's own timers stay
+    // real, so its requests resolve normally while we control cache staleness.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date(1_000_000));
+      mockedIos.mockResolvedValue({ tree: TREE, source: "ax-service" });
+      const { app, invokeTool } = harness();
+
+      await request(app).get(`/describe/${IOS_UDID}`);
+      expect(invokeTool).toHaveBeenCalledTimes(1);
+
+      // Within the TTL → still cached.
+      vi.setSystemTime(new Date(1_000_000 + 4_000));
+      await request(app).get(`/describe/${IOS_UDID}`);
+      expect(invokeTool).toHaveBeenCalledTimes(1);
+
+      // Past the TTL → one refresh.
+      vi.setSystemTime(new Date(1_000_000 + 6_000));
+      await request(app).get(`/describe/${IOS_UDID}`);
+      expect(invokeTool).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`argent lens` (and the `await_user_selection` preview flow) spams the `list-devices` tool. While variants are on screen the preview UI polls `GET /preview/describe/:udid` ~3×/s to keep each floating variant bubble anchored to its element's on-screen frame. `argent lens` keeps that window open across rounds, so the poll never stops.

Both `/preview/describe/:udid` and `/preview/simulator-server/:udid` validate the requested `:udid` against the live device list before dispatching — a deliberate guard so these auth-exempt routes can't amplify forged ids into unbounded subprocess spawns. But they did that validation by invoking the `list-devices` tool **on every request**, and `list-devices` shells out to `xcrun simctl list`, `adb devices`, `ps`, and probes Chromium CDP ports. So a steady ~3 describe polls/sec became a continuous storm of `xcrun`/`adb`/`ps` spawns.

This is a pre-existing bug on `main` (the describe route's per-request validation predates the Lens CLI session); `argent lens` (#416) just makes it constant by holding the window open.

## Fix

Cache the validated device-id set inside `createPreviewRouter` for a short (5s) window:

- The describe/simulator-server validation now reads from the cache; `list-devices` runs at most ~once per window instead of per request.
- `GET /preview/simulators` primes the cache as a side effect of building its device dropdown, so the connect (`/simulator-server/:udid`) that immediately follows — and the describe poll loop after it — ride a warm, correct set.
- Validation semantics are unchanged (iOS keyed by `udid`, every other platform by `serial`, mirroring the original `.some()` guard exactly).

The DoS guard is *tightened*, not weakened: a flood of forged ids now shares a single refresh rather than triggering one `list-devices` spawn each. A device that appears/disappears is reflected within the 5s TTL (and immediately via `/simulators`).

## Verification

- Added regression tests in `preview-describe-route.test.ts` that count `list-devices` invocations via the real router (supertest). **Reproduced before/after**: against the original code 5 describe polls → 5 `list-devices` calls, 3 connects → 3, 4 forged ids → 4; with the fix each collapses to **1**. The TTL test confirms a refresh after staleness.
- `packages/tool-server` full suite: **1521 tests pass**.
- `tsc --build`, `eslint`, and `prettier --check` all clean on the changed files.