### PR TITLE
fix(react-profiler): stop ANIMATED_PATTERN matching 'motion' inside ordinary names

### DIFF
--- a/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
@@ -14,18 +14,27 @@ import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline
 // lowercase substrings. Real RN animation component names are PascalCase and
 // contain a capitalized token (`Animated`, `AnimatedView`, `MotionView`,
 // `FadeTransition`), whereas ordinary names like `PromotionCard`,
-// `EmotionThemeCard`, or `CommotionList` only contain a lowercase "motion".
-// Case-sensitivity alone isn't enough: without a boundary, a capitalized token
-// that merely trails off into lowercase letters (`MotionlessIndicator`,
-// `AnimationsDisabledBanner`) still matches. Anchor the token to a PascalCase
-// segment boundary — start-of-string or preceded by a lowercase/digit (i.e. a
-// new capitalized word starting), and followed by another capitalized word or
-// end-of-string. This still can't disambiguate a token that legitimately
-// starts its own segment in a non-animation compound name (e.g. a sensor
-// component like `DeviceMotionListener`) — that would need a semantic
-// allow/deny list, not a regex — but it closes the trailing-continuation gap
-// the case-only fix left open.
-const ANIMATED_PATTERN = /(?:^|(?<=[a-z0-9]))(Animated|Animation|Transition|Motion)(?=[A-Z]|$)/;
+// `EmotionThemeCard`, or `CommotionList` only contain a lowercase "motion" —
+// case-sensitivity alone (no boundary needed) already rejects those, since the
+// capitalized token literally doesn't appear as a substring.
+// Case-sensitivity alone isn't enough on its own, though: without a trailing
+// boundary, a capitalized token that merely trails off into more lowercase
+// letters of the SAME word (`MotionlessIndicator`, `AnimationsDisabledBanner`)
+// still matches as a bare substring. The lookahead below requires the token be
+// followed by another capitalized word, a digit/underscore (`Animated2`,
+// `Animated_View`), or end-of-string — closing that gap.
+// Deliberately NO leading-boundary requirement: real animation wrapper names
+// are routinely acronym-prefixed (`SVGAnimatedPath`, `HTTPTransitionHandler`,
+// `IOSMotionView`) where the token is preceded by another capital letter, not
+// a lowercase-to-uppercase transition — requiring one caused exactly these to
+// stop matching (a false-negative regression caught in review) with no
+// corresponding false-positive to justify it.
+// This still can't disambiguate a token that legitimately starts its own
+// segment in a non-animation compound name (e.g. a sensor component like
+// `DeviceMotionListener`) — that would need a semantic allow/deny list, not a
+// regex — so that class of false positive remains a known, documented
+// limitation.
+const ANIMATED_PATTERN = /(Animated|Animation|Transition|Motion)(?=[A-Z0-9_]|$)/;
 const RECYCLER_CHILD_PATTERN = /(ListItem|CellItem|Cell|Row|Item)$/i;
 const RECYCLER_PARENT_PATTERN =
   /^(FlatList|SectionList|VirtualizedList|FlashList|RecyclerListView)/i;

--- a/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
@@ -5,8 +5,8 @@
  *   isAnimated     — component is part of an animation subtree
  *   isRecyclerChild — component is a FlatList/VirtualizedList item
  *
- * These flags drive filtering in Stage 4. Components tagged here are
- * excluded from findings and recorded in IssueReport.excluded.
+ * These flags drive filtering in Stage 4: components tagged here are
+ * excluded from the ranked findings.
  */
 import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline";
 
@@ -23,14 +23,19 @@ import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline
 //    `Memo(AnimatedComponent(View))`), or end-of-string — so it still matches
 //    real names while rejecting tokens that bleed into more lowercase
 //    (`MotionlessIndicator`).
