### PR TITLE
fix(cli): let a tool's own --args field win over the whole-payload flag

### DIFF
--- a/packages/argent-cli/src/flag-parser.ts
+++ b/packages/argent-cli/src/flag-parser.ts
@@ -11,6 +11,12 @@
 //   --args '<json>'       (whole-payload escape hatch; merges with parsed flags)
 //   --args -              (read whole-payload JSON from stdin)
 //
+// Exception: when the tool's own schema declares a property named `args` (e.g.
+// flow-add-step, whose `args` is a JSON string of the step's tool arguments),
+// `--args <value>` is treated as that per-field value — coerced by its declared
+// type, exactly like any other field — NOT the whole-payload escape hatch. Such
+// a tool has no whole-payload shortcut; use individual flags / --<field>-json.
+//
 // Scalar field types come from JSON Schema: string, number, integer, boolean, enum.
 // Array fields: items.type must be a scalar to get a repeatable flag.
 // Object fields and arrays of objects fall through to --field-json.
@@ -127,7 +133,11 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
     }
 
     // ── Whole-payload escape hatch ──
-    if (flag === "args") {
+    //
+    // Skipped when the tool declares its own `args` field: then `--args` is a
+    // normal per-field flag (handled below) and wins over the escape hatch, so
+    // the field's value isn't silently swallowed as the whole payload.
+    if (flag === "args" && properties.args === undefined) {
       const { value, nextIndex } =
         inlineValue !== undefined ? { value: inlineValue, nextIndex: i } : takeNext(i, "args");
       rawArgs = value;

--- a/packages/argent-cli/src/flag-parser.ts
+++ b/packages/argent-cli/src/flag-parser.ts
@@ -91,6 +91,13 @@ function parseJsonOrThrow(raw: string, label: string): unknown {
  */
 export function parseFlags(argv: string[], schema: JsonSchema | undefined): FlagParseResult {
   const properties = schema?.properties ?? {};
+  // The whole-payload `--args '<json>'` escape hatch only exists when the tool
+  // does NOT declare its own `args` field. When it does (e.g. flow-add-step),
+  // `--args` is that per-field flag, so the "or --args '<json>'" fallback the
+  // error messages suggest would be a dead end — that form re-enters per-field
+  // handling instead of the hatch, and only `--<field>-json` works. Emit the
+  // suggestion only when the hatch is actually available.
+  const argsHatchHint = properties.args === undefined ? " or --args '<json>'" : "";
   const args: Record<string, unknown> = {};
   const positional: string[] = [];
   let helpRequested = false;
@@ -165,7 +172,7 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
         // A prior --${fieldName} (scalar-array form) already populated this
         // field; overwriting it here would silently discard those values.
         throw new FlagParseException(
-          `--${fieldName} and --${flag} cannot be mixed for the same field; pass it entirely as --${flag} '<json>' or --args '<json>'`
+          `--${fieldName} and --${flag} cannot be mixed for the same field; pass it entirely as --${flag} '<json>'${argsHatchHint}`
         );
       }
       args[fieldName] = parseJsonOrThrow(value, `--${flag}`);
@@ -209,7 +216,7 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
       const itemType = propSchema.items?.type;
       if (!isScalarType(itemType)) {
         throw new FlagParseException(
-          `--${flag} is an array of objects; pass it as --${flag}-json '<json>' or --args '<json>'`
+          `--${flag} is an array of objects; pass it as --${flag}-json '<json>'${argsHatchHint}`
         );
       }
       const { value, nextIndex } =
@@ -223,7 +230,7 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
         // a scalar-coercion error — matching the --field-json branch above,
         // which checks mixing before parsing the JSON.
         throw new FlagParseException(
-          `--${flag} and --${flag}-json cannot be mixed for the same field; pass it entirely as --${flag}-json '<json>' or --args '<json>'`
+          `--${flag} and --${flag}-json cannot be mixed for the same field; pass it entirely as --${flag}-json '<json>'${argsHatchHint}`
         );
       }
       const coerced = coerceScalar(value, itemType, flag);
@@ -240,7 +247,7 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
     // ── Object field: must use --field-json ──
     if (propSchema?.type === "object") {
       throw new FlagParseException(
-        `--${flag} is an object; pass it as --${flag}-json '<json>' or --args '<json>'`
+        `--${flag} is an object; pass it as --${flag}-json '<json>'${argsHatchHint}`
       );
     }
 

--- a/packages/argent-cli/src/run.ts
+++ b/packages/argent-cli/src/run.ts
@@ -72,13 +72,21 @@ async function readStdin(): Promise<string> {
 
 function printToolHelp(meta: ToolMeta): void {
   const description = meta.description?.trim() ?? "";
+  const schema = meta.inputSchema as JsonSchema | undefined;
+  // A tool may declare its own `args` field (e.g. flow-add-step). In that case
+  // `--args` is a per-field flag shown in the schema block above, so don't also
+  // advertise the whole-payload `--args` escape hatch — it no longer applies and
+  // would contradict the per-field flag.
+  const hasOwnArgsField = schema?.properties?.args !== undefined;
   console.log(`argent run ${meta.name} [flags]`);
   if (description) console.log(`\n${description}\n`);
   console.log("Flags:");
-  console.log(formatSchemaUsage(meta.inputSchema as JsonSchema));
+  console.log(formatSchemaUsage(schema));
   console.log("\nGlobal flags:");
-  console.log("  --args <json>          Pass the entire payload as JSON (overrides flags)");
-  console.log("  --args -               Read the entire payload as JSON from stdin");
+  if (!hasOwnArgsField) {
+    console.log("  --args <json>          Pass the entire payload as JSON (overrides flags)");
+    console.log("  --args -               Read the entire payload as JSON from stdin");
+  }
   console.log("  --<field>-json <json>  Pass a single field as JSON (objects/nested arrays)");
   console.log("  --json                 Print the raw JSON result");
   console.log("  --out <path>           For image results, save to <path> instead of fetching URL");

--- a/packages/argent-cli/test/flag-parser.test.ts
+++ b/packages/argent-cli/test/flag-parser.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { parseFlags, type JsonSchema } from "../src/flag-parser.js";
+
+// A tool (like flow-add-step) whose schema declares its own `args` field — a
+// JSON string holding the recorded step's tool arguments.
+const flowAddStepSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    command: { type: "string" },
+    args: { type: "string" },
+    delayMs: { type: "integer" },
+  },
+  required: ["command"],
+};
+
+// A tool (like gesture-tap) with NO `args` field — here `--args` must stay the
+// whole-payload escape hatch.
+const gestureTapSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    udid: { type: "string" },
+    x: { type: "number" },
+    y: { type: "number" },
+  },
+  required: ["udid", "x", "y"],
+};
+
+describe("parseFlags — schema-aware --args", () => {
+  it("treats --args as the tool's own string field (space-separated form)", () => {
+    const result = parseFlags(
+      ["--command", "gesture-tap", "--args", '{"udid":"X","x":0.5}'],
+      flowAddStepSchema
+    );
+    expect(result.args.command).toBe("gesture-tap");
+    // The raw JSON string is passed through untouched into the `args` field...
+    expect(result.args.args).toBe('{"udid":"X","x":0.5}');
+    // ...and NOT consumed as the whole-payload escape hatch.
+    expect(result.rawArgs).toBeNull();
+  });
+
+  it("treats --args=<value> inline form as the tool's own field", () => {
+    const result = parseFlags(
+      ["--command", "gesture-tap", '--args={"udid":"X","x":0.5}'],
+      flowAddStepSchema
+    );
+    expect(result.args.command).toBe("gesture-tap");
+    expect(result.args.args).toBe('{"udid":"X","x":0.5}');
+    expect(result.rawArgs).toBeNull();
+  });
+
+  it("still parses sibling fields alongside the --args field", () => {
+    const result = parseFlags(
+      ["--command", "screenshot", "--args", "{}", "--delayMs", "250"],
+      flowAddStepSchema
+    );
+    expect(result.args.command).toBe("screenshot");
+    expect(result.args.args).toBe("{}");
+    expect(result.args.delayMs).toBe(250);
+    expect(result.rawArgs).toBeNull();
+  });
+});
+
+describe("parseFlags — whole-payload --args (no own `args` field)", () => {
+  it("keeps --args as the whole-payload escape hatch", () => {
+    const result = parseFlags(["--args", '{"udid":"X","x":0.5,"y":0.5}'], gestureTapSchema);
+    expect(result.rawArgs).toBe('{"udid":"X","x":0.5,"y":0.5}');
+    // `args` must not appear as a parsed field.
+    expect("args" in result.args).toBe(false);
+  });
+
+  it("keeps the --args - stdin sentinel as whole-payload", () => {
+    const result = parseFlags(["--args", "-"], gestureTapSchema);
+    expect(result.rawArgs).toBe("-");
+    expect("args" in result.args).toBe(false);
+  });
+
+  it("keeps whole-payload behavior when no schema is provided", () => {
+    const result = parseFlags(["--args", '{"udid":"X"}'], undefined);
+    expect(result.rawArgs).toBe('{"udid":"X"}');
+    expect("args" in result.args).toBe(false);
+  });
+});

