### PR TITLE
feat(tool-server): add ARGENT_SIMULATOR_NO_WINDOW to force headless iOS boots

### DIFF
--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -89,7 +89,7 @@ const zodSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "iOS only: boot the simulator core WITHOUT opening the Simulator.app GUI window. The device still streams via simulator-server; used by Argent Lens. Ignored on Android/Vega/Electron, which have no equivalent GUI step."
+      "iOS only: boot the simulator core WITHOUT opening the Simulator.app GUI window. The device still streams via simulator-server; used by Argent Lens. Set the `ARGENT_SIMULATOR_NO_WINDOW` env var (1/true/yes) to force this host-wide without passing the flag per call (the iOS analog of `ARGENT_EMULATOR_NO_WINDOW`). Ignored on Android/Vega/Electron, which have no equivalent GUI step."
     ),
   electronAppPath: z
     .string()
@@ -228,6 +228,19 @@ function selectGpuMode(): string {
 function selectExtraEmulatorArgs(): string[] {
   const trimmed = (process.env.ARGENT_EMULATOR_NO_WINDOW ?? "").trim().toLowerCase();
   return ["1", "true", "yes"].includes(trimmed) ? ["-no-window"] : [];
+}
+
+// iOS analog of ARGENT_EMULATOR_NO_WINDOW: force local simulator boots headless
+// (skip the `open -a Simulator.app` GUI attach in bootIos) without the caller
+// having to pass `headless: true` on every boot-device call. Meant for
+// CI/containers and Argent Lens hosts that stream the device via
+// simulator-server and never want the Simulator.app window to pop.
+// `simctl boot` itself is already headless, so this only gates the GUI attach.
+// Accepted truthy values: "1", "true", "yes" (case-insensitive). Anything else
+// — including "false", "no", "0", or empty — is treated as disabled.
+function iosHeadlessFromEnv(): boolean {
+  const trimmed = (process.env.ARGENT_SIMULATOR_NO_WINDOW ?? "").trim().toLowerCase();
+  return ["1", "true", "yes"].includes(trimmed);
 }
 
 // Poll cadences for the boot state machine. These intervals only pace how
@@ -572,7 +585,9 @@ async function bootIos(
   // Simulator.app only attaches the GUI window — surfaces that stream the
   // device through simulator-server (e.g. Argent Lens) don't need it, so
   // `headless` skips it to avoid popping a window the user didn't ask for.
-  if (!headless) {
+  // ARGENT_SIMULATOR_NO_WINDOW forces the same skip host-wide (the iOS analog
+  // of ARGENT_EMULATOR_NO_WINDOW) so CI/Lens hosts never have to pass the flag.
+  if (!headless && !iosHeadlessFromEnv()) {
     // Xcode 27 drops Simulator.app in favour of Device Hub.app
     // (com.apple.dt.Devices); fall back to it, and keep the GUI attach
     // best-effort so a missing app never fails a boot whose core is already up.

--- a/packages/tool-server/test/boot-device.test.ts
+++ b/packages/tool-server/test/boot-device.test.ts
@@ -182,6 +182,35 @@ describe("boot-device — iOS path", () => {
     expect(calls).not.toContainEqual(["open", ["-a", "Simulator.app"]]);
   });
 
+  it("with ARGENT_SIMULATOR_NO_WINDOW set does NOT open Simulator.app even without headless:true", async () => {
+    // Host-wide iOS analog of ARGENT_EMULATOR_NO_WINDOW: the env var forces the
+    // GUI-attach skip so CI/Lens hosts don't pass `headless` on every call.
+    const resolveService = vi.fn(async () => ({
+      getInitFailure: () => null,
+      reverifyEnv: async () => {},
+    }));
+    const registry = { resolveService } as unknown as Registry;
+    const tool = createBootDeviceTool(registry);
+
+    const prev = process.env.ARGENT_SIMULATOR_NO_WINDOW;
+    process.env.ARGENT_SIMULATOR_NO_WINDOW = "1";
+    try {
+      await expect(
+        tool.execute!({}, { udid: "11111111-1111-1111-1111-111111111111" })
+      ).resolves.toEqual({
+        platform: "ios",
+        udid: "11111111-1111-1111-1111-111111111111",
+        booted: true,
+      });
+    } finally {
+      if (prev === undefined) delete process.env.ARGENT_SIMULATOR_NO_WINDOW;
+      else process.env.ARGENT_SIMULATOR_NO_WINDOW = prev;
+    }
+
+    const calls = mockExecFile.mock.calls.map(([file, args]) => [file, args]);
+    expect(calls).not.toContainEqual(["open", ["-a", "Simulator.app"]]);
+  });
+
   it("skips pre-boot plist write when the sim is already Booted and falls back to ensureAutomationEnabled", async () => {
     const resolveService = vi.fn(async () => ({
       getInitFailure: () => null,


### PR DESCRIPTION
## What

Adds `ARGENT_SIMULATOR_NO_WINDOW` — the iOS analog of the existing Android `ARGENT_EMULATOR_NO_WINDOW` env var — to force local iOS simulator boots to run headless.

## Why

`ARGENT_EMULATOR_NO_WINDOW=1` already makes Android emulators boot headless host-wide (appends `-no-window`). iOS had no env-var equivalent: it could only boot headless via the per-call `headless: true` parameter on the `boot-device` tool, which is awkward for CI/containers and Argent Lens hosts that stream every device through `simulator-server` and never want a window.

Note: `simctl boot` is already headless at the core — the only thing that pops a window is the `open -a Simulator.app` GUI attach at the end of `bootIos`. This env var gates exactly that step.

## Changes

- `boot-device.ts`
  - New `iosHeadlessFromEnv()` helper next to Android's `selectExtraEmulatorArgs()`, with identical truthy parsing (`1`/`true`/`yes`, case-insensitive).
  - `bootIos` GUI-attach gate changed from `if (!headless)` → `if (!headless && !iosHeadlessFromEnv())`.
  - Updated the `headless` param docs to mention the env var.
- `boot-device.test.ts` — new test asserting `Simulator.app` is not opened when `ARGENT_SIMULATOR_NO_WINDOW` is set (env saved/restored around the test).

## Scope

Applies to the local iOS path (`bootIos`). The remote path (`bootIosRemote` via `sim-remote`) has no local `Simulator.app` step, so it's unaffected.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run test/boot-device.test.ts` — 23/23 pass (incl. the new test)