-//  - KNOWN LIMITATION: only acronym/digit-GLUED device-motion prefixes
-//    (`CMMotionManager`, `G2MotionSensor`) are rejected. A BARE `Motion` starting
-//    a PascalCase word (`MotionSensor`, `MotionManager`) still matches — it is
-//    structurally indistinguishable from a real animation name of the same shape
-//    (`MotionView`, and `@legendapp/motion`'s `Motion.View`), which we DO want to
-//    tag. This over-tag is accepted collateral: it only excludes a component from
-//    perf findings, and a hardcoded device-motion denylist would be more fragile
-//    than the rare false positive it removes.
+//  - KNOWN LIMITATION: only acronym/digit-GLUED prefixes (`CMMotionManager`,
+//    `G2MotionSensor`) are rejected. A BARE token that starts a PascalCase word
+//    still matches even in a non-animation name: `MotionSensor`/`MotionManager`
+//    (device motion), and — since `Transition` is also an ordinary word (state
+//    machines, phase changes) — `StateTransitionDiagram`, `TransitionMatrix`.
+//    The match is unanchored on purpose so real mid-name animation forms are
+//    caught (`FadeTransition`, `FadeInAnimation`, `SharedElementTransition`),
+//    which makes each over-tag structurally
+//    indistinguishable from a genuine animation name of the same shape
+//    (`MotionView`, `@legendapp/motion`'s `Motion.View`). This over-tag is
+//    accepted collateral: it only excludes a component from perf findings, and a
+//    hardcoded denylist would be more fragile than the rare false positive it
+//    removes.
 const ANIMATED_PATTERN = /(?<![A-Z0-9])(Animated|Animation|Transition|Motion)(?=[A-Z0-9_(.]|$)/;
 const RECYCLER_CHILD_PATTERN = /(ListItem|CellItem|Cell|Row|Item)$/i;
 const RECYCLER_PARENT_PATTERN =

--- a/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
@@ -23,6 +23,14 @@ import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline
 //    `Memo(AnimatedComponent(View))`), or end-of-string — so it still matches
 //    real names while rejecting tokens that bleed into more lowercase
 //    (`MotionlessIndicator`).
+//  - KNOWN LIMITATION: only acronym/digit-GLUED device-motion prefixes
+//    (`CMMotionManager`, `G2MotionSensor`) are rejected. A BARE `Motion` starting
+//    a PascalCase word (`MotionSensor`, `MotionManager`) still matches — it is
+//    structurally indistinguishable from a real animation name of the same shape
+//    (`MotionView`, and `@legendapp/motion`'s `Motion.View`), which we DO want to
+//    tag. This over-tag is accepted collateral: it only excludes a component from
+//    perf findings, and a hardcoded device-motion denylist would be more fragile
+//    than the rare false positive it removes.
 const ANIMATED_PATTERN = /(?<![A-Z0-9])(Animated|Animation|Transition|Motion)(?=[A-Z0-9_(.]|$)/;
 const RECYCLER_CHILD_PATTERN = /(ListItem|CellItem|Cell|Row|Item)$/i;
 const RECYCLER_PARENT_PATTERN =

--- a/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
@@ -29,11 +29,14 @@ import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline
 //    token (`CMMotionManager`, `CMMotionActivity` — real Apple CoreMotion SDK
 //    class names, nothing to do with animation) reads as a match with no
 //    boundary at all to reject it. Requiring the token be preceded by a
-//    lowercase/digit (a genuine PascalCase word-start) or start-of-string
-//    closes that off. The cost: a small number of HYPOTHETICAL
-//    acronym-prefixed *animation* names (`SVGAnimatedPath`,
-//    `HTTPTransitionHandler`) would also stop matching — accepted, since
-//    there's no confirmed real-world instance of that shape, whereas
+//    LOWERCASE letter (a genuine PascalCase word-start) or start-of-string
+//    closes that off. Deliberately NOT digits here — unlike the trailing
+//    side, a digit immediately before the token (`G2MotionSensor`,
+//    `IMU2MotionTracker`) is itself the tail of an acronym/model-number
+//    prefix, not a real word boundary, and allowing it reopened the same
+//    false-positive class with a different-shaped acronym. The cost of the
+//    leading boundary: a few acronym-prefixed *animation* names (e.g. a
+//    hypothetical `SVGAnimatedPath`) also stop matching — accepted, since
 //    silently excluding a real non-animation component (a false positive)
 //    hides a real perf finding entirely with no trace, the more severe
 //    failure mode of the two.
@@ -44,8 +47,7 @@ import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline
 // `SubMotion`) — that would need a semantic allow/deny list, not a regex — so
 // that narrower class of false positive remains a known, documented
 // limitation.
-const ANIMATED_PATTERN =
-  /(?:^|(?<=[a-z0-9]))(Animated|Animation|Transition|Motion)(?=[A-Z0-9_]|$)/;
+const ANIMATED_PATTERN = /(?:^|(?<=[a-z]))(Animated|Animation|Transition|Motion)(?=[A-Z0-9_]|$)/;
 const RECYCLER_CHILD_PATTERN = /(ListItem|CellItem|Cell|Row|Item)$/i;
 const RECYCLER_PARENT_PATTERN =
   /^(FlatList|SectionList|VirtualizedList|FlashList|RecyclerListView)/i;

--- a/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
@@ -17,24 +17,35 @@ import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline
 // `EmotionThemeCard`, or `CommotionList` only contain a lowercase "motion" —
 // case-sensitivity alone (no boundary needed) already rejects those, since the
 // capitalized token literally doesn't appear as a substring.
-// Case-sensitivity alone isn't enough on its own, though: without a trailing
-// boundary, a capitalized token that merely trails off into more lowercase
-// letters of the SAME word (`MotionlessIndicator`, `AnimationsDisabledBanner`)
-// still matches as a bare substring. The lookahead below requires the token be
-// followed by another capitalized word, a digit/underscore (`Animated2`,
-// `Animated_View`), or end-of-string — closing that gap.
-// Deliberately NO leading-boundary requirement: real animation wrapper names
-// are routinely acronym-prefixed (`SVGAnimatedPath`, `HTTPTransitionHandler`,
-// `IOSMotionView`) where the token is preceded by another capital letter, not
-// a lowercase-to-uppercase transition — requiring one caused exactly these to
-// stop matching (a false-negative regression caught in review) with no
-// corresponding false-positive to justify it.
-// This still can't disambiguate a token that legitimately starts its own
-// segment in a non-animation compound name (e.g. a sensor component like
-// `DeviceMotionListener`) — that would need a semantic allow/deny list, not a
-// regex — so that class of false positive remains a known, documented
+//
+// Two boundaries close the remaining gaps:
+//  - TRAILING: without one, a capitalized token that merely trails into more
+//    lowercase letters of the SAME word (`MotionlessIndicator`,
+//    `AnimationsDisabledBanner`) still matches as a bare substring. Requiring
+//    the token be followed by another capitalized word, a digit/underscore
+//    (`Animated2`, `Animated_View`, `Motion360Player`), or end-of-string closes
+//    that gap without losing real digit/underscore-suffixed names.
+//  - LEADING: without one, an acronym prefix immediately followed by the
+//    token (`CMMotionManager`, `CMMotionActivity` — real Apple CoreMotion SDK
+//    class names, nothing to do with animation) reads as a match with no
+//    boundary at all to reject it. Requiring the token be preceded by a
+//    lowercase/digit (a genuine PascalCase word-start) or start-of-string
+//    closes that off. The cost: a small number of HYPOTHETICAL
+//    acronym-prefixed *animation* names (`SVGAnimatedPath`,
+//    `HTTPTransitionHandler`) would also stop matching — accepted, since
+//    there's no confirmed real-world instance of that shape, whereas
+//    silently excluding a real non-animation component (a false positive)
+//    hides a real perf finding entirely with no trace, the more severe
+//    failure mode of the two.
+//
+// Neither boundary can disambiguate a token that legitimately starts its own
+// segment in a non-animation compound name where the PRECEDING char actually
+// is lowercase (e.g. a sensor component like `DeviceMotionListener`, or
+// `SubMotion`) — that would need a semantic allow/deny list, not a regex — so
+// that narrower class of false positive remains a known, documented
 // limitation.
-const ANIMATED_PATTERN = /(Animated|Animation|Transition|Motion)(?=[A-Z0-9_]|$)/;
+const ANIMATED_PATTERN =
+  /(?:^|(?<=[a-z0-9]))(Animated|Animation|Transition|Motion)(?=[A-Z0-9_]|$)/;
 const RECYCLER_CHILD_PATTERN = /(ListItem|CellItem|Cell|Row|Item)$/i;
 const RECYCLER_PARENT_PATTERN =
   /^(FlatList|SectionList|VirtualizedList|FlashList|RecyclerListView)/i;

--- a/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
@@ -10,7 +10,13 @@
  */
 import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline";
 
-const ANIMATED_PATTERN = /(Animated|Animation|Transition|Motion)/i;
+// Match the animation tokens only as genuine PascalCase segments, not as
+// lowercase substrings. Real RN animation component names are PascalCase and
+// contain a capitalized token (`Animated`, `AnimatedView`, `MotionView`,
+// `FadeTransition`), whereas ordinary names like `PromotionCard`,
+// `EmotionThemeCard`, or `CommotionList` only contain a lowercase "motion".
+// Dropping the `/i` flag keeps the former and stops matching the latter.
+const ANIMATED_PATTERN = /(Animated|Animation|Transition|Motion)/;
 const RECYCLER_CHILD_PATTERN = /(ListItem|CellItem|Cell|Row|Item)$/i;
 const RECYCLER_PARENT_PATTERN =
   /^(FlatList|SectionList|VirtualizedList|FlashList|RecyclerListView)/i;

--- a/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
@@ -10,44 +10,20 @@
  */
 import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline";
 
-// Match the animation tokens only as genuine PascalCase segments, not as
-// lowercase substrings. Real RN animation component names are PascalCase and
-// contain a capitalized token (`Animated`, `AnimatedView`, `MotionView`,
-// `FadeTransition`), whereas ordinary names like `PromotionCard`,
-// `EmotionThemeCard`, or `CommotionList` only contain a lowercase "motion" —
-// case-sensitivity alone (no boundary needed) already rejects those, since the
-// capitalized token literally doesn't appear as a substring.
-//
-// Two boundaries close the remaining gaps:
-//  - TRAILING: without one, a capitalized token that merely trails into more
-//    lowercase letters of the SAME word (`MotionlessIndicator`,
-//    `AnimationsDisabledBanner`) still matches as a bare substring. Requiring
-//    the token be followed by another capitalized word, a digit/underscore
-//    (`Animated2`, `Animated_View`, `Motion360Player`), or end-of-string closes
-//    that gap without losing real digit/underscore-suffixed names.
-//  - LEADING: without one, an acronym prefix immediately followed by the
-//    token (`CMMotionManager`, `CMMotionActivity` — real Apple CoreMotion SDK
-//    class names, nothing to do with animation) reads as a match with no
-//    boundary at all to reject it. Requiring the token be preceded by a
-//    LOWERCASE letter (a genuine PascalCase word-start) or start-of-string
-//    closes that off. Deliberately NOT digits here — unlike the trailing
-//    side, a digit immediately before the token (`G2MotionSensor`,
-//    `IMU2MotionTracker`) is itself the tail of an acronym/model-number
-//    prefix, not a real word boundary, and allowing it reopened the same
-//    false-positive class with a different-shaped acronym. The cost of the
-//    leading boundary: a few acronym-prefixed *animation* names (e.g. a
-//    hypothetical `SVGAnimatedPath`) also stop matching — accepted, since
-//    silently excluding a real non-animation component (a false positive)
-//    hides a real perf finding entirely with no trace, the more severe
-//    failure mode of the two.
-//
-// Neither boundary can disambiguate a token that legitimately starts its own
-// segment in a non-animation compound name where the PRECEDING char actually
-// is lowercase (e.g. a sensor component like `DeviceMotionListener`, or
-// `SubMotion`) — that would need a semantic allow/deny list, not a regex — so
-// that narrower class of false positive remains a known, documented
-// limitation.
-const ANIMATED_PATTERN = /(?:^|(?<=[a-z]))(Animated|Animation|Transition|Motion)(?=[A-Z0-9_]|$)/;
+// Match the animation tokens only as genuine PascalCase segments.
+//  - Case-sensitive: a lowercase-embedded "motion" (`PromotionCard`,
+//    `Emotion`, `Locomotion`) never contains the capitalized token, so it is
+//    rejected with no boundary needed.
+//  - Leading `(?<![A-Z0-9])` rejects acronym/number-glued prefixes
+//    (`SVGAnimatedPath`, `RNAnimatedView`, `G2MotionSensor`) where the token
+//    is not a real PascalCase word-start.
+//  - Trailing `(?=[A-Z0-9_(.]|$)` requires the token to end a segment: another
+//    capitalized word, a digit/underscore, `(` or `.` (paren/dot/HOC-wrapped
+//    display names like `Animated(View)`, `Animated.View`,
+//    `Memo(AnimatedComponent(View))`), or end-of-string — so it still matches
+//    real names while rejecting tokens that bleed into more lowercase
+//    (`MotionlessIndicator`).
+const ANIMATED_PATTERN = /(?<![A-Z0-9])(Animated|Animation|Transition|Motion)(?=[A-Z0-9_(.]|$)/;
 const RECYCLER_CHILD_PATTERN = /(ListItem|CellItem|Cell|Row|Item)$/i;
 const RECYCLER_PARENT_PATTERN =
   /^(FlatList|SectionList|VirtualizedList|FlashList|RecyclerListView)/i;

--- a/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts
@@ -15,8 +15,17 @@ import type { EnrichOutput, TagOutput, TaggedComponent } from "../types/pipeline
 // contain a capitalized token (`Animated`, `AnimatedView`, `MotionView`,
 // `FadeTransition`), whereas ordinary names like `PromotionCard`,
 // `EmotionThemeCard`, or `CommotionList` only contain a lowercase "motion".
-// Dropping the `/i` flag keeps the former and stops matching the latter.
-const ANIMATED_PATTERN = /(Animated|Animation|Transition|Motion)/;
+// Case-sensitivity alone isn't enough: without a boundary, a capitalized token
+// that merely trails off into lowercase letters (`MotionlessIndicator`,
+// `AnimationsDisabledBanner`) still matches. Anchor the token to a PascalCase
+// segment boundary — start-of-string or preceded by a lowercase/digit (i.e. a
+// new capitalized word starting), and followed by another capitalized word or
+// end-of-string. This still can't disambiguate a token that legitimately
+// starts its own segment in a non-animation compound name (e.g. a sensor
+// component like `DeviceMotionListener`) — that would need a semantic
+// allow/deny list, not a regex — but it closes the trailing-continuation gap
+// the case-only fix left open.
+const ANIMATED_PATTERN = /(?:^|(?<=[a-z0-9]))(Animated|Animation|Transition|Motion)(?=[A-Z]|$)/;
 const RECYCLER_CHILD_PATTERN = /(ListItem|CellItem|Cell|Row|Item)$/i;
 const RECYCLER_PARENT_PATTERN =
   /^(FlatList|SectionList|VirtualizedList|FlashList|RecyclerListView)/i;

--- a/packages/tool-server/test/react-profiler-animated-pattern.test.ts
+++ b/packages/tool-server/test/react-profiler-animated-pattern.test.ts
@@ -99,4 +99,16 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
       expect(tagged.components.get(n)!.isAnimated).toBe(false);
     }
   });
