### PR TITLE
fix(tools-client): unref spawned tool-server's stdout pipe so `argent run` exits

### DIFF
--- a/packages/argent-tools-client/src/launcher.ts
+++ b/packages/argent-tools-client/src/launcher.ts
@@ -278,9 +278,19 @@ export function spawnToolsServer(
       if (match) {
         const actualPort = parseInt(match[1]!, 10);
         rl.close();
-        // Resume stdout so the pipe stays open and the child's console.log calls
-        // don't fail with EPIPE once the readline interface stops consuming it.
+        // Resume stdout so the pipe keeps draining and the child's console.log
+        // calls don't back up once the readline interface stops consuming it.
         child.stdout?.resume();
+        // ...but unref the pipe socket so it does NOT keep OUR event loop alive.
+        // `child.unref()` only detaches the process handle; the stdout pipe is a
+        // separate ref'd handle. Without this, a short-lived caller like
+        // `argent run <tool>` would print its result and then hang forever
+        // waiting on the drained-but-open pipe. A long-lived caller (the MCP
+        // launcher) keeps its loop alive by other means, so it still drains
+        // normally; and the tool-server tolerates the eventual EPIPE when we exit.
+        // (stdio "pipe" makes this a net.Socket at runtime, which has unref();
+        // the ChildProcess type widens it to Readable, so narrow before calling.)
+        (child.stdout as { unref?: () => void } | null)?.unref?.();
         settle(() => resolve({ port: actualPort, pid }));
       }
     });

--- a/packages/argent-tools-client/test/launcher-exit.test.ts
+++ b/packages/argent-tools-client/test/launcher-exit.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { ChildProcess } from "node:child_process";
+
+// Regression guard for "argent run <tool> never exits when it has to spawn the
+// tool-server". `child.unref()` detaches the process handle, but the piped
+// `child.stdout` is a SEPARATE ref'd handle — left ref'd it keeps a short-lived
+// caller's event loop alive forever after it has printed its result. The reuse
+// path never opens that pipe, so the hang was spawn-only. spawnToolsServer must
+// unref the stdout socket once it has read the ready banner.
+//
+// We wrap the real `spawn` (via vi.mock passthrough) so the fake tool-server
+// still runs for real, capture the returned child, and assert its stdout pipe
+// was unref'd.
+let lastChild: ChildProcess | null = null;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) => {
+      const child = actual.spawn(...args);
+      // Pipe stdio makes stdout a net.Socket (has unref); the type widens it to
+      // Readable, so narrow before spying.
+      const stdout = child.stdout as unknown as { unref: () => void } | null;
+      if (stdout) vi.spyOn(stdout, "unref");
+      lastChild = child;
+      return child;
+    },
+  };
+});
+
+let launcher: typeof import("../src/launcher.js");
+let TEST_HOME: string;
+
+const FAKE_BUNDLE = resolve(__dirname, "fixtures/fake-tool-server.cjs");
+
+const fakePaths = (): import("../src/launcher.js").ToolsServerPaths => ({
+  bundlePath: FAKE_BUNDLE,
+  simulatorServerDir: "/unused/sim",
+  nativeDevtoolsDir: "/unused/dylibs",
+});
+
+beforeAll(async () => {
+  TEST_HOME = mkdtempSync(join(tmpdir(), "argent-exit-test-"));
+  process.env.HOME = TEST_HOME;
+  vi.resetModules();
+  launcher = await import("../src/launcher.js");
+  expect(existsSync(FAKE_BUNDLE)).toBe(true);
+});
+
+afterAll(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+const spawnedPids: number[] = [];
+afterEach(async () => {
+  lastChild = null;
+  for (const pid of spawnedPids.splice(0)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      /* already dead */
+    }
+  }
+  await launcher.clearToolsServerState();
+});
+
+describe("spawnToolsServer — process-exit hygiene", () => {
+  it("unrefs the child's stdout pipe so a short-lived caller can exit", async () => {
+    const port = await launcher.findFreePort();
+    const { pid } = await launcher.spawnToolsServer(fakePaths(), port);
+    spawnedPids.push(pid);
+
+    expect(lastChild).not.toBeNull();
+    const stdout = lastChild!.stdout as unknown as { unref: () => void } | null;
+    expect(stdout).toBeTruthy();
+    // The socket that used to strand `argent run` on the event loop.
+    expect(stdout!.unref).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

If the tool-server is **not** already running the first time `argent run <tool>` is called, the CLI prints its result but **never exits** — it hangs indefinitely, even when the tool call succeeded.

## Root cause

`spawnToolsServer` (in `packages/argent-tools-client/src/launcher.ts`) launches the tool-server `detached` with `stdio: ["ignore", "pipe", logFd]` and calls `child.unref()`. But `child.unref()` only detaches the **process** handle — the piped `child.stdout` is a *separate* `net.Socket` handle. After reading the "listening" banner the code calls `child.stdout.resume()` (so the child doesn't hit EPIPE) but leaves that socket **ref'd**, which keeps the short-lived caller's event loop alive forever.

The server-reuse path never opens that pipe, so only the first (spawning) invocation hangs — exactly matching the report.

## Fix

Unref the stdout socket right after the ready banner is read:

```ts
child.stdout?.resume();
(child.stdout as { unref?: () => void } | null)?.unref?.();
```

Safe for both callers:
- **`argent run`** (short-lived): the loop drains the pipe while working, then exits. The tool-server already installs an EPIPE handler on stdout (`packages/tool-server/src/index.ts`), so it tolerates the parent closing the read end.
- **MCP launcher** (long-lived): its loop stays alive by other means, so the pipe still drains normally; the unref is a no-op for it.

## Testing

- New regression test `test/launcher-exit.test.ts` — **fails without the fix**, passes with it.
- End-to-end control: a real subprocess calling the launcher **hangs** with the unref removed and **exits cleanly** with it in place.
- Full local CI parity: `tsc --build`, `typecheck:tests` (all workspaces), `typecheck:scripts`, full test suite (12 packages, ~2000 tests) — all green. ESLint + Prettier clean.