### PR TITLE
chore: release 0.15.0 (submodule + workspace bump)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5959,7 +5959,7 @@
     },
     "packages/argent": {
       "name": "@swmansion/argent",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5998,7 +5998,7 @@
     },
     "packages/argent-cli": {
       "name": "@argent/cli",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/registry": "file:../registry",
@@ -6015,7 +6015,7 @@
     },
     "packages/argent-installer": {
       "name": "@argent/installer",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@argent/registry": "file:../registry",
         "@argent/telemetry": "file:../telemetry",
@@ -6050,7 +6050,7 @@
     },
     "packages/argent-mcp": {
       "name": "@argent/mcp",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/telemetry": "file:../telemetry",
@@ -6065,7 +6065,7 @@
     },
     "packages/argent-tools-client": {
       "name": "@argent/tools-client",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6074,7 +6074,7 @@
     },
     "packages/configuration-core": {
       "name": "@argent/configuration-core",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6083,7 +6083,7 @@
     },
     "packages/native-devtools-android": {
       "name": "@argent/native-devtools-android",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6092,7 +6092,7 @@
     },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6101,7 +6101,7 @@
     },
     "packages/preview-window": {
       "name": "@argent/preview-window",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "electron": "^42.5.0",
@@ -6110,7 +6110,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "zod": "^4.0.0"
       },
@@ -6121,14 +6121,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/telemetry": {
       "name": "@argent/telemetry",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
@@ -6144,7 +6144,7 @@
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/native-devtools-android": "file:../native-devtools-android",
@@ -6191,11 +6191,11 @@
     },
     "packages/ui": {
       "name": "@argent/ui",
-      "version": "0.14.0"
+      "version": "0.15.0"
     },
     "packages/update-core": {
       "name": "@argent/update-core",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "semver": "^7.8.5"
       },

--- a/packages/argent-cli/package.json
+++ b/packages/argent-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Shell CLI commands for argent: tools, run, server, enable, disable, flags",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/installer",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Workspace setup logic for argent: init, update, uninstall",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-mcp/package.json
+++ b/packages/argent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/mcp",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "MCP stdio protocol adapter — talks to the argent tool-server and forwards calls",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-tools-client/package.json
+++ b/packages/argent-tools-client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tools-client",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Spawn-and-talk client for the argent tool-server (used by MCP and CLI)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "MCP server for iOS Simulator and Android Emulator control",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/configuration-core/package.json
+++ b/packages/configuration-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/configuration-core",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Source of truth for argent feature flags: registry, JSON storage, and isFlagEnabled",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/native-devtools-android/package.json
+++ b/packages/native-devtools-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-android",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/native-devtools-ios/package.json
+++ b/packages/native-devtools-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-ios",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/preview-window/package.json
+++ b/packages/preview-window/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/preview-window",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "description": "Electron host for Argent Lens — the variant preview & selection UI.",
   "main": "dist/main.js",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "description": "Claude Code skills for iOS simulator and Android emulator interaction via argent",
   "scripts": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/telemetry",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Opt-out telemetry client for Argent CLI / installer / tool-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Framework-agnostic tool registry for iOS simulator and Android emulator control",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/ui",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Simple browser UI that streams a simulator and forwards taps/gestures directly to the argent simulator-server.",
   "files": [
     "index.html"

--- a/packages/update-core/package.json
+++ b/packages/update-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/update-core",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Shared npm release-age detection and installable-target resolution for argent updates",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What

- Bump the `packages/argent-private` submodule pointer from `v0.11.0-8-g2953e89` to **v0.15.0** (`41484e4`). The superproject pin had drifted ~4 releases behind the checked-out submodule.
- Lockstep-bump all `packages/*` workspace packages from `0.14.0` → **0.15.0** (and the matching `package-lock.json` entries) to line up with the submodule.

## Why

The submodule and the workspace were out of sync: the working tree had `argent-private` checked out at v0.15.0 while the superproject still pinned the v0.11 era, and the JS packages sat at 0.14.0. This adopts v0.15.0 as the single, consistent version across the repo.

## Verification

- `node scripts/check-workspace-versions.mjs` → `All workspace packages are at 0.15.0.`
- `git submodule status` → clean (no `+`), pinned at `v0.15.0`.
- Lockfile diff is exactly 15 version-field swaps (no unrelated churn).