### PR TITLE
fix(registry): auto-recover a wedged simulator-server on connection-refused

### DIFF
--- a/packages/registry/src/registry.ts
+++ b/packages/registry/src/registry.ts
@@ -124,19 +124,42 @@ export class Registry {
         effectiveParams = parsed.data;
       }
 
+      // The alias→URN mapping is pure (derived from params), so compute it once
+      // up front — we need the URNs to know which services to recover if the
+      // tool fails against a dead-but-cached instance.
       const aliasToRef = definition.services(effectiveParams);
-      const resolvedServices: Record<string, unknown> = {};
-      for (const [alias, ref] of Object.entries(aliasToRef)) {
-        const urn = typeof ref === "string" ? ref : ref.urn;
-        const resolveOptions = typeof ref === "string" ? undefined : ref.options;
-        resolvedServices[alias] = await this.resolveService(urn, resolveOptions);
-      }
+      const refs = Object.entries(aliasToRef).map(([alias, ref]) => ({
+        alias,
+        urn: typeof ref === "string" ? ref : ref.urn,
+        options: typeof ref === "string" ? undefined : ref.options,
+      }));
 
       // Build the per-invocation context: caller options (e.g. signal) plus the
       // registry-owned artifact store, so any tool can register host files via
       // `ctx.artifacts` without declaring a per-tool service.
       const ctx: ToolContext = { ...options, artifacts: this.artifacts };
-      const result = await definition.execute(resolvedServices, effectiveParams, ctx);
+
+      const runOnce = async (): Promise<TResult> => {
+        const resolvedServices: Record<string, unknown> = {};
+        for (const { alias, urn, options: resolveOptions } of refs) {
+          resolvedServices[alias] = await this.resolveService(urn, resolveOptions);
+        }
+        return definition.execute(resolvedServices, effectiveParams, ctx) as Promise<TResult>;
+      };
+
+      let result: TResult;
+      try {
+        result = await runOnce();
+      } catch (execError) {
+        // Self-heal a cached-but-dead service: if any service this tool resolved
+        // declares this error recoverable (its underlying process is gone even
+        // though the handle was still cached), dispose it and retry the tool
+        // once against a freshly re-created instance. Bounded to a single retry
+        // so a genuinely broken service can't spin.
+        const recovered = await this._recoverFailedServices(refs, execError);
+        if (!recovered) throw execError;
+        result = await runOnce();
+      }
 
       const duration = performance.now() - startTime;
       this.events.emit("toolCompleted", id, toolInvocationId, duration);
@@ -187,6 +210,35 @@ export class Registry {
       namespaces: [...this.blueprints.keys()],
       tools: [...this.tools.keys()],
     };
