### PR TITLE
fix(argent-lens): strip ELECTRON_RUN_AS_NODE from spawned Electron env

### DIFF
--- a/packages/tool-server/src/tools/devices/boot-electron.ts
+++ b/packages/tool-server/src/tools/devices/boot-electron.ts
@@ -174,9 +174,10 @@ export async function bootElectronApp(options: BootElectronOptions): Promise<Ele
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
       // Strip ELECTRON_RUN_AS_NODE (see electronGuiChildEnv): if the tool-server
-      // inherited it from an Electron-based MCP host, the app would boot as a
-      // headless Node runtime with no CDP endpoint, and the readiness race below
-      // would time out instead of the app coming up.
+      // inherited it from an Electron-based MCP host, the Electron binary would
+      // run in Node mode with no CDP endpoint — so boot-device fails below (the
+      // child exits early, or the readiness probe times out) instead of the app
+      // coming up.
       env: electronGuiChildEnv({ ELECTRON_ENABLE_LOGGING: "1" }),
     });
   } catch (err) {

--- a/packages/tool-server/src/tools/devices/boot-electron.ts
+++ b/packages/tool-server/src/tools/devices/boot-electron.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { ensureCdpReachable } from "../../blueprints/chromium-cdp";
 import { chromiumIdFromPort } from "../../utils/device-info";
 import { trackChromiumPort } from "../../utils/chromium-discovery";
+import { electronGuiChildEnv } from "../../utils/electron-env";
 
 // Booting an Electron app is one way to produce a Chromium/CDP device: the
 // launched process is a Chromium runtime exposing a CDP endpoint, so the
@@ -172,7 +173,11 @@ export async function bootElectronApp(options: BootElectronOptions): Promise<Ele
     child = spawn(launcher.command, args, {
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, ELECTRON_ENABLE_LOGGING: "1" },
+      // Strip ELECTRON_RUN_AS_NODE (see electronGuiChildEnv): if the tool-server
+      // inherited it from an Electron-based MCP host, the app would boot as a
+      // headless Node runtime with no CDP endpoint, and the readiness race below
+      // would time out instead of the app coming up.
+      env: electronGuiChildEnv({ ELECTRON_ENABLE_LOGGING: "1" }),
     });
   } catch (err) {
     throw new Error(

--- a/packages/tool-server/src/utils/electron-env.ts
+++ b/packages/tool-server/src/utils/electron-env.ts
@@ -1,0 +1,26 @@
+/**
+ * Build the environment for spawning a GUI Electron process as a child of the
+ * tool-server.
+ *
+ * The tool-server routinely runs under an Electron-based MCP host — VS Code,
+ * Cursor, the Codex desktop app, and friends all spawn their Node children
+ * (this tool-server, and the MCP stdio server that starts it) with
+ * `ELECTRON_RUN_AS_NODE=1` set in the environment. That flag tells the Electron
+ * binary to boot as a bare Node runtime instead of a GUI app.
+ *
+ * If it leaks into a GUI Electron child we launch, the child boots in Node
+ * mode: `require("electron")` returns the executable PATH string (not the
+ * Electron module), so `.app` is `undefined` and the process crashes at the
+ * first `app.*` call — e.g. `app.setName()` at the top of the Lens preview
+ * window's main entry. The failure is silent from the tool-server's side: the
+ * window never appears and a parked `await_user_selection` just hangs.
+ *
+ * Stripping the variable makes a GUI Electron child boot as a real Electron app
+ * regardless of what launched the tool-server. Any per-launch additions (the
+ * preview URL, logging flags) are layered on top via `overrides`.
+ */
+export function electronGuiChildEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...overrides };
+  delete env.ELECTRON_RUN_AS_NODE;
+  return env;
+}

--- a/packages/tool-server/src/utils/electron-env.ts
+++ b/packages/tool-server/src/utils/electron-env.ts
@@ -18,9 +18,21 @@
  * Stripping the variable makes a GUI Electron child boot as a real Electron app
  * regardless of what launched the tool-server. Any per-launch additions (the
  * preview URL, logging flags) are layered on top via `overrides`.
+ *
+ * The strip is case-insensitive: Windows environment variables are
+ * case-insensitive, so a host may surface the flag under non-canonical casing
+ * (e.g. `Electron_Run_As_Node`). The plain object spread from `process.env`
+ * preserves that casing, so a case-sensitive `delete` of the canonical name
+ * would miss it and leak Node mode into the cross-platform `boot-electron`
+ * child. (On macOS/Linux the name is always the exact uppercase form, so the
+ * loop simply matches that one key.)
  */
 export function electronGuiChildEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env, ...overrides };