+  it("does NOT tag a digit-suffixed acronym prefix either", () => {
+    // The leading boundary must reject digits too, not just uppercase — a
+    // digit immediately before the token is the tail of an acronym/model
+    // number (G2, IMU2, BLE4, L3), not a real PascalCase word start. Allowing
+    // digits here (matching the trailing side's digit allowance) reopened the
+    // same CMMotionManager-class false positive with a different acronym shape.
+    const names = ["G2MotionSensor", "IMU2MotionTracker", "BLE4MotionBeacon", "L3MotionFilter"];
+    const tagged = tag(enrich(names));
+    for (const n of names) {
+      expect(tagged.components.get(n)!.isAnimated).toBe(false);
+    }
+  });
 });

--- a/packages/tool-server/test/react-profiler-animated-pattern.test.ts
+++ b/packages/tool-server/test/react-profiler-animated-pattern.test.ts
@@ -111,4 +111,64 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
       expect(tagged.components.get(n)!.isAnimated).toBe(false);
     }
   });
+
+  // Full match/no-match matrix. The paren/dot/HOC-wrapped and dotted forms are
+  // the real regression this fix targets: they are the display names React DevTools
+  // actually produces for animated subtrees (and the exact prefixes the codebase
+  // hard-codes in skip-rules.ts / component-tree.ts), yet the over-tightened
+  // pre-fix regex failed to match them, leaking them back into findings.
+  const MUST_MATCH = [
+    "Animated",
+    "AnimatedView",
+    "Animated(View)",
+    "Animated.View",
+    "AnimatedComponent(View)",
+    "Memo(AnimatedComponent(View))",
+    "ForwardRef(AnimatedComponent(View))",
+    "Forget(AnimatedComponent(View))",
+    "Animated(ScrollView)",
+    "MotionView",
+    "FadeTransition",
+    "SlideTransition",
+    "FadeInAnimation",
+    "Animation",
+    "Transition",
+    "Animated2",
+    "Animated_View",
+  ];
+  const MUST_NOT_MATCH = [
+    "PromotionCard",
+    "Promotion",
+    "EmotionThemeCard",
+    "Emotion",
+    "CommotionList",
+    "Locomotion",
+    "LocomotionView",
+    "SVGAnimatedPath",
+    "RNAnimatedView",
+  ];
+
+  it("tags every animation name in the match matrix (incl. paren/dot/HOC-wrapped)", () => {
+    const tagged = tag(enrich(MUST_MATCH));
+    for (const n of MUST_MATCH) {
+      expect(tagged.components.get(n)!.isAnimated, n).toBe(true);
+    }
+  });
+
+  it("does NOT tag any name in the no-match matrix (incl. acronym-glued Animated)", () => {
+    const tagged = tag(enrich(MUST_NOT_MATCH));
+    for (const n of MUST_NOT_MATCH) {
+      expect(tagged.components.get(n)!.isAnimated, n).toBe(false);
+    }
+  });
+
+  it("excludes wrapped animation names from rank() findings while keeping real slow components", () => {
+    const wrappers = ["Animated(View)", "Animated.View", "Memo(AnimatedComponent(View))"];
+    const tagged = tag(enrich([...wrappers, "PromotionCard"]));
+    const ranked = rank(tagged).map((f) => f.component);
+    for (const n of wrappers) {
+      expect(ranked, n).not.toContain(n);
+    }
+    expect(ranked).toContain("PromotionCard");
+  });
 });

