### PR TITLE
fix(describe): preserve accessibility label/id when collapsing Android wrappers

### DIFF
--- a/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
@@ -313,6 +313,17 @@ function descendantText(parsed: ParsedXmlNode, maxChars = 120): string {
   const stack: ParsedXmlNode[] = [parsed];
   while (stack.length > 0) {
     const x = stack.pop()!;
+    // A password field's `text` is the secret. Never mine it — or its subtree —
+    // into a borrowed container label; this walk reads the raw XML and would
+    // otherwise bypass the "[password]" redaction the rest of the parser
+    // applies to a password node's own label. Substitute the redacted marker.
+    if (attrIsTrue(x.attrs, "password")) {
+      if (!seen.has("[password]")) {
+        seen.add("[password]");
+        parts.push("[password]");
+      }
+      continue;
+    }
     for (const k of ["text", "content-desc"] as const) {
       const v = (x.attrs[k] ?? "").trim();
       if (v && !seen.has(v)) {
@@ -451,6 +462,15 @@ function computeNodeOutput(
   const interactive = isInteractive(attrs);
   let label = labelOf(attrs);
 
+  // Password fields: keep the ref but never leak the value. Redact HERE, at the
+  // point the label is derived, not just before `makeUiNode` — the collapse
+  // sites below copy this node's `label` onto a surviving child and return
+  // early, so a late redaction would be bypassed and the secret would ride out
+  // on the collapsed tap target. Redacting at the source covers every path.
+  if (attrIsTrue(attrs, "password")) {
+    label = "[password]";
+  }
+
   // A resource-id is still worth keeping even with no label — dropping it
   // silently here is the same class of bug as the collapse cases below fixed
   // (a decorative-looking wrapper can still be a real, agent-addressable
@@ -530,11 +550,6 @@ function computeNodeOutput(
           !c.clickable
         )
     );
-  }
-
-  // Password fields: keep the ref but never leak the value.
-  if (attrIsTrue(attrs, "password")) {
-    label = "[password]";
   }
 
   const node = makeUiNode(attrs, deriveUiAutomatorRole(cls), bounds, label, keptChildren);

--- a/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
@@ -467,8 +467,19 @@ function computeNodeOutput(
 
   // Layout container with no own info — pass children through. With
   // --compressed dumps this is what flattens FrameLayout > LinearLayout >
-  // ConstraintLayout chains down to their actual content.
-  if (LAYOUT_CONTAINERS.has(cls) && !interactive && !label && !identifier) {
+  // ConstraintLayout chains down to their actual content. Keeping such a
+  // container just because it carries a resource-id would re-inflate the tree
+  // the v2 trim exists to shrink AND break the duplicate-wrapper collapse
+  // below (an id-bearing, non-clickable middle container stops a clickable
+  // parent from collapsing onto its clickable child). So still pass through —
+  // but don't silently lose the id: propagate it onto a lone surviving child
+  // that has none, so a container-only identifier stays addressable. With 0 or
+  // 2+ kept children there is no single target, so the scaffolding id is
+  // dropped, exactly as it was before id-preservation was added.
+  if (LAYOUT_CONTAINERS.has(cls) && !interactive && !label) {
+    if (identifier && keptChildren.length === 1 && !keptChildren[0]!.identifier) {
+      keptChildren[0]!.identifier = identifier;
+    }
     return keptChildren;
   }
 

--- a/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
@@ -471,35 +471,17 @@ function computeNodeOutput(
     label = "[password]";
   }
 
-  // A resource-id is still worth keeping even with no label — dropping it
-  // silently here is the same class of bug as the collapse cases below fixed
-  // (a decorative-looking wrapper can still be a real, agent-addressable
-  // target via its identifier alone). Only pass straight through when there's
-  // truly no identifying info at all.
-  const identifier = attrs["resource-id"];
-
-  // Decorative ImageView (no clickable, no label, no id) — drop, pass through
-  // any surviving descendants. Most decorative images have zero kept children
+  // Decorative ImageView (no clickable, no label) — drop, pass through any
+  // surviving descendants. Most decorative images have zero kept children
   // and the entire branch evaporates.
-  if (cls.endsWith(".ImageView") && !interactive && !label && !identifier) {
+  if (cls.endsWith(".ImageView") && !interactive && !label) {
     return keptChildren;
   }
 
   // Layout container with no own info — pass children through. With
   // --compressed dumps this is what flattens FrameLayout > LinearLayout >
-  // ConstraintLayout chains down to their actual content. Keeping such a
-  // container just because it carries a resource-id would re-inflate the tree
-  // the v2 trim exists to shrink AND break the duplicate-wrapper collapse
-  // below (an id-bearing, non-clickable middle container stops a clickable
-  // parent from collapsing onto its clickable child). So still pass through —
-  // but don't silently lose the id: propagate it onto a lone surviving child
-  // that has none, so a container-only identifier stays addressable. With 0 or
-  // 2+ kept children there is no single target, so the scaffolding id is
-  // dropped, exactly as it was before id-preservation was added.
+  // ConstraintLayout chains down to their actual content.
   if (LAYOUT_CONTAINERS.has(cls) && !interactive && !label) {
-    if (identifier && keptChildren.length === 1 && !keptChildren[0]!.identifier) {
-      keptChildren[0]!.identifier = identifier;
-    }
     return keptChildren;
   }
 

--- a/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
@@ -486,6 +486,14 @@ function computeNodeOutput(
   if (interactive && bounds && keptChildren.length === 1) {
     const c = keptChildren[0]!;
     if (c.clickable && c.pixelBounds && rectsEqual(c.pixelBounds, bounds)) {
+      // The inner node is usually the more specific one, so prefer its own
+      // label/identifier. But the accessibility label can live ONLY on the
+      // outer wrapper (an RN `Pressable accessibilityLabel` wrapping a bare
+      // clickable native view) — fall back to the wrapper's values so the
+      // collapsed tap target isn't left anonymous instead of dropping them.
+      if (!c.label && label) c.label = label;
+      const rid = attrs["resource-id"];
+      if (!c.identifier && rid) c.identifier = rid;
       return [c];
     }
   }
@@ -568,12 +576,17 @@ function finalizeUiNode(
       height: sh > 0 ? clipped.h / sh : 0,
     };
   } else {
-    // No bounds: drop empty wrappers, pass through single-child wrappers, and
-    // synthesise a union frame for 2+ children. Replacing the whole subtree
-    // with `null` silently dropped every child on Compose hierarchies that
-    // emit bounds-less group containers — preserved here for that case.
+    // No bounds: drop empty wrappers, pass through single-child scaffold
+    // wrappers, and synthesise a union frame for 2+ children. Replacing the
+    // whole subtree with `null` silently dropped every child on Compose
+    // hierarchies that emit bounds-less group containers — preserved here for
+    // that case. A single-child wrapper that carries its OWN label/identifier
+    // (e.g. a bounds-less Compose group container with a content-desc) must NOT
+    // be flattened into its child: doing so discards that accessibility label.
+    // Keep it as a node whose frame is the union of its (here, sole) child so
+    // neither the wrapper's nor the child's label is dropped.
     if (children.length === 0) return null;
-    if (children.length === 1) return children[0]!;
+    if (children.length === 1 && !n.label && !n.identifier) return children[0]!;
     const x1 = Math.min(...children.map((c) => c.frame.x));
     const y1 = Math.min(...children.map((c) => c.frame.y));
     const x2 = Math.max(...children.map((c) => c.frame.x + c.frame.width));

--- a/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/uiautomator-parser.ts
@@ -451,17 +451,24 @@ function computeNodeOutput(
   const interactive = isInteractive(attrs);
   let label = labelOf(attrs);
 
-  // Decorative ImageView (no clickable, no label) — drop, pass through any
-  // surviving descendants. Most decorative images have zero kept children
+  // A resource-id is still worth keeping even with no label — dropping it
+  // silently here is the same class of bug as the collapse cases below fixed
+  // (a decorative-looking wrapper can still be a real, agent-addressable
+  // target via its identifier alone). Only pass straight through when there's
+  // truly no identifying info at all.
+  const identifier = attrs["resource-id"];
+
+  // Decorative ImageView (no clickable, no label, no id) — drop, pass through
+  // any surviving descendants. Most decorative images have zero kept children
   // and the entire branch evaporates.
-  if (cls.endsWith(".ImageView") && !interactive && !label) {
+  if (cls.endsWith(".ImageView") && !interactive && !label && !identifier) {
     return keptChildren;
   }
 
   // Layout container with no own info — pass children through. With
   // --compressed dumps this is what flattens FrameLayout > LinearLayout >
   // ConstraintLayout chains down to their actual content.
-  if (LAYOUT_CONTAINERS.has(cls) && !interactive && !label) {
+  if (LAYOUT_CONTAINERS.has(cls) && !interactive && !label && !identifier) {
     return keptChildren;
   }
 

--- a/packages/tool-server/test/describe-android-label-preserve.test.ts
+++ b/packages/tool-server/test/describe-android-label-preserve.test.ts
@@ -48,6 +48,39 @@ describe("describe android collapse preserves label/identifier", () => {
     expect(nodes.filter((n) => n.role === "StaticText")).toHaveLength(2);
   });
 
+  it("collapse copies the wrapper's resource-id onto an id-less child", () => {
+    // A clickable wrapper carrying a resource-id collapses into its single
+    // anonymous clickable child; the child must inherit the wrapper's id so the
+    // tap target stays addressable by id.
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.view.ViewGroup" bounds="[0,0][100,50]" clickable="true" resource-id="com.app:id/likeBtn">\n    <node class="android.widget.Button" bounds="[0,0][100,50]" clickable="true" content-desc="" text=""/>\n  </node>\n</hierarchy>`;
+    const ids = flatten(parseUiAutomatorDump(xml, 100, 50))
+      .map((n) => n.identifier)
+      .filter(Boolean);
+    expect(ids).toContain("com.app:id/likeBtn");
+  });
+
+  it("collapse never overwrites a real child id with the wrapper's (child wins)", () => {
+    // Both wrapper and child carry an id: the child's own id must survive, not
+    // be clobbered by the collapsing wrapper's.
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.view.ViewGroup" bounds="[0,0][100,50]" clickable="true" resource-id="com.app:id/outer">\n    <node class="android.widget.Button" bounds="[0,0][100,50]" clickable="true" resource-id="com.app:id/inner" content-desc="" text=""/>\n  </node>\n</hierarchy>`;
+    const ids = flatten(parseUiAutomatorDump(xml, 100, 50))
+      .map((n) => n.identifier)
+      .filter(Boolean);
+    expect(ids).toContain("com.app:id/inner");
+    expect(ids).not.toContain("com.app:id/outer");
+  });
+
+  it("propagates a label across MORE THAN ONE collapse level", () => {
+    // Three levels: labeled wrapper → anonymous clickable → anonymous clickable
+    // leaf, all at identical bounds. The label must survive both collapses onto
+    // the single surviving tap target.
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.view.ViewGroup" bounds="[0,0][100,50]" clickable="true" content-desc="Submit form">\n    <node class="android.view.ViewGroup" bounds="[0,0][100,50]" clickable="true" content-desc="">\n      <node class="android.widget.Button" bounds="[0,0][100,50]" clickable="true" content-desc="" text=""/>\n    </node>\n  </node>\n</hierarchy>`;
+    const labels = flatten(parseUiAutomatorDump(xml, 100, 50))
+      .map((n) => n.label)
+      .filter(Boolean);
+    expect(labels).toContain("Submit form");
+  });
+
   it("duplicate-wrapper collapse must NOT leak an outer password field's value", () => {
     // Regression: the label fallback added to the duplicate-wrapper collapse
     // copies the outer node's label onto the surviving child. When the outer

--- a/packages/tool-server/test/describe-android-label-preserve.test.ts
+++ b/packages/tool-server/test/describe-android-label-preserve.test.ts
@@ -26,4 +26,23 @@ describe("describe android collapse preserves label/identifier", () => {
       .filter(Boolean);
     expect(labels).toContain("Profile photo");
   });
+  it("decorative ImageView collapse keeps its resource-id even with no label", () => {
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.widget.ImageView" bounds="[0,0][50,50]" resource-id="com.app:id/decorative_icon"/>\n</hierarchy>`;
+    const identifiers = flatten(parseUiAutomatorDump(xml, 100, 100))
+      .map((n) => n.identifier)
+      .filter(Boolean);
+    expect(identifiers).toContain("com.app:id/decorative_icon");
+  });
+  it("layout-container collapse keeps its resource-id even with no label", () => {
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.widget.FrameLayout" bounds="[0,0][100,100]" resource-id="com.app:id/header_container">\n    <node class="android.widget.TextView" bounds="[0,0][100,100]" text="Hello"/>\n  </node>\n</hierarchy>`;
+    const tree = parseUiAutomatorDump(xml, 100, 100);
+    const identifiers = flatten(tree)
+      .map((n) => n.identifier)
+      .filter(Boolean);
+    const labels = flatten(tree)
+      .map((n) => n.label)
+      .filter(Boolean);
+    expect(identifiers).toContain("com.app:id/header_container");
+    expect(labels).toContain("Hello");
+  });
 });

--- a/packages/tool-server/test/describe-android-label-preserve.test.ts
+++ b/packages/tool-server/test/describe-android-label-preserve.test.ts
@@ -36,13 +36,41 @@ describe("describe android collapse preserves label/identifier", () => {
   it("layout-container collapse keeps its resource-id even with no label", () => {
     const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.widget.FrameLayout" bounds="[0,0][100,100]" resource-id="com.app:id/header_container">\n    <node class="android.widget.TextView" bounds="[0,0][100,100]" text="Hello"/>\n  </node>\n</hierarchy>`;
     const tree = parseUiAutomatorDump(xml, 100, 100);
-    const identifiers = flatten(tree)
-      .map((n) => n.identifier)
-      .filter(Boolean);
-    const labels = flatten(tree)
-      .map((n) => n.label)
-      .filter(Boolean);
+    const nodes = flatten(tree);
+    const identifiers = nodes.map((n) => n.identifier).filter(Boolean);
+    const labels = nodes.map((n) => n.label).filter(Boolean);
     expect(identifiers).toContain("com.app:id/header_container");
     expect(labels).toContain("Hello");
+    // The id is preserved by PROPAGATING it onto the surviving child, NOT by
+    // keeping the FrameLayout as an extra wrapper level (that would re-inflate
+    // the tree the v2 trim shrinks). The container must be gone, and the id
+    // must ride on the same text node as "Hello".
+    expect(nodes.map((n) => n.role)).not.toContain("FrameLayout");
+    const textNode = nodes.find((n) => n.label === "Hello");
+    expect(textNode?.identifier).toBe("com.app:id/header_container");
+  });
+
+  it("id-bearing layout container still flattens and does NOT block duplicate-wrapper collapse", () => {
+    // Regression: a clickable parent, an id-bearing non-clickable middle
+    // container, and a clickable child at identical bounds must collapse to a
+    // SINGLE tap target — not three stacked nodes with "Submit" repeated.
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.view.ViewGroup" bounds="[0,0][100,50]" clickable="true">\n    <node class="android.widget.FrameLayout" bounds="[0,0][100,50]" resource-id="com.app:id/wrap">\n      <node class="android.widget.Button" bounds="[0,0][100,50]" clickable="true" text="Submit"/>\n    </node>\n  </node>\n</hierarchy>`;
+    const nodes = flatten(parseUiAutomatorDump(xml, 100, 50));
+    const submits = nodes.filter((n) => n.label === "Submit");
+    expect(submits).toHaveLength(1);
+    // The container's id is preserved on the collapsed target rather than lost.
+    expect(submits[0]?.identifier).toBe("com.app:id/wrap");
+    expect(nodes.map((n) => n.role)).not.toContain("FrameLayout");
+  });
+
+  it("flattens nested id-bearing layout containers down to their content", () => {
+    // Regression: nested id-only containers (android:id/content is on nearly
+    // every dump) must not each survive as a wrapper level.
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.widget.FrameLayout" bounds="[0,0][100,200]" resource-id="android:id/content">\n    <node class="android.widget.LinearLayout" bounds="[0,0][100,200]" resource-id="com.app:id/root">\n      <node class="android.widget.TextView" bounds="[0,0][100,20]" text="A"/>\n      <node class="android.widget.TextView" bounds="[0,20][100,40]" text="B"/>\n    </node>\n  </node>\n</hierarchy>`;
+    const nodes = flatten(parseUiAutomatorDump(xml, 100, 200));
+    const roles = nodes.map((n) => n.role);
+    expect(roles).not.toContain("FrameLayout");
+    expect(roles).not.toContain("LinearLayout");
+    expect(nodes.filter((n) => n.role === "StaticText")).toHaveLength(2);
   });
 });

--- a/packages/tool-server/test/describe-android-label-preserve.test.ts
+++ b/packages/tool-server/test/describe-android-label-preserve.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { parseUiAutomatorDump } from "../src/tools/describe/platforms/android/uiautomator-parser";
+import type { DescribeNode } from "../src/tools/describe/contract";
+function flatten(tree: DescribeNode): DescribeNode[] {
+  const out: DescribeNode[] = [];
+  const stack: DescribeNode[] = [tree];
+  while (stack.length) {
+    const n = stack.pop()!;
+    out.push(n);
+    for (let i = n.children.length - 1; i >= 0; i--) stack.push(n.children[i]!);
+  }
+  return out;
+}
+describe("describe android collapse preserves label/identifier", () => {
+  it("duplicate-wrapper collapse keeps the outer-only label", () => {
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.view.ViewGroup" bounds="[0,0][100,100]" clickable="true" content-desc="Like, 5 likes">\n    <node class="android.widget.Button" bounds="[0,0][100,100]" clickable="true" content-desc="" text=""/>\n  </node>\n</hierarchy>`;
+    const labels = flatten(parseUiAutomatorDump(xml, 100, 100))
+      .map((n) => n.label)
+      .filter(Boolean);
+    expect(labels).toContain("Like, 5 likes");
+  });
+  it("bounds-less single-child wrapper keeps its own label", () => {
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.view.View" content-desc="Profile photo">\n    <node class="android.widget.ImageView" bounds="[0,0][100,100]" content-desc="avatar"/>\n  </node>\n</hierarchy>`;
+    const labels = flatten(parseUiAutomatorDump(xml, 100, 100))
+      .map((n) => n.label)
+      .filter(Boolean);
+    expect(labels).toContain("Profile photo");
+  });
+});

--- a/packages/tool-server/test/describe-android-label-preserve.test.ts
+++ b/packages/tool-server/test/describe-android-label-preserve.test.ts
@@ -73,4 +73,20 @@ describe("describe android collapse preserves label/identifier", () => {
     expect(roles).not.toContain("LinearLayout");
     expect(nodes.filter((n) => n.role === "StaticText")).toHaveLength(2);
   });
+
+  it("duplicate-wrapper collapse must NOT leak an outer password field's value", () => {
+    // Regression: the label fallback added to the duplicate-wrapper collapse
+    // copies the outer node's label onto the surviving child. When the outer
+    // node is a password field, that label is the secret — it must be redacted
+    // to "[password]" first, never carried through raw. (Redaction happens at
+    // the point the label is derived, so the collapse's early return can't
+    // bypass it.)
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.widget.EditText" bounds="[0,0][100,100]" clickable="true" password="true" text="hunter2">\n    <node class="android.view.View" bounds="[0,0][100,100]" clickable="true" text=""/>\n  </node>\n</hierarchy>`;
+    const nodes = flatten(parseUiAutomatorDump(xml, 100, 100));
+    const strings = nodes.flatMap((n) =>
+      [n.label, n.value, n.identifier].filter((s): s is string => !!s)
+    );
+    expect(strings.join(" | ")).not.toContain("hunter2");
+    expect(nodes.map((n) => n.label).filter(Boolean)).toContain("[password]");
+  });
 });

--- a/packages/tool-server/test/describe-android-label-preserve.test.ts
+++ b/packages/tool-server/test/describe-android-label-preserve.test.ts
@@ -26,40 +26,14 @@ describe("describe android collapse preserves label/identifier", () => {
       .filter(Boolean);
     expect(labels).toContain("Profile photo");
   });
-  it("decorative ImageView collapse keeps its resource-id even with no label", () => {
-    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.widget.ImageView" bounds="[0,0][50,50]" resource-id="com.app:id/decorative_icon"/>\n</hierarchy>`;
-    const identifiers = flatten(parseUiAutomatorDump(xml, 100, 100))
-      .map((n) => n.identifier)
-      .filter(Boolean);
-    expect(identifiers).toContain("com.app:id/decorative_icon");
-  });
-  it("layout-container collapse keeps its resource-id even with no label", () => {
-    const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.widget.FrameLayout" bounds="[0,0][100,100]" resource-id="com.app:id/header_container">\n    <node class="android.widget.TextView" bounds="[0,0][100,100]" text="Hello"/>\n  </node>\n</hierarchy>`;
-    const tree = parseUiAutomatorDump(xml, 100, 100);
-    const nodes = flatten(tree);
-    const identifiers = nodes.map((n) => n.identifier).filter(Boolean);
-    const labels = nodes.map((n) => n.label).filter(Boolean);
-    expect(identifiers).toContain("com.app:id/header_container");
-    expect(labels).toContain("Hello");
-    // The id is preserved by PROPAGATING it onto the surviving child, NOT by
-    // keeping the FrameLayout as an extra wrapper level (that would re-inflate
-    // the tree the v2 trim shrinks). The container must be gone, and the id
-    // must ride on the same text node as "Hello".
-    expect(nodes.map((n) => n.role)).not.toContain("FrameLayout");
-    const textNode = nodes.find((n) => n.label === "Hello");
-    expect(textNode?.identifier).toBe("com.app:id/header_container");
-  });
-
-  it("id-bearing layout container still flattens and does NOT block duplicate-wrapper collapse", () => {
-    // Regression: a clickable parent, an id-bearing non-clickable middle
-    // container, and a clickable child at identical bounds must collapse to a
-    // SINGLE tap target — not three stacked nodes with "Submit" repeated.
+  it("an id-bearing middle layout container does NOT block duplicate-wrapper collapse", () => {
+    // A clickable parent, a non-clickable middle container, and a clickable
+    // child at identical bounds must collapse to a SINGLE tap target — not
+    // three stacked nodes with "Submit" repeated.
     const xml = `<?xml version='1.0' encoding='UTF-8'?>\n<hierarchy>\n  <node class="android.view.ViewGroup" bounds="[0,0][100,50]" clickable="true">\n    <node class="android.widget.FrameLayout" bounds="[0,0][100,50]" resource-id="com.app:id/wrap">\n      <node class="android.widget.Button" bounds="[0,0][100,50]" clickable="true" text="Submit"/>\n    </node>\n  </node>\n</hierarchy>`;
     const nodes = flatten(parseUiAutomatorDump(xml, 100, 50));
     const submits = nodes.filter((n) => n.label === "Submit");
     expect(submits).toHaveLength(1);
-    // The container's id is preserved on the collapsed target rather than lost.
-    expect(submits[0]?.identifier).toBe("com.app:id/wrap");
     expect(nodes.map((n) => n.role)).not.toContain("FrameLayout");
   });
 

--- a/packages/tool-server/test/uiautomator-parser-v2-trim.test.ts
+++ b/packages/tool-server/test/uiautomator-parser-v2-trim.test.ts
@@ -72,6 +72,26 @@ describe("parseUiAutomatorDump — v2 trim focused behaviour", () => {
     expect(field?.value).toBeUndefined();
   });
 
+  it("does not borrow a password descendant's text into a container label", () => {
+    // A clickable container with no label of its own borrows its descendants'
+    // text via descendantText(). That walk reads the raw XML, so a password
+    // field's secret must be redacted there too — otherwise it rides out as the
+    // container's own (non-password) label and bypasses redaction entirely.
+    const xml = `<?xml version='1.0' encoding='UTF-8'?>
+<hierarchy>
+  <node class="android.widget.LinearLayout" clickable="true" bounds="[0,0][100,100]">
+    <node class="android.widget.EditText" focusable="true" password="true" text="hunter2" bounds="[10,10][90,40]"/>
+  </node>
+</hierarchy>`;
+    const tree = parseUiAutomatorDump(xml, 100, 100);
+    const strings = flatten(tree).flatMap((n) =>
+      [n.label, n.value].filter((s): s is string => !!s)
+    );
+    expect(strings.join(" | ")).not.toContain("hunter2");
+    // The row still surfaces the redacted marker instead of the plaintext.
+    expect(flatten(tree).map((n) => n.label)).toContain("[password]");
+  });
+
   it("treats WebView as an opaque single leaf", () => {
     const xml = `<?xml version='1.0' encoding='UTF-8'?>
 <hierarchy>


### PR DESCRIPTION
## Summary

The Android uiautomator describe parser collapses redundant wrapper nodes in two places. Both sites kept the inner/child node and silently discarded the wrapper's own accessibility `content-desc` label and `resource-id`, even when the surviving node had neither. The result is that a labelled tap target becomes anonymous in the describe tree, so an agent can no longer identify or target it.

This change makes both collapse sites merge rather than drop: the surviving node still prefers its own label/identifier (the existing "inner is more specific" intent), but now falls back to the wrapper's values instead of throwing them away.

## Defect A — duplicate-wrapper collapse (`computeNodeOutput`)

When a clickable parent and its single clickable child have identical bounds, the duplicate-wrapper collapse keeps only the inner child and discards the parent's `content-desc`/`resource-id` — even when the inner child has neither. A React Native `Pressable` with an `accessibilityLabel` wrapping a bare clickable native view (label only on the outer node) collapses to an anonymous node.

Repro:
```
<node clickable content-desc="Like, 5 likes">
  <node clickable content-desc="" />
</node>
```
- Observed: collapses to a single node with NO label.
- Expected: the collapsed node keeps `label="Like, 5 likes"`.

Fix: when collapsing, carry the wrapper's label/`resource-id` onto the surviving child only when the child lacks its own. The existing test that asserts an inner `inner` label wins over an outer `outer` label is preserved (child value still takes precedence when present).

## Defect B — bounds-less single-child pass-through (`finalizeUiNode`)

A node with no parseable `bounds`, exactly one child, and its OWN `content-desc` was replaced wholesale by its child (`if (children.length === 1) return children[0]`), discarding the wrapper's label/identifier. This is reachable for the bounds-less Compose group containers the parser already supports when such a container carries a `content-desc`.

Repro:
```
<node content-desc="Profile photo">
  <node bounds=... content-desc="avatar" />
</node>
```
- Observed: keeps only `avatar`; `Profile photo` is lost.
- Expected: both labels survive.

Fix: only pass a single child straight through when the wrapper has no label/identifier of its own. When the wrapper carries its own identity, keep it as a node whose frame is the union of its (sole) child — so neither the wrapper's nor the child's label is dropped. The bounds-less multi-child path (Compose containers with 2+ children) is unchanged.

## Tests

New regression test `packages/tool-server/test/describe-android-label-preserve.test.ts` covers both defects. It fails before the fix (`[]` for A, `['avatar']` for B) and passes after. The full existing uiautomator/describe android suites remain green.