### PR TITLE
fix(chromium): don't leak the screencast refcount on a failed start

### DIFF
--- a/packages/tool-server/src/chromium-server/screencast.ts
+++ b/packages/tool-server/src/chromium-server/screencast.ts
@@ -44,6 +44,15 @@ export class ScreencastManager {
   async start(opts: ScreencastOpts = {}): Promise<ScreencastSession> {
     this.installCdpListenerOnce();
 
+    // Tracks whether THIS call actually took a refcount slot. A call whose
+    // underlying Page.startScreencast raced a forceStop() and lost (the
+    // `startInFlight === inFlight` guards below) must return a session whose
+    // stop() is a true no-op — otherwise, once a later legitimate session
+    // starts and takes the same slot index, this phantom's stop() would
+    // decrement activeCount and potentially fire Page.stopScreencast for a
+    // stream this caller was never actually subscribed to.
+    let acquired = false;
+
     if (this.startInFlight) {
       // A first caller is mid-Page.startScreencast. Join the SAME in-flight start
       // rather than assuming a live session: await it so a transient failure
@@ -60,6 +69,7 @@ export class ScreencastManager {
       if (this.activeCount > 0) {
         if (this.optsDiffer(opts, this.currentOpts)) this.warnOptsIgnored();
         this.activeCount += 1;
+        acquired = true;
       }
     } else if (this.activeCount === 0) {
       // First subscriber, nothing in flight: issue Page.startScreencast and
@@ -83,21 +93,24 @@ export class ScreencastManager {
       if (this.startInFlight === inFlight) {
         this.startInFlight = null;
         this.activeCount += 1;
+        acquired = true;
       }
       // else: a forceStop()/dispose superseded this start while it was in flight,
       // so the screencast we started is already torn down — don't take a refcount
-      // for it (the returned session's stop() is then a harmless no-op). Mirrors
-      // the catch path's `startInFlight === inFlight` identity guard.
+      // for it (`acquired` stays false, so the returned session's stop() is a
+      // true no-op). Mirrors the catch path's `startInFlight === inFlight`
+      // identity guard.
     } else {
       // A live session is already running: join it (first writer wins on opts).
       if (this.optsDiffer(opts, this.currentOpts)) this.warnOptsIgnored();
       this.activeCount += 1;
+      acquired = true;
     }
 
     let stopped = false;
     const session: ScreencastSession = {
       stop: async () => {
-        if (stopped) return;
+        if (stopped || !acquired) return;
         stopped = true;
         this.activeCount = Math.max(0, this.activeCount - 1);
         if (this.activeCount === 0) {

--- a/packages/tool-server/src/chromium-server/screencast.ts
+++ b/packages/tool-server/src/chromium-server/screencast.ts
@@ -42,7 +42,17 @@ export class ScreencastManager {
     this.activeCount += 1;
     if (this.activeCount === 1) {
       this.currentOpts = opts;
-      await this.cdp.send("Page.startScreencast", this.toCdpStartArgs(opts));
+      try {
+        await this.cdp.send("Page.startScreencast", this.toCdpStartArgs(opts));
+      } catch (err) {
+        // Roll the refcount back so a transient failure doesn't wedge the
+        // manager: the caller never receives a session handle to undo the
+        // increment, so the next start() must see activeCount back at 0 and
+        // re-issue Page.startScreencast instead of assuming a live session.
+        this.activeCount = Math.max(0, this.activeCount - 1);
+        this.currentOpts = null;
+        throw err;
+      }
     } else if (this.optsDiffer(opts, this.currentOpts)) {
       // Subsequent callers join the existing session and accept whatever
       // format / quality / size the first caller chose. Forcing a restart

--- a/packages/tool-server/src/chromium-server/screencast.ts
+++ b/packages/tool-server/src/chromium-server/screencast.ts
@@ -17,6 +17,11 @@ import type { ScreencastFrame, ScreencastOpts, ScreencastSession, ServerEvents }
 export class ScreencastManager {
   private activeCount = 0;
   private currentOpts: ScreencastOpts | null = null;
+  // The in-flight Page.startScreencast promise for the first subscriber, shared
+  // so concurrent joiners await the SAME start instead of assuming a live
+  // session (and stranding themselves on a frame-less stream if it fails). Null
+  // when no start is in flight (idle, or a live session already running).
+  private startInFlight: Promise<void> | null = null;
   private lastFrame: ScreencastFrame | null = null;
   private cdpListenerInstalled = false;
 
@@ -39,27 +44,41 @@ export class ScreencastManager {
   async start(opts: ScreencastOpts = {}): Promise<ScreencastSession> {
     this.installCdpListenerOnce();
 
-    this.activeCount += 1;
-    if (this.activeCount === 1) {
+    if (this.startInFlight) {
+      // A first caller is mid-Page.startScreencast. Join the SAME in-flight start
+      // rather than assuming a live session: await it so a transient failure
+      // fails us too, and only take a refcount once the screencast is actually
+      // running. Incrementing before this await — as the naive refcount did —
+      // strands this caller on a frame-less stream when the owner's start
+      // rejects (activeCount never drains to 0, so no later start re-issues).
+      await this.startInFlight;
+      if (this.optsDiffer(opts, this.currentOpts)) this.warnOptsIgnored();
+      this.activeCount += 1;
+    } else if (this.activeCount === 0) {
+      // First subscriber, nothing in flight: issue Page.startScreencast and
+      // publish the promise so concurrent joiners await it. On failure nothing
+      // is left behind — no refcount, no currentOpts, no phantom session — so
+      // the next start() re-issues cleanly.
       this.currentOpts = opts;
+      const inFlight = this.cdp
+        .send("Page.startScreencast", this.toCdpStartArgs(opts))
+        .then(() => undefined);
+      this.startInFlight = inFlight;
       try {
-        await this.cdp.send("Page.startScreencast", this.toCdpStartArgs(opts));
+        await inFlight;
       } catch (err) {
-        // Roll the refcount back so a transient failure doesn't wedge the
-        // manager: the caller never receives a session handle to undo the
-        // increment, so the next start() must see activeCount back at 0 and
-        // re-issue Page.startScreencast instead of assuming a live session.
-        this.activeCount = Math.max(0, this.activeCount - 1);
-        this.currentOpts = null;
+        if (this.startInFlight === inFlight) {
+          this.startInFlight = null;
+          this.currentOpts = null;
+        }
         throw err;
       }
-    } else if (this.optsDiffer(opts, this.currentOpts)) {
-      // Subsequent callers join the existing session and accept whatever
-      // format / quality / size the first caller chose. Forcing a restart
-      // would tear down the first caller's stream mid-frame.
-      process.stderr.write(
-        `[chromium-screencast] additional caller requested screencast opts that differ from the active session; ignoring (first writer wins).\n`
-      );
+      if (this.startInFlight === inFlight) this.startInFlight = null;
+      this.activeCount += 1;
+    } else {
+      // A live session is already running: join it (first writer wins on opts).
+      if (this.optsDiffer(opts, this.currentOpts)) this.warnOptsIgnored();
+      this.activeCount += 1;
     }
 
     let stopped = false;
@@ -83,9 +102,19 @@ export class ScreencastManager {
   async forceStop(): Promise<void> {
     this.activeCount = 0;
     this.currentOpts = null;
+    this.startInFlight = null;
     await this.cdp.send("Page.stopScreencast").catch(() => {
       /* ignore */
     });
+  }
+
+  private warnOptsIgnored(): void {
+    // Subsequent callers join the existing session and accept whatever format /
+    // quality / size the first caller chose. Forcing a restart would tear down
+    // the first caller's stream mid-frame.
+    process.stderr.write(
+      `[chromium-screencast] additional caller requested screencast opts that differ from the active session; ignoring (first writer wins).\n`
+    );
   }
 
   private installCdpListenerOnce(): void {

--- a/packages/tool-server/src/chromium-server/screencast.ts
+++ b/packages/tool-server/src/chromium-server/screencast.ts
@@ -52,8 +52,15 @@ export class ScreencastManager {
       // strands this caller on a frame-less stream when the owner's start
       // rejects (activeCount never drains to 0, so no later start re-issues).
       await this.startInFlight;
-      if (this.optsDiffer(opts, this.currentOpts)) this.warnOptsIgnored();
-      this.activeCount += 1;
+      // If forceStop()/dispose superseded the start while we awaited, the owner
+      // took no refcount and the screencast is torn down — don't take a phantom
+      // one either. The owner's success continuation runs before ours (microtask
+      // FIFO on the shared promise), so activeCount already reflects whether the
+      // start was superseded (0) or is live (>0). Mirrors the owner-path guard.
+      if (this.activeCount > 0) {
+        if (this.optsDiffer(opts, this.currentOpts)) this.warnOptsIgnored();
+        this.activeCount += 1;
+      }
     } else if (this.activeCount === 0) {
       // First subscriber, nothing in flight: issue Page.startScreencast and
       // publish the promise so concurrent joiners await it. On failure nothing

--- a/packages/tool-server/src/chromium-server/screencast.ts
+++ b/packages/tool-server/src/chromium-server/screencast.ts
@@ -73,8 +73,14 @@ export class ScreencastManager {
         }
         throw err;
       }
-      if (this.startInFlight === inFlight) this.startInFlight = null;
-      this.activeCount += 1;
+      if (this.startInFlight === inFlight) {
+        this.startInFlight = null;
+        this.activeCount += 1;
+      }
+      // else: a forceStop()/dispose superseded this start while it was in flight,
+      // so the screencast we started is already torn down — don't take a refcount
+      // for it (the returned session's stop() is then a harmless no-op). Mirrors
+      // the catch path's `startInFlight === inFlight` identity guard.
     } else {
       // A live session is already running: join it (first writer wins on opts).
       if (this.optsDiffer(opts, this.currentOpts)) this.warnOptsIgnored();

--- a/packages/tool-server/test/chromium-screencast-refcount.test.ts
+++ b/packages/tool-server/test/chromium-screencast-refcount.test.ts
@@ -60,4 +60,40 @@ describe("ScreencastManager recovers after a failed start", () => {
     expect(recovered).toBeTruthy();
     expect(send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length).toBe(1);
   });
+
+  it("takes no phantom refcount when forceStop races a successful start", async () => {
+    // forceStop() (dispose) tears the screencast down while the owner's
+    // Page.startScreencast is still in flight; when it then SUCCEEDS the owner
+    // must NOT take a refcount for the now-torn-down screencast, or a later
+    // start() would see activeCount != 0 and skip re-issuing.
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    let startCalls = 0;
+    const send = vi.fn(async (method: string) => {
+      if (method === "Page.startScreencast") {
+        startCalls += 1;
+        if (startCalls === 1) await startGate;
+      }
+      return {};
+    });
+    const cdp = { events: new TypedEventEmitter(), send } as never;
+    const mgr = new ScreencastManager(
+      cdp,
+      new TypedEventEmitter() as never,
+      { recordFrame: () => {} } as never
+    );
+
+    const starting = mgr.start(); // owner: startScreencast gated (in flight)
+    await Promise.resolve();
+    await mgr.forceStop(); // dispose-style teardown mid-start
+    releaseStart(); // the gated start now resolves
+    await starting;
+
+    // No phantom refcount ⇒ a fresh start re-issues Page.startScreencast.
+    send.mockClear();
+    await mgr.start();
+    expect(send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length).toBe(1);
+  });
 });

--- a/packages/tool-server/test/chromium-screencast-refcount.test.ts
+++ b/packages/tool-server/test/chromium-screencast-refcount.test.ts
@@ -96,4 +96,41 @@ describe("ScreencastManager recovers after a failed start", () => {
     await mgr.start();
     expect(send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length).toBe(1);
   });
+
+  it("takes no phantom refcount when forceStop races a successful start with a joiner", async () => {
+    // Same race, but a JOINER is present when forceStop tears the screencast
+    // down and the owner's start then succeeds — the joiner must not take a
+    // phantom refcount either.
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    let startCalls = 0;
+    const send = vi.fn(async (method: string) => {
+      if (method === "Page.startScreencast") {
+        startCalls += 1;
+        if (startCalls === 1) await startGate;
+      }
+      return {};
+    });
+    const cdp = { events: new TypedEventEmitter(), send } as never;
+    const mgr = new ScreencastManager(
+      cdp,
+      new TypedEventEmitter() as never,
+      { recordFrame: () => {} } as never
+    );
+
+    const owner = mgr.start(); // owner: startScreencast gated (in flight)
+    const joiner = mgr.start(); // joiner: joins the in-flight start
+    await Promise.resolve();
+    await mgr.forceStop(); // dispose-style teardown mid-start
+    releaseStart(); // the gated start now resolves
+    await owner;
+    await joiner;
+
+    // Neither owner nor joiner took a refcount ⇒ a fresh start re-issues.
+    send.mockClear();
+    await mgr.start();
+    expect(send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length).toBe(1);
+  });
 });

--- a/packages/tool-server/test/chromium-screencast-refcount.test.ts
+++ b/packages/tool-server/test/chromium-screencast-refcount.test.ts
@@ -19,4 +19,45 @@ describe("ScreencastManager recovers after a failed start", () => {
     await mgr.start();
     expect(send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length).toBe(1);
   });
+
+  it("does not strand a concurrent joiner when the owner's start rejects", async () => {
+    // The owner's Page.startScreencast is gated so a second caller can join
+    // while it is in flight, then the owner's start rejects. The joiner must
+    // reject too (not hold a session for a screencast that never started), the
+    // refcount must drain to 0, and a later start must re-issue cleanly.
+    let releaseFirst!: (fail: boolean) => void;
+    const firstGate = new Promise<boolean>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let calls = 0;
+    const send = vi.fn(async (method: string) => {
+      if (method === "Page.startScreencast") {
+        calls += 1;
+        if (calls === 1 && (await firstGate)) throw new Error("transient");
+      }
+      return {};
+    });
+    const cdp = { events: new TypedEventEmitter(), send } as never;
+    const mgr = new ScreencastManager(
+      cdp,
+      new TypedEventEmitter() as never,
+      { recordFrame: () => {} } as never
+    );
+
+    const owner = mgr.start(); // owner: startScreencast is in flight (gated)
+    const joiner = mgr.start(); // joiner: enters while the owner's start is in flight
+    // Attach rejection handlers before releasing the gate (no unhandled reject).
+    const ownerRejects = expect(owner).rejects.toThrow(/transient/);
+    const joinerRejects = expect(joiner).rejects.toThrow(/transient/);
+    await Promise.resolve();
+    releaseFirst(true); // fail the owner's start
+    await ownerRejects;
+    await joinerRejects;
+
+    // Fully drained: a fresh start re-issues Page.startScreencast and succeeds.
+    send.mockClear();
+    const recovered = await mgr.start();
+    expect(recovered).toBeTruthy();
+    expect(send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length).toBe(1);
+  });
 });

--- a/packages/tool-server/test/chromium-screencast-refcount.test.ts
+++ b/packages/tool-server/test/chromium-screencast-refcount.test.ts
@@ -133,4 +133,51 @@ describe("ScreencastManager recovers after a failed start", () => {
     await mgr.start();
     expect(send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length).toBe(1);
   });
+
+  it("a phantom session's stop() does not steal a later live session's refcount", async () => {
+    // forceStop() supersedes an owner's in-flight start; that start then
+    // SUCCEEDS anyway (this is the same race the two tests above cover, which
+    // assert no refcount is taken). This test goes one step further: a real
+    // session B then starts on the same manager, and the phantom session's
+    // stop() must be a true no-op — not decrement activeCount and potentially
+    // tear down B's live stream out from under it.
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    let startCalls = 0;
+    const send = vi.fn(async (method: string) => {
+      if (method === "Page.startScreencast") {
+        startCalls += 1;
+        if (startCalls === 1) await startGate;
+      }
+      return {};
+    });
+    const cdp = { events: new TypedEventEmitter(), send } as never;
+    const mgr = new ScreencastManager(
+      cdp,
+      new TypedEventEmitter() as never,
+      { recordFrame: () => {} } as never
+    );
+    const stopCount = () => send.mock.calls.filter((c) => c[0] === "Page.stopScreencast").length;
+
+    const phantomStarting = mgr.start(); // startScreencast gated (in flight)
+    await Promise.resolve();
+    await mgr.forceStop(); // supersedes the in-flight start (calls stopScreencast once)
+    releaseStart(); // the superseded start now resolves successfully anyway
+    const phantom = await phantomStarting;
+
+    // A real session B starts fresh (activeCount was drained to 0 by forceStop).
+    send.mockClear();
+    const b = await mgr.start();
+    expect(stopCount()).toBe(0);
+
+    // The phantom's stop() must not touch B's session.
+    await phantom.stop();
+    expect(stopCount()).toBe(0);
+
+    // B's own stop() still works normally.
+    await b.stop();
+    expect(stopCount()).toBe(1);
+  });
 });

--- a/packages/tool-server/test/chromium-screencast-refcount.test.ts
+++ b/packages/tool-server/test/chromium-screencast-refcount.test.ts
@@ -180,4 +180,57 @@ describe("ScreencastManager recovers after a failed start", () => {
     await b.stop();
     expect(stopCount()).toBe(1);
   });
+
+  it("a joiner on a succeeding in-flight start shares one screencast and stops it once on the last drop", async () => {
+    // Happy-path counterpart to "does not strand a concurrent joiner when the
+    // owner's start rejects": the owner's Page.startScreencast is gated so a
+    // joiner enters while it is in flight, then the start SUCCEEDS. Both callers
+    // must take a refcount (active count 2) off a SINGLE Page.startScreencast,
+    // and on teardown Page.stopScreencast must fire exactly once — on the last
+    // drop, not per session and not before the final consumer leaves.
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let calls = 0;
+    const send = vi.fn(async (method: string) => {
+      if (method === "Page.startScreencast") {
+        calls += 1;
+        if (calls === 1) await firstGate;
+      }
+      return {};
+    });
+    const cdp = { events: new TypedEventEmitter(), send } as never;
+    const mgr = new ScreencastManager(
+      cdp,
+      new TypedEventEmitter() as never,
+      { recordFrame: () => {} } as never
+    );
+    // activeCount is a compile-time `private`; read it through a cast to assert
+    // the refcount transitions directly (0 → 2 → 1 → 0).
+    const activeCount = () => (mgr as unknown as { activeCount: number }).activeCount;
+    const startCount = () => send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length;
+    const stopCount = () => send.mock.calls.filter((c) => c[0] === "Page.stopScreencast").length;
+
+    const owner = mgr.start(); // owner: startScreencast is in flight (gated)
+    const joiner = mgr.start(); // joiner: enters while the owner's start is in flight
+    await Promise.resolve();
+    releaseFirst(); // the owner's start now succeeds
+    const ownerSession = await owner;
+    const joinerSession = await joiner;
+
+    // Both callers acquired off a single Page.startScreencast.
+    expect(startCount()).toBe(1);
+    expect(activeCount()).toBe(2);
+
+    // First drop: refcount falls to 1, Page.stopScreencast must NOT fire yet.
+    await ownerSession.stop();
+    expect(activeCount()).toBe(1);
+    expect(stopCount()).toBe(0);
+
+    // Last drop: refcount hits 0, Page.stopScreencast fires exactly once.
+    await joinerSession.stop();
+    expect(activeCount()).toBe(0);
+    expect(stopCount()).toBe(1);
+  });
 });

--- a/packages/tool-server/test/chromium-screencast-refcount.test.ts
+++ b/packages/tool-server/test/chromium-screencast-refcount.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { TypedEventEmitter } from "@argent/registry";
+import { ScreencastManager } from "../src/chromium-server/screencast";
+
+describe("ScreencastManager recovers after a failed start", () => {
+  it("re-issues Page.startScreencast after a transient failure", async () => {
+    let failNext = true;
+    const send = vi.fn(async (method: string) => {
+      if (method === "Page.startScreencast" && failNext) throw new Error("transient");
+      return {};
+    });
+    const cdp = { events: new TypedEventEmitter(), send } as never;
+    const events = new TypedEventEmitter() as never;
+    const fps = { recordFrame: () => {} } as never;
+    const mgr = new ScreencastManager(cdp, events, fps);
+    await expect(mgr.start()).rejects.toThrow(/transient/);
+    failNext = false;
+    send.mockClear();
+    await mgr.start();
+    expect(send.mock.calls.filter((c) => c[0] === "Page.startScreencast").length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Defect

`ScreencastManager` refcounts consumers of a single shared CDP screencast: 0→1 fires `Page.startScreencast`, the last dropper fires `Page.stopScreencast`. The real consumer is `GET /stream.mjpeg`, which does `session = await startScreencast(...)` and, on failure, ends the response without ever holding a session to stop.

The old code incremented `activeCount` **before** awaiting `Page.startScreencast`. If that CDP call rejected, `start()` threw with `activeCount` stuck at 1 and no session handed out. Every later `start()` then saw `activeCount !== 1`, skipped re-issuing `Page.startScreencast`, and returned a session subscribed to a stream that was never running — so a single transient failure wedged `/stream.mjpeg` (frozen, frame-less) for the rest of the device's lifetime.

## Fix

Rework `start()` into a single-flight design:
- The first subscriber publishes an in-flight `startInFlight` promise; concurrent joiners await that same promise, so a transient failure fails them too instead of leaving them attached to a dead stream.
- The refcount is taken **only after** `Page.startScreencast` actually resolves, so a failed start nets 0 (no leak); a successful start nets exactly +1.
- Each session carries an `acquired` flag; a session that lost a `forceStop()` race returns a no-op `stop()`. Identity guards (`startInFlight === inFlight`) on the success/catch/join paths handle a `forceStop()` landing mid-start, and `forceStop()` nulls `startInFlight`.

## Test

`test/chromium-screencast-refcount.test.ts` drives start→(fail)→start→stop against a CDP mock whose first `Page.startScreencast` rejects, and asserts the failed start drains to 0, the next start re-issues exactly one `Page.startScreencast`, `stop()` balances back to 0 with one `Page.stopScreencast`, a successful start nets +1, and a double `stop()` is a safe no-op. It fails on the pre-fix code (which leaks the count and never re-issues).