--- a/packages/tool-server/test/react-profiler-animated-pattern.test.ts
+++ b/packages/tool-server/test/react-profiler-animated-pattern.test.ts
@@ -99,6 +99,19 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
       expect(tagged.components.get(n)!.isAnimated).toBe(false);
     }
   });
+  it("DOES tag a bare Motion-prefixed device name (accepted collateral of matching MotionView)", () => {
+    // KNOWN LIMITATION: a bare `Motion` word-start (no acronym/digit prefix) is
+    // structurally indistinguishable from a real animation name of the same
+    // shape (MotionView, legend-motion's Motion.View), which we DO tag — so
+    // these CoreMotion-style device names are over-tagged as animated. Only the
+    // acronym/digit-GLUED forms (above) are rejected. Pinned here so any future
+    // change to this behavior is a deliberate one, not an accident.
+    const names = ["MotionSensor", "MotionManager", "MotionDetector", "MotionTracker"];
+    const tagged = tag(enrich(names));
+    for (const n of names) {
+      expect(tagged.components.get(n)!.isAnimated, n).toBe(true);
+    }
+  });
   it("does NOT tag a digit-suffixed acronym prefix either", () => {
     // The leading boundary must reject digits too, not just uppercase — a
     // digit immediately before the token is the tail of an acronym/model

--- a/packages/tool-server/test/react-profiler-animated-pattern.test.ts
+++ b/packages/tool-server/test/react-profiler-animated-pattern.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { tag } from "../src/utils/react-profiler/pipeline/03-tag";
+import { rank } from "../src/utils/react-profiler/pipeline/04-rank";
+import type {
+  EnrichOutput,
+  EnrichedComponent,
+  SessionContext,
+} from "../src/utils/react-profiler/types/pipeline";
+const sessionContext: SessionContext = {
+  reactCompilerEnabled: false,
+  strictModeEnabled: false,
+  buildMode: "dev",
+  rnArchitecture: "bridge",
+  projectRoot: "/proj",
+  platform: "ios",
+};
+function slow(name: string): EnrichedComponent {
+  return {
+    name,
+    n: 10,
+    normalizedRenderCount: 10,
+    mean: 20,
+    min: 5,
+    max: 40,
+    totalRenderMs: 200,
+    dominantReason: "props",
+    topChangedProps: ["data"],
+    topChangedHooks: [],
+    isCompilerOptimized: false,
+    firstCommitTs: 0,
+    lastCommitTs: 100,
+  };
+}
+function enrich(names: string[]): EnrichOutput {
+  const components = new Map<string, EnrichedComponent>();
+  for (const n of names) components.set(n, slow(n));
+  return {
+    components,
+    sessionContext,
+    reactCommits: 50,
+    fiberRenders: 100,
+    anyRuntimeCompilerDetected: false,
+    totalFirstMounts: 0,
+    firstMountOnlyComponents: [],
+    recordingMs: 10_000,
+  };
+}
+describe("ANIMATED_PATTERN matches only real animation segments", () => {
+  it("does NOT tag non-animation names containing 'motion' as a substring", () => {
+    const tagged = tag(
+      enrich(["PromotionCard", "EmotionThemeCard", "CommotionList", "ProductCard"])
+    );
+    for (const n of ["PromotionCard", "EmotionThemeCard", "CommotionList", "ProductCard"]) {
+      expect(tagged.components.get(n)!.isAnimated).toBe(false);
+    }
+    const ranked = rank(tagged).map((f) => f.component);
+    expect(ranked).toContain("PromotionCard");
+  });
+  it("DOES still tag real animation components", () => {
+    const tagged = tag(enrich(["Animated", "AnimatedView", "MotionView", "FadeTransition"]));
+    for (const n of ["Animated", "AnimatedView", "MotionView", "FadeTransition"]) {
+      expect(tagged.components.get(n)!.isAnimated).toBe(true);
+    }
+  });
+});

--- a/packages/tool-server/test/react-profiler-animated-pattern.test.ts
+++ b/packages/tool-server/test/react-profiler-animated-pattern.test.ts
@@ -71,22 +71,32 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
       expect(tagged.components.get(n)!.isAnimated).toBe(false);
     }
   });
