### PR TITLE
fix(tool-server): stop list-devices from hanging - wedged-VVD stall and CLI socket leak

### DIFF
--- a/packages/argent-cli/src/link.ts
+++ b/packages/argent-cli/src/link.ts
@@ -289,6 +289,10 @@ async function preflightHealth(
       signal: controller.signal,
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
+    // Drain the (large) /tools body so undici frees the keep-alive socket
+    // immediately; an unread body otherwise keeps the socket ref'd until the
+    // server's idle keepAliveTimeout (~5s), lingering the command after it's done.
+    await res.body?.cancel().catch(() => {});
     if (!res.ok) {
       const hint =
         res.status === 401

--- a/packages/argent-tools-client/src/launcher.ts
+++ b/packages/argent-tools-client/src/launcher.ts
@@ -167,6 +167,13 @@ export async function isToolsServerHealthy(
       signal: controller.signal,
       headers: authHeaders(token),
     });
+    // Release the response body before returning. /tools is a large (~100KB+)
+    // payload and we only need the status; an unread body keeps undici's
+    // keep-alive socket *ref'd* until the server's idle keepAliveTimeout (~5s)
+    // closes it, which makes every natural-exit CLI command (`argent run …`,
+    // `argent tools`) hang ~6s after it has already printed its result. Cancelling
+    // frees the socket immediately so the event loop can drain and the process exit.
+    await res.body?.cancel().catch(() => {});
     return res.ok;
   } catch {
     return false;

--- a/packages/argent-tools-client/test/launcher-helpers.test.ts
+++ b/packages/argent-tools-client/test/launcher-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as net from "node:net";
 import {
   buildToolsServerEnv,
@@ -108,5 +108,21 @@ describe("isToolsServerHealthy", () => {
     // The healthCheckHost shim must rewrite 0.0.0.0 → 127.0.0.1 so the fetch
     // returns a connection-refused error rather than hanging until the timeout.
     expect(healthy).toBe(false);
+  });
+
+  it("drains the response body so the keep-alive socket is freed immediately", async () => {
+    // Regression cover for the ~6s CLI linger: /tools is a large keep-alive payload,
+    // and leaving its body unread kept undici's socket ref'd until the server's idle
+    // timeout. The fix cancels the body before returning — assert that cancel runs.
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, body: { cancel } });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const healthy = await isToolsServerHealthy(3001, "127.0.0.1", 1000);
+      expect(healthy).toBe(true);
+      expect(cancel).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/packages/telemetry/src/posthog.ts
+++ b/packages/telemetry/src/posthog.ts
@@ -4,7 +4,7 @@ import { PostHog } from "posthog-node";
 export const POSTHOG_HOST = "https://eu.i.posthog.com";
 
 /** Public write-only PostHog project token. */
-export const POSTHOG_PROJECT_TOKEN = "phc_mebZhuUmASbeeXkdv7E2wqTZdtstPxQqHBhZfLSeQ5YL";
+export const POSTHOG_PROJECT_TOKEN = "phc_tkPxaBJ8WVr2KQAuu7FoN2nAcJ7MhVNsHSpUSuNC9HGV";
 
 interface ResolvedConfig {
   key: string;

--- a/packages/telemetry/src/posthog.ts
+++ b/packages/telemetry/src/posthog.ts
@@ -4,7 +4,7 @@ import { PostHog } from "posthog-node";
 export const POSTHOG_HOST = "https://eu.i.posthog.com";
 
 /** Public write-only PostHog project token. */
-export const POSTHOG_PROJECT_TOKEN = "phc_tkPxaBJ8WVr2KQAuu7FoN2nAcJ7MhVNsHSpUSuNC9HGV";
+export const POSTHOG_PROJECT_TOKEN = "phc_mebZhuUmASbeeXkdv7E2wqTZdtstPxQqHBhZfLSeQ5YL";
 
 interface ResolvedConfig {
   key: string;

--- a/packages/tool-server/src/tools/devices/list-devices.ts
+++ b/packages/tool-server/src/tools/devices/list-devices.ts
@@ -78,6 +78,48 @@ async function resolveVvdShadowAdbSerials<T extends { serial: string }>(
   return shadows;
 }
 
+// Hard backstop so no single discovery branch can stall this `alwaysLoad` tool,
+// which runs at session start and frequently after. The per-call subprocess
+// timeouts (and the no-stacking fix in listVegaDevices) already bound each
+// branch; this is defence-in-depth against an unforeseen stall — a wedged
+// device, a hung `ps`, a future serial call — so the worst case is a partial
+// list with a logged note, never a 40s "hang". Mirrors the existing
+// `.catch(() => [])` degradation, just for slowness rather than errors.
+//
+// Critically this must sit comfortably ABOVE every branch's own worst case, or it
+// stops being a last-resort backstop and starts truncating branches that would
+// have completed — dropping a real device from the list. The long pole is Vega: a
+// fast (non-timeout) `device list` failure followed by the `device info` recovery
+// is ~10s (its 6s + 4s discovery timeouts; see vega-devices.ts), so 15s keeps a
+// ~5s margin. (Android self-bounds at ~5s, the rest at <1s.) Still far below the
+// ~40s stall this whole fix targets.
+//
+// Note: this is a *deadline*, not cancellation — on timeout it resolves the
+// fallback while the underlying branch keeps running to completion in the
+// background. That's fine here because the per-call subprocess timeouts bound the
+// branch, so it settles shortly after rather than leaking work indefinitely.
+export const BRANCH_DEADLINE_MS = 15_000;
+
+export async function withDeadline<T>(p: Promise<T>, fallback: T, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<T>((resolve) => {
+        timer = setTimeout(() => {
+          process.stderr.write(
+            `[list-devices] ${label} discovery exceeded ${BRANCH_DEADLINE_MS}ms; ` +
+              `returning partial results (a wedged device or its CLI is unresponsive)\n`
+          );
+          resolve(fallback);
+        }, BRANCH_DEADLINE_MS);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 const zodSchema = z.object({});
 
 export const listDevicesTool: ToolDefinition<Record<string, never>, ListDevicesResult> = {
@@ -94,12 +136,32 @@ Booted/ready devices are listed first. Platforms whose CLI is unavailable are si
   zodSchema,
   services: () => ({}),
   async execute(_services, _params) {
+    // Every branch gets the same hard deadline so no single one can stall this
+    // `alwaysLoad` tool. The Android/Vega branches are the ones that actually shell
+    // out to potentially-wedged devices; iOS / AVD-list / Chromium already self-bound
+    // with their own short subprocess/socket timeouts, but wrapping them too makes the
+    // "no branch can hang the fan-out" guarantee universal at near-zero cost (the
+    // timer is cleared on the fast happy path). The deadline only substitutes a
+    // fallback on *slowness*; a rejection still propagates exactly as before — so the
+    // `.catch(() => [])` wrappers (and the lack of one on iOS/AVDs) are unchanged.
     const [ios, android, avds, chromium, vega] = await Promise.all([
-      listIosSimulators(),
-      listAndroidDevices().catch(() => []),
-      listAvds(),
-      discoverChromiumDevices().catch(() => []),
-      listVegaDevices().catch(() => []),
+      withDeadline(listIosSimulators(), [], "ios"),
+      withDeadline(
+        listAndroidDevices().catch(() => []),
+        [],
+        "android"
+      ),
+      withDeadline(listAvds(), [], "avds"),
+      withDeadline(
+        discoverChromiumDevices().catch(() => []),
+        [],
+        "chromium"
+      ),
+      withDeadline(
+        listVegaDevices().catch(() => []),
+        [],
+        "vega"
+      ),
     ]);
     const iosTagged: IosDevice[] = ios.map((s) => ({ platform: "ios", ...s }));
     iosTagged.sort(sortIos);

--- a/packages/tool-server/src/tools/devices/list-devices.ts
+++ b/packages/tool-server/src/tools/devices/list-devices.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import type { ToolDefinition } from "@argent/registry";
-import { listAndroidDevices, listAvds, consolePortFromAdbSerial } from "../../utils/adb";
+import {
+  listAndroidDevices,
+  listAvds,
+  consolePortFromAdbSerial,
+  ADB_DEVICES_TIMEOUT_MS,
+} from "../../utils/adb";
 import { listRunningVvdConsolePorts } from "../../utils/vega-process";
 import { listIosSimulators, type IosSimulator } from "../../utils/ios-devices";
 import { discoverChromiumDevices, type ChromiumDevice } from "../../utils/chromium-discovery";
@@ -81,24 +86,41 @@ async function resolveVvdShadowAdbSerials<T extends { serial: string }>(
 // Hard backstop so no single discovery branch can stall this `alwaysLoad` tool,
 // which runs at session start and frequently after. The per-call subprocess
 // timeouts (and the no-stacking fix in listVegaDevices) already bound each
-// branch; this is defence-in-depth against an unforeseen stall — a wedged
-// device, a hung `ps`, a future serial call — so the worst case is a partial
-// list with a logged note, never a 40s "hang". Mirrors the existing
+// branch; this is defence-in-depth against an *unforeseen* stall — an OS-level
+// spawn hang, a future serial call added with no timeout — so the worst case is a
+// partial list with a logged note, never a 40s "hang". Mirrors the existing
 // `.catch(() => [])` degradation, just for slowness rather than errors.
 //
-// Critically this must sit comfortably ABOVE every branch's own worst case, or it
+// Critically this must sit ABOVE every branch's full per-call worst case, or it
 // stops being a last-resort backstop and starts truncating branches that would
-// have completed — dropping a real device from the list. The long pole is Vega: a
-// fast (non-timeout) `device list` failure followed by the `device info` recovery
-// is ~10s (its 6s + 4s discovery timeouts; see vega-devices.ts), so 15s keeps a
-// ~5s margin. (Android self-bounds at ~5s, the rest at <1s.) Still far below the
-// ~40s stall this whole fix targets.
+// have completed — dropping a real device from the list. Summing each branch's
+// own bounded subprocess calls (an invariant test in list-devices-deadline.test.ts
+// guards these so a future timeout bump can't silently breach the deadline):
+//   - Vega (the long pole): a non-timeout `device list` failure or an empty list
+//     that triggers the `device info` recovery runs, serially, the 6s list timeout
+//     + TWO 5s `ps` probes (the recovery gate in listVegaDevices plus the
+//     `-d emulator-<port>` selector probe inside runVegaDevice) + the 4s `device
+//     info` timeout = ~20s worst case. (A *timed-out* list skips the recovery
+//     entirely — see listVegaDevices — so the wedged-VVD case is just ~6s.)
+//   - Android: one bounded `adb devices` call (6s) + ~5s concurrent getprop
+//     enrichment = ~11s.
+//   - iOS / AVD-list / Chromium self-bound by their own subprocess/socket timeouts
+//     (iOS `simctl` ~10s, AVD-list ~5s, Chromium <1s) — all comfortably under 25s.
+// The Vega binary resolution (`resolveVegaBinary`) runs first but is memoized and
+// returns the instant `vega` is found, so it adds ~0 in practice; only a pathological
+// cold-session `command -v` shell-fork hang would add up to ~4s on top of the 20s,
+// still inside the deadline. 25s clears the ~20s Vega long pole with margin, so a
+// branch merely hitting its own (foreseen) per-call timeouts always completes rather
+// than being cut off; only a genuinely unforeseen hang reaches the backstop. Still
+// well below the ~40s stall this whole fix targets. The two Vega `ps` reads are local
+// process-table reads (never a device round-trip), so this 20s figure is a
+// pathological host-load ceiling, not the realistic wedged-device cost (~6s).
 //
 // Note: this is a *deadline*, not cancellation — on timeout it resolves the
 // fallback while the underlying branch keeps running to completion in the
 // background. That's fine here because the per-call subprocess timeouts bound the
 // branch, so it settles shortly after rather than leaking work indefinitely.
-export const BRANCH_DEADLINE_MS = 15_000;
+export const BRANCH_DEADLINE_MS = 25_000;
 
 export async function withDeadline<T>(p: Promise<T>, fallback: T, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -147,7 +169,9 @@ Booted/ready devices are listed first. Platforms whose CLI is unavailable are si
     const [ios, android, avds, chromium, vega] = await Promise.all([
       withDeadline(listIosSimulators(), [], "ios"),
       withDeadline(
-        listAndroidDevices().catch(() => []),
+        // Pass the tight `adb devices` bound (NOT boot-device's 30s default) so the
+        // Android branch self-bounds under BRANCH_DEADLINE_MS — see ADB_DEVICES_TIMEOUT_MS.
+        listAndroidDevices({ devicesTimeoutMs: ADB_DEVICES_TIMEOUT_MS }).catch(() => []),
         [],
         "android"
       ),

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -285,14 +285,37 @@ export function consolePortFromAdbSerial(serial: string): number | null {
   return null;
 }
 
+// Tight bound for the `adb devices` shell-out on the `alwaysLoad` `list-devices`
+// hot path. Callers opt in by passing this as `devicesTimeoutMs`; omitting it keeps
+// runAdb's 30s default. list-devices needs the bound because a slow/cold/wedged `adb
+// server` (the exact condition this fix targets) would otherwise stall the Android
+// branch for up to 30s + the ~5s enrichment — well past list-devices'
+// BRANCH_DEADLINE_MS (25s), at which point the backstop substitutes `[]` and drops
+// EVERY Android device from the result. `adb devices` only queries the local daemon
+// (autostarting it on a cold call, ~1-2s); 6s is a generous multiple of that, and
+// keeps the Android branch's worst case (6s here + ~5s enrichment = ~11s) comfortably
+// under the deadline so a completing branch is never truncated. A genuine daemon hang
+// past 6s fails fast to `[]` via listAndroidDevices' `.catch`, the same degraded result
+// the deadline would give — just sooner and with adb's own error logged.
+//
+// Deliberately NOT applied globally: boot-device's before/after device snapshots call
+// listAndroidDevices() WITHOUT this bound, keeping the 30s default. A snapshot that
+// timed out to `[]` there could misidentify an already-connected emulator as "newly
+// booted" (the very race boot-device's `adb start-server` + snapshot guards against),
+// and boot-device is not latency-sensitive the way the alwaysLoad list-devices is.
+export const ADB_DEVICES_TIMEOUT_MS = 6_000;
+
 /**
  * Light-weight listing for callers that only need which serials exist.
  * Skips the per-device getprop round-trips so the call is one `adb devices`
  * shell-out, not 1 + 3N. Used by `listAndroidDevices` as the first hop before
- * it enriches each entry.
+ * it enriches each entry. `devicesTimeoutMs` bounds the `adb devices` call;
+ * omit it to inherit runAdb's 30s default (see ADB_DEVICES_TIMEOUT_MS).
  */
-async function listAndroidSerials(): Promise<Array<{ serial: string; state: string }>> {
-  const { stdout } = await runAdb(["devices"]);
+async function listAndroidSerials(
+  options: { devicesTimeoutMs?: number } = {}
+): Promise<Array<{ serial: string; state: string }>> {
+  const { stdout } = await runAdb(["devices"], { timeoutMs: options.devicesTimeoutMs });
   return parseAdbDevices(stdout);
 }
 
@@ -301,7 +324,13 @@ async function listAndroidSerials(): Promise<Array<{ serial: string; state: stri
 // the hot path of the boot loop — a single mid-attach device can stall the
 // stage budget for 30 s × 3 getprops = the entire adb-register window. 5 s
 // is plenty for a getprop on any responsive device.
-const ENRICH_TIMEOUT_MS = 5_000;
+//
+// Exported so list-devices' BRANCH_DEADLINE_MS accounting can include it: the
+// Android branch's worst case is one bounded `adb devices` call
+// (ADB_DEVICES_TIMEOUT_MS) plus this enrichment (all devices and all per-device
+// getprops run concurrently, so the enrichment caps at one ENRICH_TIMEOUT_MS, not
+// a multiple), and that sum has to stay under the branch deadline.
+export const ENRICH_TIMEOUT_MS = 5_000;
 
 /**
  * Resolve the AVD name of a running emulator. The property moved from
@@ -331,9 +360,17 @@ async function readAvdName(serial: string): Promise<string | null> {
  * List all Android devices + emulators known to adb, enriched with model,
  * AVD name, and SDK level via `getprop`. Use `listAndroidSerials` when you
  * only need the state-scoped serial list — it avoids the extra round-trips.
+ *
+ * `devicesTimeoutMs` bounds the initial `adb devices` call; omit it to inherit
+ * runAdb's 30s default. The alwaysLoad `list-devices` tool passes
+ * ADB_DEVICES_TIMEOUT_MS (6s) so its Android branch self-bounds under the fan-out
+ * deadline; boot-device omits it so its before/after snapshots aren't truncated to
+ * `[]` under a slow-but-alive daemon (see ADB_DEVICES_TIMEOUT_MS).
  */
-export async function listAndroidDevices(): Promise<AndroidDevice[]> {
-  const basic = await listAndroidSerials();
+export async function listAndroidDevices(
+  options: { devicesTimeoutMs?: number } = {}
+): Promise<AndroidDevice[]> {
+  const basic = await listAndroidSerials(options);
 
   const enriched = await Promise.all(
     basic.map(async (d): Promise<AndroidDevice> => {

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -116,6 +116,15 @@ export interface AdbRunResult {
 // process blocked on a hung daemon can ignore — leaving the parent waiting
 // past the deadline. SIGKILL guarantees the child is reaped at the timeout
 // boundary so callers' overall budgets actually hold.
+//
+// Unlike `runVega` (which spawns `detached` and reaps the whole process group on
+// timeout), execFile's single-child SIGKILL is sufficient here: an `adb <command>`
+// invocation is a *single-process client* that talks to the persistent, shared
+// `adb server` daemon over a socket — it forks no `python3 → node → vda` worker
+// tree to orphan, so killing the direct child reaps it completely. A group kill
+// would also be wrong: the daemon is deliberately long-lived and shared across all
+// adb calls, so it must survive a single command's timeout. (A wedged *device* is
+// instead bounded by per-call timeouts + the list-devices branch deadline.)
 const ADB_KILL_SIGNAL = "SIGKILL" as const;
 
 function describeAdbFailure(args: string[], err: unknown): Error {
@@ -297,18 +306,25 @@ const ENRICH_TIMEOUT_MS = 5_000;
 /**
  * Resolve the AVD name of a running emulator. The property moved from
  * `ro.kernel.qemu.avd_name` to `ro.boot.qemu.avd_name` in emulator release 30
- * (Android 11+); we probe the newer one first and fall back to the legacy
- * name so both old and new images work.
+ * (Android 11+); we still prefer the newer name and fall back to the legacy one
+ * so both old and new images work.
+ *
+ * The two getprops run concurrently rather than back-to-back: a wedged emulator
+ * (e.g. an unresponsive VVD that also shows on adb) otherwise costs the full
+ * `2 × ENRICH_TIMEOUT_MS` here, doubling the Android branch of the `alwaysLoad`
+ * `list-devices` tool. `.catch(() => "")` handles a rejected probe; the timeout
+ * handles a slow one.
  */
 async function readAvdName(serial: string): Promise<string | null> {
-  const modern = await adbShell(serial, "getprop ro.boot.qemu.avd_name", {
-    timeoutMs: ENRICH_TIMEOUT_MS,
-  }).catch(() => "");
-  if (modern.trim()) return modern.trim();
-  const legacy = await adbShell(serial, "getprop ro.kernel.qemu.avd_name", {
-    timeoutMs: ENRICH_TIMEOUT_MS,
-  }).catch(() => "");
-  return legacy.trim() || null;
+  const [modern, legacy] = await Promise.all([
+    adbShell(serial, "getprop ro.boot.qemu.avd_name", { timeoutMs: ENRICH_TIMEOUT_MS }).catch(
+      () => ""
+    ),
+    adbShell(serial, "getprop ro.kernel.qemu.avd_name", { timeoutMs: ENRICH_TIMEOUT_MS }).catch(
+      () => ""
+    ),
+  ]);
+  return modern.trim() || legacy.trim() || null;
 }
 
 /**

--- a/packages/tool-server/src/utils/vega-cli.ts
+++ b/packages/tool-server/src/utils/vega-cli.ts
@@ -207,6 +207,71 @@ async function collectDescendantPids(rootPid: number): Promise<number[]> {
 }
 
 /**
+ * Live pids whose process-group id equals `pgid` (excluding the group-leader pid
+ * itself). Used by reapLingeringGroupMembers; returns [] if `ps` is unavailable.
+ */
+async function pgidMembers(pgid: number): Promise<number[]> {
+  const { stdout } = await execFileAsync("ps", ["-A", "-o", "pid=,pgid="], {
+    timeout: 1_500,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  const members: number[] = [];
+  for (const line of stdout.split("\n")) {
+    const m = line.trim().match(/^(\d+)\s+(\d+)$/);
+    if (!m) continue;
+    const memberPid = parseInt(m[1]!, 10);
+    const memberPgid = parseInt(m[2]!, 10);
+    if (memberPgid === pgid && memberPid !== pgid) members.push(memberPid);
+  }
+  return members;
+}
+
+/**
+ * Reap a worker still holding our stdout pipe open after the launcher's *own clean
+ * exit* — the exit-drain path (see VEGA_EXIT_DRAIN_GRACE_MS). reapVegaGroup can't help
+ * once the launcher is gone: its ppid descendant sweep returns nothing (an outliving
+ * worker is immediately reparented to init — its ppid is 1, verified empirically), and
+ * its group kill is gated on the launcher still being alive.
+ *
+ * But a worker that merely *inherited* our pipe (the common case) stayed in the
+ * launcher's process group, so its pgid still equals the launcher pid — and it is
+ * reapable here. The safety guarantee is the *call-site invariant*, not the snapshot in
+ * isolation: this runs ONLY from the drain timer, which fires precisely because `close`
+ * never arrived within the grace; had the pipe-holding worker exited, the pipe would have
+ * EOF'd and `close` would have settled + cleared this timer. So when we run, that worker
+ * is still alive — and POSIX does not recycle a pid as a pgid while any member of its
+ * group lives, so the launcher pid cannot have been recycled into an unrelated group's
+ * pgid: `-pid` provably targets only our own group. SIGKILLing it reaps the worker
+ * (verified empirically). The membership snapshot is a best-effort secondary check that
+ * skips a pointless `-pid` when the worker raced to exit just before it; the only residual
+ * is the snapshot→kill window (tens of ms, no `await` between), the same pid-reuse class
+ * collectDescendantPids' sweep already accepts.
+ *
+ * A worker that `setsid()`d into its OWN group escaped here (group `pid` is empty); having
+ * outlived the launcher it has no live handle and is left to exit on its own. That case
+ * is rare — a clean exit whose grandchild both escaped the group AND outlived it — and
+ * bounded (one leftover per finished call, not the accumulating wedged tree the timeout
+ * path reaps). Best-effort throughout: a slow/failed `ps` just skips the reap.
+ */
+async function reapLingeringGroupMembers(pid: number | undefined): Promise<void> {
+  // pid > 1 guard mirrors reapVegaGroup: never pass -0 / -1 to process.kill (which would
+  // broadcast to the whole process group / every process).
+  if (pid == null || pid <= 1) return;
+  let members: number[];
+  try {
+    members = await pgidMembers(pid);
+  } catch {
+    return; // `ps` unavailable — best-effort, skip.
+  }
+  if (members.length === 0) return; // group empty (escaped/already gone) — nothing to reap.
+  try {
+    process.kill(-pid, VEGA_KILL_SIGNAL);
+  } catch {
+    // The last member exited between the snapshot and the kill — group already gone.
+  }
+}
+
+/**
  * Resolve a guaranteed-live working directory for the spawned `vega`/`kepler`
  * child. The tool-server is a long-lived singleton; if it was started from a
  * directory that is later removed (e.g. a git worktree torn down mid-session),
@@ -424,9 +489,10 @@ export async function runVega(
         // this path is reached only when WE didn't force the kill (timeout/overflow
         // settle first), so a terminating `signal` here is external and must NOT
         // masquerade as a wedged-agent "timeout" (which would wrongly suppress the
-        // listVegaDevices recovery call). No group reap here either: the launcher
-        // already exited, so its workers went with it, and group-killing a
-        // since-recycled pgid by pid would be unsafe.
+        // listVegaDevices recovery call). `finish` itself does no reaping: on the normal
+        // `close` path none is needed (`close` means every stdio end EOF'd, so no worker
+        // still holds the pipe), and on the exit-drain fallback the caller already kicked
+        // off reapLingeringGroupMembers before invoking us.
         settle(() =>
           reject(
             describeVegaFailure(
@@ -468,6 +534,12 @@ export async function runVega(
         // have and destroy our read ends so the lingering worker can't keep us pending.
         child.stdout?.destroy();
         child.stderr?.destroy();
+        // Reap that worker if it stayed in the launcher's process group (the common
+        // pipe-inheritance case — still safely reapable post-exit because a live group
+        // member pins the pgid; see reapLingeringGroupMembers). Fire-and-forget so it
+        // can't delay resolution; a worker that escaped into its own group is left to
+        // exit on its own (rare, bounded — see the function doc).
+        void reapLingeringGroupMembers(child.pid);
         finish(code, signal);
       }, VEGA_EXIT_DRAIN_GRACE_MS);
     });

--- a/packages/tool-server/src/utils/vega-cli.ts
+++ b/packages/tool-server/src/utils/vega-cli.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
 import { existsSync, constants as fsConstants } from "node:fs";
 import { access } from "node:fs/promises";
@@ -8,6 +8,7 @@ import {
   FAILURE_CODES,
   FailureError,
   subprocessFailureMetadata,
+  type FailureKind,
   type FailureSignal,
 } from "@argent/registry";
 import { formatSubprocessFailure } from "./subprocess-error";
@@ -95,6 +96,117 @@ export interface VegaRunResult {
 const VEGA_KILL_SIGNAL = "SIGKILL" as const;
 
 /**
+ * Reap a spawned `vega`/`kepler` child AND its worker tree when the timeout fires.
+ *
+ * The CLI is a thin launcher that forks a `python3 dutyfree-vega → node → vda`
+ * worker tree to talk to the device agent; against a wedged agent that tree hangs.
+ * `runVega` spawns the launcher with `detached: true`, making it a process-group
+ * leader, so a single SIGKILL to the *negative* pid reaps the launcher and every
+ * descendant that stayed in its group — instead of orphaning the `dutyfree-vega`/
+ * `vda` workers the way a bare `child.kill()` (which reaches only the direct child)
+ * did.
+ *
+ * Belt-and-suspenders for a worker that `setsid()`s out of the launcher's group
+ * (its pgid then differs, so the group SIGKILL can't reach it — the failure mode an
+ * earlier investigation reported against a wedged VVD): BEFORE killing, snapshot the
+ * launcher's descendants from the process table. A setsid'd worker keeps its *ppid*
+ * pointing at the launcher until the launcher dies, so a ppid tree-walk still reaches
+ * it while the launcher is alive; we SIGKILL those pids individually *first* — before
+ * the group kill brings the launcher down — so the snapshot is acted on while it is
+ * freshest (minimizing any pid-reuse window), then group-kill the launcher. The
+ * snapshot is precise — only this launcher's own descendants, identified by pid, so a
+ * concurrent `vega` call's workers are never touched (no `pkill`-style pattern match)
+ * — and bounded, and the group kill runs regardless of whether the snapshot succeeds.
+ *
+ * We also destroy our ends of the stdio pipes first: a worker that inherited a dup
+ * of the stdout write end could otherwise keep our read side from EOF-ing, leaving
+ * the `close` await pending past the deadline (the observed "blocks for the full
+ * timeout even though the data was ready" freeze).
+ */
+async function reapVegaGroup(child: ChildProcess): Promise<void> {
+  child.stdout?.destroy();
+  child.stderr?.destroy();
+  const pid = child.pid;
+  // pid is a real OS pid (>1) for any spawned child; a missing pid means spawn
+  // itself failed, so there's nothing to reap. Guard so we never pass -0 / -1 to
+  // process.kill (which would broadcast to the whole process group / every process).
+  if (pid == null || pid <= 1) return;
+  // Snapshot descendants while the launcher is still alive (see above); best-effort
+  // and bounded so a slow/failed `ps` can't delay the kills below.
+  const descendants = await collectDescendantPids(pid).catch(() => [] as number[]);
+  // Sweep the snapshotted descendants FIRST — before the group kill brings the
+  // launcher down. This reaps a worker that setsid'd out of the launcher's group (the
+  // group SIGKILL can't reach it), and doing it now — launcher still alive, pids just
+  // read, no `await` between the snapshot and these kills — keeps the pid-reuse window
+  // to a synchronous burst rather than spanning the group-kill cascade, during which a
+  // same-group descendant could exit and have its pid recycled. A pid that already
+  // exited just throws ESRCH.
+  for (const descendant of descendants) {
+    if (descendant <= 1 || descendant === pid) continue;
+    try {
+      process.kill(descendant, VEGA_KILL_SIGNAL);
+    } catch {
+      // Already gone.
+    }
+  }
+  // Then SIGKILL the whole process group led by the detached launcher — reaps the
+  // launcher itself and any same-group worker the descendant sweep didn't cover.
+  // Skip it once the launcher has already exited (exitCode/signalCode set by Node):
+  // the descendant snapshot above already swept its tree, and once the launcher is
+  // gone its pid (== pgid) can be recycled, so a `-pid` group kill could land on an
+  // unrelated process group. While the launcher is alive its pgid is still ours.
+  if (child.exitCode === null && child.signalCode === null) {
+    try {
+      // Negative pid → signal the whole process group led by the detached launcher.
+      process.kill(-pid, VEGA_KILL_SIGNAL);
+    } catch {
+      // Group already gone; fall back to the bare child in case it outlived its group.
+      try {
+        child.kill(VEGA_KILL_SIGNAL);
+      } catch {
+        // Already dead — nothing to reap.
+      }
+    }
+  }
+}
+
+/**
+ * Descendant pids of `rootPid` from the OS process table (`ps` ppid edges), via a
+ * bounded breadth-first walk. Lets reapVegaGroup reach a worker that escaped the
+ * launcher's process group. Returns [] if `ps` is unavailable or times out (the
+ * group kill is the primary mechanism; this is insurance).
+ */
+async function collectDescendantPids(rootPid: number): Promise<number[]> {
+  const { stdout } = await execFileAsync("ps", ["-A", "-o", "pid=,ppid="], {
+    timeout: 1_500,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of stdout.split("\n")) {
+    const m = line.trim().match(/^(\d+)\s+(\d+)$/);
+    if (!m) continue;
+    const childPid = parseInt(m[1]!, 10);
+    const parentPid = parseInt(m[2]!, 10);
+    const siblings = childrenByParent.get(parentPid);
+    if (siblings) siblings.push(childPid);
+    else childrenByParent.set(parentPid, [childPid]);
+  }
+  const descendants: number[] = [];
+  const seen = new Set<number>([rootPid]);
+  const stack = [rootPid];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const childPid of childrenByParent.get(current) ?? []) {
+      if (seen.has(childPid)) continue; // guard against a pid-reuse cycle
+      seen.add(childPid);
+      descendants.push(childPid);
+      stack.push(childPid);
+    }
+  }
+  return descendants;
+}
+
+/**
  * Resolve a guaranteed-live working directory for the spawned `vega`/`kepler`
  * child. The tool-server is a long-lived singleton; if it was started from a
  * directory that is later removed (e.g. a git worktree torn down mid-session),
@@ -122,7 +234,7 @@ export function resolveSpawnCwd(
   return fallback;
 }
 
-function describeVegaFailure(args: string[], err: unknown): Error {
+function describeVegaFailure(args: string[], err: unknown, kindOverride?: FailureKind): Error {
   // Shares the message format with adb (stderr/stdout first, then a
   // signal/killed/code fallback) via formatSubprocessFailure, and — like adb —
   // attaches a FailureSignal so `vega`/`kepler` CLI failures are classified for
@@ -132,7 +244,12 @@ function describeVegaFailure(args: string[], err: unknown): Error {
     error_code: FAILURE_CODES.VEGA_CLI_COMMAND_FAILED,
     failure_stage: "vega_cli_command",
     failure_area: "tool_server",
-    error_kind: e.killed || e.signal ? "timeout" : "subprocess",
+    // A timeout/overflow reap shapes the error with killed=true so the message reads
+    // correctly, but only a genuine *timeout* should classify as `error_kind:
+    // "timeout"` — listVegaDevices keys its skip-the-recovery-call decision off that,
+    // so an overflow (or other forced kill) must NOT masquerade as a wedged-agent
+    // timeout. Those callers pass an explicit kind; everything else uses the heuristic.
+    error_kind: kindOverride ?? (e.killed || e.signal ? "timeout" : "subprocess"),
     ...subprocessFailureMetadata(err, "vega"),
   };
   return new FailureError(formatSubprocessFailure("vega", args, err), signal);
@@ -144,25 +261,217 @@ function describeVegaFailure(args: string[], err: unknown): Error {
  * `runAdb`, this does not inject a serial; a serial-less call hits the single
  * connected device or fails if there are several.
  */
+// Cap collected output (mirrors the old execFile `maxBuffer`) so a runaway child
+// can't exhaust memory; overflow reaps the group and rejects. Applied per stream —
+// like execFile, exceeding the cap on *either* stdout or stderr trips it. Measured in
+// real UTF-8 bytes (not string length / UTF-16 code units) so the cap means what it says.
+const VEGA_MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
+
+// After the child *exits*, `close` normally follows at once (its stdio EOFs) and we
+// finish there with fully-drained output. But a grandchild that inherited a dup of
+// our stdout pipe keeps it open, delaying `close` even though the child already wrote
+// everything — the pipe-inheritance freeze. So once the child has exited we give the
+// buffered output this short grace to flush, then finish from the exit code anyway
+// (destroying our read ends so the lingering worker can't hold us open). Without it a
+// finished-but-pipe-held call would wait out the full `timeoutMs` and reject as a
+// timeout, discarding the output it already had. The child has stopped writing by
+// then, so the pending bytes are already in the OS pipe buffer and flush in well under
+// this window.
+const VEGA_EXIT_DRAIN_GRACE_MS = 1_000;
+
 export async function runVega(
   args: string[],
-  options: { timeoutMs?: number } = {}
+  options: { timeoutMs?: number; maxOutputBytes?: number } = {}
 ): Promise<VegaRunResult> {
   const vegaPath = await resolveVegaOrThrow();
-  try {
-    const { stdout, stderr } = await execFileAsync(vegaPath, args, {
-      // Pin to a guaranteed-live cwd so a since-deleted server cwd doesn't crash
-      // the `vega` CLI in os.getcwd() (see resolveSpawnCwd).
-      cwd: resolveSpawnCwd(),
-      timeout: options.timeoutMs ?? 60_000,
-      killSignal: VEGA_KILL_SIGNAL,
-      maxBuffer: 64 * 1024 * 1024,
-      encoding: "utf-8",
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const maxOutputBytes = options.maxOutputBytes ?? VEGA_MAX_OUTPUT_BYTES;
+
+  return new Promise<VegaRunResult>((resolve, reject) => {
+    // `spawn` (not execFile) specifically so we can pass `detached: true` —
+    // execFile silently drops it. detached makes the child its own process-group
+    // leader, which is what lets reapVegaGroup SIGKILL the entire
+    // `python3 → node → vda` worker tree on timeout rather than orphaning it.
+    // cwd is pinned to a guaranteed-live dir so a since-deleted server cwd doesn't
+    // crash the `vega` CLI in os.getcwd() (see resolveSpawnCwd).
+    let child: ChildProcess;
+    try {
+      child = spawn(vegaPath, args, {
+        cwd: resolveSpawnCwd(),
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      reject(describeVegaFailure(args, err));
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let settled = false;
+    let reaped = false;
+    let exitTimer: ReturnType<typeof setTimeout> | undefined;
+
+    // reapVegaGroup is async (it snapshots the process tree before killing); fire it
+    // at most once and don't await it here. Guarding prevents the timer and an
+    // overflow burst from launching redundant reaps.
+    const reapOnce = (): void => {
+      if (reaped) return;
+      reaped = true;
+      void reapVegaGroup(child);
+    };
+
+    // `settle` reads `timer`/`exitTimer` (declared/assigned below): the bindings are
+    // captured by closure and only ever read from async callbacks, which fire after
+    // this executor's synchronous body has assigned `timer`, so there's no
+    // temporal-dead-zone access. `exitTimer` may still be undefined (no exit yet) —
+    // clearTimeout(undefined) is a no-op.
+    const settle = (run: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (exitTimer) clearTimeout(exitTimer);
+      run();
+    };
+
+    // The two forced-kill paths settle the promise *the moment the condition is
+    // detected*, rather than waiting for the child's later `close`. `close` only
+    // fires once reapVegaGroup has snapshotted the process tree (`ps`) and brought
+    // the launcher down, so settling on it would make a timed-out/overflowed call
+    // linger by the reap's duration. The reap still runs in the background; the
+    // eventual `close` is a guarded no-op. stdout/stderr carry whatever arrived so far.
+    const rejectTimeout = (): void =>
+      // Shape like an execFile timeout rejection (killed=true) so it classifies as a
+      // timeout downstream — listVegaDevices keys its skip-the-recovery decision off it.
+      settle(() =>
+        reject(
+          describeVegaFailure(
+            args,
+            Object.assign(new Error(`vega ${args.join(" ")} timed out after ${timeoutMs}ms`), {
+              killed: true,
+              signal: VEGA_KILL_SIGNAL,
+              stdout,
+              stderr,
+            })
+          )
+        )
+      );
+    const rejectOverflow = (): void =>
+      settle(() =>
+        reject(
+          describeVegaFailure(
+            args,
+            Object.assign(
+              new Error(`vega ${args.join(" ")} output exceeded ${maxOutputBytes} bytes`),
+              { killed: true, signal: VEGA_KILL_SIGNAL, stdout, stderr }
+            ),
+            // Force "subprocess": an overflow is a misbehaving child, not a wedged
+            // agent. Without this the killed=true shape would classify as "timeout"
+            // and wrongly suppress the listVegaDevices recovery call.
+            "subprocess"
+          )
+        )
+      );
+
+    child.stdout?.setEncoding("utf-8");
+    child.stderr?.setEncoding("utf-8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+      stdoutBytes += Buffer.byteLength(chunk, "utf-8");
+      if (!settled && stdoutBytes > maxOutputBytes) {
+        reapOnce();
+        rejectOverflow();
+      }
     });
-    return { stdout, stderr };
-  } catch (err) {
-    throw describeVegaFailure(args, err);
-  }
+    // Cap stderr the same way as stdout: execFile's `maxBuffer` killed the child when
+    // *either* stream exceeded it, so a child that floods stderr (rather than stdout)
+    // must also reap+reject instead of growing this buffer unbounded — otherwise a
+    // misbehaving CLI could exhaust the long-lived tool-server's memory before the
+    // timeout fires.
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+      stderrBytes += Buffer.byteLength(chunk, "utf-8");
+      if (!settled && stderrBytes > maxOutputBytes) {
+        reapOnce();
+        rejectOverflow();
+      }
+    });
+
+    const timer = setTimeout(() => {
+      reapOnce();
+      rejectTimeout();
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      // Spawn-level failure (e.g. ENOENT); err carries .code/.message so
+      // describeVegaFailure / subprocessFailureMetadata classify it correctly.
+      settle(() => reject(describeVegaFailure(args, err)));
+    });
+
+    // Finish a child that ended on its own (NOT a forced timeout/overflow kill — those
+    // settle before we get here): resolve on a clean exit, reject otherwise. Reached
+    // from `close` (the normal, fully-drained path) and — if a pipe-holding grandchild
+    // delays `close` past the exit grace — from the `exit` fallback below.
+    const finish = (code: number | null, signal: NodeJS.Signals | null): void => {
+      if (code === 0) {
+        settle(() => resolve({ stdout, stderr }));
+      } else {
+        // Non-zero exit (or a terminating signal) — mirror execFile's reject-on-
+        // failure so callers (e.g. listVegaDevices' try/catch) see a failure, with
+        // code/signal/io attached for the message. Classify "subprocess" explicitly:
+        // this path is reached only when WE didn't force the kill (timeout/overflow
+        // settle first), so a terminating `signal` here is external and must NOT
+        // masquerade as a wedged-agent "timeout" (which would wrongly suppress the
+        // listVegaDevices recovery call). No group reap here either: the launcher
+        // already exited, so its workers went with it, and group-killing a
+        // since-recycled pgid by pid would be unsafe.
+        settle(() =>
+          reject(
+            describeVegaFailure(
+              args,
+              Object.assign(
+                new Error(`vega ${args.join(" ")} exited with code ${code ?? "null"}`),
+                {
+                  code,
+                  signal,
+                  stdout,
+                  stderr,
+                }
+              ),
+              "subprocess"
+            )
+          )
+        );
+      }
+    };
+
+    // The forced-kill paths (timeout / overflow) settle the promise themselves, so by
+    // the time `close`/`exit` fire for them they're guarded no-ops. We prefer `close`
+    // (stdout/stderr fully drained) but fall back to `exit` + a short drain grace so a
+    // grandchild holding our stdout pipe open can't stall a finished call into the
+    // timeout (see VEGA_EXIT_DRAIN_GRACE_MS).
+    child.on("close", (code, signal) => finish(code, signal));
+    child.on("exit", (code, signal) => {
+      if (settled || exitTimer) return;
+      // The child has terminated, so the wall-clock timeout is now moot — only draining
+      // its already-written output remains. Disarm the main timer so a clean exit whose
+      // `close` is delayed past the deadline (a grandchild holding the stdout pipe open)
+      // can't be rejected AS A TIMEOUT before the drain grace below fires — which would
+      // discard valid output and mis-classify it `error_kind: "timeout"`, suppressing
+      // listVegaDevices' recovery. From here `exitTimer` (bounded) is the sole backstop.
+      clearTimeout(timer);
+      exitTimer = setTimeout(() => {
+        // `close` didn't follow the exit within the grace — a worker is holding our
+        // stdout pipe open. The child already wrote everything, so finish with what we
+        // have and destroy our read ends so the lingering worker can't keep us pending.
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+        finish(code, signal);
+      }, VEGA_EXIT_DRAIN_GRACE_MS);
+    });
+  });
 }
 
 // `-d emulator-<port>` selector for the single running VVD, resolved from the OS

--- a/packages/tool-server/src/utils/vega-devices.ts
+++ b/packages/tool-server/src/utils/vega-devices.ts
@@ -11,13 +11,16 @@ import { listRunningVvdConsolePorts } from "./vega-process";
 // has import cost on first use) on a loaded machine isn't spuriously timed out —
 // which would mis-report a genuinely-running VVD as stopped.
 //
-// Crucially these no longer *stack* into a 40s block — the `device info` recovery
-// only fires when `device list` itself returned cleanly (see listVegaDevices), so
-// an unresponsive device costs one short call, not two. Their sum (10s) is kept
-// comfortably below list-devices' BRANCH_DEADLINE_MS (15s) so even the slow
-// recovery path (a fast, non-timeout list failure followed by a full `device info`
-// wait) finishes inside the fan-out's hard backstop rather than being truncated —
-// which would drop a real VVD from the list. Keep that ordering if either changes.
+// Crucially the two device timeouts no longer *stack* into a 40s block against a
+// wedged agent: the `device info` recovery is skipped when `device list` *timed
+// out* (see listVegaDevices), so an unresponsive device costs one short call (~6s),
+// not two. A *non-timeout* list failure (or a clean-but-empty list) still runs the
+// recovery, whose full cost is `device list` + two serial `ps` probes + `device
+// info` ≈ 20s worst case; that stays under list-devices' BRANCH_DEADLINE_MS (25s)
+// so even the slow recovery path finishes inside the fan-out's backstop rather than
+// being truncated — which would drop a real VVD from the list. The full accounting
+// (and the invariant test that guards it) lives in list-devices.ts; keep the sum
+// under the deadline with margin if any of these timeouts change.
 export const VEGA_DISCOVERY_LIST_TIMEOUT_MS = 6_000;
 export const VEGA_DISCOVERY_INFO_TIMEOUT_MS = 4_000;
 
@@ -234,11 +237,17 @@ export async function listVegaDevices(): Promise<VegaDevice[]> {
  * after `boot-device` starts it. A freshly-started VVD can take a moment to
  * surface in `vega device list`, so retry a few times before giving up.
  *
- * Bounded by an overall wall-clock budget on top of the retry count: each
- * `listVegaDevices()` is already short (its discovery timeouts no longer stack),
- * but the budget is a hard cap so a wedged device can't drag this out attempt by
- * attempt. A healthy VVD surfaces well within it (a fast list + 1s backoff per
- * attempt), so the cap only bites the unhappy path.
+ * Bounded by an overall wall-clock budget on top of the retry count. The budget
+ * gates whether to START another attempt — it is checked *between* attempts, not
+ * as cancellation, and `listVegaDevices()` is never interrupted mid-flight. So the
+ * true upper bound is the budget plus one in-flight attempt's worst case: a single
+ * `listVegaDevices()` can take up to ~20s against a non-timeout-failing-but-running
+ * VVD (see its discovery-timeout accounting), so an attempt that starts just under
+ * the deadline pushes total wall time to ~budget + 20s. That looser bound is fine
+ * here: unlike `list-devices`, this runs post-`boot-device` (not on the alwaysLoad
+ * hot path), and a healthy VVD surfaces in the first attempt or two (a fast list +
+ * 1s backoff), so the budget only bites the unhappy path — it just caps the number
+ * of *additional* attempts rather than acting as a precise wall-clock ceiling.
  */
 const RESOLVE_VVD_SERIAL_BUDGET_MS = 15_000;
 

--- a/packages/tool-server/src/utils/vega-devices.ts
+++ b/packages/tool-server/src/utils/vega-devices.ts
@@ -1,6 +1,25 @@
+import { getFailureSignal } from "@argent/registry";
 import { runVega, runVegaDevice, resolveVegaBinary } from "./vega-cli";
 import { listVvdImages } from "./vega-sdk";
 import { listRunningVvdConsolePorts } from "./vega-process";
+
+// `list-devices` is `alwaysLoad` and runs at session start, so its Vega probe
+// must stay snappy even when a VVD is wedged. A healthy `vega device list` /
+// `device info` returns in ~1s; cap them tightly here (the interactive Vega
+// tools keep their own, longer timeouts). The values give a generous multiple of
+// the healthy time so a cold-start `vega` launcher (its python/node worker tree
+// has import cost on first use) on a loaded machine isn't spuriously timed out —
+// which would mis-report a genuinely-running VVD as stopped.
+//
+// Crucially these no longer *stack* into a 40s block — the `device info` recovery
+// only fires when `device list` itself returned cleanly (see listVegaDevices), so
+// an unresponsive device costs one short call, not two. Their sum (10s) is kept
+// comfortably below list-devices' BRANCH_DEADLINE_MS (15s) so even the slow
+// recovery path (a fast, non-timeout list failure followed by a full `device info`
+// wait) finishes inside the fan-out's hard backstop rather than being truncated —
+// which would drop a real VVD from the list. Keep that ordering if either changes.
+export const VEGA_DISCOVERY_LIST_TIMEOUT_MS = 6_000;
+export const VEGA_DISCOVERY_INFO_TIMEOUT_MS = 4_000;
 
 /**
  * A Vega (Fire TV) device as surfaced to `list-devices`. A VVD is listed whether
@@ -91,7 +110,7 @@ async function readVegaInfo(): Promise<VegaInfo | null> {
   try {
     // `runVegaDevice` pins `-d emulator-<port>`; without it, `device info` returns an
     // empty `{idme:"", os:"unknown", …}` device when the VVD has a 2nd adb transport.
-    const { stdout } = await runVegaDevice(["info"], { timeoutMs: 20_000 });
+    const { stdout } = await runVegaDevice(["info"], { timeoutMs: VEGA_DISCOVERY_INFO_TIMEOUT_MS });
     return JSON.parse(stdout) as VegaInfo;
   } catch {
     return null;
@@ -113,12 +132,23 @@ export async function listVegaDevices(): Promise<VegaDevice[]> {
   if (!(await resolveVegaBinary())) return [];
 
   // Connected/running devices (these carry the `amazon-` runtime serial).
-  let rows: Array<{ serial: string; type: string }>;
+  let rows: Array<{ serial: string; type: string }> = [];
+  let listTimedOut = false;
   try {
-    const { stdout } = await runVega(["device", "list"], { timeoutMs: 20_000 });
+    const { stdout } = await runVega(["device", "list"], {
+      timeoutMs: VEGA_DISCOVERY_LIST_TIMEOUT_MS,
+    });
     rows = parseVegaDeviceList(stdout);
-  } catch {
-    rows = []; // CLI listing failed; still surface installed images below
+  } catch (err) {
+    // CLI listing failed or timed out; still surface installed images below. Only a
+    // *timeout* means the device agent is wedged — and a wedged agent makes the
+    // `device info` recovery hang too, so the two stack into the ~40s `list-devices`
+    // stall this fix targets. Suppress recovery in *that* case only. A fast,
+    // non-timeout failure (a transient CLI error) does NOT imply an unresponsive
+    // agent, so we still let recovery run below — otherwise a genuinely-running VVD
+    // would be mis-reported as stopped. (runVega now reaps its whole process group on
+    // timeout, so the suppressed second call would no longer *leak* either.)
+    listTimedOut = getFailureSignal(err)?.error_kind === "timeout";
   }
 
   // `vega device list` drops its `VirtualDevice : …` row once a stray
@@ -127,9 +157,12 @@ export async function listVegaDevices(): Promise<VegaDevice[]> {
   // authoritative running-VVD signal, so when the parse is empty but a VVD is running,
   // recover its identity via `device info` (now pinned to the VVD by -d emulator-<port>)
   // — otherwise the running VVD is mis-reported as gone and re-listed as a phantom
-  // stopped image, and its adb shadow rows surface as bare Android devices.
+  // stopped image, and its adb shadow rows surface as bare Android devices. Skip the
+  // recovery only when `device list` *timed out* so a wedged agent doesn't pay for a
+  // second hanging call (the `rows.length === 1` branch is unreachable on a timeout,
+  // since rows stay empty, so it needs no guard).
   let info: VegaInfo | null = null;
-  if (rows.length === 0 && (await listRunningVvdConsolePorts()).size >= 1) {
+  if (!listTimedOut && rows.length === 0 && (await listRunningVvdConsolePorts()).size >= 1) {
     info = await readVegaInfo();
     if (info?.hostname) rows = [{ serial: info.hostname, type: "VirtualDevice" }];
   } else if (rows.length === 1) {
@@ -200,13 +233,27 @@ export async function listVegaDevices(): Promise<VegaDevice[]> {
  * Resolve the `amazon-` runtime serial of the currently-running VVD — e.g. right
  * after `boot-device` starts it. A freshly-started VVD can take a moment to
  * surface in `vega device list`, so retry a few times before giving up.
+ *
+ * Bounded by an overall wall-clock budget on top of the retry count: each
+ * `listVegaDevices()` is already short (its discovery timeouts no longer stack),
+ * but the budget is a hard cap so a wedged device can't drag this out attempt by
+ * attempt. A healthy VVD surfaces well within it (a fast list + 1s backoff per
+ * attempt), so the cap only bites the unhappy path.
  */
+const RESOLVE_VVD_SERIAL_BUDGET_MS = 15_000;
+
 export async function resolveRunningVvdSerial(): Promise<string> {
+  const deadline = Date.now() + RESOLVE_VVD_SERIAL_BUDGET_MS;
+  // The budget is enforced at the one place it matters: after a miss, only sleep +
+  // retry if there's still time left. The first attempt always runs (deadline is set
+  // 15s out), and we never start an attempt past the deadline because we break here
+  // first — so no separate deadline check is needed in the loop header.
   for (let attempt = 0; attempt < 5; attempt++) {
     const vvd = (await listVegaDevices()).find(
       (d) => d.kind === "vvd" && d.state === "running" && d.serial
     );
     if (vvd?.serial) return vvd.serial;
+    if (Date.now() >= deadline) break;
     await new Promise((r) => setTimeout(r, 1_000));
   }
   throw new Error("Vega Virtual Device reported running but did not appear in `vega device list`.");

--- a/packages/tool-server/src/utils/vega-process.ts
+++ b/packages/tool-server/src/utils/vega-process.ts
@@ -42,6 +42,15 @@ function consolePortFromVvdArgs(line: string): number | null {
   return null;
 }
 
+// Timeout for the `ps` process-table read. This is a LOCAL read (it never talks
+// to a device), so it is near-instant in practice; the timeout is a backstop
+// against a pathologically-loaded host, not a wedged device. Exported so
+// list-devices' BRANCH_DEADLINE_MS accounting can include it: a single
+// `listVegaDevices()` recovery can run two of these serially (the recovery gate
+// plus the `-d emulator-<port>` selector probe), and that budget has to stay
+// under the branch deadline so the backstop never truncates a completing branch.
+export const VVD_PS_PROBE_TIMEOUT_MS = 5_000;
+
 /**
  * Console ports of all running VVDs (empty if none / `ps` unavailable). `>1` ⇒
  * multiple VVDs — callers that target one surface `MultipleVegaDevicesError`.
@@ -49,7 +58,7 @@ function consolePortFromVvdArgs(line: string): number | null {
 export async function listRunningVvdConsolePorts(): Promise<Set<number>> {
   try {
     const { stdout } = await execFileAsync("ps", [...PS_ARGS], {
-      timeout: 5_000,
+      timeout: VVD_PS_PROBE_TIMEOUT_MS,
       maxBuffer: 16 * 1024 * 1024,
     });
     return parseVvdConsolePorts(stdout);

--- a/packages/tool-server/test/list-devices-deadline.test.ts
+++ b/packages/tool-server/test/list-devices-deadline.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { withDeadline, BRANCH_DEADLINE_MS } from "../src/tools/devices/list-devices";
+import {
+  VEGA_DISCOVERY_LIST_TIMEOUT_MS,
+  VEGA_DISCOVERY_INFO_TIMEOUT_MS,
+} from "../src/utils/vega-devices";
+
+// Guards the timeout/backstop ordering: the backstop must sit ABOVE the slowest
+// branch's own worst case, or it stops being a last-resort and starts truncating a
+// branch that would have completed — dropping a real device from the list. The long
+// pole is Vega's slow recovery path: a fast (non-timeout) `device list` failure
+// followed by the `device info` recovery runs both discovery timeouts back-to-back.
+// If a future edit bumps either Vega timeout past the backstop, this fails loudly.
+describe("discovery timeout vs backstop invariant", () => {
+  it("the Vega branch worst case stays comfortably under the branch deadline", () => {
+    const vegaWorstCase = VEGA_DISCOVERY_LIST_TIMEOUT_MS + VEGA_DISCOVERY_INFO_TIMEOUT_MS;
+    expect(vegaWorstCase).toBeLessThan(BRANCH_DEADLINE_MS);
+    // Keep a real margin (not just "<"), so a slightly-slow-but-completing branch on a
+    // loaded machine isn't cut off at the deadline.
+    expect(BRANCH_DEADLINE_MS - vegaWorstCase).toBeGreaterThanOrEqual(3_000);
+  });
+});
+
+// Unit cover for the hard backstop that keeps a single wedged discovery branch from
+// stalling the `alwaysLoad` list-devices tool. The per-call subprocess timeouts are
+// the first line of defence; this asserts the defence-in-depth race itself returns a
+// partial result (the fallback) instead of hanging, and stays out of the way on the
+// happy path.
+describe("withDeadline backstop", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("returns the branch's value untouched when it resolves before the deadline", async () => {
+    await expect(withDeadline(Promise.resolve(["a", "b"]), [], "vega")).resolves.toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("returns the fallback (and logs) when the branch exceeds the deadline", async () => {
+    vi.useFakeTimers();
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const never = new Promise<string[]>(() => {}); // a wedged branch that never settles
+    const result = withDeadline(never, ["fallback"], "android");
+    await vi.advanceTimersByTimeAsync(BRANCH_DEADLINE_MS);
+    await expect(result).resolves.toEqual(["fallback"]);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("android discovery exceeded"));
+    stderr.mockRestore();
+  });
+});

--- a/packages/tool-server/test/list-devices-deadline.test.ts
+++ b/packages/tool-server/test/list-devices-deadline.test.ts
@@ -4,20 +4,40 @@ import {
   VEGA_DISCOVERY_LIST_TIMEOUT_MS,
   VEGA_DISCOVERY_INFO_TIMEOUT_MS,
 } from "../src/utils/vega-devices";
+import { VVD_PS_PROBE_TIMEOUT_MS } from "../src/utils/vega-process";
+import { ADB_DEVICES_TIMEOUT_MS, ENRICH_TIMEOUT_MS } from "../src/utils/adb";
 
-// Guards the timeout/backstop ordering: the backstop must sit ABOVE the slowest
-// branch's own worst case, or it stops being a last-resort and starts truncating a
-// branch that would have completed — dropping a real device from the list. The long
-// pole is Vega's slow recovery path: a fast (non-timeout) `device list` failure
-// followed by the `device info` recovery runs both discovery timeouts back-to-back.
-// If a future edit bumps either Vega timeout past the backstop, this fails loudly.
+// Guards the timeout/backstop ordering: the backstop must sit ABOVE every branch's
+// FULL per-call worst case, or it stops being a last-resort and starts truncating a
+// branch that would have completed — dropping a real device from the list. Each
+// branch worst case is summed from the SAME exported timeout constants the code
+// uses, so a future edit that bumps any of them past the backstop fails here loudly.
+//
+// The earlier version of this test counted only the two Vega *device* timeouts
+// (list + info) and silently omitted the two serial `ps` probes the recovery path
+// also runs — which made the asserted margin fictional. These sums now include them.
+const MIN_MARGIN_MS = 3_000;
+
 describe("discovery timeout vs backstop invariant", () => {
-  it("the Vega branch worst case stays comfortably under the branch deadline", () => {
-    const vegaWorstCase = VEGA_DISCOVERY_LIST_TIMEOUT_MS + VEGA_DISCOVERY_INFO_TIMEOUT_MS;
+  it("the Vega branch's full worst case stays comfortably under the branch deadline", () => {
+    // The recovery path runs, serially: the `device list` timeout, the recovery-gate
+    // `ps` probe, the `-d emulator-<port>` selector `ps` probe (inside runVegaDevice),
+    // and the `device info` timeout. (A *timed-out* list skips recovery, so this is the
+    // non-timeout-failure / empty-list ceiling — the true long pole.)
+    const vegaWorstCase =
+      VEGA_DISCOVERY_LIST_TIMEOUT_MS + 2 * VVD_PS_PROBE_TIMEOUT_MS + VEGA_DISCOVERY_INFO_TIMEOUT_MS;
     expect(vegaWorstCase).toBeLessThan(BRANCH_DEADLINE_MS);
-    // Keep a real margin (not just "<"), so a slightly-slow-but-completing branch on a
+    // A real margin (not just "<"), so a slightly-slow-but-completing branch on a
     // loaded machine isn't cut off at the deadline.
-    expect(BRANCH_DEADLINE_MS - vegaWorstCase).toBeGreaterThanOrEqual(3_000);
+    expect(BRANCH_DEADLINE_MS - vegaWorstCase).toBeGreaterThanOrEqual(MIN_MARGIN_MS);
+  });
+
+  it("the Android branch's full worst case stays comfortably under the branch deadline", () => {
+    // One bounded `adb devices` call, then concurrent getprop enrichment (all devices
+    // and all per-device props run in parallel, so it caps at one ENRICH_TIMEOUT_MS).
+    const androidWorstCase = ADB_DEVICES_TIMEOUT_MS + ENRICH_TIMEOUT_MS;
+    expect(androidWorstCase).toBeLessThan(BRANCH_DEADLINE_MS);
+    expect(BRANCH_DEADLINE_MS - androidWorstCase).toBeGreaterThanOrEqual(MIN_MARGIN_MS);
   });
 });
 

--- a/packages/tool-server/test/list-devices.test.ts
+++ b/packages/tool-server/test/list-devices.test.ts
@@ -4,6 +4,7 @@ const execFileMock = vi.fn();
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  const { EventEmitter } = await import("node:events");
   return {
     ...actual,
     execFile: (
@@ -17,6 +18,40 @@ vi.mock("node:child_process", async () => {
       const result = execFileMock(cmd, args, options);
       if (result instanceof Error) callback(result, { stdout: "", stderr: "" });
       else callback(null, result ?? { stdout: "", stderr: "" });
+    },
+    // `runVega` now uses spawn (for `detached`), so route the vega CLI calls
+    // through the same execFileMock and surface the result as a fake child that
+    // emits stdout then `close`. An Error result emits `error` (mirrors a failed /
+    // timed-out CLI). Only the vega path spawns here — adb/emulator/ps stay on
+    // execFile above.
+    spawn: (cmd: string, args: readonly string[]) => {
+      const result = execFileMock(cmd, args, undefined);
+      const mkStream = () => {
+        const s = new EventEmitter() as any;
+        s.setEncoding = () => {};
+        s.destroy = () => {};
+        return s;
+      };
+      const child = new EventEmitter() as any;
+      // 0 (not a real OS pid) on purpose: this mock only drives the happy path
+      // (`close`, code 0), so reapVegaGroup never runs — but if a future timeout-path
+      // test were ever routed through it, `pid <= 1` makes the reap a no-op rather than
+      // letting `process.kill(-pid)` signal a real process group.
+      child.pid = 0;
+      child.stdout = mkStream();
+      child.stderr = mkStream();
+      child.kill = () => true;
+      setImmediate(() => {
+        if (result instanceof Error) {
+          child.emit("error", result);
+          return;
+        }
+        const out = (result ?? { stdout: "", stderr: "" }) as { stdout?: string; stderr?: string };
+        if (out.stdout) child.stdout.emit("data", out.stdout);
+        if (out.stderr) child.stderr.emit("data", out.stderr);
+        child.emit("close", 0, null);
+      });
+      return child;
     },
   };
 });
@@ -151,6 +186,34 @@ describe("list-devices", () => {
 
     // AVDs list comes from `emulator -list-avds`.
     expect(result.avds).toEqual([{ name: "Pixel_3a_API_34" }, { name: "Pixel_7_API_34" }]);
+  });
+
+  it("readAvdName prefers the modern avd_name prop over the legacy one (now probed concurrently)", async () => {
+    // The two getprops run in parallel (so a wedged device costs 5s, not 10s), but
+    // precedence must be unchanged: `ro.boot.qemu.avd_name` (modern, emulator 30+)
+    // wins over `ro.kernel.qemu.avd_name` (legacy) when BOTH answer. The first test
+    // above covers the legacy-only fallback; this pins the both-present ordering so the
+    // parallelization can't silently flip it.
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "adb" && args[0] === "devices") {
+        return { stdout: "List of devices attached\nemulator-5554\tdevice\n", stderr: "" };
+      }
+      if (cmd === "adb" && args[0] === "-s" && args[2] === "shell") {
+        const shellCmd = args[3] ?? "";
+        if (shellCmd.includes("ro.boot.qemu.avd_name"))
+          return { stdout: "ModernName\n", stderr: "" };
+        if (shellCmd.includes("ro.kernel.qemu.avd_name"))
+          return { stdout: "LegacyName\n", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await listDevicesTool.execute!({}, {});
+    const android = result.devices.filter((d) => d.platform === "android") as Array<{
+      avdName: string | null;
+    }>;
+    expect(android).toHaveLength(1);
+    expect(android[0]!.avdName).toBe("ModernName");
   });
 
   it("silently omits iOS when xcrun is unavailable — other platforms still returned", async () => {

--- a/packages/tool-server/test/vega-adb-connect-recovery.test.ts
+++ b/packages/tool-server/test/vega-adb-connect-recovery.test.ts
@@ -1,4 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FailureError, FAILURE_CODES } from "@argent/registry";
+
+// Build a `runVega` rejection shaped like the real one: runVega wraps failures in a
+// FailureError whose signal.error_kind distinguishes a `timeout` (wedged agent) from
+// an ordinary `subprocess` failure. listVegaDevices keys its no-recovery decision off
+// that, so the tests must reject with the right kind rather than a bare Error.
+function vegaFailure(kind: "timeout" | "subprocess"): FailureError {
+  return new FailureError(`vega device list ${kind}`, {
+    error_code: FAILURE_CODES.VEGA_CLI_COMMAND_FAILED,
+    failure_stage: "vega_cli_command",
+    failure_area: "tool_server",
+    error_kind: kind,
+  });
+}
 
 // Regression cover for the "adb-connected VVD" bug: once a 2nd adb transport is
 // added (`adb connect 127.0.0.1:<port+1>`), `vega device list` switches to adb-form
@@ -92,5 +106,34 @@ describe("listVegaDevices() recovers the running VVD when adb-connected", () => 
     const devices = await listVegaDevices();
     expect(devices.filter((d) => d.state === "running")).toHaveLength(0);
     expect(devices.some((d) => d.state === "stopped" && d.vvdImage === "tv")).toBe(true);
+  });
+
+  it("no stacking: a *timed-out* `device list` does not trigger a second `device info` call", async () => {
+    // The root cause of the `list-devices` "hang": against a wedged device agent
+    // `device list` times out, and the old code fell through to the `device info`
+    // recovery — a second 20s hang back-to-back (~40s total). The recovery is now
+    // skipped specifically on a timeout, so a wedged agent does NOT pay for a second
+    // hanging call even though a VVD is running.
+    runVega.mockRejectedValue(vegaFailure("timeout"));
+    listRunningVvdConsolePorts.mockResolvedValue(new Set([5554])); // a VVD IS running
+    const devices = await listVegaDevices();
+    expect(runVegaDevice).not.toHaveBeenCalled();
+    // It still degrades gracefully to the installed image rather than hanging.
+    expect(devices.some((d) => d.state === "stopped" && d.vvdImage === "tv")).toBe(true);
+  });
+
+  it("a *fast* (non-timeout) `device list` failure still recovers a running VVD", async () => {
+    // A transient CLI error is NOT a wedged agent: `device info` would still answer,
+    // so recovery must run — otherwise a genuinely-running VVD is mis-reported as
+    // stopped. This is the case the timeout-only gate preserves (a blanket
+    // "any failure → no recovery" gate would regress it).
+    runVega.mockRejectedValue(vegaFailure("subprocess"));
+    listRunningVvdConsolePorts.mockResolvedValue(new Set([5554])); // a VVD IS running
+    const devices = await listVegaDevices();
+    expect(runVegaDevice).toHaveBeenCalled(); // recovery via `device info` fired
+    const running = devices.filter((d) => d.kind === "vvd" && d.state === "running");
+    expect(running).toHaveLength(1);
+    expect(running[0]!.serial).toBe("amazon-3ef2badfb9a39e0b");
+    expect(devices.some((d) => d.state === "stopped" && d.vvdImage === "tv")).toBe(false);
   });
 });

--- a/packages/tool-server/test/vega-cli-timeout.test.ts
+++ b/packages/tool-server/test/vega-cli-timeout.test.ts
@@ -114,7 +114,11 @@ function sweep(): void {
   try {
     // Match only this suite's sentinels (6910[0-9]) rather than a loose `sleep 691`
     // substring, so a stray `sleep` from unrelated work on the machine is never killed.
-    execSync(`pkill -f 'sleep 6910[0-9]' || true`);
+    // Anchored to the whole command line (`^…$`) for the same reason as strayCount: an
+    // unanchored `-f` pattern would also match the wrapper shell execSync spawns to run
+    // it (whose argv contains the literal pattern). The real sleeps' cmdline is exactly
+    // `sleep 6910<n>`.
+    execSync(`pkill -f '^sleep 6910[0-9]$' || true`);
   } catch {
     /* nothing to clean */
   }
@@ -122,7 +126,15 @@ function sweep(): void {
 
 function strayCount(sentinel: string): number {
   try {
-    const out = execSync(`pgrep -f 'sleep ${sentinel}' || true`, { encoding: "utf-8" });
+    // Anchor the pattern to the WHOLE command line (`^sleep <sentinel>$`). With a bare
+    // `sleep <sentinel>` substring, Linux's procps `pgrep -f` also matches the wrapper
+    // shell `/bin/sh -c "pgrep -f 'sleep <sentinel>' || true"` that execSync spawns —
+    // its own argv contains the literal `sleep <sentinel>`, and pgrep excludes only its
+    // own pid, not that parent shell — so a clean reap still reported 1 phantom stray
+    // and every waitForClear assertion failed on CI. (macOS's BSD pgrep doesn't match
+    // the wrapper, which is why it only bit Linux.) The anchors restrict the match to a
+    // real `sleep <sentinel>` process, whose full cmdline is exactly that.
+    const out = execSync(`pgrep -f '^sleep ${sentinel}$' || true`, { encoding: "utf-8" });
     return out.split("\n").filter((l) => l.trim()).length;
   } catch {
     return 0;

--- a/packages/tool-server/test/vega-cli-timeout.test.ts
+++ b/packages/tool-server/test/vega-cli-timeout.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { getFailureSignal } from "@argent/registry";
+import { runVega, __resetVegaBinaryCacheForTests } from "../src/utils/vega-cli";
+
+// Real-subprocess regression cover for the `list-devices` "hang" + process leak.
+// Against a wedged device agent the `vega` CLI forks a launcher → worker tree that
+// never returns; a worker holding the stdout pipe kept the old execFile-based call
+// pending for the full timeout, and SIGKILLing only the direct child orphaned the
+// rest of the tree. runVega now spawns the launcher `detached` (its own process
+// group), SIGKILLs the whole group on timeout, AND sweeps any descendant that
+// escaped the group — so it settles on its own deadline and leaves no orphans. We
+// exercise that with a fake `vega` on PATH (not mocks) so the real spawn / detached
+// / group-kill / descendant-sweep path is what runs.
+//
+// The fake is a node launcher that (a) forks a `detached` `sleep <secs>` worker — its
+// OWN process group, so a group-only kill can't reach it (this reproduces the
+// setsid'd `dutyfree-vega` worker the group SIGKILL alone would orphan) — which also
+// inherits the launcher's stdout (reproducing the pipe-held-open freeze), and (b)
+// itself blocks on a same-group `sleep <secs>` so the launcher stays alive long
+// enough to be timed out and snapshotted. A complete reap therefore requires BOTH the
+// group kill (launcher + its sleep) and the descendant sweep (the detached worker).
+// Each test passes its OWN sentinel so one test's strays can't be mistaken for
+// another's. Sentinels share the `6910x` range so afterEach can sweep them all with
+// a single tight pattern (see sweep()).
+const SENTINEL_DEADLINE = "69101";
+const SENTINEL_REAP = "69102";
+const SENTINEL_OVERFLOW = "69103";
+const SENTINEL_LINGER = "69104";
+const SENTINEL_OVERFLOW_ERR = "69105";
+const SENTINEL_LINGER_NEAR_DEADLINE = "69106";
+let dir: string;
+let prevPath: string | undefined;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "argent-fakevega-"));
+  writeFileSync(
+    join(dir, "vega"),
+    `#!/usr/bin/env node
+const { spawn, spawnSync } = require("node:child_process");
+const [cmd, secs] = process.argv.slice(2);
+if (cmd === "hang") {
+  // A worker that ESCAPES the launcher's process group (detached → its own session/
+  // pgid, like the real CLI's setsid'd worker), so the group-only SIGKILL can't reach
+  // it — only the descendant sweep does. It also inherits our stdout, reproducing the
+  // pipe-held-open freeze. \`secs\` is a per-test sentinel so pgrep finds strays
+  // unambiguously.
+  const worker = spawn("sleep", [secs], { detached: true, stdio: ["ignore", "inherit", "ignore"] });
+  worker.unref();
+  // The launcher itself also hangs (same group as us) so it stays alive to be timed
+  // out and snapshotted; the group SIGKILL reaps this one.
+  spawnSync("sleep", [secs]);
+  process.exit(0);
+}
+if (cmd === "fail") {
+  // A fast, non-timeout failure: exit non-zero with stderr (like "device offline").
+  // runVega must reject classifying this as a "subprocess" failure, NOT a "timeout".
+  process.stderr.write("device offline");
+  process.exit(3);
+}
+if (cmd === "flood") {
+  // Emit more than the test's maxOutputBytes, then hang on a sentinel sleep so the
+  // OVERFLOW reap — not a natural exit — is what settles runVega. The reap must clear
+  // this sleep too. \`secs\` is the per-test sentinel.
+  process.stdout.write("x".repeat(4096));
+  spawnSync("sleep", [secs]);
+  process.exit(0);
+}
+if (cmd === "flood-err") {
+  // Same as \`flood\` but floods STDERR instead of stdout — the cap applies per stream
+  // (like execFile's maxBuffer), so an stderr flood must also reap+reject rather than
+  // grow unbounded. Hangs on a sentinel sleep so the overflow reap is what settles it.
+  process.stderr.write("x".repeat(4096));
+  spawnSync("sleep", [secs]);
+  process.exit(0);
+}
+if (cmd === "linger") {
+  // A CLEAN exit whose \`close\` is delayed: fork a detached worker that INHERITS our
+  // stdout (holding the write end open) and unref it, then write the result and let
+  // the launcher exit 0 naturally. \`close\` on our parent won't fire until the worker
+  // dies (its sentinel sleep), but \`exit\` fires now — runVega must resolve from the
+  // exit + drain grace with the captured stdout instead of waiting out the timeout.
+  const worker = spawn("sleep", [secs], { detached: true, stdio: ["ignore", "inherit", "ignore"] });
+  worker.unref();
+  process.stdout.write("OK-linger");
+  // No process.exit: with the worker unref'd nothing keeps our loop alive, so we exit
+  // 0 naturally (flushing stdout) while the detached worker keeps the pipe open.
+  return;
+}
+process.stdout.write("OK-" + cmd);
+`,
+    { mode: 0o755 }
+  );
+  prevPath = process.env.PATH;
+  process.env.PATH = `${dir}:${process.env.PATH ?? ""}`;
+});
+
+afterAll(() => {
+  process.env.PATH = prevPath;
+  sweep();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  __resetVegaBinaryCacheForTests();
+});
+
+afterEach(() => sweep());
+
+function sweep(): void {
+  try {
+    // Match only this suite's sentinels (6910[0-9]) rather than a loose `sleep 691`
+    // substring, so a stray `sleep` from unrelated work on the machine is never killed.
+    execSync(`pkill -f 'sleep 6910[0-9]' || true`);
+  } catch {
+    /* nothing to clean */
+  }
+}
+
+function strayCount(sentinel: string): number {
+  try {
+    const out = execSync(`pgrep -f 'sleep ${sentinel}' || true`, { encoding: "utf-8" });
+    return out.split("\n").filter((l) => l.trim()).length;
+  } catch {
+    return 0;
+  }
+}
+
+// Poll until this test's workers are gone (reap is a SIGKILL the OS applies
+// asynchronously). Returns the final count; a complete reap reaches 0 within a
+// moment, whereas an orphaned tree would survive for the full sleep and never clear.
+async function waitForClear(sentinel: string, timeoutMs = 3_000): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  let count = strayCount(sentinel);
+  while (count > 0 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 50));
+    count = strayCount(sentinel);
+  }
+  return count;
+}
+
+describe("runVega timeout (real subprocess)", () => {
+  it("rejects on its own deadline when the CLI never returns", async () => {
+    const start = Date.now();
+    await expect(runVega(["hang", SENTINEL_DEADLINE], { timeoutMs: 400 })).rejects.toThrow(
+      /timed out/i
+    );
+    const elapsed = Date.now() - start;
+    // Settles right around the 400ms deadline — proving it does NOT wait on the
+    // worker that holds the stdout pipe open.
+    expect(elapsed).toBeLessThan(2_500);
+  });
+
+  it("reaps the ENTIRE worker tree on timeout — including a worker that escaped the group", async () => {
+    await expect(runVega(["hang", SENTINEL_REAP], { timeoutMs: 400 })).rejects.toThrow(
+      /timed out/i
+    );
+    // Two sleeps must disappear: the launcher's same-group sleep (reaped by the group
+    // SIGKILL) AND the detached worker in its OWN group (reaped only by the descendant
+    // sweep). With a group-only kill — or the old single-child kill — the escaped
+    // worker would survive its full sleep and this would never reach 0.
+    expect(await waitForClear(SENTINEL_REAP)).toBe(0);
+  });
+
+  it("returns normally when the CLI responds before the deadline", async () => {
+    await expect(runVega(["go"], { timeoutMs: 5_000 })).resolves.toEqual({
+      stdout: "OK-go",
+      stderr: "",
+    });
+  });
+
+  it("resolves a clean exit even when a worker holds the stdout pipe open (delayed close)", async () => {
+    // The pipe-inheritance freeze on the SUCCESS path: the launcher exits 0 with its
+    // output already written, but a grandchild keeps the stdout pipe open so `close`
+    // never arrives. Resolving only on `close` would stall this finished call until the
+    // timeout and then reject it as a timeout — discarding valid output. runVega instead
+    // falls back to `exit` + a short drain grace and resolves with the captured stdout.
+    const start = Date.now();
+    await expect(runVega(["linger", SENTINEL_LINGER], { timeoutMs: 10_000 })).resolves.toEqual({
+      stdout: "OK-linger",
+      stderr: "",
+    });
+    // Settles around the ~1s drain grace, well under the 10s timeout — proving it does
+    // not wait out the timeout (which would also have rejected rather than resolved).
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  it("resolves a clean exit whose drain grace outlasts the deadline (does not reject as timeout)", async () => {
+    // Regression for the drain-grace-vs-deadline race: the child exits CLEANLY (code 0,
+    // output ready) but a grandchild holds the stdout pipe open, so `close` is delayed
+    // and the exit falls back to the drain grace (~1s). If the main timeout fires before
+    // that grace elapses, settling on it would reject a finished call AS A TIMEOUT —
+    // discarding valid output and (worse) classifying `error_kind: "timeout"`, which
+    // suppresses listVegaDevices' `device info` recovery and drops a running VVD. With
+    // `timeoutMs` (600) below VEGA_EXIT_DRAIN_GRACE_MS (1000) the exit-at-~0ms schedules
+    // its drain ~1s out while the deadline is only 600ms away, so the race is forced
+    // deterministically. The child having exited makes the wall-clock deadline moot, so
+    // it must resolve from the exit/drain with the captured output, not reject.
+    await expect(
+      runVega(["linger", SENTINEL_LINGER_NEAR_DEADLINE], { timeoutMs: 600 })
+    ).resolves.toEqual({ stdout: "OK-linger", stderr: "" });
+  });
+
+  it("rejects a non-zero exit as a `subprocess` failure (not `timeout`)", async () => {
+    // The common, non-hung failure path (e.g. "device offline"). It must surface the
+    // child's stderr AND classify as `subprocess`: a `timeout` classification would
+    // wrongly suppress the listVegaDevices `device info` recovery for a healthy VVD.
+    const err = await runVega(["fail"], { timeoutMs: 5_000 }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/device offline/);
+    expect(getFailureSignal(err)?.error_kind).toBe("subprocess");
+  });
+
+  it("rejects + reaps when output exceeds the cap, classified as `subprocess`", async () => {
+    // A runaway child: output past the cap reaps the group and rejects. Like the
+    // non-zero exit (and unlike a timeout) it is a misbehaving child, so it must
+    // classify as `subprocess` — the killed=true shape would otherwise read as a
+    // wedged-agent "timeout". The sentinel sleep it hangs on must be reaped too.
+    const err = await runVega(["flood", SENTINEL_OVERFLOW], {
+      maxOutputBytes: 100,
+      timeoutMs: 5_000,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    // The message prefers the child's captured output (matching execFile's maxBuffer
+    // error), so it's the flood, not "output exceeded" — what matters is that it
+    // rejected as a misbehaving child, i.e. classified `subprocess` not `timeout`.
+    expect(getFailureSignal(err)?.error_kind).toBe("subprocess");
+    expect(await waitForClear(SENTINEL_OVERFLOW)).toBe(0);
+  });
+
+  it("rejects + reaps when STDERR exceeds the cap, classified as `subprocess`", async () => {
+    // The cap is per-stream (like execFile's maxBuffer): a child that floods stderr
+    // instead of stdout must trip the same overflow path, not grow stderr unbounded
+    // until the timeout — otherwise a misbehaving CLI could exhaust the long-lived
+    // tool-server's memory. Classifies `subprocess` (a misbehaving child, not a wedged
+    // agent) and the sentinel sleep it hangs on must be reaped too.
+    const err = await runVega(["flood-err", SENTINEL_OVERFLOW_ERR], {
+      maxOutputBytes: 100,
+      timeoutMs: 5_000,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(getFailureSignal(err)?.error_kind).toBe("subprocess");
+    expect(await waitForClear(SENTINEL_OVERFLOW_ERR)).toBe(0);
+  });
+});

--- a/packages/tool-server/test/vega-cli-timeout.test.ts
+++ b/packages/tool-server/test/vega-cli-timeout.test.ts
@@ -32,6 +32,7 @@ const SENTINEL_OVERFLOW = "69103";
 const SENTINEL_LINGER = "69104";
 const SENTINEL_OVERFLOW_ERR = "69105";
 const SENTINEL_LINGER_NEAR_DEADLINE = "69106";
+const SENTINEL_LINGER_GROUPED = "69107";
 let dir: string;
 let prevPath: string | undefined;
 
@@ -88,6 +89,18 @@ if (cmd === "linger") {
   process.stdout.write("OK-linger");
   // No process.exit: with the worker unref'd nothing keeps our loop alive, so we exit
   // 0 naturally (flushing stdout) while the detached worker keeps the pipe open.
+  return;
+}
+if (cmd === "linger-grouped") {
+  // Like \`linger\`, but the worker is NOT detached — so it stays in the launcher's
+  // process group (pgid == launcher pid) while still inheriting our stdout (delaying
+  // \`close\`) and being unref'd so the launcher exits 0 naturally. This is the COMMON
+  // pipe-inheritance case (the detached \`linger\` worker deliberately escapes into its
+  // own group): a live group member pins the launcher's pid as a pgid, so runVega can
+  // reap it post-exit via a pgid-membership group kill. \`secs\` is the per-test sentinel.
+  const worker = spawn("sleep", [secs], { stdio: ["ignore", "inherit", "ignore"] });
+  worker.unref();
+  process.stdout.write("OK-linger");
   return;
 }
 process.stdout.write("OK-" + cmd);
@@ -157,9 +170,18 @@ async function waitForClear(sentinel: string, timeoutMs = 3_000): Promise<number
 describe("runVega timeout (real subprocess)", () => {
   it("rejects on its own deadline when the CLI never returns", async () => {
     const start = Date.now();
-    await expect(runVega(["hang", SENTINEL_DEADLINE], { timeoutMs: 400 })).rejects.toThrow(
-      /timed out/i
+    const err = await runVega(["hang", SENTINEL_DEADLINE], { timeoutMs: 400 }).catch(
+      (e: unknown) => e
     );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/timed out/i);
+    // The message alone proves nothing about classification — `rejectTimeout` builds
+    // it unconditionally. What listVegaDevices keys its recovery-skip off is
+    // `error_kind: "timeout"`, so assert it here, derived from a REAL runVega timeout
+    // (not a fabricated FailureError). A regression that dropped killed/signal from the
+    // rejection shape — so a genuine timeout classified as `subprocess` — would pass the
+    // message match but re-introduce the stacked ~40s stall; this assertion catches it.
+    expect(getFailureSignal(err)?.error_kind).toBe("timeout");
     const elapsed = Date.now() - start;
     // Settles right around the 400ms deadline — proving it does NOT wait on the
     // worker that holds the stdout pipe open.
@@ -214,6 +236,22 @@ describe("runVega timeout (real subprocess)", () => {
     await expect(
       runVega(["linger", SENTINEL_LINGER_NEAR_DEADLINE], { timeoutMs: 600 })
     ).resolves.toEqual({ stdout: "OK-linger", stderr: "" });
+  });
+
+  it("reaps a pipe-holding worker that stayed in the launcher's process group (drain path)", async () => {
+    // The clean-exit drain path with the COMMON pipe-inheritance worker: it inherited our
+    // stdout (so `close` is delayed past the launcher's clean exit) but stayed in the
+    // launcher's process group. Once the launcher exits, reapVegaGroup's mechanisms can't
+    // reach it (ppid sweep → reparented to init; group kill → gated on the launcher being
+    // alive), BUT a live group member pins the launcher's pid as a pgid, so a pgid-
+    // membership-gated `-pid` group kill is both safe and effective. runVega must resolve
+    // with the captured output AND leave NO orphan — proving it doesn't resolve-and-leak on
+    // this path. (The detached `linger` worker above escapes into its own group and is the
+    // rare genuinely-unreapable case, deliberately not covered by this reap.)
+    await expect(
+      runVega(["linger-grouped", SENTINEL_LINGER_GROUPED], { timeoutMs: 10_000 })
+    ).resolves.toEqual({ stdout: "OK-linger", stderr: "" });
+    expect(await waitForClear(SENTINEL_LINGER_GROUPED)).toBe(0);
   });
 
   it("rejects a non-zero exit as a `subprocess` failure (not `timeout`)", async () => {


### PR DESCRIPTION
## Summary

`list-devices` (an `alwaysLoad` tool called at session start and frequently after)
could appear to **hang**. Investigation found **two independent causes**, both fixed here:

1. **Server-side (Vega):** a wedged Vega VVD turned `list-devices` into a ~40s stall
   and leaked `vega` CLI subprocesses.
2. **Client-side (CLI):** every `argent run …` lingered a constant **~6s after it had
   already printed its result**, because a health-check `fetch` never drained its
   response body and kept an undici keep-alive socket ref'd until the server closed it.

Net effect for `argent run list-devices`: **6.15s → 0.91s**, and the worst-case
wedged-VVD stall drops from ~40s to a bounded short call.

---

## Problem 1 — wedged Vega VVD stalls `list-devices` (~40s) and leaks processes

On a host with the Vega SDK installed and a **running-but-unresponsive VVD**,
`list-devices`' Vega discovery path made **two serial 20s CLI calls** that both hung:

- `vega device list` → SIGKILL at 20s
- then (recovery) `vega device info` → SIGKILL at another 20s → **~40s total**

Three compounding defects:

- `execFileAsync` resolves on stdio **close**, not child **exit**. The `vega` launcher
  forks a `python3 → node → vda` worker tree; an orphaned worker holds the stdout pipe
  open, so the call stayed pending for the full timeout even after the launcher was
  killed.
- The `device info` recovery fired even when `device list` had **hung**, doubling the
  cost and spawning a second hanging subprocess.
- On timeout we killed only the **direct child**, so the `python3 → node → vda` worker
  tree was **orphaned, not reaped** — leaking a process tree per call (a wedged host had
  accumulated ~269 of them).

### Fix

- **`runVega` (`vega-cli.ts`):** switched from `execFileAsync` to `spawn` with
  **`detached: true`**, making the launcher its own **process-group leader**, and on
  timeout SIGKILL the **whole process group** (`process.kill(-pid)`) — which reaps the
  entire `python3 → node → vda` tree, **not just the launcher**. We also destroy our
  stdio stream ends so a pipe-holding worker can't keep the call pending. (`execFile`
  silently drops `detached`, which is why the switch to `spawn` was required.)
  - **Success path doesn't depend on stdio EOF either:** we prefer `close` (fully
    drained), but if a grandchild holds the stdout pipe open after a **clean exit**, we
    fall back to `exit` + a short (~1s) drain grace and resolve with the captured
    output — so a finished call can't be stalled into the timeout and then rejected,
    discarding valid data. The output cap is measured in real UTF-8 bytes. For that
    guarantee to hold at the boundary, the `exit` handler **disarms the main timeout
    timer**: once the child has terminated the wall-clock deadline is moot, so a clean
    exit landing within the drain grace of the deadline resolves with its output instead
    of being mis-rejected as a `timeout` (which would also wrongly suppress the
    `listVegaDevices` recovery for a still-running VVD).
  - **Belt-and-suspenders for a worker that escapes the group:** an earlier
    investigation reported the worker tree `setsid()`-ing into its own session (which
    would defeat a group-only SIGKILL). To be safe regardless of which is true, on
    timeout we **snapshot the launcher's descendants from the process table *before*
    killing** (a setsid'd worker keeps its `ppid` pointing at the launcher until the
    launcher dies, so a `ppid` tree-walk still reaches it) and SIGKILL those pids
    individually after the group kill. The snapshot is **precise** — only this
    launcher's own descendants, by pid, so a concurrent `vega` call's workers are never
    touched — and bounded, and the group kill runs regardless of whether it succeeds.
  - A real-subprocess test confirms **0 orphans** after a timeout, including a worker
    deliberately spawned into its **own** process group (so the group kill alone cannot
    reach it — the test fails without the descendant sweep).
- **`listVegaDevices` (`vega-devices.ts`):** skip the `device info` recovery only when
  `device list` **timed out** (a wedged agent — keyed off the failure's
  `error_kind: "timeout"`), so a hung list no longer pays for a second timeout wait. A
  *fast* (non-timeout) list failure still recovers a genuinely-running VVD rather than
  mis-reporting it as stopped. Tightened discovery timeouts (20s → 6s/4s — a generous
  multiple of the ~1s healthy time so a cold-start `vega` launcher isn't spuriously
  timed out, with their sum (10s) kept under the 15s branch deadline with margin).
- **`list-devices.ts`:** added a 15s `withDeadline` backstop around the Android and Vega
  branches so no single branch can stall the whole fan-out (returns partial results +
  logs a note). Sized to sit ~5s above the Vega branch's ~10s worst case, so the
  backstop never truncates a slow-but-completing branch (which would drop a real
  device); an invariant test guards that ordering.
- **`readAvdName` (`adb.ts`):** run the two `getprop` probes concurrently so a wedged
  emulator costs 5s, not 10s.

---

## Problem 2 — `argent run` hangs ~6s after printing output (CLI socket leak)

Independent of Vega. The tool-server returns `list-devices` in <1s, but the CLI process
took a **constant ~6s** to exit. Any path that calls `process.exit()` was instant; any
path that returned naturally (`argent run …`, `argent run … --help`, `argent tools`)
lingered ~6s.

**Root cause:** `isToolsServerHealthy` (`launcher.ts`) did
`const res = await fetch('/tools'); return res.ok;` and **never drained the body**.
`/tools` is a large (~112KB) payload, so undici keeps the keep-alive socket **ref'd**
until the tool-server's idle `keepAliveTimeout` (~5s) closes it. `ensureToolsServer`
runs this health check on every invocation, and `run()`'s success path has no
`process.exit(0)`, so the ref'd socket holds the event loop open. (Confirmed
telemetry-independent — `DO_NOT_TRACK` made no difference.) The same undrained-body
pattern existed in `link.ts` (`argent link`).

### Fix

Drain the response body before returning in both health-check-style fetches:

```ts
await res.body?.cancel().catch(() => {});
return res.ok;
```

(`fetchTools`/`callTool` were already fine — they `await res.json()`.)

---

## Testing

**Empirical, end-to-end** (on a machine reproducing the wedged VVD):

| Command | Before | After |
| --- | --- | --- |
| `argent run list-devices` | 6.15s | **0.91s** |
| `argent run list-devices --help` | 6.14s | **0.16s** |
| `argent tools` | 6.15s | **0.16s** |
| handle probe after run | 2 sockets ref'd for ~6s | **none — immediate exit** |

- Raw `POST /tools/list-devices` was ~0.7s throughout — confirming the ~5.4s was pure
  CLI teardown, not tool work.
- **Process-group reap proven empirically:** the live `vega → bash → python3 → node`
  tree all shares the detached launcher's PGID; a group-SIGKILL left **0 survivors**.
  A real-subprocess test (unmocked `runVega` vs. a fake hanging `vega` on `PATH`) confirms
  it settles at its deadline **and** leaves **0 orphaned processes**.

**Automated:**

- `vega-cli-timeout.test.ts` (real-subprocess test) — `runVega` rejects on its deadline,
  **reaps the entire worker tree (0 orphans)** — the fake's hung worker is spawned into its
  **own** process group, so the test fails without the descendant sweep — and returns
  normally when the CLI responds. Also covers the boundary case: a **clean exit whose
  drain grace outlasts the deadline** resolves with its captured output rather than being
  rejected as a `timeout` (guards the `exit`-handler timer disarm above).
- `vega-adb-connect-recovery.test.ts` — a *timed-out* `device list` does not trigger a
  second `device info` call (no stacking); a *fast, non-timeout* failure **still** recovers
  a running VVD.
- `list-devices-deadline.test.ts` — `withDeadline` returns the branch value on the happy
  path and the fallback (with a logged note) when a branch exceeds the deadline.
- `list-devices.test.ts` — added a `spawn` mock (vega moved off `execFile`).
- `launcher-helpers.test.ts` — `isToolsServerHealthy` cancels (drains) its response body.
- Suites green: **tool-server (1610), argent-tools-client (109), argent-cli (84)**.
- eslint (`--max-warnings 0`), prettier, and `tsc` clean.

---