### PR TITLE
perf(argent-mcp): wait for the screen to settle before the auto-screenshot

### DIFF
--- a/packages/argent-mcp/src/auto-screenshot.ts
+++ b/packages/argent-mcp/src/auto-screenshot.ts
@@ -27,8 +27,11 @@ export const AUTO_SCREENSHOT_TOOLS = new Set([
 ]);
 
 /**
- * Per-tool delay (ms) before capturing the screenshot.
- * +1 000 ms over baseline research values to cover slow devices/transitions.
+ * Per-tool cap (ms) on how long the auto-screenshot waits for the screen to
+ * settle before capturing (via the `await-screen-idle` tool). The readiness
+ * poll usually returns well under this; the cap only bounds a screen that never
+ * settles. Values sit ~1 000 ms above baseline research figures to stay safe on
+ * slow devices/transitions.
  */
 export const AUTO_SCREENSHOT_DELAY_MS_BY_TOOL: Record<string, number> = {
   "launch-app": 3000,

--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -304,8 +304,28 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
 
       const udid = getUdidFromArgs(params.arguments);
       if (autoScreenshotOn && udid && shouldAutoScreenshot(params.name)) {
-        const delayMs = getAutoScreenshotDelayMs(params.name);
-        if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+        // Wait until the screen has settled before capturing, bounded by the
+        // per-tool budget. Replaces a blind `setTimeout(delayMs)`: the
+        // `await-screen-idle` tool polls the AX tree server-side and returns as
+        // soon as the screen renders and holds still, so a relaunch that used to
+        // always cost the full 3000ms usually returns in a fraction of it. The
+        // per-tool delay is now the cap. If the tool is unavailable (older or
+        // remote tool-server), fall back to the previous fixed settle.
+        const maxWaitMs = getAutoScreenshotDelayMs(params.name);
+        if (maxWaitMs > 0) {
+          try {
+            const idle = await callTool("await-screen-idle", { udid, timeoutMs: maxWaitMs });
+            await spyLog({
+              ts: new Date().toISOString(),
+              event: "auto_screenshot_readiness",
+              name: params.name,
+              maxWaitMs,
+              ...(idle.result as Record<string, unknown>),
+            });
+          } catch {
+            await new Promise((r) => setTimeout(r, maxWaitMs));
+          }
+        }
 
         try {
           const screenshotResult = await callTool("screenshot", { udid });

--- a/packages/tool-server/src/tools/await-screen-idle/index.ts
+++ b/packages/tool-server/src/tools/await-screen-idle/index.ts
@@ -1,0 +1,172 @@
+import { z } from "zod";
+import type {
+  DeviceInfo,
+  Registry,
+  ServiceRef,
+  ToolCapability,
+  ToolContext,
+  ToolDefinition,
+} from "@argent/registry";
+import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-cdp";
+import { resolveDevice } from "../../utils/device-info";
+import { isTvOsSimulator } from "../../utils/ios-devices";
+import { assertSupported } from "../../utils/capability";
+import { ensureDeps } from "../../utils/check-deps";
+import { pollDescribeTree } from "../../utils/poll-describe-tree";
+import type { DescribeNode, DescribeTreeData } from "../describe/contract";
+import { describeIos, iosRequires } from "../describe/platforms/ios";
+import { describeAndroid, androidRequires } from "../describe/platforms/android";
+import { describeChromium } from "../describe/platforms/chromium";
+
+export const AWAIT_SCREEN_IDLE_TOOL_ID = "await-screen-idle";
+
+const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_POLL_INTERVAL_MS = 200;
+const DEFAULT_MIN_STABLE_MS = 250;
+
+const zodSchema = z.object({
+  udid: z
+    .string()
+    .min(1)
+    .describe("Target device id from `list-devices` (iOS UDID, Android serial, or Chromium id)."),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(120_000)
+    .optional()
+    .describe(
+      `Max time to wait for the screen to settle before giving up (default ${DEFAULT_TIMEOUT_MS}).`
+    ),
+  pollIntervalMs: z
+    .number()
+    .int()
+    .min(50)
+    .max(5000)
+    .optional()
+    .describe(`How often to re-read the tree (default ${DEFAULT_POLL_INTERVAL_MS}).`),
+  minStableMs: z
+    .number()
+    .int()
+    .min(0)
+    .max(10_000)
+    .optional()
+    .describe(
+      `The screen must hold the same content for at least this long to count as settled (default ${DEFAULT_MIN_STABLE_MS}).`
+    ),
+});
+
+type Params = z.infer<typeof zodSchema>;
+
+interface IdleResult {
+  /** True if the screen rendered content and went still before the timeout. */
+  settled: boolean;
+  /** Wall-clock time waited (ms). */
+  waitedMs: number;
+  /** Number of tree reads taken. */
+  polls: number;
+}
+
+const capability: ToolCapability = {
+  apple: { simulator: true, device: true },
+  android: { emulator: true, device: true, unknown: true },
+  chromium: { app: true },
+};
+
+// A cheap fingerprint of the screen: role + label + value + frame (rounded to
+// 1% of the screen) for every node below the synthetic root. Rounding tolerates
+// sub-pixel jitter while still catching real motion (a slide/fade animation),
+// so an unchanged signature means the screen has genuinely stopped moving.
+function treeSignature(root: DescribeNode): string {
+  const round = (n: number) => Math.round(n * 100) / 100;
+  const parts: string[] = [];
+  const walk = (node: DescribeNode): void => {
+    const f = node.frame;
+    parts.push(
+      `${node.role}|${node.label ?? ""}|${node.value ?? ""}|${round(f.x)},${round(f.y)},${round(f.width)},${round(f.height)}`
+    );
+    for (const child of node.children) walk(child);
+  };
+  for (const child of root.children) walk(child);
+  return parts.join("\n");
+}
+
+// `await-screen-idle` waits for the screen to *settle* — render content and stop
+// changing — rather than for a named element like `await-ui-element`. The MCP
+// layer uses it to time its auto-screenshot: capture once the screen is stable
+// instead of after a fixed delay.
+export function createAwaitScreenIdleTool(registry: Registry): ToolDefinition<Params, IdleResult> {
+  function fetchTree(
+    device: DeviceInfo,
+    services: Record<string, unknown>,
+    isTvOs: boolean
+  ): Promise<DescribeTreeData> {
+    if (device.platform === "ios") {
+      return describeIos(registry, device, {}, { isTvOs });
+    }
+    if (device.platform === "android") {
+      return describeAndroid(registry, device.id);
+    }
+    return describeChromium(services.chromium as ChromiumCdpApi);
+  }
+
+  return {
+    id: AWAIT_SCREEN_IDLE_TOOL_ID,
+    description: `Block until the screen has rendered content and stopped changing, or a timeout elapses.
+
+Polls the same accessibility / DOM tree as \`describe\` every pollIntervalMs (default ${DEFAULT_POLL_INTERVAL_MS}ms) until it
+has content and that content holds identical for minStableMs (default ${DEFAULT_MIN_STABLE_MS}ms), or timeoutMs (default
+${DEFAULT_TIMEOUT_MS}ms) is reached. Returns { settled, waitedMs, polls } — settled=false means the screen never went
+still before the timeout. Use after a launch/navigation to wait for the UI to render before screenshotting or tapping.`,
+    searchHint:
+      "wait until screen settles idle stable stops changing animation transition rendered ready before screenshot",
+    longRunning: true,
+    zodSchema,
+    capability,
+    services: (params): Record<string, ServiceRef> => {
+      const device = resolveDevice(params.udid);
+      if (device.platform === "chromium") {
+        return { chromium: chromiumCdpRef(device) };
+      }
+      return {};
+    },
+    async execute(services, params, ctx?: ToolContext) {
+      const device = resolveDevice(params.udid);
+      assertSupported(AWAIT_SCREEN_IDLE_TOOL_ID, capability, device);
+      if (device.platform === "ios") await ensureDeps(iosRequires);
+      else if (device.platform === "android") await ensureDeps(androidRequires);
+
+      const isTvOs = device.platform === "ios" && (await isTvOsSimulator(device.id));
+      const minStableMs = params.minStableMs ?? DEFAULT_MIN_STABLE_MS;
+
+      let stableSignature: string | undefined;
+      let stableSince = 0;
+
+      const poll = await pollDescribeTree<true>({
+        fetchTree: () => fetchTree(device, services, isTvOs),
+        timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        pollIntervalMs: params.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+        signal: ctx?.signal,
+        onSample: (data, nowMs) => {
+          // An empty tree (blank/loading, or a degraded AX read) is not settled.
+          if (data.tree.children.length === 0) {
+            stableSignature = undefined;
+            stableSince = 0;
+            return { done: false };
+          }
+          const signature = treeSignature(data.tree);
+          if (signature === stableSignature) {
+            if (nowMs - stableSince >= minStableMs) return { done: true, result: true };
+          } else {
+            stableSignature = signature;
+            stableSince = nowMs;
+            if (minStableMs === 0) return { done: true, result: true };
+          }
+          return { done: false };
+        },
+      });
+
+      return { settled: poll.result === true, waitedMs: poll.elapsedMs, polls: poll.polls };
+    },
+  };
+}

--- a/packages/tool-server/src/tools/await-ui-element/index.ts
+++ b/packages/tool-server/src/tools/await-ui-element/index.ts
@@ -12,7 +12,7 @@ import { resolveDevice } from "../../utils/device-info";
 import { isTvOsSimulator } from "../../utils/ios-devices";
 import { assertSupported } from "../../utils/capability";
 import { ensureDeps } from "../../utils/check-deps";
-import { sleepOrAbort } from "../../utils/timing";
+import { pollDescribeTree } from "../../utils/poll-describe-tree";
 import type { DescribeNode, DescribeTreeData } from "../describe/contract";
 import { describeIos, iosRequires } from "../describe/platforms/ios";
 import { describeAndroid, androidRequires } from "../describe/platforms/android";
@@ -318,46 +318,6 @@ function timeoutNote(
   return appendDiagnostics(base, lastData);
 }
 
-// ── Per-fetch deadline / abort ─────────────────────────────────────────────
-
-type Settled<T> =
-  | { type: "value"; value: T }
-  | { type: "error"; error: string }
-  | { type: "timeout" }
-  | { type: "aborted" };
-
-// Race a tree fetch against the remaining wait budget and the abort signal. The
-// underlying describe fetch isn't cancellable (no AbortSignal reaches adb /
-// AXRuntime), so a slow or hung fetch — e.g. the Android `uiautomator dump`
-// fallback, which allows up to 20s — would otherwise blow past `timeoutMs` and
-// ignore an abort that arrives mid-fetch. We can't kill the orphaned fetch, but
-// we stop waiting on it; its eventual settle is consumed here (handlers attached
-// up front) so it can't surface as an unhandled rejection.
-function settleWithin<T>(p: Promise<T>, ms: number, signal?: AbortSignal): Promise<Settled<T>> {
-  return new Promise((resolve) => {
-    let done = false;
-    const teardown: Array<() => void> = [];
-    const finish = (r: Settled<T>) => {
-      if (done) return;
-      done = true;
-      for (const fn of teardown) fn();
-      resolve(r);
-    };
-    // Attach the settle handlers up front so a late settle from an abandoned
-    // fetch is always consumed (no unhandled rejection) even after we've moved on.
-    p.then(
-      (value) => finish({ type: "value", value }),
-      (err) => finish({ type: "error", error: err instanceof Error ? err.message : String(err) })
-    );
-    if (signal?.aborted) return finish({ type: "aborted" });
-    const onAbort = () => finish({ type: "aborted" });
-    signal?.addEventListener("abort", onAbort, { once: true });
-    teardown.push(() => signal?.removeEventListener("abort", onAbort));
-    const timer = setTimeout(() => finish({ type: "timeout" }), Math.max(0, ms));
-    teardown.push(() => clearTimeout(timer));
-  });
-}
-
 // ── Tool ─────────────────────────────────────────────────────────────────
 
 // `await-ui-element` is a factory (like `describe`) because the iOS / Android
@@ -436,52 +396,19 @@ or before tapping an element that appears asynchronously.`,
 
       const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
       const pollIntervalMs = params.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-      const deadline = start + timeoutMs;
       const selector = params.selector;
 
-      let lastTree: DescribeNode | null = null;
-      let lastData: DescribeTreeData | null = null;
-      let fetchError: string | undefined;
       // For `hidden`: did the selector ever match across polls? Distinguishes
       // "the element was there and disappeared" from "the selector never matched
       // at all" — otherwise a typo'd selector is an instant false-positive.
       let everMatched = false;
 
-      for (;;) {
-        if (signal?.aborted) return cancelled();
-
-        // Bound each fetch to the time left before the deadline so a slow / hung
-        // describe can't overshoot timeoutMs, and an abort mid-fetch is observed
-        // promptly instead of after the fetch resolves.
-        const remaining = Math.max(0, deadline - Date.now());
-        const settled = await settleWithin(
-          fetchTree(device, params, services, isTvOs),
-          remaining,
-          signal
-        );
-
-        if (settled.type === "aborted") return cancelled();
-        if (settled.type === "timeout") {
-          // The fetch outran the time left before the deadline. Two cases:
-          //  - We never got a usable tree (a genuinely slow/hung fetch, e.g. the
-          //    Android 20s dump under a small timeoutMs) → report that as the
-          //    cause so the agent knows the screen was never read.
-          //  - We already have a tree from an earlier poll and this final fetch
-          //    merely straddled the deadline (describe latency varies) → fall
-          //    through to the normal condition-not-met note built from lastTree,
-          //    which is far more useful than "fetch did not complete".
-          if (lastTree === null) {
-            fetchError ??= `tree fetch did not complete within the ${timeoutMs}ms wait budget`;
-          }
-          break;
-        }
-        if (settled.type === "error") {
-          fetchError = settled.error;
-        } else {
-          const data = settled.value;
-          lastData = data;
-          lastTree = data.tree;
-          fetchError = undefined;
+      const poll = await pollDescribeTree<WaitResult>({
+        fetchTree: () => fetchTree(device, params, services, isTvOs),
+        timeoutMs,
+        pollIntervalMs,
+        signal,
+        onSample: (data) => {
           const matches = findAll(data.tree, selector);
           if (matches.length > 0) everMatched = true;
           // Compute `blind` after `everMatched` so an empty tree that follows an
@@ -494,23 +421,19 @@ or before tapping an element that appears asynchronously.`,
                 "condition met immediately — the selector never matched any element, " +
                 "so it may have already been hidden before the wait, or the selector is wrong";
             }
-            return result;
+            return { done: true, result };
           }
-        }
+          return { done: false };
+        },
+      });
 
