### PR TITLE
feat(telemetry): distinguish tvOS and Android TV from iOS/Android

### DIFF
--- a/packages/telemetry/src/events.ts
+++ b/packages/telemetry/src/events.ts
@@ -4,10 +4,26 @@
 import type { FailureSignal } from "@argent/registry";
 import type { AiTelemetryProps } from "./ai-identity.js";
 
-// Single source of truth for the device platform enum: the TS union below and
-// sanitize.ts's runtime allowlist both derive from this tuple, so adding a
-// platform can't silently drift the two apart.
-export const PLATFORMS = ["ios", "ios-remote", "android", "chromium", "vega"] as const;
+// Single source of truth for the telemetry device-platform enum: the TS union
+// below and sanitize.ts's runtime allowlist both derive from this tuple, so
+// adding a platform can't silently drift the two apart.
+//
+// This is the *telemetry* platform, deliberately a superset of the tool-server's
+// device `Platform` (@argent/registry): `tvos` and `android-tv` have no
+// standalone device platform there — a TV is a `runtimeKind` ("tv") layered on
+// an `ios`/`android` device, not its own platform, so capability gating and
+// dispatch stay TV-agnostic. Telemetry splits them out only for reporting: the
+// inference in tool-server/http.ts maps `ios`->`tvos` / `android`->`android-tv`
+// when a device's cached runtime kind is "tv".
+export const PLATFORMS = [
+  "ios",
+  "ios-remote",
+  "android",
+  "chromium",
+  "vega",
+  "tvos",
+  "android-tv",
+] as const;
 export type Platform = (typeof PLATFORMS)[number];
 
 // Installation events

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -16,7 +16,8 @@ import { emitDebugError, emitDebugPayload, isDebugEnabled } from "./debug.js";
 import { forget as forgetImpl, type ForgetOptions, type ForgetResult } from "./erasure.js";
 import type { EventName, EventPropertyMap } from "./events.js";
 
-export type { EventName, EventPropertyMap } from "./events.js";
+export type { EventName, EventPropertyMap, Platform } from "./events.js";
+export { PLATFORMS } from "./events.js";
 export type { Runtime } from "./base-props.js";
 export type { ForgetOptions, ForgetResult } from "./erasure.js";
 export type { ConsentState, ConsentSource } from "./consent.js";

--- a/packages/telemetry/test/sanitize.test.ts
+++ b/packages/telemetry/test/sanitize.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { FAILURE_CODES } from "@argent/registry";
 import { sanitize, ALLOWED } from "../src/sanitize.js";