+  }
+
+  /**
+   * After a tool failed, ask each service it resolved whether the error means
+   * that service's instance is dead (`blueprint.recoverable(error)`). Dispose
+   * every one that says yes so the next `resolveService` re-creates it, and
+   * report whether anything was disposed (i.e. whether a retry is worthwhile).
+   *
+   * Only currently-RUNNING nodes are considered: a service that already
+   * errored/torn down during resolution needs no recovery here, and a URN this
+   * tool never resolved must not be touched.
+   */
+  private async _recoverFailedServices(
+    refs: ReadonlyArray<{ urn: URN }>,
+    error: unknown
+  ): Promise<boolean> {
+    let recoveredAny = false;
+    for (const { urn } of refs) {
+      const node = this.services.get(urn);
+      if (!node || node.state !== ServiceState.RUNNING) continue;
+      if (node.blueprint.recoverable?.(error) !== true) continue;
+      try {
+        await this.disposeService(urn);
+        recoveredAny = true;
+      } catch {
+        /* best-effort: if teardown fails, fall through and surface the original error */
+      }
+    }
+    return recoveredAny;
   }
 
   /**

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -52,6 +52,21 @@ export interface ServiceBlueprint<T = unknown, C = unknown> {
     context: C,
     options?: Record<string, unknown>
   ): Promise<ServiceInstance<T>>;
+  /**
+   * Optional: decide whether an error thrown by a tool that used this service's
+   * instance means the instance is dead and should be torn down + re-created.
+   *
+   * When a tool fails, the registry asks each of that tool's resolved services
+   * this question; any that answer `true` are disposed and the tool is retried
+   * once against freshly-resolved instances. This is how a cached instance whose
+   * underlying process is still alive but no longer serving (e.g. a simulator
+   * that was un-booted, so its simulator-server stopped listening) self-heals
+   * instead of returning the same connection error on every subsequent call.
+   *
+   * Keep this conservative: only return `true` for errors that prove the request
+   * never took effect (so retrying can't double-apply a side effect).
+   */
+  recoverable?(error: unknown): boolean;
 }
 
 /**

--- a/packages/registry/tests/registry-service-recovery.test.ts
+++ b/packages/registry/tests/registry-service-recovery.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { Registry } from "../src/registry";
+import { TypedEventEmitter } from "../src/event-emitter";
+import { ServiceState } from "../src/types";
+import type { ServiceBlueprint, ServiceEvents, ToolDefinition } from "../src/types";
+import { ToolExecutionError } from "../src/errors";
+
+/**
+ * A blueprint whose instances carry an incrementing `epoch` and whose
+ * `recoverable` predicate matches a marker error. `stats()` exposes how many
+ * instances were created and disposed so a test can prove the registry tore a
+ * dead one down and re-created a fresh one.
+ */
+function makeRecoverableBlueprint(namespace = "recov") {
+  let created = 0;
+  let disposed = 0;
+  const blueprint: ServiceBlueprint<{ epoch: number }, string> = {
+    namespace,
+    getURN() {
+      return `${namespace}:only`;
+    },
+    async factory() {
+      const epoch = created++;
+      const events = new TypedEventEmitter<ServiceEvents>();
+      return {
+        api: { epoch },
+        dispose: async () => {
+          disposed++;
+        },
+        events,
+      };
+    },
+    recoverable(error: unknown): boolean {
+      return error instanceof Error && error.message.includes("DEAD_SERVER");
+    },
+  };
+  return {
+    blueprint,
+    urn: `${namespace}:only`,
+    stats: () => ({ created, disposed }),
+  };
+}
+
+/** Tool that throws a marker error while the resolved service's epoch is below `healthyFrom`. */
+function makeProbeTool(
+  urn: string,
+  opts: { healthyFrom: number; recoverableError?: boolean } = { healthyFrom: 1 }
+): ToolDefinition<unknown, { epoch: number }> {
+  return {
+    id: "probe",
+    services: () => ({ svc: urn }),
+    async execute(resolved): Promise<{ epoch: number }> {
+      const svc = resolved.svc as { epoch: number };
+      if (svc.epoch < opts.healthyFrom) {
+        throw new Error(
+          opts.recoverableError === false
+            ? "plain failure, do not recover"
+            : "DEAD_SERVER: connect ECONNREFUSED"
+        );
+      }
+      return { epoch: svc.epoch };
+    },
+  };
+}
+
+describe("Registry -- service self-recovery on recoverable tool failure", () => {
+  it("disposes a dead service and retries once, succeeding against a fresh instance", async () => {
+    const registry = new Registry();
+    const { blueprint, urn, stats } = makeRecoverableBlueprint();
+    registry.registerBlueprint(blueprint);
+    registry.registerTool(makeProbeTool(urn, { healthyFrom: 1 }));
+
+    const result = await registry.invokeTool<{ epoch: number }>("probe");
+
+    // Retried against a freshly re-created instance (epoch 1), not the dead one.
+    expect(result.epoch).toBe(1);
+    expect(stats()).toEqual({ created: 2, disposed: 1 });
+    // The replacement instance is live and cached.
+    expect(registry.getServiceState(urn)).toBe(ServiceState.RUNNING);
+  });
+
+  it("does not retry when the error is not recoverable", async () => {
+    const registry = new Registry();
+    const { blueprint, urn, stats } = makeRecoverableBlueprint();
+    registry.registerBlueprint(blueprint);
+    registry.registerTool(makeProbeTool(urn, { healthyFrom: 1, recoverableError: false }));
+
+    await expect(registry.invokeTool("probe")).rejects.toBeInstanceOf(ToolExecutionError);
+
+    // No dispose, no re-create — the original instance is left intact.
+    expect(stats()).toEqual({ created: 1, disposed: 0 });
+    expect(registry.getServiceState(urn)).toBe(ServiceState.RUNNING);
+  });
+
+  it("retries at most once, then surfaces the failure (no infinite respawn)", async () => {
+    const registry = new Registry();
+    const { blueprint, urn, stats } = makeRecoverableBlueprint();
+    registry.registerBlueprint(blueprint);
+    // healthyFrom huge → every instance throws the recoverable error.
+    registry.registerTool(makeProbeTool(urn, { healthyFrom: 999 }));
+
+    await expect(registry.invokeTool("probe")).rejects.toBeInstanceOf(ToolExecutionError);
+
+    // Exactly one recovery: first instance disposed, one replacement created,
+    // and the retry's failure is not itself retried.
+    expect(stats()).toEqual({ created: 2, disposed: 1 });
+  });
+
+  it("only disposes the service that reports the error as recoverable", async () => {
+    const registry = new Registry();
+    const dead = makeRecoverableBlueprint("dead");
+    const healthy = makeRecoverableBlueprint("healthy");
+    // The healthy service never claims an error is recoverable.
+    healthy.blueprint.recoverable = () => false;
+    registry.registerBlueprint(dead.blueprint);
+    registry.registerBlueprint(healthy.blueprint);
+
+    // Tool resolves BOTH services; fails against the dead one on epoch 0.
+    const tool: ToolDefinition<unknown, { epoch: number }> = {
+      id: "probe",
+      services: () => ({ dead: dead.urn, healthy: healthy.urn }),
+      async execute(resolved): Promise<{ epoch: number }> {
+        const d = resolved.dead as { epoch: number };
+        if (d.epoch < 1) throw new Error("DEAD_SERVER: connect ECONNREFUSED");
+        return { epoch: d.epoch };
+      },
+    };
+    registry.registerTool(tool);
+
+    const result = await registry.invokeTool<{ epoch: number }>("probe");
+
+    expect(result.epoch).toBe(1);
+    // Dead service was torn down + re-created; healthy one was left untouched.
+    expect(dead.stats()).toEqual({ created: 2, disposed: 1 });
+    expect(healthy.stats()).toEqual({ created: 1, disposed: 0 });
+  });
+});