-        if (Date.now() >= deadline) break;
-        // Clamp the poll sleep to the time left before the deadline so a large
-        // pollIntervalMs can't overshoot timeoutMs. The next iteration then does
-        // one final poll at the deadline before the loop breaks, so the
-        // condition still gets its full time budget.
-        const sleepMs = Math.min(pollIntervalMs, Math.max(0, deadline - Date.now()));
-        if (!(await sleepOrAbort(sleepMs, signal))) return cancelled();
-      }
+      if (poll.aborted) return cancelled();
+      if (poll.result) return poll.result;
 
       return {
         success: false,
         elapsed: Date.now() - start,
-        note: timeoutNote(params, lastTree, fetchError, lastData),
+        note: timeoutNote(params, poll.lastData?.tree ?? null, poll.lastError, poll.lastData),
       };
     },
   };

--- a/packages/tool-server/src/utils/poll-describe-tree.ts
+++ b/packages/tool-server/src/utils/poll-describe-tree.ts
@@ -1,0 +1,108 @@
+import type { DescribeTreeData } from "../tools/describe/contract";
+import { settleWithin, sleepOrAbort } from "./timing";
+
+/**
+ * Shared accessibility/DOM-tree polling loop used by the wait tools
+ * (`await-ui-element`, `await-screen-idle`). It re-reads the `describe` tree on
+ * an interval until a caller-supplied `onSample` predicate is satisfied or the
+ * timeout elapses, keeping the robust bits in one place:
+ *
+ *  - each fetch is raced against the remaining budget + abort via `settleWithin`,
+ *    so a slow/hung read can't overshoot `timeoutMs` and an abort is observed
+ *    promptly instead of after the fetch resolves;
+ *  - the poll sleep is clamped to the deadline so a large `pollIntervalMs` can't
+ *    overshoot, while still allowing one final poll at the deadline.
+ *
+ * The predicate owns the tool-specific meaning of "done" (an element reached a
+ * state, or the screen settled); this loop owns timing, cancellation, and the
+ * fetch lifecycle.
+ */
+
+/** Verdict from evaluating one successfully-fetched tree. */
+export type PollVerdict<R> = { done: true; result: R } | { done: false };
+
+export interface PollDescribeTreeArgs<R> {
+  /** Read the current tree. Called once per poll; must be read-only. */
+  fetchTree: () => Promise<DescribeTreeData>;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  signal?: AbortSignal;
+  /**
+   * Evaluate one successfully-fetched tree. `nowMs` is the poll clock
+   * (`Date.now()` at the sample) so predicates can track stability windows
+   * without their own timer. Return `{ done: true, result }` to stop early.
+   */
+  onSample: (data: DescribeTreeData, nowMs: number) => PollVerdict<R>;
+}
+
+export interface PollDescribeTreeResult<R> {
+  /** Result from the first `onSample` that returned done; undefined on timeout. */
+  result: R | undefined;
+  /** True if the wait was cancelled via the abort signal. */
+  aborted: boolean;
+  /** Number of tree fetches attempted. */
+  polls: number;
+  /** Wall-clock time spent polling (ms). */
+  elapsedMs: number;
+  /** Most recent successfully-fetched tree, or null if none ever arrived. */
+  lastData: DescribeTreeData | null;
+  /** Most recent fetch error / timeout message, if the last fetch failed. */
+  lastError?: string;
+}
+
+export async function pollDescribeTree<R>(
+  args: PollDescribeTreeArgs<R>
+): Promise<PollDescribeTreeResult<R>> {
+  const { fetchTree, timeoutMs, pollIntervalMs, signal, onSample } = args;
+  const start = Date.now();
+  const deadline = start + timeoutMs;
+
+  let polls = 0;
+  let lastData: DescribeTreeData | null = null;
+  let lastError: string | undefined;
+
+  const outcome = (result: R | undefined, aborted: boolean): PollDescribeTreeResult<R> => ({
+    result,
+    aborted,
+    polls,
+    elapsedMs: Date.now() - start,
+    lastData,
+    lastError,
+  });
+
+  for (;;) {
+    if (signal?.aborted) return outcome(undefined, true);
+
+    // Bound each fetch to the time left before the deadline.
+    const remaining = Math.max(0, deadline - Date.now());
+    const settled = await settleWithin(fetchTree(), remaining, signal);
+    polls += 1;
+
+    if (settled.type === "aborted") return outcome(undefined, true);
+    if (settled.type === "timeout") {
+      // Only synthesize a "did not complete" error when we never got a usable
+      // tree; a final fetch that merely straddled the deadline leaves lastData
+      // in place so the caller can build a content-based note from it.
+      if (lastData === null) {
+        lastError ??= `tree fetch did not complete within the ${timeoutMs}ms wait budget`;
+      }
+      break;
+    }
+    if (settled.type === "error") {
+      lastError = settled.error;
+    } else {
+      lastData = settled.value;
+      lastError = undefined;
+      const verdict = onSample(settled.value, Date.now());
+      if (verdict.done) return outcome(verdict.result, false);
+    }
+
+    if (Date.now() >= deadline) break;
+    // Clamp the poll sleep so a large pollIntervalMs can't overshoot the
+    // deadline; the next iteration still does one final poll at the deadline.
+    const sleepMs = Math.min(pollIntervalMs, Math.max(0, deadline - Date.now()));
+    if (!(await sleepOrAbort(sleepMs, signal))) return outcome(undefined, true);
+  }
+
+  return outcome(undefined, false);
+}

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -48,6 +48,7 @@ import { networkLogsTool } from "../tools/network/network-logs";
 import { networkRequestTool } from "../tools/network/network-request";
 import { createDescribeTool } from "../tools/describe";
 import { createAwaitUiElementTool } from "../tools/await-ui-element";