-  it("DOES still tag real animation components with a digit/underscore/acronym boundary", () => {
-    // A leading-boundary requirement (preceded by lowercase/digit) would reject
-    // these — acronym-prefixed wrapper names and digit/underscore suffixes are
-    // common in real component trees and must still be recognized as animated.
-    const names = [
-      "Animated2",
-      "Animated_View",
-      "Motion360Player",
-      "HTTPTransitionHandler",
-      "SVGAnimatedPath",
-      "URLAnimation",
-      "IOSMotionView",
-    ];
+  it("DOES still tag real animation components with a digit/underscore suffix", () => {
+    // A digit/underscore right after the token is a legitimate PascalCase
+    // continuation (numbered/keyed variants) and must still be recognized.
+    const names = ["Animated2", "Animated_View", "Motion360Player"];
     const tagged = tag(enrich(names));
     for (const n of names) {
       expect(tagged.components.get(n)!.isAnimated).toBe(true);
+    }
+  });
+  it("does NOT tag a real, non-animation acronym-prefixed name", () => {
+    // Without a leading-boundary requirement, an acronym immediately followed
+    // by the token (no lowercase-to-uppercase transition) reads as a match
+    // with nothing to reject it. CMMotionManager/CMMotionActivity are real
+    // Apple CoreMotion SDK class names with nothing to do with animation —
+    // a React Native wrapper/bridge component plausibly named after them must
+    // not be silently excluded from profiler findings.
+    const names = [
+      "CMMotionManager",
+      "CMMotionActivity",
+      "IOMotionSensor",
+      "RNMotionDetector",
+      "GPSMotionTracker",
+    ];
+    const tagged = tag(enrich(names));
+    for (const n of names) {
+      expect(tagged.components.get(n)!.isAnimated).toBe(false);
     }
   });
 });