--- a/packages/argent-cli/test/flag-parser.test.ts
+++ b/packages/argent-cli/test/flag-parser.test.ts
@@ -58,6 +58,25 @@ describe("parseFlags — schema-aware --args", () => {
     expect(result.args.delayMs).toBe(250);
     expect(result.rawArgs).toBeNull();
   });
+
+  it("treats --args - as the literal field value, NOT the stdin sentinel", () => {
+    // For a tool that owns `args`, `-` is just this field's value. The
+    // whole-payload stdin sentinel must not fire, so `rawArgs` stays null and
+    // nothing is read from stdin. This is the inverse of the no-`args` case
+    // below; asserting it here guards against a refactor that moved the `-`
+    // sentinel ahead of the `properties.args === undefined` gate and started
+    // routing flow-add-step's `--args -` to stdin.
+    const result = parseFlags(["--command", "gesture-tap", "--args", "-"], flowAddStepSchema);
+    expect(result.args.command).toBe("gesture-tap");
+    expect(result.args.args).toBe("-");
+    expect(result.rawArgs).toBeNull();
+  });
+
+  it("treats --args=- inline form as the literal field value too", () => {
+    const result = parseFlags(["--command", "gesture-tap", "--args=-"], flowAddStepSchema);
+    expect(result.args.args).toBe("-");
+    expect(result.rawArgs).toBeNull();
+  });
 });
 
 describe("parseFlags — whole-payload --args (no own `args` field)", () => {

--- a/packages/argent-cli/test/flag-parser.test.ts
+++ b/packages/argent-cli/test/flag-parser.test.ts
@@ -186,6 +186,70 @@ describe("parseFlags — schema-aware --args", () => {
   });
 });
 
