### PR TITLE
chore: add glama.json for Glama MCP server directory

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": ["latekvo"]
+  "maintainers": ["latekvo", "kacperkapusciak", "filip131311", "hubgan"]
 }

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["latekvo"]
+}


### PR DESCRIPTION
Adds `glama.json` to the repo root so the Argent MCP server can be claimed and listed on [Glama](https://glama.ai/mcp), per their [onboarding docs](https://glama.ai/blog/2024-11-02-glama-json).

The file declares the schema and the maintainer GitHub handle used for the "Login with GitHub to claim" flow.