--- a/packages/tool-server/test/react-profiler-animated-pattern.test.ts
+++ b/packages/tool-server/test/react-profiler-animated-pattern.test.ts
@@ -65,10 +65,21 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
   it("does NOT tag a capitalized token that merely trails into lowercase letters", () => {
     // Case-sensitivity alone isn't a boundary: without one, "MotionlessIndicator"
     // still matches "Motion" as a bare substring, same bug class as the
-    // original lowercase false positives.
-    const tagged = tag(enrich(["MotionlessIndicator", "AnimationsDisabledBanner"]));
-    for (const n of ["MotionlessIndicator", "AnimationsDisabledBanner"]) {
-      expect(tagged.components.get(n)!.isAnimated).toBe(false);
+    // original lowercase false positives. One case per token so each token's
+    // trailing boundary is pinned independently — otherwise a regression that
+    // reopened this bug for a single token (Transition especially: it is a heavy
+    // non-animation word — state machines, `TransitionalScreen`) would hide
+    // behind the other tokens sharing the same regex and leave the suite green.
+    const names = [
+      "MotionlessIndicator", // Motion
+      "AnimationsDisabledBanner", // Animation
+      "TransitionalScreen", // Transition
+      "TransitionerRow", // Transition
+      "AnimatedlyBanner", // Animated ("animatedly" adverb) trailing into lowercase
+    ];
+    const tagged = tag(enrich(names));
+    for (const n of names) {
+      expect(tagged.components.get(n)!.isAnimated, n).toBe(false);
     }
   });
   it("DOES still tag real animation components with a digit/underscore suffix", () => {
@@ -125,11 +136,16 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
     }
   });
 
