### PR TITLE
fix(tool-server): pass MoQ auth token on remote connect URL

### DIFF
--- a/packages/tool-server/src/utils/moq-client.ts
+++ b/packages/tool-server/src/utils/moq-client.ts
@@ -94,6 +94,9 @@ export async function openMoqClient(udid: string): Promise<MoqClient> {
 export async function openMoqClientFromInfo(info: MoqInfo): Promise<MoqClient> {
   await ensurePolyfill();
   const url = new URL(info.url);
+  // sim-server rejects MoQ sessions without the lease token; the relay
+  // forwards it end-to-end from the `?token=` query param.
+  if (info.token) url.searchParams.set("token", info.token);
   const fingerprint = decodeHexFingerprint(info.fingerprint);
 
   let established;

--- a/packages/tool-server/src/utils/sim-remote.ts
+++ b/packages/tool-server/src/utils/sim-remote.ts
@@ -232,6 +232,7 @@ export async function proxyStop(udid: string, port: number): Promise<void> {
 export interface MoqInfo {
   url: string;
   fingerprint: string;
+  token: string;
 }
 
 export async function moqInfo(udid: string): Promise<MoqInfo> {


### PR DESCRIPTION
## Problem

radon-cloud's ARG-208 auth change token-gates remote simulator MoQ sessions: sim-server now rejects any MoQ session that doesn't present the per-acquire lease token as a `?token=` query param on the WebTransport connect URL (the relay forwards it verbatim end-to-end). Argent's MoQ client never attached the token, so remote connections broke.

## Fix

- Add `token` to the `MoqInfo` shape returned by `sim-remote moq-info`.
- In `openMoqClientFromInfo`, set `?token=` on the connect URL before `Connection.connect`, mirroring the radon-cloud webui (`useMoQ.ts`). The guard keeps older `sim-remote` binaries (no `token` field) from producing a literal `token=undefined`.

No transport change was needed — the client already connects over WebTransport (`@moq/net` + `@fails-components/webtransport` polyfill), and `@moq/net` passes the URL query through to `new WebTransport(...)`.