+// A hypothetical future tool that OWNS its top-level `args` field but as an
+// object / array of objects (flow-add-step's is a string). The whole-payload
+// `--args '<json>'` hatch is disabled for any tool that owns `args`, so the
+// error text must NOT suggest that dead-end form — only `--<field>-json` works.
+const objectArgsSchema: JsonSchema = {
+  type: "object",
+  properties: { args: { type: "object" } },
+};
+const arrayArgsSchema: JsonSchema = {
+  type: "object",
+  properties: { args: { type: "array", items: { type: "object" } } },
+};
+// A control tool that does NOT own `args`, with an object field. Here the
+// whole-payload hatch exists, so the "or --args '<json>'" suggestion must stay.
+const objectFieldSchema: JsonSchema = {
+  type: "object",
+  properties: { filter: { type: "object" } },
+};
+
+describe("parseFlags — error hints omit the whole-payload --args form when the tool owns `args`", () => {
+  it("object `args`: suggests only --args-json, not the dead-end --args '<json>'", () => {
+    let err: unknown;
+    try {
+      parseFlags(["--args", '{"a":1}'], objectArgsSchema);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(FlagParseException);
+    const msg = (err as Error).message;
+    expect(msg).toBe("--args is an object; pass it as --args-json '<json>'");
+    // The whole-payload form no longer routes to the hatch for this tool, so it
+    // must not be advertised as a fallback (it would just re-enter this branch).
+    expect(msg).not.toContain("or --args '<json>'");
+  });
+
+  it("array-of-objects `args`: suggests only --args-json, not the dead-end --args '<json>'", () => {
+    let err: unknown;
+    try {
+      parseFlags(["--args", '[{"a":1}]'], arrayArgsSchema);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(FlagParseException);
+    const msg = (err as Error).message;
+    expect(msg).toBe("--args is an array of objects; pass it as --args-json '<json>'");
+    expect(msg).not.toContain("or --args '<json>'");
+  });
+
+  it("still suggests --args '<json>' for an object field on a tool WITHOUT its own `args`", () => {
+    // Control: dropping the whole-payload suggestion is scoped to tools that own
+    // `args`; for everyone else the hatch exists and stays advertised.
+    let err: unknown;
+    try {
+      parseFlags(["--filter", '{"a":1}'], objectFieldSchema);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(FlagParseException);
+    expect((err as Error).message).toBe(
+      "--filter is an object; pass it as --filter-json '<json>' or --args '<json>'"
+    );
+  });
+});
+
 describe("parseFlags — whole-payload --args (no own `args` field)", () => {
   it("keeps --args as the whole-payload escape hatch", () => {
     const result = parseFlags(["--args", '{"udid":"X","x":0.5,"y":0.5}'], gestureTapSchema);

--- a/packages/argent-cli/test/run-flow-add-step-payload.test.ts
+++ b/packages/argent-cli/test/run-flow-add-step-payload.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as http from "node:http";
+import { run, type RunCommandOptions } from "../src/run.js";
+
+// End-to-end regression guard for issue #452 at the `run()` layer.
+//
+// The documented per-flag form
+//   argent run flow-add-step --command gesture-tap --args '{"udid":...}'
+// must reach the tool-server with BOTH `command` AND the tool's own `args`
+// field in the payload. The bug shadowed the `args` field with the
+// whole-payload escape hatch, so `args` was consumed as the entire payload and
+// the field arrived `undefined` (with udid/x/y hoisted to the top level).
+//
+// `parseFlags` is unit-tested directly, and `--help` suppression is covered in
+// run-help.test.ts. Neither drives the whole `run()` path through to the wire.
+// This does: a real in-process tool-server captures the exact POST body the
+// CLI sends, so a future change that reconnected flag parsing to the payload
+// builder incorrectly would fail here even with the parser unit tests green.
+
+interface Captured {
+  path: string | null;
+  body: string | null;
+}
+
+function startServer(cap: Captured): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? "";
+    if (url === "/tools" && req.method === "GET") {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          tools: [
+            {
+              name: "flow-add-step",
+              description: "Add a step to the active flow recording",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  command: { type: "string" },
+                  args: { type: "string" },
+                  delayMs: { type: "integer" },
+                },
+                required: ["command"],
+              },
+            },
+          ],
+        })
+      );
+      return;
+    }
+    if (url.startsWith("/tools/flow-add-step") && req.method === "POST") {
+      let data = "";
+      req.on("data", (c) => (data += c));
+      req.on("end", () => {
+        cap.path = url;
+        cap.body = data;
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            data: { message: 'Step added to "t" flow', toolResult: { tapped: true } },
+          })
+        );
+      });
+      return;
+    }
+    res.statusCode = 404;
+    res.end("not found");
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe("CLI run — flow-add-step --args reaches the payload (issue #452)", () => {
+  let server: { url: string; close: () => Promise<void> };
+  let cap: Captured;
+  let errs: string[];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const opts: RunCommandOptions = { paths: {} as never }; // unused: ARGENT_TOOLS_URL is set
+
+  beforeEach(async () => {
+    cap = { path: null, body: null };
+    server = await startServer(cap);
+    process.env.ARGENT_TOOLS_URL = server.url;
+
+    errs = [];
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation((...a) => void errs.push(a.join(" ")));
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code}) called: ${errs.join("; ")}`);
+    }) as never);
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    delete process.env.ARGENT_TOOLS_URL;
+    await server.close();
+  });
+
+  it("per-flag form: --command X --args '<json>' sends BOTH fields verbatim to the server", async () => {
+    const stepArgs = '{"udid":"SIM-1","x":0.5,"y":0.35}';
+
+    await run(["flow-add-step", "--command", "gesture-tap", "--args", stepArgs], opts);
+
+    expect(cap.path).toMatch(/^\/tools\/flow-add-step/);
+    expect(cap.body).not.toBeNull();
+    const payload = JSON.parse(cap.body!) as Record<string, unknown>;
+    // The exact regression from #452: `args` survives as the tool's own string
+    // field (the raw JSON passed through untouched), and its keys are NOT
+    // hoisted to the top level as they were when `--args` was swallowed whole.
+    expect(payload).toEqual({ command: "gesture-tap", args: stepArgs });
+  });
+
+  it("inline --args=<json> form also sends both fields", async () => {
+    const stepArgs = '{"udid":"SIM-1","x":0.5,"y":0.35}';
+
+    await run(["flow-add-step", "--command", "gesture-tap", `--args=${stepArgs}`], opts);
+
+    const payload = JSON.parse(cap.body!) as Record<string, unknown>;
+    expect(payload).toEqual({ command: "gesture-tap", args: stepArgs });
+  });
+});

--- a/packages/argent-cli/test/run-help.test.ts
+++ b/packages/argent-cli/test/run-help.test.ts
@@ -94,8 +94,10 @@ describe("argent run --help — whole-payload --args advertisement", () => {
     const help = capturedHelp();
     expect(help).not.toContain(WHOLE_PAYLOAD_LINE);
     expect(help).not.toContain(STDIN_SENTINEL_LINE);
-    // Its own `args` field is still shown as a per-field flag in the schema block.
-    expect(help).toContain("--args");
+    // Its own `args` field is still shown as a per-field flag in the schema
+    // block (rendered as `--args <value>` by formatSchemaUsage), so suppression
+    // removes the whole-payload hatch without hiding the field itself.
+    expect(help).toContain("--args <value>");
     expect(toolsClientMock.callTool).not.toHaveBeenCalled();
   });
 });

--- a/packages/argent-cli/test/run-help.test.ts
+++ b/packages/argent-cli/test/run-help.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { run } from "../src/run.js";
+
+// Drive `printToolHelp` through the real `run(..., "--help")` entry point with a
+// mocked tools-client, capturing console.log. This locks in the user-visible
+// half of the fix: a tool that declares its own `args` field must NOT advertise
+// the whole-payload `--args <json>` / `--args -` escape hatch (it no longer
+// applies), while a tool without one keeps it.
+
+const toolsClientMock = vi.hoisted(() => ({
+  fetchTool: vi.fn(),
+  callTool: vi.fn(),
+}));
+
+const telemetryMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  shutdown: vi.fn(async () => undefined),
+  track: vi.fn(),
+}));
+
+vi.mock("@argent/tools-client", () => ({
+  createToolsClient: vi.fn(() => toolsClientMock),
+}));
+
+vi.mock("@argent/telemetry", () => telemetryMock);
+
+// A tool (like flow-add-step) that owns its `args` field.
+const flowAddStepMeta = {
+  name: "flow-add-step",
+  description: "Add a step to the active flow recording",
+  inputSchema: {
+    type: "object",
+    properties: {
+      command: { type: "string" },
+      args: { type: "string" },
+      delayMs: { type: "integer" },
+    },
+    required: ["command"],
+  },
+};
+
+// A tool (like gesture-tap) with NO `args` field.
+const gestureTapMeta = {
+  name: "gesture-tap",
+  description: "Tap the screen",
+  inputSchema: {
+    type: "object",
+    properties: {
+      udid: { type: "string" },
+      x: { type: "number" },
+      y: { type: "number" },
+    },
+    required: ["udid", "x", "y"],
+  },
+};
+
+// Unique text from the two suppressible whole-payload help lines.
+const WHOLE_PAYLOAD_LINE = "Pass the entire payload as JSON";
+const STDIN_SENTINEL_LINE = "Read the entire payload as JSON from stdin";
+
+describe("argent run --help — whole-payload --args advertisement", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  function capturedHelp(): string {
+    return logSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? "")).join("\n");
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("advertises the whole-payload --args escape hatch for a tool without its own `args` field", async () => {
+    toolsClientMock.fetchTool.mockResolvedValue(gestureTapMeta);
+
+    await run(["gesture-tap", "--help"], { paths: {} as never });
+
+    const help = capturedHelp();
+    expect(help).toContain(WHOLE_PAYLOAD_LINE);
+    expect(help).toContain(STDIN_SENTINEL_LINE);
+    // The tool call must never happen on the help path.
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the whole-payload --args lines for a tool that declares its own `args` field", async () => {
+    toolsClientMock.fetchTool.mockResolvedValue(flowAddStepMeta);
+
+    await run(["flow-add-step", "--help"], { paths: {} as never });
+
+    const help = capturedHelp();
+    expect(help).not.toContain(WHOLE_PAYLOAD_LINE);
+    expect(help).not.toContain(STDIN_SENTINEL_LINE);
+    // Its own `args` field is still shown as a per-field flag in the schema block.
+    expect(help).toContain("--args");
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Bug

`argent run flow-add-step` declares its own `args` field — a JSON string holding the recorded step's tool arguments. But the CLI flag parser hardcoded `--args` as a whole-payload escape hatch, so `--args` shadowed the tool's own `args` field. The documented per-flag form

```
argent run flow-add-step --command gesture-tap --args '{"udid":"...","x":0.5,"y":0.5}'
```

silently dropped the step arguments: the `--args` JSON was consumed as the whole payload and the tool's `args` field stayed `undefined`, producing a misleading downstream validation error. Only the nested full-payload form worked.

## Fix

Make `--args` schema-aware in `parseFlags()`:

- When the tool's schema declares a property named `args` (`schema.properties.args`), `--args <value>` is routed through the normal per-field handling and coerced by its declared type (a `string` for flow-add-step, so the raw JSON string passes straight into the `args` field). Both `--args value` and `--args=value` forms are supported.
- When the schema does NOT declare `args`, the existing whole-payload behavior is preserved exactly, including the `--args -` stdin sentinel.

`printToolHelp()` no longer prints the global whole-payload `--args <json>` / `--args -` lines for tools that declare their own `args` field, so the help stops contradicting the per-field `--args` shown in the schema flags.

The change is general: any tool with an `args` field benefits, with no special-casing by tool name.

## Verification

- `npm run build` (root tsc) — clean.
- `npm test -w @argent/cli` — 172 passed, including 6 new `parseFlags` cases covering schema-with-`args` (space-separated + inline forms, plus sibling fields) and schema-without-`args` (whole-payload preserved, `--args -` sentinel, no-schema fallback).
- Prettier + ESLint (`--max-warnings 0`) clean on the touched files.

Full CLI end-to-end (running `flow-add-step` against a live tool-server with an active flow recording) was not exercised here; the added unit tests prove the parser behavior.

Fixes #452
---

### CLI end-to-end verification

Ran the documented per-flag form against a live tool-server with an active flow recording:

- **Before (global argent 0.13.0):** `argent run flow-add-step --command gesture-tap --args '{"udid":"...","x":0.5,"y":0.35}'` → `Invalid params for tool "gesture-tap": udid expected string, received undefined ...` (args dropped).
- **After (this branch):** same command → `{ "message": "Step added to \"colltest\" flow", "toolResult": { "tapped": true } }`, and the recorded YAML contains the step **with** its args (`udid`/`x`/`y`). The per-flag form now works as documented.