### PR TITLE
fix(screenshot-diff): rescale OCR text bounds into the normalized diff space

### DIFF
--- a/packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts
@@ -166,17 +166,22 @@ export async function diffPngFiles(options: {
   const mismatchPercentage =
     totalPixels === 0 ? 0 : (pixelDiff.differentPixels / totalPixels) * 100;
 
-  // The OCR/font-geometry pass re-reads the original files from disk, so it
-  // must receive the originally-decoded images (whose dimensions match those
-  // files) rather than the normalized copies. Derive its top cutoff from the
-  // original baseline height for the same reason.
+  // The OCR pass re-reads the two files from disk, so each image's text bounds
+  // come back in its own original coordinate space. When the inputs were
+  // normalized to a common size, rescale those bounds into that shared space
+  // (and hand the font-geometry pass the normalized images to match) so the
+  // cross-image comparison and the summary share the same coordinates the pixel
+  // diff uses. The scale factors are 1/1 when the inputs already match, and the
+  // top cutoff is derived from the normalized height for the same reason.
   const textAnalysis = await analyzeScreenshotTextChangesSafely({
     baselinePath: options.baselinePath,
     currentPath: options.currentPath,
     hasPixelDiff: pixelDiff.differentPixels > 0,
-    baselineImage: decodedBaseline,
-    currentImage: decodedCurrent,
-    ignoreTopPixels: ignoredTopRowsFor(decodedBaseline.height, settings.ignoreTopNormalizedY),
+    baselineImage: baseline,
+    currentImage: current,
+    baselineRegionScale: regionScaleBetween(decodedBaseline, baseline),
+    currentRegionScale: regionScaleBetween(decodedCurrent, current),
+    ignoreTopPixels: ignoredTopRowsFor(baseline.height, settings.ignoreTopNormalizedY),
     textChangeMinConfidence: DEFAULT_TEXT_CHANGE_MIN_CONFIDENCE,
   });
 
@@ -259,6 +264,15 @@ function markChangedPixels(params: {
 
 function ignoredTopRowsFor(height: number, ignoreTopNormalizedY: number): number {
   return Math.min(height, Math.ceil(height * ignoreTopNormalizedY));
+}
+
+// Factors that map a bound from `from`'s pixel space into `to`'s pixel space.
+// Both dimensions are 1 when the sizes match, so same-size inputs are untouched.
+function regionScaleBetween(from: Size, to: Size): { x: number; y: number } {
+  return {
+    x: from.width === 0 ? 1 : to.width / from.width,
+    y: from.height === 0 ? 1 : to.height / from.height,
+  };
 }
 
 function getChangedRegions(params: {

--- a/packages/tool-server/src/tools/screenshot-diff/text-diff.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/text-diff.ts
@@ -65,12 +65,26 @@ export interface TextAnalysis {
   changes: TextChange[];
 }
 
+export interface RegionScale {
+  x: number;
+  y: number;
+}
+
 export interface AnalyzeScreenshotTextOptions {
   baselinePath: string;
   currentPath: string;
   hasPixelDiff?: boolean;
   baselineImage?: FontGeometryImage;
   currentImage?: FontGeometryImage;
+  /**
+   * Multipliers that map the baseline image's OCR bounds into the common
+   * coordinate space the pixel diff uses. Supply when the inputs were
+   * normalized to a different resolution; omit (or pass 1/1) when they already
+   * share dimensions.
+   */
+  baselineRegionScale?: RegionScale;
+  /** Same as {@link baselineRegionScale}, for the current image's OCR bounds. */
+  currentRegionScale?: RegionScale;
   ignoreTopPixels?: number;
   textChangeMinConfidence?: number;
 }
@@ -125,14 +139,42 @@ export async function analyzeScreenshotTextChanges(
     };
   }
 
+  // OCR ran on each original file, so baseline and current bounds come back in
+  // their own image's coordinate space. Rescale both into the common space the
+  // pixel diff already uses so the cross-image geometry compares like with like.
   return analyzeTextRegions({
-    baselineRegions: baselineOcr.blocks,
-    currentRegions: currentOcr.blocks,
+    baselineRegions: rescaleTextRegions(baselineOcr.blocks, options.baselineRegionScale),
+    currentRegions: rescaleTextRegions(currentOcr.blocks, options.currentRegionScale),
     baselineImage: options.baselineImage,
     currentImage: options.currentImage,
     ignoreTopPixels: options.ignoreTopPixels,
     textChangeMinConfidence: options.textChangeMinConfidence,
   });
+}
+
+/**
+ * Map OCR text regions (and their per-word bounds) from one image's coordinate
+ * space into another by multiplying every bound by `scale`. Used to bring
+ * baseline and current OCR output into the common, normalized coordinate space
+ * the pixel diff compares in. Returns the regions untouched when `scale` is
+ * absent or an identity (1/1) scale, so same-size inputs are unaffected.
+ */
+export function rescaleTextRegions(regions: TextRegion[], scale?: RegionScale): TextRegion[] {
+  if (!scale || (scale.x === 1 && scale.y === 1)) return regions;
+  return regions.map((region) => ({
+    ...region,
+    bounds: scaleBounds(region.bounds, scale),
+    words: region.words?.map((word) => ({ ...word, bounds: scaleBounds(word.bounds, scale) })),
+  }));
+}
+
+function scaleBounds(bounds: DiffBounds, scale: RegionScale): DiffBounds {
+  return {
+    x: bounds.x * scale.x,
+    y: bounds.y * scale.y,
+    width: bounds.width * scale.x,
+    height: bounds.height * scale.y,
+  };
 }
 
 export function analyzeTextRegions(params: {

--- a/packages/tool-server/test/screenshot-diff-ocr-coordinate-space.test.ts
+++ b/packages/tool-server/test/screenshot-diff-ocr-coordinate-space.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OcrTextBlock } from "../src/tools/screenshot-diff/screenshot-diff-ocr";
+import {
+  analyzeScreenshotTextChanges,
+  analyzeTextRegions,
+  rescaleTextRegions,
+  type TextRegion,
+} from "../src/tools/screenshot-diff/text-diff";
+
+// This suite guards the OCR coordinate-space fix WITHOUT any OCR engine. It
+// never shells out to tesseract/python/PIL: OCR output is supplied directly as
+// synthetic regions (and, for the pipeline test, via a mocked OCR module), so
+// it runs as a pure unit test in CI where tesseract is not installed.
+
+const ocrMock = vi.hoisted(() => ({
+  extractOcrTextBlocks: vi.fn(),
+}));
+
+vi.mock("../src/tools/screenshot-diff/screenshot-diff-ocr", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/tools/screenshot-diff/screenshot-diff-ocr")>();
+  return {
+    ...actual,
+    extractOcrTextBlocks: ocrMock.extractOcrTextBlocks,
+  };
+});
+
+// "Settings" rendered at the same logical location, captured at two resolutions
+// with the same 2:1 aspect ratio. The baseline file is twice the size of the
+// current file, so its OCR bounds are exactly double the current bounds.
+const SETTINGS_IN_BASELINE_480x240: TextRegion = {
+  text: "Settings",
+  confidence: 0.94,
+  bounds: { x: 200, y: 100, width: 80, height: 18 },
+  words: [
+    { text: "Settings", confidence: 0.94, bounds: { x: 200, y: 100, width: 80, height: 18 } },
+  ],
+};
+const SETTINGS_IN_CURRENT_240x120: TextRegion = {
+  text: "Settings",
+  confidence: 0.94,
+  bounds: { x: 100, y: 50, width: 40, height: 9 },
+  words: [{ text: "Settings", confidence: 0.94, bounds: { x: 100, y: 50, width: 40, height: 9 } }],
+};
+
+// Normalized common space (the smaller image's dimensions), which is what the
+// pixel diff and the summary report against.
+const NORMALIZED = { width: 240, height: 120 };
+const BASELINE_TO_NORMALIZED = { x: 240 / 480, y: 120 / 240 };
+const CURRENT_TO_NORMALIZED = { x: 1, y: 1 };
+
+describe("screenshot-diff OCR coordinate space", () => {
+  beforeEach(() => {
+    ocrMock.extractOcrTextBlocks.mockReset();
+  });
+
+  it("rescales region and word bounds while leaving an identity scale untouched", () => {
+    const regions: TextRegion[] = [structuredClone(SETTINGS_IN_BASELINE_480x240)];
+
+    expect(rescaleTextRegions(regions, { x: 1, y: 1 })).toBe(regions);
+    expect(rescaleTextRegions(regions)).toBe(regions);
+
+    const scaled = rescaleTextRegions(regions, BASELINE_TO_NORMALIZED);
+    expect(scaled[0].bounds).toEqual({ x: 100, y: 50, width: 40, height: 9 });
+    expect(scaled[0].words?.[0].bounds).toEqual({ x: 100, y: 50, width: 40, height: 9 });
+    // The source regions are not mutated.
+    expect(regions[0].bounds).toEqual({ x: 200, y: 100, width: 80, height: 18 });
+  });
+
+  it("flags identical text in mismatched coordinate spaces as a spurious move (the bug)", () => {
+    const result = analyzeTextRegions({
+      baselineRegions: [SETTINGS_IN_BASELINE_480x240],
+      currentRegions: [SETTINGS_IN_CURRENT_240x120],
+    });
+
+    const moved = result.changes.find((change) => change.kind === "moved");
+    expect(moved).toBeDefined();
+    // A half-image "move" of text that never actually moved.
+    expect(Math.abs(moved?.delta?.x ?? 0)).toBeGreaterThanOrEqual(80);
+    expect(Math.abs(moved?.delta?.y ?? 0)).toBeGreaterThanOrEqual(40);
+  });
+
+  it("reports no move once both OCR bound sets are rescaled into the common space", () => {
+    const baseline = rescaleTextRegions([SETTINGS_IN_BASELINE_480x240], BASELINE_TO_NORMALIZED);
+    const current = rescaleTextRegions([SETTINGS_IN_CURRENT_240x120], CURRENT_TO_NORMALIZED);
+
+    const result = analyzeTextRegions({ baselineRegions: baseline, currentRegions: current });
+
+    expect(result.status).toBe("ok");
+    expect(result.changes.some((change) => change.kind === "moved")).toBe(false);
+    expect(result.changes).toEqual([]);
+
+    // The rescaled baseline bounds now coincide with the current bounds and sit
+    // inside the normalized frame, so the summary cannot clamp a normalized
+    // width to 1 (the compounding symptom of the bug).
+    expect(baseline[0].bounds).toEqual(current[0].bounds);
+    expect(baseline[0].bounds.x / NORMALIZED.width).toBeLessThan(1);
+    expect(baseline[0].bounds.width / NORMALIZED.width).toBeLessThan(1);
+    expect(baseline[0].bounds.y / NORMALIZED.height).toBeLessThan(1);
+    expect(baseline[0].bounds.height / NORMALIZED.height).toBeLessThan(1);
+  });
+
+  it("does not invent a move when analyzeScreenshotTextChanges receives per-image scales", async () => {
+    ocrMock.extractOcrTextBlocks.mockImplementation(async (imagePath: string) =>
+      imagePath === "baseline.png"
+        ? okOcr(SETTINGS_IN_BASELINE_480x240)
+        : okOcr(SETTINGS_IN_CURRENT_240x120)
+    );
+
+    const result = await analyzeScreenshotTextChanges({
+      baselinePath: "baseline.png",
+      currentPath: "current.png",
+      hasPixelDiff: true,
+      baselineRegionScale: BASELINE_TO_NORMALIZED,
+      currentRegionScale: CURRENT_TO_NORMALIZED,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.changes.some((change) => change.kind === "moved")).toBe(false);
+    expect(result.changes).toEqual([]);
+  });
+});
+
+function okOcr(region: TextRegion): {
+  status: "ok";
+  provider: "tesseract";
+  blocks: OcrTextBlock[];
+} {
+  return {
+    status: "ok",
+    provider: "tesseract",
+    blocks: [
+      {
+        text: region.text,
+        confidence: region.confidence ?? 1,
+        bounds: region.bounds,
+        words: (region.words ?? []).map((word) => ({
+          text: word.text,
+          confidence: word.confidence,
+          bounds: word.bounds,
+          blockNum: 1,
+          parNum: 1,
+          lineNum: 1,
+          wordNum: 1,
+        })),
+      },
+    ],
+  };
+}

--- a/packages/tool-server/test/screenshot-diff.test.ts
+++ b/packages/tool-server/test/screenshot-diff.test.ts
@@ -274,6 +274,29 @@ describe("diffPngFiles", () => {
       expect.objectContaining({ textChangeMinConfidence: 0.7, ignoreTopPixels: 2 })
     );
   });
+
+  it("hands OCR the decoded->normalized region scale for each image (diffPngFiles wiring)", async () => {
+    // Same 2:1 aspect, different resolution: normalizeToCommonSize downscales the
+    // larger baseline (480x240) to the current's size (240x120). diffPngFiles must
+    // compute each image's decoded->normalized scale and pass it to the OCR pass,
+    // so text bounds land in the shared pixel-diff coordinate space. Without this
+    // wiring (the pre-fix screenshot-diff.ts) OCR is called with no region scales
+    // and the half-image spurious "moved" change returns.
+    const dir = await makeTempDir();
+    const baselinePath = path.join(dir, "baseline.png");
+    const currentPath = path.join(dir, "current.png");
+    await writePng(baselinePath, 480, 240, { r: 0, g: 0, b: 0 });
+    await writePng(currentPath, 240, 120, { r: 0, g: 0, b: 0 });
+
+    await diffPngFiles({ baselinePath, currentPath, outputDir: dir });
+
+    expect(analyzeScreenshotTextChangesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baselineRegionScale: { x: 0.5, y: 0.5 },
+        currentRegionScale: { x: 1, y: 1 },
+      })
+    );
+  });
 });
 
 async function makeTempDir(): Promise<string> {


### PR DESCRIPTION
## Problem

When two same-aspect screenshots of different resolution are compared (the explicitly supported flow, e.g. a 0.3x saved baseline vs a full-res live capture), `diffPngFiles` calls `normalizeToCommonSize` to downscale both framebuffers to a common size for the pixel diff and sets `imageSize` to those normalized dimensions. The OCR/text pass, however, ran OCR on the original decoded images: baseline OCR bounds came back in baseline-original coordinates and current OCR bounds in current-original coordinates - two different coordinate spaces.

`analyzeTextRegions` then compared those bounds directly (boundsDelta / centerDistance / IoU), so identical text at the same logical position was flagged as a half-image `moved` change. The summary compounded it by normalizing the baseline bounds against the smaller normalized `imageSize`, clamping the reported "from" width to 1. A uniform rescale of one framebuffer is not a content change.

### Behavior repro

The same "Settings" text rendered at 480x240 vs 240x120 (2:1, same aspect) produced one `kind:"moved"` change with a delta of roughly negative half-image and a "from" normalized width of 1.

## Fix

Rescale each image's OCR text bounds (and per-word bounds) into the normalized common coordinate space before the cross-image geometric comparison and the normalized-coordinate reporting. Baseline bounds are multiplied by `(normalizedW / baselineOrigW, normalizedH / baselineOrigH)` and current bounds by `(normalizedW / currentOrigW, normalizedH / currentOrigH)`, so both sets live in the same space the pixel diff already uses. The font-geometry pass is handed the normalized images to match the rescaled bounds, and the top cutoff is derived from the normalized height. The scale factors are 1/1 when the inputs already share dimensions, so same-size comparisons are unchanged.

A small pure helper `rescaleTextRegions(regions, scale)` performs the mapping; `analyzeScreenshotTextChanges` accepts optional `baselineRegionScale` / `currentRegionScale` and applies it to the OCR output, and `diffPngFiles` computes the factors from the original vs normalized dimensions.

## Test

`packages/tool-server/test/screenshot-diff-ocr-coordinate-space.test.ts` is a pure unit test with no OCR engine dependency - it never shells out to tesseract, python, or PIL. It supplies synthetic OCR regions for "Settings" at the same logical location in the 480x240 baseline space and the 240x120 current space, documents the spurious half-image `moved` change from mismatched spaces, and asserts that after rescaling into the common space the geometry produces no `moved` change and sane normalized coordinates. A pipeline-level case mocks the OCR module and verifies the same through `analyzeScreenshotTextChanges` with per-image scales.