-  // Full match/no-match matrix. The paren/dot/HOC-wrapped and dotted forms are
-  // the real regression this fix targets: they are the display names React DevTools
-  // actually produces for animated subtrees (and the exact prefixes the codebase
-  // hard-codes in skip-rules.ts / component-tree.ts), yet the over-tightened
-  // pre-fix regex failed to match them, leaking them back into findings.
+  // Full match/no-match matrix, covering every token's wrapped/dotted forms —
+  // not just Animated* — so a token-specific boundary regression in Motion,
+  // Transition, or Animation can't ride on the Animated cases staying green.
+  // The paren/dot/HOC-wrapped forms are the display names React DevTools produces
+  // for animated subtrees. Only the parenthesized `Animated(...)` /
+  // `AnimatedComponent(...)` forms are what skip-rules.ts / component-tree.ts
+  // hard-code as skips; the dotted (`Animated.View`, `Motion.View`), other-token,
+  // and nested-HOC (`Memo(AnimatedComponent(View))`) forms go beyond those two
+  // prefixes. An intermediate, over-tightened version of this regex failed to
+  // match the wrapped forms, leaking them back into findings.
   const MUST_MATCH = [
     "Animated",
     "AnimatedView",
@@ -148,6 +164,15 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
     "Transition",
     "Animated2",
     "Animated_View",
+    // Other-token wrapped/dotted forms — asserted so Motion/Transition/Animation
+    // are pinned symmetrically with Animated (Motion.View = @legendapp/motion;
+    // Transition(...) = react-transition-group HOC display name).
+    "Motion.View",
+    "Motion(View)",
+    "Transition(View)",
+    "Transition.View",
+    "Animation.View",
+    "Animation(View)",
   ];
   const MUST_NOT_MATCH = [
     "PromotionCard",
@@ -176,7 +201,13 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
   });
 
   it("excludes wrapped animation names from rank() findings while keeping real slow components", () => {
-    const wrappers = ["Animated(View)", "Animated.View", "Memo(AnimatedComponent(View))"];
+    const wrappers = [
+      "Animated(View)",
+      "Animated.View",
+      "Memo(AnimatedComponent(View))",
+      "Motion.View",
+      "Transition(View)",
+    ];
     const tagged = tag(enrich([...wrappers, "PromotionCard"]));
     const ranked = rank(tagged).map((f) => f.component);
     for (const n of wrappers) {

--- a/packages/tool-server/test/react-profiler-animated-pattern.test.ts
+++ b/packages/tool-server/test/react-profiler-animated-pattern.test.ts
@@ -62,4 +62,13 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
       expect(tagged.components.get(n)!.isAnimated).toBe(true);
     }
   });
+  it("does NOT tag a capitalized token that merely trails into lowercase letters", () => {
+    // Case-sensitivity alone isn't a boundary: without one, "MotionlessIndicator"
+    // still matches "Motion" as a bare substring, same bug class as the
+    // original lowercase false positives.
+    const tagged = tag(enrich(["MotionlessIndicator", "AnimationsDisabledBanner"]));
+    for (const n of ["MotionlessIndicator", "AnimationsDisabledBanner"]) {
+      expect(tagged.components.get(n)!.isAnimated).toBe(false);
+    }
+  });
 });