-import { EVENT_NAMES } from "../src/events.js";
+import { EVENT_NAMES, PLATFORMS } from "../src/events.js";
 
 describe("sanitize", () => {
   describe("event allowlist", () => {
@@ -44,6 +44,20 @@ describe("sanitize", () => {
       expect(sanitize("tool:invoke", { tool: "list-devices", platform: "unknown" })).toEqual({
         tool: "list-devices",
       });
+    });
+
+    it("accepts every telemetry platform, including the TV variants", () => {
+      // The TV variants (`tvos`, `android-tv`) are telemetry-only refinements of
+      // `ios` / `android`; the sanitizer must let them through so the split
+      // survives to PostHog.
+      for (const platform of PLATFORMS) {
+        expect(sanitize("tool:invoke", { tool: "describe", platform })).toEqual({
+          tool: "describe",
+          platform,
+        });
+      }
+      expect(PLATFORMS).toContain("tvos");
+      expect(PLATFORMS).toContain("android-tv");
     });
 
     it("drops the legacy `from_tar` decision (developer-only path is off the books)", () => {

--- a/packages/tool-server/src/blueprints/tv-control.ts
+++ b/packages/tool-server/src/blueprints/tv-control.ts
@@ -10,7 +10,7 @@ import {
 } from "@argent/registry";
 import { tvosAxServiceBinaryPath, tvosHidDaemonBinaryPath } from "@argent/native-devtools-ios";
 import { ensureAutomationEnabled } from "./ax-service";
-import { listIosSimulators } from "../utils/ios-devices";
+import { listIosSimulators, cacheSimulatorRuntimeKind } from "../utils/ios-devices";
 import { UnsupportedOperationError } from "../utils/capability";
 import type { TvControlApi, TvDescribeResponse, TvDirection, TvElement } from "./tv-control-types";
 
@@ -234,6 +234,12 @@ export const tvControlBlueprint: ServiceBlueprint<TvControlApi, DeviceInfo> = {
         `${TV_CONTROL_NAMESPACE}: no available simulator with udid '${udid}'. Run list-devices to find a booted Apple TV.`
       );
     }
+    // Warm the synchronous runtime-kind cache the telemetry hot path reads. Without
+    // this, a tv-remote-only Apple TV session never touches describe/screenshot/
+    // streaming and so stays attributed to the coarse `ios` platform — whereas the
+    // Android TV factory warms its cache via getAndroidRuntimeKind. Warming here
+    // makes the two TV platforms symmetric (refined from the call after the first).
+    cacheSimulatorRuntimeKind(udid, match.runtimeKind);
     if (match.runtimeKind !== "tv") {
       // Wrong device class (an iPhone shape-classifies as iOS and reaches here).
       // UnsupportedOperationError so http.ts maps it to 400, not 500 — a 500

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -128,7 +128,9 @@ type HttpFailureMeta = { platform?: TelemetryPlatform } & AiTelemetryProps;
  * `tvos` / `android-tv` here for reporting only when the cache already knows the
  * kind, and leave it coarse otherwise. The first tool call on a device may land
  * before the cache is warm and report the base platform; subsequent calls, once
- * describe/screenshot/streaming have run, report the TV variant.
+ * a describe/interaction path has warmed the runtime-kind cache (the per-platform
+ * warmers are listed on `getCachedSimulatorRuntimeKind` /
+ * `getCachedAndroidRuntimeKind`), report the TV variant.
  */
 function refineTvPlatform(basePlatform: DevicePlatform, deviceId: string): TelemetryPlatform {
   if (basePlatform === "ios" && getCachedSimulatorRuntimeKind(deviceId) === "tv") {
@@ -180,14 +182,21 @@ function extractInvocationMeta(
   return Object.keys(meta).length > 0 ? meta : null;
 }
 
-/** Coarse platform from a tool call's device arg (`udid` / `device_id` / `avdName`), or null. */
+/**
+ * Telemetry platform from a tool call's device arg, or null when it carries none.
+ * A `udid` / `device_id` resolves through the runtime-kind cache and refines to
+ * `tvos` / `android-tv` once that cache is warm (coarse `ios` / `android` until
+ * then); only the `avdName`-only fallback is unconditionally coarse.
+ */
 function platformFromArgs(data: unknown): TelemetryPlatform | null {
   if (!data || typeof data !== "object") return null;
   const deviceArg = extractDeviceArg(data);
   if (deviceArg) return inferPlatform(deviceArg) ?? null;
   // An `avdName`-only call (boot-device before the emulator exists) has no serial
-  // to resolve a runtime kind from, so it stays the coarse `android` platform —
-  // an Android TV AVD is attributed to `android-tv` on its first device-arg call.
+  // to resolve a runtime kind from, so it stays the coarse `android` platform.
+  // Once the emulator is up, later `udid` / `device_id` calls refine an Android TV
+  // AVD to `android-tv` — from the call after describe/launch has warmed the cache,
+  // not the first (see `refineTvPlatform`).
   if (typeof (data as Record<string, unknown>).avdName === "string") return "android";
   return null;
 }

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -5,11 +5,17 @@ import {
   FAILURE_CODES,
   type FailureSignal,
   type FileInputSpec,
-  type Platform,
+  // The tool-server's coarse *device* platform (TV-agnostic). Telemetry's own
+  // Platform (imported below) is a superset that also carries `tvos`/`android-tv`.
+  type Platform as DevicePlatform,
   type Registry,
   type ResolvedFileInput,
 } from "@argent/registry";
-import { AI_CLIENTS, type AiTelemetryProps } from "@argent/telemetry";
+import {
+  AI_CLIENTS,
+  type AiTelemetryProps,
+  type Platform as TelemetryPlatform,
+} from "@argent/telemetry";
 import { ToolNotFoundError } from "@argent/registry";
 import { createIdleTimer, IDLE_CHECK_INTERVAL_MS } from "./utils/idle-timer";
 import { DependencyMissingError, ensureDeps } from "./utils/check-deps";
@@ -25,6 +31,8 @@ import {
   UnsupportedOperationError,
 } from "./utils/capability";
 import { resolveDevice } from "./utils/device-info";
+import { getCachedSimulatorRuntimeKind } from "./utils/ios-devices";
+import { getCachedAndroidRuntimeKind } from "./utils/adb";
 import type { Server as HttpServer } from "node:http";
 import {
   CHROMIUM_CDP_NAMESPACE,
@@ -103,16 +111,39 @@ function extractDeviceArg(data: unknown): string | null {
   return null;
 }
 
-type InvocationMeta = { platform?: Platform } & AiTelemetryProps;
+type InvocationMeta = { platform?: TelemetryPlatform } & AiTelemetryProps;
 // Only coarse platform context is retained for failure telemetry. The raw
 // device id (UDID / serial) is used transiently to infer platform and never
 // stored or forwarded.
-type HttpFailureMeta = { platform?: Platform } & AiTelemetryProps;
+type HttpFailureMeta = { platform?: TelemetryPlatform } & AiTelemetryProps;
 
-function inferPlatform(deviceId: string | null): HttpFailureMeta["platform"] | null {
+/**
+ * Split a TV target out of its base mobile platform for telemetry, using only
+ * the already-memoized runtime kind — never a fresh `simctl`/`adb` probe, since
+ * this runs on the per-tool-call hot path. A tvOS simulator and an iPhone
+ * simulator share the same UDID shape (both classify as `ios`); an Android TV
+ * emulator and a phone share the `emulator-NNNN` serial shape (both `android`).
+ * The device platform stays coarse (a TV is a `runtimeKind`, not its own device
+ * platform — capability gating and dispatch are TV-agnostic); we refine it to
+ * `tvos` / `android-tv` here for reporting only when the cache already knows the
+ * kind, and leave it coarse otherwise. The first tool call on a device may land
+ * before the cache is warm and report the base platform; subsequent calls, once
+ * describe/screenshot/streaming have run, report the TV variant.
+ */
+function refineTvPlatform(basePlatform: DevicePlatform, deviceId: string): TelemetryPlatform {
+  if (basePlatform === "ios" && getCachedSimulatorRuntimeKind(deviceId) === "tv") {
+    return "tvos";
+  }
+  if (basePlatform === "android" && getCachedAndroidRuntimeKind(deviceId) === "tv") {
+    return "android-tv";
+  }
+  return basePlatform;
+}
+
+function inferPlatform(deviceId: string | null): TelemetryPlatform | null {
   if (!deviceId) return null;
   try {
-    return resolveDevice(deviceId).platform;
+    return refineTvPlatform(resolveDevice(deviceId).platform, deviceId);
   } catch {
     return null;
   }
@@ -150,10 +181,13 @@ function extractInvocationMeta(
 }
 
 /** Coarse platform from a tool call's device arg (`udid` / `device_id` / `avdName`), or null. */
-function platformFromArgs(data: unknown): Platform | null {
+function platformFromArgs(data: unknown): TelemetryPlatform | null {
   if (!data || typeof data !== "object") return null;
   const deviceArg = extractDeviceArg(data);
   if (deviceArg) return inferPlatform(deviceArg) ?? null;
+  // An `avdName`-only call (boot-device before the emulator exists) has no serial
+  // to resolve a runtime kind from, so it stays the coarse `android` platform —
+  // an Android TV AVD is attributed to `android-tv` on its first device-arg call.
   if (typeof (data as Record<string, unknown>).avdName === "string") return "android";
   return null;
 }

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -493,6 +493,36 @@ export async function isAndroidTv(serial: string): Promise<boolean> {
 }
 
 /**
+ * Synchronous, cache-only view of a serial's runtime kind: returns the memoized
+ * "mobile"/"tv" verdict if a prior probe resolved it, otherwise undefined. It
+ * NEVER runs `adb` — callers on a latency-sensitive hot path (telemetry platform
+ * inference) use this to distinguish Android TV from a phone/tablet only when the
+ * kind is already known, falling back to the coarse `android` platform otherwise
+ * rather than paying a `pm list features` round-trip per call. The cache is
+ * warmed by the describe/launch/keyboard/tv-control paths any real Android TV
+ * session exercises.
+ *
+ * The verdict is returned regardless of the caller supplying an avdName: unlike
+ * the async path this can't cheaply re-read `ro.boot.qemu.avd_name` to detect a
+ * reclaimed `emulator-NNNN` slot, so if a TV AVD's slot is later reclaimed by a
+ * phone AVD (or the reverse) within one tool-server lifetime, this can report the
+ * prior occupant's kind. Acceptable for best-effort coarse telemetry — no crash,
+ * and no dispatch impact since dispatch stays TV-agnostic: the TV→phone direction
+ * mislabels a phone as `android-tv`, the phone→TV direction only falls back to
+ * the coarse `android`. The stale entry is corrected only when an async path
+ * re-touches the serial: `getAndroidRuntimeKind`/`isAndroidTv` (via
+ * describe/launch/restart/keyboard/tv-control) delete it when the serial has gone
+ * offline and re-probe it on an avdName mismatch, while the `list-devices`
+ * enrichment re-probes on an avdName mismatch too (so a live reclaiming AVD fixes
+ * it) but does not evict a merely-offline entry. A session that triggers none of
+ * these (e.g. a describe-free, gesture-only replay) keeps the stale verdict — so
+ * the mislabel is bounded to that process, not guaranteed transient.
+ */
+export function getCachedAndroidRuntimeKind(serial: string): "mobile" | "tv" | undefined {
+  return androidRuntimeKindCache.get(serial)?.kind;
+}
+
+/**
  * List all Android devices + emulators known to adb, enriched with model,
  * AVD name, and SDK level via `getprop`. Use `listAndroidSerials` when you
  * only need the state-scoped serial list — it avoids the extra round-trips.

--- a/packages/tool-server/src/utils/ios-devices.ts
+++ b/packages/tool-server/src/utils/ios-devices.ts
@@ -82,3 +82,22 @@ export async function getSimulatorRuntimeKind(udid: string): Promise<"mobile" | 
 export async function isTvOsSimulator(udid: string): Promise<boolean> {
   return (await getSimulatorRuntimeKind(udid)) === "tv";
 }
+
+/**
+ * Synchronous, cache-only view of a UDID's runtime kind: returns the memoized
+ * "mobile"/"tv" verdict if a prior `getSimulatorRuntimeKind` call resolved it,
+ * otherwise undefined. It NEVER runs `simctl` — callers on a latency-sensitive
+ * hot path (telemetry platform inference) use this to distinguish tvOS from iOS
+ * only when the kind is already known, and fall back to the coarse platform when
+ * it isn't, rather than paying a ~100ms probe per call. The cache is warmed as a
+ * side effect of the describe/screenshot/keyboard/streaming paths that any real
+ * tvOS session exercises.
+ */
+export function getCachedSimulatorRuntimeKind(udid: string): "mobile" | "tv" | undefined {
+  return runtimeKindCache.get(udid);
+}
+
+/** Test-only: clear the iOS runtime-kind memo so cases don't leak verdicts. */
+export function __resetSimulatorRuntimeKindCacheForTesting(): void {
+  runtimeKindCache.clear();
+}

--- a/packages/tool-server/src/utils/ios-devices.ts
+++ b/packages/tool-server/src/utils/ios-devices.ts
@@ -84,14 +84,26 @@ export async function isTvOsSimulator(udid: string): Promise<boolean> {
 }
 
 /**
+ * Memoize a runtime-kind verdict a caller already resolved out-of-band — e.g. the
+ * tv-control factory, which fetches the simulator list to validate the target and
+ * so holds the kind in hand. Warming the cache here lets the synchronous telemetry
+ * reader refine that device without a redundant `simctl` probe, and mirrors how
+ * the Android TV factory's `getAndroidRuntimeKind` warms its cache. No-op for an
+ * undefined kind; a simulator's kind is fixed at creation, so it never goes stale.
+ */
+export function cacheSimulatorRuntimeKind(udid: string, kind: "mobile" | "tv" | undefined): void {
+  if (kind) runtimeKindCache.set(udid, kind);
+}
+
+/**
  * Synchronous, cache-only view of a UDID's runtime kind: returns the memoized
  * "mobile"/"tv" verdict if a prior `getSimulatorRuntimeKind` call resolved it,
  * otherwise undefined. It NEVER runs `simctl` — callers on a latency-sensitive
  * hot path (telemetry platform inference) use this to distinguish tvOS from iOS
  * only when the kind is already known, and fall back to the coarse platform when
  * it isn't, rather than paying a ~100ms probe per call. The cache is warmed as a
- * side effect of the describe/screenshot/keyboard/streaming paths that any real
- * tvOS session exercises.
+ * side effect of the describe/screenshot/keyboard/streaming and tv-remote
+ * (tv-control) paths that any real tvOS session exercises.
  */
 export function getCachedSimulatorRuntimeKind(udid: string): "mobile" | "tv" | undefined {
   return runtimeKindCache.get(udid);

--- a/packages/tool-server/test/android-tv-discovery.test.ts
+++ b/packages/tool-server/test/android-tv-discovery.test.ts
@@ -31,6 +31,7 @@ import {
   getAndroidRuntimeKind,
   isAndroidTv,
   __resetAndroidRuntimeKindCacheForTesting,
+  getCachedAndroidRuntimeKind,
 } from "../src/utils/adb";
 
 // Mock one device. `features` is the `pm list features` output (the primary TV
@@ -261,5 +262,33 @@ describe("Android TV discovery — getAndroidRuntimeKind / isAndroidTv", () => {
       return { stdout: "", stderr: "" };
     });
     expect(await getAndroidRuntimeKind("emulator-5554")).toBeUndefined();
+  });
+});
+
+describe("getCachedAndroidRuntimeKind — synchronous cache-only read", () => {
+  it("returns undefined for a serial that has never been probed", () => {
+    // No async probe has warmed the cache → the hot-path reader stays coarse.
+    expect(getCachedAndroidRuntimeKind("emulator-5554")).toBeUndefined();
+  });
+
+  it("returns the memoized 'tv' verdict after an async probe warms it, without any adb call", async () => {
+    mockDevice("emulator-5556", { features: LEANBACK_FEATURES });
+    expect(await getAndroidRuntimeKind("emulator-5556")).toBe("tv");
+    const callsBefore = execFileMock.mock.calls.length;
+    expect(getCachedAndroidRuntimeKind("emulator-5556")).toBe("tv");
+    // The cache read must not shell out to adb.
+    expect(execFileMock.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("returns the memoized 'mobile' verdict for a warmed phone serial", async () => {
+    mockDevice("emulator-5554", { features: PHONE_FEATURES });
+    expect(await getAndroidRuntimeKind("emulator-5554")).toBe("mobile");
+    expect(getCachedAndroidRuntimeKind("emulator-5554")).toBe("mobile");
+  });
+
+  it("does not cache (stays undefined) when the probe was indeterminate", async () => {
+    mockDevice("emulator-5554", {});
+    expect(await getAndroidRuntimeKind("emulator-5554")).toBeUndefined();
+    expect(getCachedAndroidRuntimeKind("emulator-5554")).toBeUndefined();
   });
 });

--- a/packages/tool-server/test/http-tools-meta.test.ts
+++ b/packages/tool-server/test/http-tools-meta.test.ts
@@ -13,6 +13,25 @@ vi.mock("../src/utils/update-checker", () => ({
   suppressUpdateNote: vi.fn(),
 }));
 
+// Drive the synchronous, cache-only runtime-kind readers that http.ts consults
+// to split a TV target out of its base mobile platform. Real code warms these
+// caches via simctl/adb; here we mock only the two getters so a case can pretend
+// the cache is cold ("mobile"/undefined → coarse platform) or warm for TV.
+const tvKinds = vi.hoisted(() => ({
+  ios: undefined as "mobile" | "tv" | undefined,
+  android: undefined as "mobile" | "tv" | undefined,
+}));
+
+vi.mock("../src/utils/ios-devices", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/utils/ios-devices")>();
+  return { ...actual, getCachedSimulatorRuntimeKind: () => tvKinds.ios };
+});
+
+vi.mock("../src/utils/adb", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/utils/adb")>();
+  return { ...actual, getCachedAndroidRuntimeKind: () => tvKinds.android };
+});
+
 function stubRegistry(): Registry {
   return {
     getSnapshot: vi.fn(() => ({
@@ -82,6 +101,8 @@ describe("GET /tools progressive-loading metadata", () => {
   const request = supertest;
 
   beforeEach(async () => {
+    tvKinds.ios = undefined;
+    tvKinds.android = undefined;
     handle = createHttpApp(stubRegistry());
   });
 
@@ -167,6 +188,103 @@ describe("GET /tools progressive-loading metadata", () => {
     await request(handle.app).post("/tools/boot-tool").send({ avdName: "Pixel_9" }).expect(200);
 
     expect(recordInvocation).toHaveBeenCalledWith(expect.any(String), { platform: "android" });
+  });
+
+  it("refines an iOS device to `tvos` when its cached runtime kind is tv", async () => {
+    tvKinds.ios = "tv";
+    let seenMeta: Record<string, unknown> | undefined;
+    const recordInvocation = vi.fn((_id: string, meta: Record<string, unknown>) => {
+      seenMeta = meta;
+      return vi.fn();
+    });
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .send({ udid: "11111111-1111-1111-1111-111111111111" })
+      .expect(200);
+
+    // Same UDID shape as an iPhone sim, but the warm cache splits it out as tvOS.
+    expect(seenMeta).toEqual({ platform: "tvos" });
+  });
+
+  it("refines an Android device to `android-tv` when its cached runtime kind is tv", async () => {
+    tvKinds.android = "tv";
+    let seenMeta: Record<string, unknown> | undefined;
+    const recordInvocation = vi.fn((_id: string, meta: Record<string, unknown>) => {
+      seenMeta = meta;
+      return vi.fn();
+    });
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .send({ udid: "emulator-5554" })
+      .expect(200);
+
+    expect(seenMeta).toEqual({ platform: "android-tv" });
+  });
+
+  it("keeps the coarse `ios` platform when the cached kind is mobile (not tv)", async () => {
+    tvKinds.ios = "mobile";
+    let seenMeta: Record<string, unknown> | undefined;
+    const recordInvocation = vi.fn((_id: string, meta: Record<string, unknown>) => {
+      seenMeta = meta;
+      return vi.fn();
+    });
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .send({ udid: "11111111-1111-1111-1111-111111111111" })
+      .expect(200);
+
+    expect(seenMeta).toEqual({ platform: "ios" });
+  });
+
+  it("keeps the coarse platform when the cache is cold (first call before warm-up)", async () => {
+    // tvKinds default to undefined → the reader can't yet tell TV from mobile, so
+    // the first tool call on a device reports the base platform. A later call,
+    // once describe/streaming has warmed the cache, would report the TV variant.
+    let seenMeta: Record<string, unknown> | undefined;
+    const recordInvocation = vi.fn((_id: string, meta: Record<string, unknown>) => {
+      seenMeta = meta;
+      return vi.fn();
+    });
+    handle.dispose();
+    handle = createHttpApp(stubRegistry(), { recordInvocation });
+
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .send({ udid: "11111111-1111-1111-1111-111111111111" })
+      .expect(200);
+
+    expect(seenMeta).toEqual({ platform: "ios" });
+  });
+
+  it("re-derives a child sub-tool's TV platform from its own device arg", async () => {
+    tvKinds.android = "tv";
+    const recordInvocation = vi.fn((_id: string, _meta: Record<string, unknown>) => vi.fn());
+    const registry = stubRegistry();
+    handle.dispose();
+    handle = createHttpApp(registry, { recordInvocation });
+
+    // Parent targets an Android TV device.
+    await request(handle.app)
+      .post("/tools/device-tool")
+      .send({ udid: "emulator-5554" })
+      .expect(200);
+
+    const { recordChildInvocation } = vi.mocked(registry.invokeTool).mock.calls[0]![2] as {
+      recordChildInvocation: (id: string, childArgs?: unknown) => () => void;
+    };
+
+    // A sub-tool targeting the same TV device is attributed to android-tv too.
+    recordChildInvocation("tv-child", { udid: "emulator-5554" });
+    expect(recordInvocation).toHaveBeenCalledWith("tv-child", { platform: "android-tv" });
   });
 
   it("records the AI client from request headers alongside platform", async () => {

--- a/packages/tool-server/test/ios-devices-runtime-kind.test.ts
+++ b/packages/tool-server/test/ios-devices-runtime-kind.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.fn();
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFile: (
+      cmd: string,
+      args: readonly string[],
+      opts: unknown,
+      cb?: (err: Error | null, out: { stdout: string; stderr: string }) => void
+    ) => {
+      const callback = typeof opts === "function" ? opts : cb!;
+      const options = typeof opts === "function" ? undefined : opts;
+      const result = execFileMock(cmd, args, options);
+      if (result instanceof Error) callback(result, { stdout: "", stderr: "" });
+      else callback(null, result ?? { stdout: "", stderr: "" });
+    },
+  };
+});
+
+import {
+  getSimulatorRuntimeKind,
+  getCachedSimulatorRuntimeKind,
+  __resetSimulatorRuntimeKindCacheForTesting,
+} from "../src/utils/ios-devices";
+
+const TV_UDID = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA";
+const PHONE_UDID = "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB";
+
+// Shape a `simctl list devices --json` payload: one tvOS device and one iOS
+// device, so both a "tv" and a "mobile" verdict can be resolved from one probe.
+function mockSimctl(): void {
+  execFileMock.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "xcrun" && args[0] === "simctl" && args[1] === "list") {
+      return {
+        stdout: JSON.stringify({
+          devices: {
+            "com.apple.CoreSimulator.SimRuntime.tvOS-18-0": [
+              {
+                udid: TV_UDID,
+                name: "Apple TV",
+                state: "Booted",
+                deviceTypeIdentifier:
+                  "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation",
+                isAvailable: true,
+              },
+            ],
+            "com.apple.CoreSimulator.SimRuntime.iOS-18-0": [
+              {
+                udid: PHONE_UDID,
+                name: "iPhone 16",
+                state: "Booted",
+                deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+                isAvailable: true,
+              },
+            ],
+          },
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "", stderr: "" };
+  });
+}
+
+beforeEach(() => {
+  execFileMock.mockReset();
+  __resetSimulatorRuntimeKindCacheForTesting();
+});
+
+describe("getCachedSimulatorRuntimeKind — synchronous cache-only read", () => {
+  it("returns undefined for a UDID that has never been probed", () => {
+    // No async resolution has warmed the cache → the hot-path reader stays coarse
+    // and never triggers a simctl call.
+    mockSimctl();
+    expect(getCachedSimulatorRuntimeKind(TV_UDID)).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 'tv' after an async probe warms the cache, without any simctl call", async () => {
+    mockSimctl();
+    expect(await getSimulatorRuntimeKind(TV_UDID)).toBe("tv");
+    const callsBefore = execFileMock.mock.calls.length;
+    expect(getCachedSimulatorRuntimeKind(TV_UDID)).toBe("tv");
+    // The synchronous read must not shell out.
+    expect(execFileMock.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("returns 'mobile' for a warmed iPhone simulator UDID", async () => {
+    mockSimctl();
+    expect(await getSimulatorRuntimeKind(PHONE_UDID)).toBe("mobile");
+    expect(getCachedSimulatorRuntimeKind(PHONE_UDID)).toBe("mobile");
+  });
+
+  it("stays undefined for an unknown UDID even after another device warms the cache", async () => {
+    mockSimctl();
+    await getSimulatorRuntimeKind(TV_UDID);
+    expect(getCachedSimulatorRuntimeKind("CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")).toBeUndefined();
+  });
+});

--- a/packages/tool-server/test/ios-devices-runtime-kind.test.ts
+++ b/packages/tool-server/test/ios-devices-runtime-kind.test.ts
@@ -24,6 +24,7 @@ vi.mock("node:child_process", async () => {
 import {
   getSimulatorRuntimeKind,
   getCachedSimulatorRuntimeKind,
+  cacheSimulatorRuntimeKind,
   __resetSimulatorRuntimeKindCacheForTesting,
 } from "../src/utils/ios-devices";
 
@@ -99,5 +100,26 @@ describe("getCachedSimulatorRuntimeKind — synchronous cache-only read", () => 
     mockSimctl();
     await getSimulatorRuntimeKind(TV_UDID);
     expect(getCachedSimulatorRuntimeKind("CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")).toBeUndefined();
+  });
+});
+
+describe("cacheSimulatorRuntimeKind — warm from an out-of-band verdict", () => {
+  it("seeds the cache so the synchronous reader refines without any simctl call", () => {
+    // The tv-control factory already holds the runtime kind from its own
+    // listIosSimulators() call; warming here lets the telemetry reader see `tv`
+    // with no further probe (the whole point of the synchronous hot path).
+    cacheSimulatorRuntimeKind(TV_UDID, "tv");
+    expect(getCachedSimulatorRuntimeKind(TV_UDID)).toBe("tv");
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("caches a mobile verdict too (an iPhone that reached a tv path)", () => {
+    cacheSimulatorRuntimeKind(PHONE_UDID, "mobile");
+    expect(getCachedSimulatorRuntimeKind(PHONE_UDID)).toBe("mobile");
+  });
+
+  it("is a no-op for an undefined kind, leaving the entry unwarmed", () => {
+    cacheSimulatorRuntimeKind(TV_UDID, undefined);
+    expect(getCachedSimulatorRuntimeKind(TV_UDID)).toBeUndefined();
   });
 });

--- a/packages/tool-server/test/tv-control-blueprint.test.ts
+++ b/packages/tool-server/test/tv-control-blueprint.test.ts
@@ -150,8 +150,10 @@ vi.mock("@argent/native-devtools-ios", () => ({
 }));
 
 const listIosSimulatorsMock = vi.fn();
+const cacheSimulatorRuntimeKindMock = vi.fn();
 vi.mock("../src/utils/ios-devices", () => ({
   listIosSimulators: () => listIosSimulatorsMock(),
+  cacheSimulatorRuntimeKind: (...args: unknown[]) => cacheSimulatorRuntimeKindMock(...args),
 }));
 
 import { tvControlBlueprint, typeTimeoutMs } from "../src/blueprints/tv-control";
@@ -179,6 +181,7 @@ beforeEach(() => {
   h.state.hidSpawnError = false;
   h.state.axConnectHook = null;
   listIosSimulatorsMock.mockReset();
+  cacheSimulatorRuntimeKindMock.mockReset();
   listIosSimulatorsMock.mockResolvedValue([
     { udid: UDID, name: "Apple TV", runtime: "tvOS 17.0", runtimeKind: "tv", state: "Booted" },
   ]);
@@ -371,6 +374,20 @@ describe("tvControlBlueprint — target validation", () => {
     );
     expect(err).toBeInstanceOf(UnsupportedOperationError);
     expect(err.message).toMatch(/tvOS-only/);
+    // The warm runs BEFORE this reject, so a misrouted iPhone caches its true
+    // `mobile` kind (keeping its telemetry coarse `ios`, never mislabeled tvOS).
+    // Pins the warm-before-reject ordering: moving the warm below the throw would
+    // silently regress refinement for this path with no other test catching it.
+    expect(cacheSimulatorRuntimeKindMock).toHaveBeenCalledWith(UDID, "mobile");
+  });
+
+  it("warms the telemetry runtime-kind cache with the resolved tvOS kind", async () => {
+    // The factory already fetched the simulator list to validate the target, so it
+    // seeds the synchronous cache the telemetry hot path reads — without this, a
+    // tv-remote-only Apple TV session never warms the cache and stays coarse `ios`,
+    // asymmetric with the Android TV factory. Refinement lands from the next call.
+    await buildService();
+    expect(cacheSimulatorRuntimeKindMock).toHaveBeenCalledWith(UDID, "tv");
   });
 
   it("rejects a tvOS simulator that isn't booted", async () => {
@@ -383,5 +400,7 @@ describe("tvControlBlueprint — target validation", () => {
   it("rejects when no simulator matches the udid", async () => {
     listIosSimulatorsMock.mockResolvedValue([]);
     await expect(buildService()).rejects.toThrow(/no available simulator/);
+    // The no-match throw is before the warm call, so nothing is cached.
+    expect(cacheSimulatorRuntimeKindMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Telemetry inferred the device platform purely from device-id **shape** on the per-tool-call hot path, so a tvOS simulator (same 8-4-4-4-12 UUID as an iPhone) and an Android TV emulator (same `emulator-NNNN` serial as a phone) were both reported as `ios` / `android` — TV usage was invisible in analytics.

This adds `tvos` and `android-tv` to the **telemetry** `PLATFORMS` enum and refines the inference so a TV target is attributed correctly.

## Approach

- The runtime kind (`mobile` / `tv`) is already resolved and memoized in two module-level caches (`runtimeKindCache` in `ios-devices.ts`, `androidRuntimeKindCache` in `adb.ts`), warmed by the usual TV-path tools (describe, screenshot, keyboard, launch/restart-app, the streaming blueprint, tv-control).
- New synchronous, **cache-only** readers (`getCachedSimulatorRuntimeKind`, `getCachedAndroidRuntimeKind`) let `refineTvPlatform` in `http.ts` map `ios → tvos` / `android → android-tv` with **no new `simctl`/`adb` round-trip** on the hot path.
- The registry **device** `Platform` (`@argent/registry`) is intentionally left unchanged — a TV stays a `runtimeKind`, not its own device platform, so capability gating and dispatch remain TV-agnostic. The two new values are confined to the telemetry boundary (`tool:invoke` / `tool:complete` / `tool:fail` and child sub-tool attribution).

## Behavior notes

- The **first** tool call on a device may land before the cache is warm and reports the coarse base platform (`ios`/`android`); subsequent calls, once describe/screenshot/streaming have run, report the TV variant. This is best-effort coarse telemetry by design.
- For an `emulator-NNNN` slot reclaimed by a different-form-factor AVD within one tool-server lifetime, the synchronous reader can momentarily report the prior occupant's kind until an async, avdName-checked path re-probes. Documented inline; no crash and no dispatch impact.

## Verification

- **Live E2E** against real booted devices (real `simctl`/`adb` → real cache → real http telemetry recording): Apple TV → `tvos` (cold-cache `ios`, warm `tvos`); iPhone → `ios`; Android phone → `android`. The `android-tv` path is symmetric and covered by unit/integration tests with real leanback-feature probing.
- Unit + integration tests added: sanitize allowlist, http platform inference (cold/warm/TV/child), and cache readers. Telemetry suite 192/192; tool-server affected suites green.
- `tsc` build, `typecheck:tests`, eslint (`--max-warnings 0`), and prettier all clean.

## Out of scope

- The `Telemetry.md` privacy-notice update (adding TV/Fire TV to the collected platform-family list) is intentionally **not** in this PR — it will come from a separate PR.
