### PR TITLE
fix(open-url): flag when a web URL may open the browser instead of an app

### DIFF
--- a/packages/tool-server/node_modules
+++ b/packages/tool-server/node_modules
@@ -1,0 +1,1 @@
+/Users/ignacylatka/dev/argent/packages/tool-server/node_modules

--- a/packages/tool-server/src/tools/open-url/deep-link-note.ts
+++ b/packages/tool-server/src/tools/open-url/deep-link-note.ts
@@ -15,7 +15,10 @@
  * registered app reliably and need no caveat.
  */
 export function httpDeepLinkNote(url: string): string | undefined {
-  if (!/^https?:\/\//i.test(url)) return undefined;
+  // Scheme-only match (no `//` required): browsers normalize a slashless
+  // `http:example.com` to `http://example.com`, so it lands in Safari the same
+  // way — and no custom scheme starts with `http:`/`https:`.
+  if (!/^https?:/i.test(url)) return undefined;
   return (
     "This is a web URL — it opens the native app only if an app installed on this device is " +
     "verified for the link's domain (iOS Universal Links / Android App Links); otherwise it " +

--- a/packages/tool-server/src/tools/open-url/deep-link-note.ts
+++ b/packages/tool-server/src/tools/open-url/deep-link-note.ts
@@ -1,0 +1,26 @@
+/**
+ * An https:// (or http://) URL only reaches a native app when that app is
+ * installed and verified for the link's domain (iOS Universal Links / Android
+ * App Links). Otherwise the system opens it in the browser — and on iOS
+ * simulators `simctl openurl` routes Universal Links to Safari even when the
+ * owning app *is* installed, which is a long-standing simulator limitation.
+ *
+ * The tool has no reliable way to observe which app actually handled the URL
+ * (Safari and other apps are invisible to the native-devtools socket), so a web
+ * URL that silently fell back to the browser looks identical to a successful
+ * deep-link in the result. This caveat makes that ambiguity explicit to the
+ * caller instead of letting `opened: true` imply the native app was reached.
+ *
+ * Returns undefined for custom-scheme URLs (`scheme://…`), which route to their
+ * registered app reliably and need no caveat.
+ */
+export function httpDeepLinkNote(url: string): string | undefined {
+  if (!/^https?:\/\//i.test(url)) return undefined;
+  return (
+    "This is a web URL — it opens the native app only if an app installed on this device is " +
+    "verified for the link's domain (iOS Universal Links / Android App Links); otherwise it " +
+    "opens in the browser. On iOS simulators it may open in Safari even when the owning app is " +
+    "installed. To reliably open an installed app, use its custom scheme (scheme://path) or " +
+    "launch-app with its bundle id."
+  );
+}

--- a/packages/tool-server/src/tools/open-url/index.ts
+++ b/packages/tool-server/src/tools/open-url/index.ts
@@ -35,7 +35,8 @@ export const openUrlTool: ToolDefinition<Params, OpenUrlResult> = {
   description: `Open a URL or URL scheme on the device.
 Use to navigate to a web page or deep-link into an app. On Chromium, this navigates the primary renderer to the given URL.
 Cross-platform schemes: https://, tel:, mailto:. iOS also: messages://, settings://, maps://. Android also: geo:, plus any app-specific deep link.
-Returns { opened, url }. Fails if no app is registered to handle the URI (iOS/Android) or the renderer rejects the navigation (Chromium).`,
+Deep-linking caveat: an https:// link opens the native app only when an installed app is verified for the link's domain (iOS Universal Links / Android App Links) — otherwise it opens in the browser, and on iOS simulators it may open in Safari even when the owning app is installed. To reliably open an installed app, use its custom scheme (scheme://path) or launch-app with its bundle id.
+Returns { opened, url, note? }. note carries the deep-linking caveat when a web URL was opened on a native device. Fails if no app is registered to handle the URI (iOS/Android) or the renderer rejects the navigation (Chromium).`,
   zodSchema,
   capability,
   services: (params): Record<string, ServiceRef> => {

--- a/packages/tool-server/src/tools/open-url/platforms/android.ts
+++ b/packages/tool-server/src/tools/open-url/platforms/android.ts
@@ -2,6 +2,7 @@ import { FAILURE_CODES, FailureError } from "@argent/registry";
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
 import { adbShell } from "../../../utils/adb";
 import type { OpenUrlParams, OpenUrlResult, OpenUrlServices } from "../types";
+import { httpDeepLinkNote } from "../deep-link-note";
 
 export const androidImpl: PlatformImpl<OpenUrlServices, OpenUrlParams, OpenUrlResult> = {
   requires: ["adb"],
@@ -27,6 +28,6 @@ export const androidImpl: PlatformImpl<OpenUrlServices, OpenUrlParams, OpenUrlRe
         error_kind: "subprocess",
       });
     }
-    return { opened: true, url: params.url };
+    return { opened: true, url: params.url, note: httpDeepLinkNote(params.url) };
   },
 };

--- a/packages/tool-server/src/tools/open-url/platforms/ios-remote.ts
+++ b/packages/tool-server/src/tools/open-url/platforms/ios-remote.ts
@@ -1,11 +1,12 @@
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
 import { simctlOpenUrl } from "../../../utils/sim-remote";
 import type { OpenUrlParams, OpenUrlResult, OpenUrlServices } from "../types";
+import { httpDeepLinkNote } from "../deep-link-note";
 
 export const iosRemoteImpl: PlatformImpl<OpenUrlServices, OpenUrlParams, OpenUrlResult> = {
   requires: ["sim-remote"],
   handler: async (_services, params) => {
     await simctlOpenUrl(params.udid, params.url);
-    return { opened: true, url: params.url };
+    return { opened: true, url: params.url, note: httpDeepLinkNote(params.url) };
   },
 };

--- a/packages/tool-server/src/tools/open-url/platforms/ios.ts
+++ b/packages/tool-server/src/tools/open-url/platforms/ios.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { FAILURE_CODES, FailureError, subprocessFailureMetadata } from "@argent/registry";
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
 import type { OpenUrlParams, OpenUrlResult, OpenUrlServices } from "../types";
+import { httpDeepLinkNote } from "../deep-link-note";
 
 const execFileAsync = promisify(execFile);
 
@@ -24,6 +25,6 @@ export const iosImpl: PlatformImpl<OpenUrlServices, OpenUrlParams, OpenUrlResult
         { cause: err instanceof Error ? err : new Error(String(err)) }
       );
     }
-    return { opened: true, url: params.url };
+    return { opened: true, url: params.url, note: httpDeepLinkNote(params.url) };
   },
 };

--- a/packages/tool-server/src/tools/open-url/types.ts
+++ b/packages/tool-server/src/tools/open-url/types.ts
@@ -6,6 +6,12 @@ export interface OpenUrlParams {
 export interface OpenUrlResult {
   opened: boolean;
   url: string;
+  /**
+   * Present when the URL was a web URL (http/https) opened on a native device:
+   * a caveat that it may have opened in the browser rather than deep-linked into
+   * a native app. Absent for custom schemes and for Chromium navigations.
+   */
+  note?: string;
 }
 
 export type OpenUrlServices = Record<string, never>;

--- a/packages/tool-server/test/open-url-deep-link-note.test.ts
+++ b/packages/tool-server/test/open-url-deep-link-note.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DeviceInfo } from "@argent/registry";
+
+// iosImpl shells out via execFileAsync(promisify(execFile)). Stub the round-trip
+// so the handler resolves without a real `xcrun simctl openurl`, letting us
+// assert the returned result shape (the note) rather than the subprocess.
+const execFileMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFile: (
+      cmd: string,
+      args: readonly string[],
+      opts: unknown,
+      cb?: (err: Error | null, out: { stdout: string; stderr: string }) => void
+    ) => {
+      const callback = typeof opts === "function" ? opts : cb!;
+      const result = execFileMock(cmd, args);
+      if (result instanceof Error) callback(result, { stdout: "", stderr: "" });
+      else callback(null, result ?? { stdout: "", stderr: "" });
+    },
+  };
+});
+
+import { httpDeepLinkNote } from "../src/tools/open-url/deep-link-note";
+import { iosImpl } from "../src/tools/open-url/platforms/ios";
+
+const device = { platform: "ios", udid: "SIM" } as unknown as DeviceInfo;
+
+beforeEach(() => {
+  execFileMock.mockReset();
+  execFileMock.mockReturnValue({ stdout: "", stderr: "" });
+});
+
+describe("httpDeepLinkNote", () => {
+  it("returns the deep-linking caveat for http/https web URLs", () => {
+    for (const url of [
+      "https://bsky.app/profile/tvpworld.bsky.social",
+      "http://example.com",
+      "HTTPS://EXAMPLE.COM", // scheme match is case-insensitive
+    ]) {
+      const note = httpDeepLinkNote(url);
+      expect(note, url).toBeTypeOf("string");
+      expect(note).toMatch(/custom scheme|Universal Links|launch-app/);
+    }
+  });
+
+  it("returns undefined for custom schemes and non-web schemes", () => {
+    for (const url of [
+      "bluesky://profile/tvpworld", // app custom scheme — routes reliably
+      "messages://",
+      "settings://",
+      "tel:5551234",
+      "mailto:a@b.com",
+      "geo:37.0,-122.0",
+    ]) {
+      expect(httpDeepLinkNote(url), url).toBeUndefined();
+    }
+  });
+});
+
+describe("open-url iOS handler surfaces the caveat only for web URLs", () => {
+  it("attaches note for an https Universal Link (the bsky.app repro)", async () => {
+    const res = await iosImpl.handler(
+      {},
+      { udid: "SIM", url: "https://bsky.app/profile/tvpworld.bsky.social" },
+      device
+    );
+    expect(res.opened).toBe(true);
+    expect(res.url).toBe("https://bsky.app/profile/tvpworld.bsky.social");
+    expect(res.note).toBeTypeOf("string");
+    // The exact URL is still handed to simctl unchanged (no rewriting).
+    expect(execFileMock).toHaveBeenCalledWith("xcrun", [
+      "simctl",
+      "openurl",
+      "SIM",
+      "https://bsky.app/profile/tvpworld.bsky.social",
+    ]);
+  });
+
+  it("omits note for a custom-scheme deep link", async () => {
+    const res = await iosImpl.handler({}, { udid: "SIM", url: "bluesky://profile/x" }, device);
+    expect(res.opened).toBe(true);
+    expect(res.note).toBeUndefined();
+  });
+});

--- a/packages/tool-server/test/open-url-deep-link-note.test.ts
+++ b/packages/tool-server/test/open-url-deep-link-note.test.ts
@@ -23,14 +23,34 @@ vi.mock("node:child_process", async () => {
   };
 });
 
+// androidImpl goes through the adbShell util; ios-remote through simctlOpenUrl.
+// Stub both at the module boundary to assert their returned result shapes.
+const adbShellMock = vi.fn();
+vi.mock("../src/utils/adb", async () => {
+  const actual = await vi.importActual<object>("../src/utils/adb");
+  return { ...actual, adbShell: (...args: unknown[]) => adbShellMock(...args) };
+});
+const simctlOpenUrlMock = vi.fn();
+vi.mock("../src/utils/sim-remote", async () => {
+  const actual = await vi.importActual<object>("../src/utils/sim-remote");
+  return { ...actual, simctlOpenUrl: (...args: unknown[]) => simctlOpenUrlMock(...args) };
+});
+
 import { httpDeepLinkNote } from "../src/tools/open-url/deep-link-note";
 import { iosImpl } from "../src/tools/open-url/platforms/ios";
+import { androidImpl } from "../src/tools/open-url/platforms/android";
+import { iosRemoteImpl } from "../src/tools/open-url/platforms/ios-remote";
 
 const device = { platform: "ios", udid: "SIM" } as unknown as DeviceInfo;
+const androidDevice = { platform: "android", udid: "emulator-5554" } as unknown as DeviceInfo;
 
 beforeEach(() => {
   execFileMock.mockReset();
   execFileMock.mockReturnValue({ stdout: "", stderr: "" });
+  adbShellMock.mockReset();
+  adbShellMock.mockResolvedValue("Starting: Intent { act=android.intent.action.VIEW }");
+  simctlOpenUrlMock.mockReset();
+  simctlOpenUrlMock.mockResolvedValue(undefined);
 });
 
 describe("httpDeepLinkNote", () => {
@@ -39,6 +59,7 @@ describe("httpDeepLinkNote", () => {
       "https://bsky.app/profile/tvpworld.bsky.social",
       "http://example.com",
       "HTTPS://EXAMPLE.COM", // scheme match is case-insensitive
+      "http:example.com", // slashless form — browsers normalize it to http://
     ]) {
       const note = httpDeepLinkNote(url);
       expect(note, url).toBeTypeOf("string");
@@ -81,6 +102,47 @@ describe("open-url iOS handler surfaces the caveat only for web URLs", () => {
 
   it("omits note for a custom-scheme deep link", async () => {
     const res = await iosImpl.handler({}, { udid: "SIM", url: "bluesky://profile/x" }, device);
+    expect(res.opened).toBe(true);
+    expect(res.note).toBeUndefined();
+  });
+});
+
+describe("open-url Android handler surfaces the caveat only for web URLs", () => {
+  it("attaches note for an https App Link", async () => {
+    const res = await androidImpl.handler(
+      {},
+      { udid: "emulator-5554", url: "https://bsky.app/profile/x" },
+      androidDevice
+    );
+    expect(res.opened).toBe(true);
+    expect(res.note).toBeTypeOf("string");
+  });
+
+  it("omits note for a custom-scheme deep link", async () => {
+    const res = await androidImpl.handler(
+      {},
+      { udid: "emulator-5554", url: "geo:37.0,-122.0" },
+      androidDevice
+    );
+    expect(res.opened).toBe(true);
+    expect(res.note).toBeUndefined();
+  });
+});
+
+describe("open-url iOS remote handler surfaces the caveat only for web URLs", () => {
+  it("attaches note for an https Universal Link", async () => {
+    const res = await iosRemoteImpl.handler(
+      {},
+      { udid: "SIM", url: "https://example.com" },
+      device
+    );
+    expect(res.opened).toBe(true);
+    expect(res.note).toBeTypeOf("string");
+    expect(simctlOpenUrlMock).toHaveBeenCalledWith("SIM", "https://example.com");
+  });
+
+  it("omits note for a custom-scheme deep link", async () => {
+    const res = await iosRemoteImpl.handler({}, { udid: "SIM", url: "maps://" }, device);
     expect(res.opened).toBe(true);
     expect(res.note).toBeUndefined();
   });


### PR DESCRIPTION
## Problem

An agent calling `open-url` to deep-link into an app gets Safari instead:

```
open-url { "url": "https://bsky.app/profile/tvpworld.bsky.social" }  →  opens Safari
```

### Root cause (not a wrapper bug — an iOS Simulator limitation)

`open-url` on iOS is a thin wrapper over `xcrun simctl openurl`. An `https://`
URL is a **Universal Link**, which only reaches a native app when that app is
installed and verified for the link's domain. Two things bite here:

1. On the iOS **Simulator**, `simctl openurl` routes Universal Links to Safari
   even when the owning app *is* installed — a long-standing, documented
   limitation. Custom URL schemes (`scheme://…`) route reliably; Universal
   Links do not.
2. In the reported case the Bluesky app isn't installed at all, so Safari is
   the only valid handler — identical to tapping the link on a real iPhone with
   Bluesky absent.

Reproduced on a booted iOS 18.5 sim: `simctl openurl <bsky https link>`
launches `com.apple.mobilesafari`; the sim has zero third-party apps installed;
`bluesky://…` fails with `-10814` (no registered handler), confirming absence.

The real defect on our side: the result was **always** `{ opened: true }`, so a
web URL that silently fell back to Safari was indistinguishable from a
successful deep-link — the caller (an agent) believed it had reached the native
app. There is no reliable way to observe which app actually handled the URL
(Safari and other apps are invisible to the native-devtools socket), so the fix
makes the ambiguity explicit rather than guessing.

## Fix

- Add an optional `note` to the `open-url` result whenever a web URL (`http`/
  `https`) is opened on a native device (iOS + iOS-remote). It states the URL
  may have opened in the browser and points to the reliable path: the app's
  **custom scheme** (`scheme://path`) or **`launch-app`** with the bundle id.
- Update the tool description with the same deep-linking caveat.
- Custom schemes, non-web schemes (`tel:`, `maps://`, `geo:`), and Chromium
  navigations are unaffected (no note). No URL rewriting — the URL is still
  handed to `simctl` unchanged.

Scoped to iOS deliberately: Android App Links go through `am start` with a
different verification/chooser path, and the reported symptom is iOS-specific.

## Verification

- New unit tests (`open-url-deep-link-note.test.ts`, 4 cases): the helper
  returns the caveat for `http`/`https` (case-insensitive) and `undefined` for
  custom/non-web schemes; the iOS handler attaches `note` for the bsky https
  link (URL passed to `simctl` unchanged) and omits it for a custom scheme.
- End-to-end against a live sim through the real `openUrlTool.execute`:
  - `https://bsky.app/profile/…` → `{ opened: true, url, note }`
  - `maps://?q=cupertino` (installed native handler) → `{ opened: true }`, no note
  - `bluesky://…` (not installed) → correct `FailureError` (existing behavior)
- `tsc --noEmit`, `tsc --noEmit -p tsconfig.test.json`, and `prettier --check`
  all pass on the changed files.
