### PR TITLE
feat(ios): pass ax identifier to the `DescribeNode`

### DIFF
--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -57,6 +57,7 @@ export interface AXDescribeElement {
   tapPoint?: { x: number; y: number };
   traits?: string[];
   value?: string;
+  identifier?: string;
 }
 
 export interface AXDescribeResponse {

--- a/packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/ios-ax-adapter.ts
@@ -31,6 +31,7 @@ export function adaptAXElement(el: AXDescribeElement): DescribeNode | null {
     children: [],
     label: el.label,
     value: el.value,
+    identifier: el.identifier,
   };
 }
 


### PR DESCRIPTION
Requires https://github.com/software-mansion/argent-private/pull/21

Passes the identifiers read from the ax-tree to `DescribeNodes`