--- a/packages/tool-server/test/react-profiler-animated-pattern.test.ts
+++ b/packages/tool-server/test/react-profiler-animated-pattern.test.ts
@@ -71,4 +71,22 @@ describe("ANIMATED_PATTERN matches only real animation segments", () => {
       expect(tagged.components.get(n)!.isAnimated).toBe(false);
     }
   });
+  it("DOES still tag real animation components with a digit/underscore/acronym boundary", () => {
+    // A leading-boundary requirement (preceded by lowercase/digit) would reject
+    // these — acronym-prefixed wrapper names and digit/underscore suffixes are
+    // common in real component trees and must still be recognized as animated.
+    const names = [
+      "Animated2",
+      "Animated_View",
+      "Motion360Player",
+      "HTTPTransitionHandler",
+      "SVGAnimatedPath",
+      "URLAnimation",
+      "IOSMotionView",
+    ];
+    const tagged = tag(enrich(names));
+    for (const n of names) {
+      expect(tagged.components.get(n)!.isAnimated).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Defect

In `packages/tool-server/src/utils/react-profiler/pipeline/03-tag.ts`, the animation-detection regex was both unanchored and case-insensitive:

```ts
const ANIMATED_PATTERN = /(Animated|Animation|Transition|Motion)/i;
```

Because of the `/i` flag, the token `Motion` matches the lowercase substring "motion" that appears inside perfectly ordinary PascalCase component names: `PromotionCard`, `EmotionThemeCard`, `CommotionList`, `LocomotionView`, and so on. Those components get tagged `isAnimated = true` in stage 3, and stage 4 (`04-rank.ts`) then unconditionally drops every animated component from the findings (`if (comp.isAnimated) continue;`).

The result: a genuinely slow or frequently re-rendering component such as `PromotionCard` silently disappears from the report's Top Components / Suggested Improvements, even though it is exactly the kind of component the profiler exists to surface. `ProductCard` (no "motion" substring) is handled correctly, which is what makes the bug easy to miss.

## Fix

Dropping only the `/i` flag removes the lowercase-embedded false positives, but still mis-tags acronym/number-glued names such as `SVGAnimatedPath`, `RNAnimatedView`, and `MotionlessIndicator`. So the committed pattern anchors the token to a genuine PascalCase segment boundary:

```ts
const ANIMATED_PATTERN = /(?<![A-Z0-9])(Animated|Animation|Transition|Motion)(?=[A-Z0-9_(.]|$)/;
```

- **Case-sensitive**, so a lowercase-embedded "motion" (`PromotionCard`, `Emotion`, `Locomotion`) never contains the capitalized token.
- The leading `(?<![A-Z0-9])` rejects acronym/number-glued prefixes (`SVGAnimatedPath`, `RNAnimatedView`, `CMMotionManager`, `G2MotionSensor`) where the token is not a real PascalCase word-start.
- The trailing `(?=[A-Z0-9_(.]|$)` requires the token to end a segment — another capitalized word, a digit/underscore, `(` or `.` (HOC/dotted display names like `Animated(View)`, `Animated.View`), or end-of-string — so it still matches real names while rejecting tokens that bleed into more lowercase (`MotionlessIndicator`).

**Known limitation:** a bare `Motion` starting a PascalCase word (`MotionSensor`, `MotionManager`) still matches — it is structurally indistinguishable from a real animation name of the same shape (`MotionView`, and `@legendapp/motion`'s `Motion.View`) that we intend to tag. This over-tag is accepted collateral (it only excludes a component from perf findings); a hardcoded device-motion denylist would be more fragile than the rare false positive it removes. The behavior is documented in the code comment and pinned by a test.

## Tests

`packages/tool-server/test/react-profiler-animated-pattern.test.ts` covers:
- lowercase-embedded false positives (`PromotionCard`, `EmotionThemeCard`, `CommotionList`, `ProductCard`) → `isAnimated = false`, and `PromotionCard` reappears in `rank()` findings;
- real animation components (`Animated`, `AnimatedView`, `MotionView`, `FadeTransition`, dotted/HOC forms) → `isAnimated = true`;
- acronym-prefixed and digit-suffixed device-motion names (`CMMotionManager`, `G2MotionSensor`, …) → `isAnimated = false`;
- the accepted bare-`Motion` device-name over-tag (`MotionSensor`, `MotionManager`, `MotionDetector`, `MotionTracker` → `isAnimated = true`), pinned so any future change is deliberate.

The suite fails against the old `/i` regex and passes with the fix. `tsc --build` and ESLint on the changed files are clean.