+import { createAwaitScreenIdleTool } from "../tools/await-screen-idle";
 import { createReactProfilerStartTool } from "../tools/profiler/react/react-profiler-start";
 import { createReactProfilerStopTool } from "../tools/profiler/react/react-profiler-stop";
 import { createReactProfilerStatusTool } from "../tools/profiler/react/react-profiler-status";
@@ -138,6 +139,7 @@ export function createRegistry(): Registry {
   registry.registerTool(networkRequestTool);
   registry.registerTool(createDescribeTool(registry));
   registry.registerTool(createAwaitUiElementTool(registry));
+  registry.registerTool(createAwaitScreenIdleTool(registry));
   registry.registerTool(createReactProfilerStartTool(registry));
   registry.registerTool(createReactProfilerStopTool(registry));
   registry.registerTool(createReactProfilerStatusTool(registry));

--- a/packages/tool-server/src/utils/timing.ts
+++ b/packages/tool-server/src/utils/timing.ts
@@ -19,3 +19,45 @@ export function sleepOrAbort(ms: number, signal?: AbortSignal): Promise<boolean>
     signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
+
+export type Settled<T> =
+  | { type: "value"; value: T }
+  | { type: "error"; error: string }
+  | { type: "timeout" }
+  | { type: "aborted" };
+
+// Race a promise against a time budget and an abort signal. The underlying work
+// often isn't cancellable (no AbortSignal reaches adb / AXRuntime), so a slow or
+// hung operation — e.g. an Android `uiautomator dump`, which allows up to 20s —
+// would otherwise blow past its caller's deadline and ignore an abort that
+// arrives mid-flight. We can't kill the orphaned work, but we stop waiting on
+// it; its eventual settle is consumed here (handlers attached up front) so it
+// can't surface as an unhandled rejection.
+export function settleWithin<T>(
+  p: Promise<T>,
+  ms: number,
+  signal?: AbortSignal
+): Promise<Settled<T>> {
+  return new Promise((resolve) => {
+    let done = false;
+    const teardown: Array<() => void> = [];
+    const finish = (r: Settled<T>) => {
+      if (done) return;
+      done = true;
+      for (const fn of teardown) fn();
+      resolve(r);
+    };
+    // Attach the settle handlers up front so a late settle from abandoned work is
+    // always consumed (no unhandled rejection) even after we've moved on.
+    p.then(
+      (value) => finish({ type: "value", value }),
+      (err) => finish({ type: "error", error: err instanceof Error ? err.message : String(err) })
+    );
+    if (signal?.aborted) return finish({ type: "aborted" });
+    const onAbort = () => finish({ type: "aborted" });
+    signal?.addEventListener("abort", onAbort, { once: true });
+    teardown.push(() => signal?.removeEventListener("abort", onAbort));
+    const timer = setTimeout(() => finish({ type: "timeout" }), Math.max(0, ms));
+    teardown.push(() => clearTimeout(timer));
+  });
+}

--- a/packages/tool-server/test/await-screen-idle.test.ts
+++ b/packages/tool-server/test/await-screen-idle.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AXServiceApi, AXDescribeResponse } from "../src/blueprints/ax-service";
+import { createAwaitScreenIdleTool } from "../src/tools/await-screen-idle";
+import { __primeDepCacheForTests, __resetDepCacheForTests } from "../src/utils/check-deps";
+
+const IOS_UDID = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA";
+const FRAME = { x: 0.1, y: 0.4, width: 0.8, height: 0.05 };
+
+// AX service that walks `responses` one per call, repeating the last — lets a
+// test simulate a screen that is blank, then renders, then holds still.
+function makeSequencedAXService(responses: AXDescribeResponse[]): AXServiceApi {
+  let i = 0;
+  return {
+    degraded: false,
+    describe: async () => responses[Math.min(i++, responses.length - 1)],
+    alertCheck: async () => false,
+    ping: async () => true,
+  };
+}
+
+function axResponse(elements: AXDescribeResponse["elements"]): AXDescribeResponse {
+  return { alertVisible: false, screenFrame: { width: 440, height: 956 }, elements };
+}
+
+function iosRegistry(ax: AXServiceApi) {
+  return {
+    resolveService: vi.fn(async (urn: string) => {
+      if (urn.startsWith("AXService:")) return ax;
+      throw new Error(`unexpected service: ${urn}`);
+    }),
+  } as any;
+}
+
+const content = () => axResponse([{ label: "Settings", frame: FRAME, traits: ["button"] }]);
+
+describe("await-screen-idle tool", () => {
+  beforeEach(() => {
+    __resetDepCacheForTests();
+    __primeDepCacheForTests(["xcrun", "adb"]);
+  });
+
+  it("exposes the await-screen-idle id", () => {
+    expect(createAwaitScreenIdleTool(iosRegistry({} as AXServiceApi)).id).toBe("await-screen-idle");
+  });
+
+  it("settles once content renders and holds still", async () => {
+    // blank, then the same content on every later poll → stable
+    const tool = createAwaitScreenIdleTool(
+      iosRegistry(makeSequencedAXService([axResponse([]), content()]))
+    );
+
+    const result = await tool.execute(
+      {},
+      { udid: IOS_UDID, timeoutMs: 2000, pollIntervalMs: 10, minStableMs: 30 }
+    );
+
+    expect(result.settled).toBe(true);
+    expect(result.waitedMs).toBeGreaterThanOrEqual(30);
+    expect(result.waitedMs).toBeLessThan(2000);
+    expect(result.polls).toBeGreaterThan(1);
+  });
+
+  it("does not settle while the screen stays blank (times out)", async () => {
+    const tool = createAwaitScreenIdleTool(iosRegistry(makeSequencedAXService([axResponse([])])));
+
+    const result = await tool.execute(
+      {},
+      { udid: IOS_UDID, timeoutMs: 60, pollIntervalMs: 10, minStableMs: 30 }
+    );
+
+    expect(result.settled).toBe(false);
+    expect(result.waitedMs).toBeGreaterThanOrEqual(60);
+  });
+
+  it("does not settle while content keeps changing (times out)", async () => {
+    // a different label every poll never holds for minStableMs
+    const changing = Array.from({ length: 30 }, (_, i) =>
+      axResponse([{ label: `item-${i}`, frame: FRAME, traits: ["button"] }])
+    );
+    const tool = createAwaitScreenIdleTool(iosRegistry(makeSequencedAXService(changing)));
+
+    const result = await tool.execute(
+      {},
+      { udid: IOS_UDID, timeoutMs: 80, pollIntervalMs: 5, minStableMs: 40 }
+    );
+
+    expect(result.settled).toBe(false);
+    expect(result.waitedMs).toBeGreaterThanOrEqual(80);
+  });
+
+  it("settles on the first non-empty read when minStableMs is 0", async () => {
+    const tool = createAwaitScreenIdleTool(iosRegistry(makeSequencedAXService([content()])));
+
+    const result = await tool.execute(
+      {},
+      { udid: IOS_UDID, timeoutMs: 2000, pollIntervalMs: 50, minStableMs: 0 }
+    );
+
+    expect(result.settled).toBe(true);
+    expect(result.polls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

After an interaction, the MCP layer appends a screenshot so the agent can see the screen. It first slept a **fixed per-tool delay** — `3000ms` for `launch-app`/`restart-app`, `2000ms` for `open-url`, `1500ms` for gestures ([`auto-screenshot.ts`](https://github.com/software-mansion/argent/blob/main/packages/argent-mcp/src/auto-screenshot.ts#L33-L49)) — so the capture wouldn't catch a blank/splash/transition frame:

```ts
const delayMs = getAutoScreenshotDelayMs(params.name);
if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
```

That blind sleep is paid **in full on every call** even when the screen settled far sooner, and the `ARGENT_AUTO_SCREENSHOT_DELAY_MS` override is a `Math.max` floor — it can only *raise* the delay, never lower it. On an agent's relaunch→verify→tap loop the fixed `3000ms` dominates time-to-interaction.

## Change

Replace the blind sleep with a **bounded readiness wait that runs tool-server-side**, reusing the polling machinery `await-ui-element` already has instead of adding a second describe-polling loop.

- **`pollDescribeTree`** (new `utils/poll-describe-tree.ts`) — `await-ui-element`'s fetch/poll loop, extracted: it re-reads the `describe` tree on an interval until a caller-supplied predicate holds or the timeout elapses, racing each fetch against the deadline + abort via `settleWithin` (moved to `utils/timing.ts`) and clamping the poll sleep to the deadline. `await-ui-element` now uses this shared loop (**−77 lines**); its 791-line suite is unchanged and green, so behavior is preserved.
- **`await-screen-idle`** (new tool) — reuses the loop with a *stability* predicate: poll until the tree has content whose fingerprint (role/label/value + frame rounded to 1%) holds identical for `minStableMs`, bounded by `timeoutMs`. Returns `{ settled, waitedMs, polls }`.
- **MCP path** — calls `await-screen-idle` **once** (server-side, no per-poll round trips) with the per-tool delay as the cap. Falls back to the previous fixed sleep if the tool is unavailable (older / remote tool-server).

### Why not just `await-ui-element`?

It waits for a **caller-named** element (`{text|identifier|role}` + `exists|visible|hidden|text`) — its schema requires a selector. After `launch-app`/`restart-app` there's no element to name, and it has no "screen settled" condition. So the *predicate* is genuinely different; only the *loop* is shared, which is exactly what this PR extracts.

## How expensive is the polling?

Measured on a booted **iPhone 17 Pro (iOS 26.4)** relaunching Settings:

| metric | value |
| --- | --- |
| **time-to-ready** | **3000ms → ~1810ms** (~40% faster), `settled` every run |
| polls per relaunch | 4–5 |
| `describe` cost / poll | ~62ms settled screen, ~290ms mid-launch |
| loop overhead (excl. probe) | negligible |

The cost is entirely the `describe` reads, which run *while the app is launching anyway* and let the capture fire ~1.2s early instead of sleeping through it. On slower apps the wait simply extends up to the same cap — it adapts instead of over-padding.

## Behavior / bounds

- **Never slower than before:** a probe is never started past the deadline; a screen that never settles falls back to the full cap, exactly like the old sleep.
- **Static splash screens:** if an app holds a static splash for `minStableMs` (250ms), the wait can settle on it — the same case the fixed delay was tuned for; bounded by the cap, so no worse than a shorter fixed delay.
- **TV / Vega / unsupported:** `await-screen-idle` isn't capable there, so the MCP path's `catch` falls back to the fixed sleep.

## Testing

- Full **tool-server** suite: **1847 passing** (incl. `await-ui-element`'s 791-line suite green after the refactor) + 4 new `await-screen-idle` tests.
- Full **`@argent/mcp`** suite green. `tsc --build`, `eslint`, `prettier` all clean.
- Net **−68 lines**.
