### PR TITLE
fix(telemetry): drop prototype-named keys in the sanitizer allowlist

### DIFF
--- a/packages/telemetry/src/sanitize.ts
+++ b/packages/telemetry/src/sanitize.ts
@@ -215,12 +215,12 @@ export const ALLOWED: ValidatorMap = {
 
 /** Strip keys and values that are not allowed for this event. */
 export function sanitize(event: string, raw: Record<string, unknown>): Record<string, unknown> {
+  if (!Object.hasOwn(ALLOWED, event)) return {};
   const validators = (ALLOWED as Record<string, Record<string, Validator>>)[event];
-  if (!validators) return {};
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(raw)) {
+    if (!Object.hasOwn(validators, k)) continue;
     const validate = validators[k];
-    if (!validate) continue;
     const cleaned = validate(v);
     if (cleaned !== undefined) out[k] = cleaned;
   }

--- a/packages/telemetry/test/sanitize.test.ts
+++ b/packages/telemetry/test/sanitize.test.ts
@@ -500,3 +500,25 @@ describe("sanitize", () => {
     });
   });
 });
+
+describe("sanitize ignores prototype-named keys (allowlist integrity)", () => {
+  it("drops 'constructor' and never leaks the value smuggled under it", () => {
+    const out = sanitize("tool:invoke", {
+      tool: "gesture-tap",
+      constructor: "/Users/alice/.ssh/id_rsa",
+    } as Record<string, unknown>);
+    expect(Object.keys(out)).toEqual(["tool"]);
+    expect(JSON.stringify(out)).not.toContain("/Users/alice");
+  });
+  it("drops other prototype-named keys (toString, valueOf, __proto__)", () => {
+    const out = sanitize("tool:invoke", {
+      tool: "gesture-tap",
+      toString: "x",
+      valueOf: "y",
+    } as Record<string, unknown>);
+    expect(Object.keys(out)).toEqual(["tool"]);
+  });
+  it("returns {} for an event name that is a prototype member", () => {
+    expect(sanitize("constructor", { tool: "gesture-tap" } as Record<string, unknown>)).toEqual({});
+  });
+});


### PR DESCRIPTION
## The defect

`sanitize()` in `packages/telemetry/src/sanitize.ts` is the documented last line of defense before telemetry reaches PostHog — its header comment promises that "Unknown keys and invalid values are dropped before anything reaches PostHog."

Both of its allowlist lookups read plain objects with bracket access, so they walk the prototype chain:

- The event lookup `ALLOWED[event]` resolves an `Object.prototype` member name (e.g. `"constructor"`, `"toString"`) to a truthy inherited member instead of `undefined`, so the `if (!validators) return {}` guard does not fire.
- The per-key lookup `const validate = validators[k]` does the same. For `k === "constructor"`, `validate` is the `Object` constructor, which is truthy (so `if (!validate) continue` does not drop it) and `validate(v) === Object(v)` boxes the value into a wrapper that JSON-serializes straight back to the original — so a value smuggled under a `constructor` key is emitted verbatim, defeating the allowlist.

## Hard reproduction

```ts
sanitize("tool:invoke", { tool: "gesture-tap", constructor: "/Users/alice/.ssh/id_rsa" })
```

- Observed: returns an object whose JSON still contains `"/Users/alice/.ssh/id_rsa"` (the `constructor` key survives).
- Expected: `{ tool: "gesture-tap" }` — the unknown key is dropped, as the contract states.

```ts
sanitize("tool:invoke", { tool: "gesture-tap", toString: "x" })
```

- Observed: the `toString` key is kept (and on some keys the inherited member is not callable, throwing).
- Expected: `{ tool: "gesture-tap" }`.

## The fix

Guard both lookups with an own-property check (`Object.hasOwn`, already targeted by the repo's ES2022 config and used elsewhere in the codebase):

- Treat `ALLOWED[event]` as valid only when `Object.hasOwn(ALLOWED, event)`.
- In the per-key loop, `continue` unless `Object.hasOwn(validators, k)` before reading/calling the validator.

Behavior for legitimate allowed keys is unchanged.

## Defense-in-depth note

This is not currently reachable through the typed `track()` surface (the event/property types preclude these keys), but the sanitizer is the explicit last line of defense and its stated contract was broken regardless of how the payload is constructed. Fixing it keeps that guarantee intact for any non-typed caller or future regression.

## Tests

Added a regression `describe` block to `packages/telemetry/test/sanitize.test.ts` that fails before the fix and passes after. Full telemetry suite (194 tests) passes; `tsc --build`, prettier, and eslint (`--max-warnings 0`) are all clean.