-  delete env.ELECTRON_RUN_AS_NODE;
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === "electron_run_as_node") {
+      delete env[key];
+    }
+  }
   return env;
 }

--- a/packages/tool-server/src/utils/preview-window.ts
+++ b/packages/tool-server/src/utils/preview-window.ts
@@ -2,6 +2,7 @@ import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { electronGuiChildEnv } from "./electron-env";
 
 /**
  * macOS only. Build (and cache) a thin `.app` wrapper around the installed
@@ -192,7 +193,11 @@ export function createPreviewWindowManager(
     const launchBin = wrapperBin ?? electronBin;
     const launchArgs = wrapperBin ? ["--no-sandbox", mainScript] : [mainScript];
     const next = spawn(launchBin, launchArgs, {
-      env: { ...process.env, ARGENT_PREVIEW_URL: url },
+      // Strip ELECTRON_RUN_AS_NODE so the child boots as a GUI Electron app, not
+      // a bare Node runtime (see electronGuiChildEnv). An Electron-based MCP
+      // host puts it in our env, and inheriting it makes main.cjs crash at
+      // app.setName() with `app` undefined — the window never opens.
+      env: electronGuiChildEnv({ ARGENT_PREVIEW_URL: url }),
       stdio: ["pipe", "ignore", "pipe"],
     });
     // `spawn` does not throw synchronously for ENOENT / EACCES — the error

--- a/packages/tool-server/test/boot-electron-spawn-error.test.ts
+++ b/packages/tool-server/test/boot-electron-spawn-error.test.ts
@@ -88,6 +88,42 @@ describe("bootElectronApp — spawn error handling", () => {
     expect(child.listenerCount("error")).toBeGreaterThan(0);
   });
 
+  it("strips ELECTRON_RUN_AS_NODE from the spawned electron env (GUI boot, not Node mode)", async () => {
+    // Regression: an Electron-based MCP host (VS Code / Cursor / Codex desktop)
+    // spawns the tool-server with ELECTRON_RUN_AS_NODE=1. If that leaks into the
+    // Electron app we boot, the binary runs in Node mode — it never comes up as
+    // a browser with a CDP endpoint, so boot-device fails instead of the app
+    // launching. The env must strip the flag while keeping the per-launch
+    // override (ELECTRON_ENABLE_LOGGING).
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const prev = process.env.ELECTRON_RUN_AS_NODE;
+    process.env.ELECTRON_RUN_AS_NODE = "1";
+    try {
+      // With `port` provided, bootElectronApp reaches spawn() synchronously
+      // (no `await pickFreePort()`), so the spawn env is observable immediately.
+      const promise = bootElectronApp({
+        appPath: appDir,
+        // Unreachable port → the readiness race rejects fast; we only care about
+        // the spawn env, so detach and swallow the rejection.
+        port: 1,
+        readyTimeoutMs: 50,
+      });
+      promise.catch(() => {});
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      const spawnEnv = (spawnMock.mock.calls[0]![2] as { env: NodeJS.ProcessEnv }).env;
+      expect(spawnEnv.ELECTRON_RUN_AS_NODE).toBeUndefined();
+      expect(spawnEnv.ELECTRON_ENABLE_LOGGING).toBe("1");
+
+      await promise.catch(() => {});
+    } finally {
+      if (prev === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+      else process.env.ELECTRON_RUN_AS_NODE = prev;
+    }
+  });
+
   it("rejects with a clear, actionable message when spawn emits ENOENT", async () => {
     const child = makeFakeChild();
     spawnMock.mockReturnValue(child);

--- a/packages/tool-server/test/electron-env.test.ts
+++ b/packages/tool-server/test/electron-env.test.ts
@@ -20,7 +20,13 @@ describe("electronGuiChildEnv", () => {
 
   it("layers overrides on top and never lets an override re-introduce Node mode", () => {
     process.env.ELECTRON_RUN_AS_NODE = "1";
-    const env = electronGuiChildEnv({ ARGENT_PREVIEW_URL: "http://x/preview/" });
+    // The delete runs AFTER the overrides spread, so even an override that
+    // explicitly re-sets the flag cannot bring Node mode back. This asserts the
+    // ordering, not just the parent-env strip.
+    const env = electronGuiChildEnv({
+      ARGENT_PREVIEW_URL: "http://x/preview/",
+      ELECTRON_RUN_AS_NODE: "1",
+    });
     expect(env.ARGENT_PREVIEW_URL).toBe("http://x/preview/");
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
   });

--- a/packages/tool-server/test/electron-env.test.ts
+++ b/packages/tool-server/test/electron-env.test.ts
@@ -39,4 +39,32 @@ describe("electronGuiChildEnv", () => {
       delete process.env.__ARGENT_ENV_TEST__;
     }
   });
+
+  it("strips the flag regardless of key casing (Windows env is case-insensitive)", () => {
+    // On Windows the OS environment is case-insensitive, so a host may surface
+    // the flag under non-canonical casing (e.g. `Electron_Run_As_Node`). The
+    // plain object spread from process.env preserves that casing, and a
+    // case-sensitive delete of the canonical name would miss it — leaking the
+    // flag into the cross-platform boot-electron child, which then boots in Node
+    // mode with no CDP endpoint.
+    delete process.env.ELECTRON_RUN_AS_NODE;
+    process.env.Electron_Run_As_Node = "1";
+    try {
+      const env = electronGuiChildEnv();
+      const leaked = Object.keys(env).filter((k) => k.toLowerCase() === "electron_run_as_node");
+      expect(leaked).toEqual([]);
+    } finally {
+      delete process.env.Electron_Run_As_Node;
+    }
+  });
+
+  it("does not mutate the caller's process.env", () => {
+    // The flag must be stripped from a COPY only. Deleting it from the real
+    // process.env would permanently disable Node mode for the tool-server
+    // process itself — invisible to every other case here because each restores
+    // the global in afterEach.
+    process.env.ELECTRON_RUN_AS_NODE = "1";
+    electronGuiChildEnv();
+    expect(process.env.ELECTRON_RUN_AS_NODE).toBe("1");
+  });
 });

--- a/packages/tool-server/test/electron-env.test.ts
+++ b/packages/tool-server/test/electron-env.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { electronGuiChildEnv } from "../src/utils/electron-env";
+
+describe("electronGuiChildEnv", () => {
+  const prev = process.env.ELECTRON_RUN_AS_NODE;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+    else process.env.ELECTRON_RUN_AS_NODE = prev;
+  });
+
+  it("removes ELECTRON_RUN_AS_NODE inherited from the parent env", () => {
+    process.env.ELECTRON_RUN_AS_NODE = "1";
+    expect(electronGuiChildEnv().ELECTRON_RUN_AS_NODE).toBeUndefined();
+  });
+
+  it("is a no-op for that key when the parent never set it", () => {
+    delete process.env.ELECTRON_RUN_AS_NODE;
+    expect("ELECTRON_RUN_AS_NODE" in electronGuiChildEnv()).toBe(false);
+  });
+
+  it("layers overrides on top and never lets an override re-introduce Node mode", () => {
+    process.env.ELECTRON_RUN_AS_NODE = "1";
+    const env = electronGuiChildEnv({ ARGENT_PREVIEW_URL: "http://x/preview/" });
+    expect(env.ARGENT_PREVIEW_URL).toBe("http://x/preview/");
+    expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+  });
+
+  it("preserves other inherited env vars", () => {
+    process.env.__ARGENT_ENV_TEST__ = "keep-me";
+    try {
+      expect(electronGuiChildEnv().__ARGENT_ENV_TEST__).toBe("keep-me");
+    } finally {
+      delete process.env.__ARGENT_ENV_TEST__;
+    }
+  });
+});

--- a/packages/tool-server/test/preview-window-launch-failure.test.ts
+++ b/packages/tool-server/test/preview-window-launch-failure.test.ts
@@ -147,6 +147,36 @@ describe("createPreviewWindowManager — onLaunchFailure", () => {
     expect(failures).toHaveLength(0); // launch already succeeded
   });
 
+  it("strips ELECTRON_RUN_AS_NODE from the child env so the child boots as a GUI app", () => {
+    // Regression: an Electron-based MCP host (VS Code / Cursor / Codex desktop)
+    // spawns the tool-server with ELECTRON_RUN_AS_NODE=1. If that leaks into the
+    // preview-window child, the Electron binary boots in Node mode —
+    // `require("electron")` returns the binary path string, `.app` is undefined,
+    // and main.cjs crashes at `app.setName()` (the window never opens).
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const prev = process.env.ELECTRON_RUN_AS_NODE;
+    process.env.ELECTRON_RUN_AS_NODE = "1";
+    try {
+      const mgr = createPreviewWindowManager({
+        electronBinaryPath: "/fake/electron",
+        mainScript: "/fake/main.cjs",
+        onError: () => {},
+      });
+      mgr.ensureOpen("http://127.0.0.1:1234/preview/");
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      const spawnEnv = (spawnMock.mock.calls[0]![2] as { env: NodeJS.ProcessEnv }).env;
+      expect(spawnEnv.ELECTRON_RUN_AS_NODE).toBeUndefined();
+      // The per-launch override still comes through.
+      expect(spawnEnv.ARGENT_PREVIEW_URL).toBe("http://127.0.0.1:1234/preview/");
+    } finally {
+      if (prev === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+      else process.env.ELECTRON_RUN_AS_NODE = prev;
+    }
+  });
+
   it("does NOT fire onLaunchFailure when the window is already alive (re-open foregrounds)", () => {
     const child = makeFakeChild();
     spawnMock.mockReturnValue(child);


### PR DESCRIPTION
## Problem

QA report: **Argent Lens preview window never launches** — `propose_variant` / `await_user_selection` stage variants correctly, but the native window never appears and `await_user_selection` hangs. The tool-server log shows the child crashing at launch:

```
dist/preview-window/main.cjs:28
import_electron.app.setName("Argent Lens");
                    ^
TypeError: Cannot read properties of undefined (reading 'setName')
    ...
    at c._load (node:electron/js2c/node_init:2:18095)
```

## Root cause (reproduced & proven)

`import_electron.app` being `undefined` while the JS still executes is the exact signature of the Electron binary booting in **Node mode**. For a downloaded, non-fused Electron the only trigger is `ELECTRON_RUN_AS_NODE` in the environment. In Node mode `require("electron")` returns the executable *path string* (not the module), so `.app` is `undefined`.

The tool-server routinely runs under an Electron-based MCP host (VS Code, Cursor, the Codex desktop app), which sets `ELECTRON_RUN_AS_NODE=1` in the env of the Node children it spawns. `createPreviewWindowManager.ensureOpen()` spread `{ ...process.env }` straight into its Electron child, so the flag leaked in and the child booted headless as Node → crash before any window.

Verified against the real Electron binary + the real `main.cjs`:

| Env | Result |
|-----|--------|
| `ELECTRON_RUN_AS_NODE=1` | Crashes at `main.cjs:28` — **byte-identical to the report**, incl. the `node:electron/js2c/node_init` frame |
| unset | Boots as a real Electron GUI, gets past `setName`, only fails later at `loadURL` |

The wrapper-bundle / code-signing theory in the report was a **red herring** — the reporter never controlled for the spawn *environment*. The same node-mode surfaces differently depending on whether the `.app` wrapper built: plain path → `setName` crash (what they saw); wrapper path → Node rejects the Electron-only `--no-sandbox` flag (`bad option: --no-sandbox`). One fix cures both.

## Fix

Strip `ELECTRON_RUN_AS_NODE` before spawning, via a shared `electronGuiChildEnv()` helper, at **both** GUI-Electron spawn sites:
- `preview-window.ts` — the Lens window (the reported bug).
- `boot-electron.ts` — the same latent flaw would boot a headless CDP app with **no debug port**, timing out `boot-device --electronAppPath`.

## Verification

- **Root cause** reproduced byte-for-byte, both directions, against the real binary.
- **End-to-end**: ran the real fixed `ensureOpen()` path via ts-node with `ELECTRON_RUN_AS_NODE=1` leaked into the parent env against the real Electron binary — child boots as a real GUI app (`VERDICT: PASS`). Reverting the one-line fix flips it to `FAIL`, confirming the test discriminates.
- **Unit tests**: added `electron-env.test.ts` (helper contract) + a regression case in `preview-window-launch-failure.test.ts` asserting the spawn env strips the var and keeps the override. 21/21 pass.
- `tsc --noEmit` (build) and `tsc --noEmit -p tsconfig.test.json` (CI "Unit tests" gate) both clean; prettier + eslint clean on all changed files.