--- a/packages/tool-server/src/blueprints/simulator-server.ts
+++ b/packages/tool-server/src/blueprints/simulator-server.ts
@@ -5,6 +5,7 @@ import {
   FailureError,
   TypedEventEmitter,
   subprocessFailureMetadata,
+  getFailureSignal,
   type DeviceInfo,
   type ServiceBlueprint,
   type ServiceInstance,
@@ -278,6 +279,26 @@ export const simulatorServerBlueprint: ServiceBlueprint<SimulatorServerApi, Devi
   namespace: SIMULATOR_SERVER_NAMESPACE,
   getURN(device: DeviceInfo) {
     return `${SIMULATOR_SERVER_NAMESPACE}:${device.id}`;
+  },
+  /**
+   * A cached simulator-server handle can outlive the thing it points at: when a
+   * simulator is un-booted (or the native server crashes) the child process may
+   * stay alive but stop listening on its API port, so every subsequent request
+   * fails with `ECONNREFUSED` against the now-dead port — the exact "worked once,
+   * then every call times out" symptom, unrecoverable until a human runs
+   * `stop-simulator-server`. The process never emitting `exit` means the
+   * registry's normal teardown (wired to `proc.on("exit")`) never fires.
+   *
+   * Treat a connection-refused failure as proof the instance is dead so the
+   * registry disposes it (killing the wedged process) and re-spawns a fresh
+   * simulator-server on the next call. Scoped to connection-refused only:
+   * ECONNREFUSED means the request never reached the server, so retrying can't
+   * double-apply a gesture. Timeouts and resets are deliberately excluded — the
+   * request there may have taken effect, and a hung-but-listening server is a
+   * different failure that respawning wouldn't fix.
+   */
+  recoverable(error: unknown): boolean {
+    return getFailureSignal(error)?.network_failure === "connection_refused";
   },
   async factory(_deps, _payload, options) {
     const opts = options as unknown as SimulatorServerFactoryOptions | undefined;

--- a/packages/tool-server/test/simulator-server-blueprint.test.ts
+++ b/packages/tool-server/test/simulator-server-blueprint.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import type { DeviceInfo } from "@argent/registry";
+import { toSimulatorNetworkError } from "../src/utils/format-error";
 
 // ─── Mocks ───────────────────────────────────────────────────────────
 //
@@ -249,5 +250,49 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("simulatorServerBlueprint.recoverable — self-heal a wedged sim-server", () => {
+  const apiUrl = "http://127.0.0.1:58710";
+
+  // Mirror what `fetch()` throws so the classifier walks the real cause chain:
+  // a `TypeError: fetch failed` wrapping the low-level connect error.
+  function fetchError(causeMessage: string, name = "TypeError"): Error {
+    const cause = new Error(causeMessage);
+    const err = new Error("fetch failed", { cause });
+    err.name = name;
+    return err;
+  }
+
+  it("recovers on ECONNREFUSED — the un-booted-simulator symptom", async () => {
+    const { simulatorServerBlueprint } = await import("../src/blueprints/simulator-server");
+    const err = toSimulatorNetworkError(
+      "Screenshot",
+      fetchError("connect ECONNREFUSED 127.0.0.1:58710"),
+      apiUrl
+    );
+    expect(simulatorServerBlueprint.recoverable!(err)).toBe(true);
+  });
+
+  it("does NOT recover on a reset — the request may have taken effect", async () => {
+    const { simulatorServerBlueprint } = await import("../src/blueprints/simulator-server");
+    const err = toSimulatorNetworkError("Screenshot", fetchError("read ECONNRESET"), apiUrl);
+    expect(simulatorServerBlueprint.recoverable!(err)).toBe(false);
+  });
+
+  it("does NOT recover on a timeout — a hung-but-listening server won't be fixed by respawning", async () => {
+    const { simulatorServerBlueprint } = await import("../src/blueprints/simulator-server");
+    const err = toSimulatorNetworkError(
+      "Screenshot",
+      fetchError("The operation was aborted", "AbortError"),
+      apiUrl
+    );
+    expect(simulatorServerBlueprint.recoverable!(err)).toBe(false);
+  });
+
+  it("does NOT recover on an unrelated error carrying no failure signal", async () => {
+    const { simulatorServerBlueprint } = await import("../src/blueprints/simulator-server");
+    expect(simulatorServerBlueprint.recoverable!(new Error("boom"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

A user reported that argent "worked once, then every call timed out" — an hour of `this is taking longer than expected` / `request timed out`. Their logs showed the tell: dozens of

```
Screenshot failed: cannot connect to simulator-server (connection refused at http://127.0.0.1:<port>) … ECONNREFUSED
```

against a single stale port, starting right after `Simulator state changed to 4 (not booted)`.

**Root cause — liveness ≠ readiness.** When a simulator is un-booted (or the native server crashes), the `simulator-server` child process can stay **alive** while its API socket stops **listening**. The registry only tears a service down on the child's `exit` event, so the dead-but-cached handle is reused on every subsequent call → `ECONNREFUSED` forever — *even after the simulator is booted again*. The only escape was a manual `stop-simulator-server`, which no ordinary user discovers.

## Fix

A generic, opt-in recovery hook on the service registry: **`ServiceBlueprint.recoverable(error)`**. After a tool fails, the registry asks each service that tool resolved whether the error means its instance is dead; any that say yes are disposed (killing the wedged process) and the tool is **retried once** against a freshly re-created instance. Bounded to a single retry so a genuinely broken service can't spin. The registry stays generic — it learns nothing about simulators.

The **simulator-server blueprint** implements `recoverable` for **connection-refused only**:
- `ECONNREFUSED` proves the request never reached the server, so respawning + retrying can't double-apply a gesture.
- **Timeouts and resets are deliberately excluded** — the request there may have taken effect, and a hung-but-listening server is a different failure that respawning wouldn't fix.

## Verification

Reproduced live on a real simulator (un-boot → re-boot mid-session), same harness for both arms:

| | Result |
|---|---|
| **Fix enabled** | second screenshot succeeds automatically in ~2.8s (fresh sim-server respawned) — `RECOVERED` |
| **Fix disabled** (1-line toggle) | `connection refused at :<port>` persists through the reboot — `WEDGED`, the reported symptom |

Automated:
- **Registry** (`registry-service-recovery.test.ts`) — retry-once success, no-retry on non-recoverable errors, single-retry cap (no infinite respawn), and targeted disposal (only the service that reports the error is torn down).
- **Blueprint** (`simulator-server-blueprint.test.ts`) — recovers on ECONNREFUSED; does **not** on reset / timeout / unrelated errors.
- Full suites green: registry 87, tool-server 1846. Lint + prettier clean.

## Files
- `packages/registry/src/types.ts` — add optional `recoverable?(error)` to `ServiceBlueprint`.
- `packages/registry/src/registry.ts` — `invokeTool` disposes recoverable services and retries once.
- `packages/tool-server/src/blueprints/simulator-server.ts` — implement `recoverable` (connection-refused only).
- Tests for both layers.