### PR TITLE
fix(tools-client): key downloaded-artifact cache by unique id, not filename

### DIFF
--- a/packages/argent-tools-client/src/artifacts.ts
+++ b/packages/argent-tools-client/src/artifacts.ts
@@ -248,7 +248,14 @@ export async function materializeArtifacts(
         // whole. Mirrors the gate's size check on the local path; skipped when
         // size is unknown (0, e.g. a lazily-registered file).
         if (value.size > 0 && data.length !== value.size) return null;
-        const downloadedPath = join(dir, sanitizeSegment(value.filename));
+        // Key the cache path by the unique `id`, not `filename`: `filename`
+        // defaults to `basename(hostPath)` server-side and carries no uniqueness
+        // guarantee, so two distinct handles in one result can share it. Keying
+        // by filename alone would collide them onto one path — the second
+        // download overwriting the first, and both handles rewritten to those
+        // bytes. The id prefix keeps the human-readable filename while making
+        // the path collision-free.
+        const downloadedPath = join(dir, sanitizeSegment(`${value.id}-${value.filename}`));
         await writeFile(downloadedPath, data);
         if (value.mimeType.startsWith("image/")) {
           images.push({ localPath: downloadedPath, data, mimeType: value.mimeType });

--- a/packages/argent-tools-client/test/artifacts-collision.test.ts
+++ b/packages/argent-tools-client/test/artifacts-collision.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { materializeArtifacts, ARTIFACT_MARKER, type ArtifactHandle } from "../src/artifacts.js";
+
+const h = (p: Partial<ArtifactHandle>): ArtifactHandle =>
+  ({
+    [ARTIFACT_MARKER]: true,
+    id: "x",
+    filename: "f.bin",
+    mimeType: "application/octet-stream",
+    size: 0,
+    ...p,
+  }) as ArtifactHandle;
+
+describe("materializeArtifacts keys the download cache by unique id", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "art-collision-"));
+    process.env.ARGENT_ARTIFACTS_DIR = root;
+  });
+
+  afterEach(async () => {
+    delete process.env.ARGENT_ARTIFACTS_DIR;
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("two same-filename artifacts keep their own content", async () => {
+    const bodies: Record<string, string> = { "1": "AAA", "2": "BBBBBB" };
+    const fetchImpl = (async (url: string) => {
+      const id = url.split("/").pop()!;
+      const buf = Buffer.from(bodies[id]!);
+      return {
+        ok: true,
+        arrayBuffer: async () => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+      };
+    }) as unknown as typeof fetch;
+
+    const result = {
+      a: h({ id: "1", filename: "shot.png", mimeType: "image/png", size: 3 }),
+      b: h({ id: "2", filename: "shot.png", mimeType: "image/png", size: 6 }),
+    };
+    const out = await materializeArtifacts(result, {
+      toolsUrl: "http://server",
+      deviceId: "dev1",
+      fetchImpl,
+    });
+    const r = out.result as { a: string; b: string };
+
+    // Distinct ids must resolve to distinct local paths…
+    expect(r.a).not.toBe(r.b);
+    // …each holding its own downloaded bytes (filename-keyed caching collided them).
+    expect(await readFile(r.a, "utf8")).toBe("AAA");
+    expect(await readFile(r.b, "utf8")).toBe("BBBBBB");
+  });
+});


### PR DESCRIPTION
## Defect

In `packages/argent-tools-client/src/artifacts.ts`, the `materializeArtifacts()` download path cached the downloaded bytes at a path keyed by `value.filename`:

```ts
const downloadedPath = join(dir, sanitizeSegment(value.filename));
```

`filename` carries no uniqueness guarantee — server-side it defaults to `basename(hostPath)`, while the wire `id` field is the unique identifier. So two distinct `ArtifactHandle`s in one result that share a `filename` mapped to the **same** local file: the second download overwrote the first, and both handles were rewritten to that one path. The first artifact's path then contained the second's bytes (and for an array of same-named handles, the concurrent `Promise.all` writes could even race).

Only the download branch (remote / `argent link` mode, or when the local integrity check misses) was affected. The co-located `hostPath` fast-path is correct and is left unchanged.

### Repro

`materializeArtifacts` on `{ a: {id:"1", filename:"shot.png", …}, b: {id:"2", filename:"shot.png", …} }` with a fetch returning `"AAA"` for id 1 and `"BBBBBB"` for id 2 → reading the rewritten path for `a` yields `"BBBBBB"` (should be `"AAA"`), because both handles resolve to the same `shot.png` cache path.

## Fix

Key the download cache path by the unique `id` while keeping the human-readable filename:

```ts
const downloadedPath = join(dir, sanitizeSegment(`${value.id}-${value.filename}`));
```

Distinct artifacts can no longer collide, the filename stays legible in the path, and the existing flat cache dir + `sanitizeSegment` usage is preserved (no new directory to create). The local `hostPath` fast-path is untouched.

## Impact

Today's first-party tools happen to emit distinct basenames, so current real-world impact is low. But this is a genuine correctness violation of a public API for inputs the wire format explicitly allows — same-`filename`, distinct-`id` handles — so a remote/linked tool-server (or any future tool emitting same-named artifacts) would silently serve one artifact's bytes under another's path.

## Test

Adds `packages/argent-tools-client/test/artifacts-collision.test.ts`, which materializes two same-`filename`, distinct-`id` image handles through the injected `fetchImpl` download branch and asserts each rewritten path holds its own content. Verified it **fails** before the fix (both paths identical) and **passes** after. Full package suite: 114 tests pass; `tsc --build` and `eslint` clean.
