### PR TITLE
fix(ios-remote): unblock native-devtools and keyboard on non-macOS hosts

### DIFF
--- a/packages/native-devtools-ios/src/index.ts
+++ b/packages/native-devtools-ios/src/index.ts
@@ -11,10 +11,15 @@ const BIN_DIR = process.env.ARGENT_SIMULATOR_SERVER_DIR ?? path.join(__dirname, 
 const DYLIB_TCP_DIR = process.env.ARGENT_NATIVE_DEVTOOLS_TCP_DIR ?? path.join(DYLIB_DIR, "tcp");
 const DYLIB_TVOS_DIR = path.join(DYLIB_DIR, "tvos");
 
-// iOS Simulator only runs on macOS, so the dylibs that get injected into it
-// and the ax-service that gets `simctl spawn`d into it are only ever usable
-// on darwin hosts. Throw with a clear, root-cause message so a Linux user
+// The *local* and *tvos* accessors are darwin-only: the dylibs they return get
+// `simctl spawn`d / injected into a simulator on *this* host, and iOS Simulator
+// only runs on macOS. Throw with a clear, root-cause message so a Linux user
 // invoking these accidentally doesn't get a confusing "file not found".
+//
+// The *TCP* accessors (`*Tcp`) are intentionally NOT gated: they are upload
+// artifacts shipped to a remote Mac orchestrator via `sim-remote` (see
+// `remoteIosHost` in tool-server), so they must be readable on any host — the
+// file-existence check below is the only guard they need.
 function requireDarwin(what: string): void {
   if (process.platform !== "darwin") {
     throw new Error(
@@ -45,7 +50,6 @@ export const keyboardPatchDylibPath = () => {
 };
 
 export const bootstrapDylibPathTcp = () => {
-  requireDarwin("bootstrapDylibPathTcp");
   return requireDylibIn(DYLIB_TCP_DIR, "libArgentInjectionBootstrap.dylib");
 };
 
@@ -58,11 +62,9 @@ export const nativeDevtoolsDylibPathTvos = () => {
   return requireDylibIn(DYLIB_TVOS_DIR, "libNativeDevtoolsIos.dylib");
 };
 export const nativeDevtoolsDylibPathTcp = () => {
-  requireDarwin("nativeDevtoolsDylibPathTcp");
   return requireDylibIn(DYLIB_TCP_DIR, "libNativeDevtoolsIos.dylib");
 };
 export const keyboardPatchDylibPathTcp = () => {
-  requireDarwin("keyboardPatchDylibPathTcp");
   return requireDylibIn(DYLIB_TCP_DIR, "libKeyboardPatch.dylib");
 };
 
@@ -141,7 +143,6 @@ export function axServiceBinaryPath(): string {
 }
 
 export function axServiceBinaryPathTcp(): string {
-  requireDarwin("ax-service (tcp)");
   return requireBinIn(platformTcpBinDir(), "ax-service");
 }
 

--- a/packages/native-devtools-ios/test/index.test.ts
+++ b/packages/native-devtools-ios/test/index.test.ts
@@ -20,6 +20,8 @@ const originalPlatform = process.platform;
 const originalArch = process.arch;
 const originalDevtoolsDir = process.env.ARGENT_NATIVE_DEVTOOLS_DIR;
 const originalSimulatorDir = process.env.ARGENT_SIMULATOR_SERVER_DIR;
+const originalDevtoolsTcpDir = process.env.ARGENT_NATIVE_DEVTOOLS_TCP_DIR;
+const originalSimulatorTcpDir = process.env.ARGENT_SIMULATOR_SERVER_TCP_DIR;
 
 function setPlatform(value: NodeJS.Platform) {
   Object.defineProperty(process, "platform", { value, configurable: true });
@@ -41,11 +43,17 @@ afterAll(() => {
   else process.env.ARGENT_NATIVE_DEVTOOLS_DIR = originalDevtoolsDir;
   if (originalSimulatorDir === undefined) delete process.env.ARGENT_SIMULATOR_SERVER_DIR;
   else process.env.ARGENT_SIMULATOR_SERVER_DIR = originalSimulatorDir;
+  if (originalDevtoolsTcpDir === undefined) delete process.env.ARGENT_NATIVE_DEVTOOLS_TCP_DIR;
+  else process.env.ARGENT_NATIVE_DEVTOOLS_TCP_DIR = originalDevtoolsTcpDir;
+  if (originalSimulatorTcpDir === undefined) delete process.env.ARGENT_SIMULATOR_SERVER_TCP_DIR;
+  else process.env.ARGENT_SIMULATOR_SERVER_TCP_DIR = originalSimulatorTcpDir;
 });
 
 afterEach(() => {
   setPlatform(originalPlatform);
   setArch(originalArch);
+  delete process.env.ARGENT_NATIVE_DEVTOOLS_TCP_DIR;
+  delete process.env.ARGENT_SIMULATOR_SERVER_TCP_DIR;
 });
 
 /**
@@ -73,14 +81,31 @@ describe("requireDarwin gating", () => {
     expect(() => r.keyboardPatchDylibPath()).toThrow(/requires a macOS host/);
   });
 
-  it("throws with a root-cause message on linux for TCP iOS-only dylibs", async () => {
-    // TCP variants are equally iOS-Simulator-only; the guard must fire before
-    // the file-existence check so Linux callers get the platform error, not
-    // a misleading "dylib not found" for the tcp/ subdirectory.
+  it("resolves TCP dylibs on linux (remote upload artifacts, not gated)", async () => {
+    // TCP variants are payloads uploaded to a remote Mac orchestrator via
+    // sim-remote, so a Linux host must be able to resolve them. They are guarded
+    // only by the file-existence check below, NOT by requireDarwin.
     setPlatform("linux");
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "tcp-dylibs-"));
+    fs.writeFileSync(path.join(dir, "libArgentInjectionBootstrap.dylib"), "");
+    fs.writeFileSync(path.join(dir, "libNativeDevtoolsIos.dylib"), "");
+    fs.writeFileSync(path.join(dir, "libKeyboardPatch.dylib"), "");
+    process.env.ARGENT_NATIVE_DEVTOOLS_TCP_DIR = dir;
     const r = await loadResolver();
-    expect(() => r.bootstrapDylibPathTcp()).toThrow(/requires a macOS host/);
-    expect(() => r.nativeDevtoolsDylibPathTcp()).toThrow(/requires a macOS host/);
+    expect(r.bootstrapDylibPathTcp()).toBe(path.join(dir, "libArgentInjectionBootstrap.dylib"));
+    expect(r.nativeDevtoolsDylibPathTcp()).toBe(path.join(dir, "libNativeDevtoolsIos.dylib"));
+    expect(r.keyboardPatchDylibPathTcp()).toBe(path.join(dir, "libKeyboardPatch.dylib"));
+  });
+
+  it("throws a plain not-found (not a macOS-host error) for missing TCP dylibs on linux", async () => {
+    // When the TCP artifacts haven't been downloaded, the file-existence check
+    // gives a "not found" error — never the "requires a macOS host" gate.
+    setPlatform("linux");
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "tcp-dylibs-missing-"));
+    process.env.ARGENT_NATIVE_DEVTOOLS_TCP_DIR = dir;
+    const r = await loadResolver();
+    expect(() => r.bootstrapDylibPathTcp()).toThrow(/dylib not found/);
+    expect(() => r.bootstrapDylibPathTcp()).not.toThrow(/requires a macOS host/);
   });
 
   it("throws with a root-cause message on linux for ax-service", async () => {
@@ -92,11 +117,19 @@ describe("requireDarwin gating", () => {
     expect(() => r.axServiceBinaryPath()).toThrow(/requires a macOS host/);
   });
 
-  it("throws with a root-cause message on linux for ax-service (tcp)", async () => {
+  it("resolves the ax-service TCP binary on linux (remote upload artifact)", async () => {
+    // The TCP ax-service is uploaded to and `simctl spawn`d on the remote Mac
+    // orchestrator, so a Linux host must be able to resolve it — no darwin gate.
     setPlatform("linux");
-    process.env.ARGENT_SIMULATOR_SERVER_DIR = tmpRoot;
+    setArch("x64");
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "ax-tcp-linux-"));
+    const tcpDir = path.join(dir, "linux", "tcp");
+    fs.mkdirSync(tcpDir, { recursive: true });
+    const binPath = path.join(tcpDir, "ax-service");
+    fs.writeFileSync(binPath, "", { mode: 0o755 });
+    process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
     const r = await loadResolver();
-    expect(() => r.axServiceBinaryPathTcp()).toThrow(/requires a macOS host/);
+    expect(r.axServiceBinaryPathTcp()).toBe(binPath);
   });
 });
 

--- a/packages/tool-server/src/tools/keyboard/index.ts
+++ b/packages/tool-server/src/tools/keyboard/index.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { Registry, ToolCapability, ToolDefinition } from "@argent/registry";
 import { dispatchByPlatform } from "../../utils/cross-platform-tool";
 import type { KeyboardParams, KeyboardResult } from "./types";
-import { makeIosImpl } from "./platforms/ios";
+import { makeIosImpl, makeIosRemoteImpl } from "./platforms/ios";
 import { makeAndroidImpl } from "./platforms/android";
 import { makeChromiumImpl } from "./platforms/chromium";
 import { vegaImpl } from "./platforms/vega";
@@ -78,6 +78,7 @@ Provide text, key, or both.`,
       toolId: "keyboard",
       capability,
       ios: makeIosImpl(registry),
+      iosRemote: makeIosRemoteImpl(registry),
       android: makeAndroidImpl(registry),
       chromium: makeChromiumImpl(registry),
       vega: vegaImpl,

--- a/packages/tool-server/src/tools/keyboard/platforms/ios.ts
+++ b/packages/tool-server/src/tools/keyboard/platforms/ios.ts
@@ -18,3 +18,15 @@ export function makeIosImpl(
         : typeSimulatorServer(registry, device, params),
   };
 }
+
+// Remote sims are always iOS (never tvOS), so skip the tvOS probe — which shells
+// out to local `xcrun` and would fail on a non-macOS host anyway — and type
+// straight over the simulator-server, whose blueprint routes an ios-remote
+// device through the sim-remote MoQ transport.
+export function makeIosRemoteImpl(
+  registry: Registry
+): PlatformImpl<Record<string, unknown>, KeyboardParams, KeyboardResult> {
+  return {
+    handler: async (_services, params, device) => typeSimulatorServer(registry, device, params),
+  };
+}

--- a/packages/tool-server/test/cross-platform-tool.test.ts
+++ b/packages/tool-server/test/cross-platform-tool.test.ts
@@ -13,7 +13,13 @@ const capabilityIosOnly: ToolCapability = {
   apple: { simulator: true, device: true },
 };
 
+const capabilityRemote: ToolCapability = {
+  apple: { simulator: true, device: true },
+  appleRemote: { simulator: true },
+};
+
 const iosUdid = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA";
+const iosRemoteUdid = `remote:${iosUdid}`;
 const androidUdid = "emulator-5554";
 
 beforeEach(() => {
@@ -43,6 +49,50 @@ describe("dispatchByPlatform", () => {
 
     expect(await execute({}, { udid: androidUdid })).toBe("from-android");
     expect(androidHandler).toHaveBeenCalledOnce();
+  });
+
+  it("routes ios-remote UDIDs to the iosRemote handler, not the local ios handler", async () => {
+    const iosHandler = vi.fn().mockResolvedValue("from-ios");
+    const remoteHandler = vi.fn().mockResolvedValue("from-remote");
+
+    const execute = dispatchByPlatform<
+      Record<string, never>,
+      Record<string, never>,
+      { udid: string },
+      string
+    >({
+      toolId: "test",
+      capability: capabilityRemote,
+      ios: { handler: iosHandler },
+      android: { handler: async () => "should-not-run" },
+      iosRemote: { handler: remoteHandler },
+    });
+
+    expect(await execute({}, { udid: iosRemoteUdid })).toBe("from-remote");
+    expect(remoteHandler).toHaveBeenCalledOnce();
+    expect(iosHandler).not.toHaveBeenCalled();
+  });
+
+  it("throws a wiring error when a device is ios-remote but no iosRemote branch is provided", async () => {
+    // Capability declares appleRemote, so assertSupported passes — but the tool
+    // forgot to wire the iosRemote branch. Surface a clear wiring error instead
+    // of silently falling through to the local (xcrun-based) ios handler. This
+    // is the exact gap the `keyboard` tool had.
+    const execute = dispatchByPlatform<
+      Record<string, never>,
+      Record<string, never>,
+      { udid: string },
+      string
+    >({
+      toolId: "no-remote-branch",
+      capability: capabilityRemote,
+      ios: { handler: async () => "should-not-run" },
+      android: { handler: async () => "should-not-run" },
+    });
+
+    await expect(execute({}, { udid: iosRemoteUdid })).rejects.toThrow(
+      /declares ios-remote capability but has no iosRemote branch/
+    );
   });
 
   it("rejects with UnsupportedOperationError when capability does not declare the platform", async () => {


### PR DESCRIPTION
## Problem

Argent can drive a **remote** iOS simulator (`ios-remote` / `remote:` device ids) from a non-macOS host via the `sim-remote` CLI. Two tools that were supposed to work in that setup failed because local-only guards fired on the remote code path:

1. **native-devtools family** (`native-describe-screen`, `native-find-views`, keyboard injection, …) threw `... requires a macOS host` on Linux. Root cause: `requireDarwin()` in `packages/native-devtools-ios/src/index.ts` gated **every** dylib/binary accessor — including the **TCP variants** that exist specifically to be *uploaded to the remote Mac orchestrator*, never executed locally. `remoteIosHost` reaches those accessors (`setupNativeDevtoolsEnvRemote` → `tcpInjectionDylibs()`; `spawnAxDaemonRemote` → `axServiceBinaryPathTcp()`) *after* the code has already committed to the remote path, so the gate was redundant and wrong.

2. **`keyboard`** declared `appleRemote: { simulator: true }` capability but its `dispatchByPlatform` had **no `iosRemote` branch**, so an `ios-remote` device passed the capability check and then threw `declares ios-remote capability but has no iosRemote branch` at dispatch. Its local iOS handler also probes tvOS via local `xcrun`, which can't run off-Mac anyway — but remote sims are always iOS.

## Change

- **native-devtools-ios**: remove `requireDarwin(...)` from the four `*Tcp` accessors (`bootstrapDylibPathTcp`, `nativeDevtoolsDylibPathTcp`, `keyboardPatchDylibPathTcp`, `axServiceBinaryPathTcp`); the existing file-existence check stays, so a host missing the downloaded TCP artifacts still gets a clear "not found" error. Local and tvOS accessors remain darwin-gated (they're `simctl spawn`d on the local host, and `ios-remote` is iOS-only).
- **keyboard**: add `makeIosRemoteImpl` that skips the tvOS probe and types straight over `typeSimulatorServer` (which already routes `ios-remote` through the sim-remote MoQ transport), and wire an `iosRemote` branch into the dispatch — mirroring how `paste` already works.

No other changes needed: `boot-device`'s remote path already skips the darwin check, and the `native-*` tools already preflight the `sim-remote` dependency for `ios-remote`. An audit of every iOS tool handler confirmed these two were the complete set of "advertised-but-blocked" remote services; the profiler / `await-*` tools are intentionally local-only (they declare `apple`, not `appleRemote`, and cleanly reject).

## Tests

- `native-devtools-ios`: inverted the two tests that asserted the TCP accessors throw on Linux — they now assert the TCP dylibs/ax-service **resolve** on a simulated Linux host, plus a case that a missing artifact yields a plain not-found error rather than the macOS-host gate.
- `tool-server`: added two `dispatchByPlatform` regression tests — correct `ios-remote` routing, and the "declares appleRemote but no iosRemote branch" wiring error that the keyboard bug tripped.
- All package tests pass; both packages typecheck clean.

## Verification

On a non-macOS host with `sim-remote` configured against a remote Mac sim:
1. Attach a `remote:<uuid>` simulator (`list-devices` shows it as `ios-remote`).
2. Run `native-describe-screen` / `native-find-views` and the `keyboard` tool — confirm they operate instead of throwing the macOS-host / no-branch errors.
3. On macOS, confirm local (non-remote) native-devtools + keyboard still work (removing the guard is a no-op on darwin).