### PR TITLE
Full tgz-only E2E harness (scripts/e2e-full)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ pnpm-lock.yaml
 
 # Generated.
 **/tsconfig.tsbuildinfo
+scripts/e2e-full/results/

--- a/scripts/e2e-full/README.md
+++ b/scripts/e2e-full/README.md
@@ -26,14 +26,14 @@ hard assertion failed (skips do not fail the run).
 
 ## What it does (phases)
 
-| phase | needs | covers |
-|---|---|---|
-| `install` | npm + network | `npm i -g <tgz>`, bundled binaries, `init` (global + `--local`), `update`, `uninstall`, telemetry, MCP-config generation |
-| `introspection` | — | `--version/--help`, `tools`, `tools describe` for **all 70** tools, feature flags, `server start/status/logs/stop`, `link/unlink` |
-| `validation` | — | for every tool: missing-required / bad-enum / bad-type rejection (deterministic, no hardware) |
-| `android` | Android emulator | happy-path of every touch/gesture/screenshot/app-lifecycle tool |
-| `chromium` | Electron (bundled optional dep) + a display | boots a generated Electron app; drives CDP tools (scroll/drag/tabs/cookies/storage) |
-| `rn` | `~/dev/bluesky` + Android device | debugger + react/native profiler + network chain against the real Bluesky app |
+| phase           | needs                                       | covers                                                                                                                            |
+| --------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `install`       | npm + network                               | `npm i -g <tgz>`, bundled binaries, `init` (global + `--local`), `update`, `uninstall`, telemetry, MCP-config generation          |
+| `introspection` | —                                           | `--version/--help`, `tools`, `tools describe` for **all 70** tools, feature flags, `server start/status/logs/stop`, `link/unlink` |
+| `validation`    | —                                           | for every tool: missing-required / bad-enum / bad-type rejection (deterministic, no hardware)                                     |
+| `android`       | Android emulator                            | happy-path of every touch/gesture/screenshot/app-lifecycle tool                                                                   |
+| `chromium`      | Electron (bundled optional dep) + a display | boots a generated Electron app; drives CDP tools (scroll/drag/tabs/cookies/storage)                                               |
+| `rn`            | `~/dev/bluesky` + Android device            | debugger + react/native profiler + network chain against the real Bluesky app                                                     |
 
 Tiers auto-skip (with a recorded reason) when their prerequisites are missing, so
 a partial run still produces a meaningful report. iOS / tvOS / Vega tiers are

--- a/scripts/e2e-full/README.md
+++ b/scripts/e2e-full/README.md
@@ -1,0 +1,91 @@
+# Full Argent E2E harness
+
+A release-gating end-to-end test that starts from **nothing but a
+`swmansion-argent-*.tgz` bundle** and exercises the whole product: the install
+flow, every CLI command, all 70 tools' argument validation, and a happy-path run
+of every tool that applies against real devices.
+
+Run it on the real Linux box and the real Mac before a release.
+
+## Quick start
+
+```bash
+# from the repo root, with a swmansion-argent-*.tgz present there:
+bash scripts/e2e-full/run-e2e.sh
+
+# a subset of phases:
+bash scripts/e2e-full/run-e2e.sh --phase install,introspection,validation
+
+# offline core only, driving the unpacked bundle (no npm install, fast):
+bash scripts/e2e-full/run-e2e.sh --skip-install --phase introspection,validation
+```
+
+A markdown report is written to `scripts/e2e-full/results/report-<ts>.md` and the
+raw per-case log to `results/e2e-<ts>.jsonl`. The process exits non-zero if any
+hard assertion failed (skips do not fail the run).
+
+## What it does (phases)
+
+| phase | needs | covers |
+|---|---|---|
+| `install` | npm + network | `npm i -g <tgz>`, bundled binaries, `init` (global + `--local`), `update`, `uninstall`, telemetry, MCP-config generation |
+| `introspection` | — | `--version/--help`, `tools`, `tools describe` for **all 70** tools, feature flags, `server start/status/logs/stop`, `link/unlink` |
+| `validation` | — | for every tool: missing-required / bad-enum / bad-type rejection (deterministic, no hardware) |
+| `android` | Android emulator | happy-path of every touch/gesture/screenshot/app-lifecycle tool |
+| `chromium` | Electron (bundled optional dep) + a display | boots a generated Electron app; drives CDP tools (scroll/drag/tabs/cookies/storage) |
+| `rn` | `~/dev/bluesky` + Android device | debugger + react/native profiler + network chain against the real Bluesky app |
+
+Tiers auto-skip (with a recorded reason) when their prerequisites are missing, so
+a partial run still produces a meaningful report. iOS / tvOS / Vega tiers are
+intentionally out of scope.
+
+## Isolation
+
+Everything runs under a throwaway `HOME` and npm prefix (`$(mktemp -d)`), so the
+real machine's `~/.argent`, editor MCP configs, and global packages are never
+touched — safe to run on a shared box. Add `--keep` to inspect the sandbox after.
+
+## Providing a device
+
+The device tiers need a booted device. Two ways:
+
+- **Inject** an already-booted one (recommended on shared/CI machines):
+  `--android-serial emulator-5554` (the harness attaches, doesn't boot/teardown it).
+- **Let the harness boot it**: `--android-avd Pixel_9a` (uses `boot-device`).
+
+The Chromium tier needs no device — it generates and boots its own Electron app
+(requires `DISPLAY`, or `xvfb-run` on a headless Linux box).
+
+## RN (Bluesky) tier
+
+```bash
+E2E_RN_DIR=~/dev/bluesky E2E_RN_PKG=xyz.blueskyweb.app \
+  bash scripts/e2e-full/run-e2e.sh --phase rn --android-serial <serial>
+```
+
+Assumes the Bluesky dev-client is already built and installed on the device
+(`E2E_RN_PREBUILT`, the default). Pass `E2E_RN_BUILD=1` to let it run
+`expo run:android` first (slow). It starts Metro itself and tears it down.
+
+## Flags
+
+```
+--tgz PATH             tarball to test (default: newest swmansion-argent-*.tgz at repo root)
+--phase a,b,c          subset of: install introspection validation android chromium rn
+--skip-install         drive the unpacked bundle directly (offline phases only; skips `install`)
+--system               install to the REAL global prefix (dedicated release machine only)
+--android-serial S     use an already-booted Android device
+--android-avd NAME     boot this AVD via boot-device
+--keep                 leave the sandbox dir for inspection
+```
+
+## Layout
+
+```
+run-e2e.sh          orchestrator: env setup, phase dispatch, report, exit code
+lib/common.sh       logging, argent_cli/run_tool, assert_* helpers, server + screenshot helpers
+lib/discover-tools.sh   parses `argent tools describe` into per-tool arg models
+lib/report.py       JSONL -> markdown (per-phase + per-tool coverage matrix + failures)
+phases/*.sh         one run_phase() per phase
+results/            generated JSONL + report (gitignored)
+```

--- a/scripts/e2e-full/lib/common.sh
+++ b/scripts/e2e-full/lib/common.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Shared library for the full Argent E2E harness.
+#
+# Sourced by run-e2e.sh and every phase module. Provides:
+#   - logging (log/warn/err/group)
+#   - the argent CLI wrapper (argent_cli) and tool driver (run_tool)
+#   - result recording to a JSONL log (pass/fail/skip) + counters
+#   - assertion helpers built on the proven contract:
+#       `argent run <tool>` exits 0 on success (JSON on stdout),
+#       non-zero on validation error / unknown tool / service failure.
+#   - a private tool-server lifecycle (own port + own HOME so it never
+#     collides with a foreign server on a shared machine)
+#
+# Every phase runs with a sandbox HOME ($E2E_HOME) so ~/.argent, MCP configs,
+# and the npm global prefix land in a throwaway dir, never the real machine.
+#
+# Requires: bash 4+, jq, python3, node, npm. (adb / xvfb / expo are checked
+# per-tier and gate with a recorded skip when absent.)
+
+# ---------------------------------------------------------------------------
+# Strictness. Phases opt into this by sourcing us; we do NOT set -e globally
+# because assertions must keep running after an individual tool call fails.
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Colors (respect NO_COLOR / non-tty)
+# ---------------------------------------------------------------------------
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_RED=$'\033[31m'; C_GRN=$'\033[32m'; C_YEL=$'\033[33m'
+  C_BLU=$'\033[34m'; C_DIM=$'\033[2m'; C_RST=$'\033[0m'
+else
+  C_RED=""; C_GRN=""; C_YEL=""; C_BLU=""; C_DIM=""; C_RST=""
+fi
+
+log()   { printf '%s\n' "${C_BLU}▸${C_RST} $*" >&2; }
+info()  { printf '%s\n' "${C_DIM}  $*${C_RST}" >&2; }
+warn()  { printf '%s\n' "${C_YEL}! $*${C_RST}" >&2; }
+err()   { printf '%s\n' "${C_RED}✗ $*${C_RST}" >&2; }
+group() { printf '\n%s\n' "${C_BLU}==== $* ====${C_RST}" >&2; }
+
+# ---------------------------------------------------------------------------
+# Configuration derived from the environment exported by run-e2e.sh.
+# ---------------------------------------------------------------------------
+: "${E2E_JSONL:?E2E_JSONL must be set by run-e2e.sh}"
+# ARGENT_BIN (e.g. "/sandbox/bin/argent" or "node /path/dist/cli.js") is set by
+# run-e2e.sh AFTER the install decision — resolved lazily at call time below.
+TOOL_TIMEOUT="${TOOL_TIMEOUT:-120}"                       # seconds per tool call
+E2E_OS="${E2E_OS:-$(uname -s | tr '[:upper:]' '[:lower:]')}"
+
+# ---------------------------------------------------------------------------
+# argent_cli — invoke the argent CLI with a timeout. Captures combined output
+# in CLI_OUT and the exit code as the return value. Never aborts the script.
+# The command is rebuilt from ARGENT_BIN each call so it tracks the value
+# run-e2e.sh sets after installing.
+# ---------------------------------------------------------------------------
+argent_cli() {
+  local out rc cmd
+  read -ra cmd <<< "${ARGENT_BIN:?ARGENT_BIN not set yet}"
+  out=$(timeout "$TOOL_TIMEOUT" "${cmd[@]}" "$@" 2>&1); rc=$?
+  CLI_OUT="$out"
+  return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# run_tool <tool> [json-args] — drive one tool via `argent run`.
+# Sets: RT_RC (exit code), RT_JSON (stdout only), RT_ERR (stderr), RT_OUT (both).
+# ---------------------------------------------------------------------------
+run_tool() {
+  local tool="$1" args="${2:-}"
+  local errf cmd; errf=$(mktemp)
+  read -ra cmd <<< "${ARGENT_BIN:?ARGENT_BIN not set yet}"
+  if [ -n "$args" ]; then
+    RT_JSON=$(timeout "$TOOL_TIMEOUT" "${cmd[@]}" run "$tool" --args "$args" 2>"$errf"); RT_RC=$?
+  else
+    RT_JSON=$(timeout "$TOOL_TIMEOUT" "${cmd[@]}" run "$tool" 2>"$errf"); RT_RC=$?
+  fi
+  RT_ERR=$(cat "$errf"); rm -f "$errf"
+  RT_OUT="${RT_JSON}
+${RT_ERR}"
+  return "$RT_RC"
+}
+
+# ---------------------------------------------------------------------------
+# Result recording. One JSON object per test case appended to $E2E_JSONL.
+# Counters live in files so subshells/phases aggregate correctly.
+# ---------------------------------------------------------------------------
+PASS_N=0; FAIL_N=0; SKIP_N=0
+
+_record() { # phase tool case status detail
+  jq -nc \
+    --arg phase "$1" --arg tool "$2" --arg case "$3" \
+    --arg status "$4" --arg detail "$5" \
+    '{phase:$phase,tool:$tool,case:$case,status:$status,detail:$detail}' \
+    >> "$E2E_JSONL"
+}
+
+pass() { # phase tool case [detail]
+  _record "$1" "$2" "$3" "pass" "${4:-}"
+  PASS_N=$((PASS_N + 1))
+  printf '%s\n' "  ${C_GRN}✓${C_RST} ${C_DIM}$2${C_RST} $3" >&2
+}
+fail() { # phase tool case detail
+  _record "$1" "$2" "$3" "fail" "${4:-}"
+  FAIL_N=$((FAIL_N + 1))
+  printf '%s\n' "  ${C_RED}✗${C_RST} $2 ${C_DIM}[$3]${C_RST} ${4:-}" >&2
+}
+skip() { # phase tool case reason
+  _record "$1" "$2" "$3" "skip" "${4:-}"
+  SKIP_N=$((SKIP_N + 1))
+  printf '%s\n' "  ${C_YEL}∼${C_RST} ${C_DIM}$2 ($3): ${4:-}${C_RST}" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Assertion helpers (all take: phase tool case ...).
+# ---------------------------------------------------------------------------
+
+# The tool call must SUCCEED (rc 0).
+assert_ok() { # phase tool case json-args
+  local phase="$1" tool="$2" case="$3" args="${4:-}"
+  run_tool "$tool" "$args"
+  if [ "$RT_RC" -eq 0 ]; then
+    pass "$phase" "$tool" "$case"
+  else
+    fail "$phase" "$tool" "$case" "$(printf '%s' "$RT_OUT" | tr '\n' ' ' | cut -c1-200)"
+  fi
+}
+
+# The tool call must SUCCEED and a jq filter over stdout must equal `expected`.
+assert_field() { # phase tool case json-args jq-filter expected
+  local phase="$1" tool="$2" case="$3" args="$4" filter="$5" expected="$6"
+  run_tool "$tool" "$args"
+  if [ "$RT_RC" -ne 0 ]; then
+    fail "$phase" "$tool" "$case" "rc=$RT_RC: $(printf '%s' "$RT_OUT" | tr '\n' ' ' | cut -c1-160)"
+    return
+  fi
+  local got; got=$(printf '%s' "$RT_JSON" | jq -r "$filter" 2>/dev/null)
+  if [ "$got" = "$expected" ]; then
+    pass "$phase" "$tool" "$case" "$filter=$got"
+  else
+    fail "$phase" "$tool" "$case" "expected $filter=$expected got '$got'"
+  fi
+}
+
+# The tool call must SUCCEED and a jq boolean filter over stdout must be true.
+assert_true() { # phase tool case json-args jq-filter
+  local phase="$1" tool="$2" case="$3" args="$4" filter="$5"
+  run_tool "$tool" "$args"
+  if [ "$RT_RC" -ne 0 ]; then
+    fail "$phase" "$tool" "$case" "rc=$RT_RC: $(printf '%s' "$RT_OUT" | tr '\n' ' ' | cut -c1-160)"
+    return
+  fi
+  local got; got=$(printf '%s' "$RT_JSON" | jq -r "$filter" 2>/dev/null)
+  if [ "$got" = "true" ]; then
+    pass "$phase" "$tool" "$case" "$filter"
+  else
+    fail "$phase" "$tool" "$case" "expected $filter to be true, got '$got'"
+  fi
+}
+
+# The tool call must FAIL (rc != 0). If `path` is given, and stdout is a zod
+# issue array, at least one issue must match that path (proves the specific
+# field was rejected, not just an unrelated error).
+assert_reject() { # phase tool case json-args [zod-path] [zod-code]
+  local phase="$1" tool="$2" case="$3" args="$4" zpath="${5:-}" zcode="${6:-}"
+  run_tool "$tool" "$args"
+  if [ "$RT_RC" -eq 0 ]; then
+    fail "$phase" "$tool" "$case" "expected rejection but tool SUCCEEDED"
+    return
+  fi
+  if [ -n "$zpath" ]; then
+    # Best-effort structured check: if stdout is a zod issue array, assert a
+    # matching issue exists. If output isn't JSON (e.g. plain service error),
+    # the non-zero exit alone satisfies the case.
+    local hit
+    hit=$(printf '%s' "$RT_JSON" | jq -e --arg p "$zpath" --arg c "$zcode" '
+      if type=="array" then
+        any(.[]; (.path[0] == $p) and ($c=="" or .code==$c))
+      else false end' 2>/dev/null)
+    if [ "$hit" = "true" ]; then
+      pass "$phase" "$tool" "$case" "rejected $zpath${zcode:+/$zcode}"
+    else
+      # Non-structured failure still counts as a rejection, but note it.
+      pass "$phase" "$tool" "$case" "rc=$RT_RC (unstructured)"
+    fi
+  else
+    pass "$phase" "$tool" "$case" "rc=$RT_RC"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Private tool-server lifecycle. Uses ARGENT_TOOLS_URL so `argent run` targets
+# OUR server (own port), and a sandbox HOME so its state file is isolated.
+# ---------------------------------------------------------------------------
+# Is a healthy tool-server discoverable for this install (via ~/.argent state)?
+server_running() {
+  argent_cli server status --json || return 1
+  printf '%s' "$CLI_OUT" | jq -e '.running==true and (.healthy==true or .alive==true)' >/dev/null 2>&1
+}
+
+# Ensure a tool-server is up. We do NOT pin a port or ARGENT_TOOLS_URL: the CLI
+# auto-spawns on demand and records the port in the sandbox ~/.argent state, so
+# every `argent run`/`tools`/`status` call discovers the same server. On a
+# shared machine this stays isolated because HOME is the sandbox.
+ensure_server() {
+  server_running && return 0
+  log "starting sandbox tool-server (detached, no-auth, auto-port)"
+  argent_cli server start --detach --no-auth --port 0 >/dev/null 2>&1 || true
+  local i
+  for i in $(seq 1 30); do
+    server_running && return 0
+    sleep 1
+  done
+  warn "tool-server did not become ready"
+  return 1
+}
+
+# PNG "real pixels" floor, shared with drive-device.sh rationale.
+MIN_SHOT_BYTES="${MIN_SHOT_BYTES:-20000}"
+
+# Extract an artifact hostPath from a screenshot-style envelope on stdout.
+artifact_path() { # <jq-path-to-artifact-object, default .image>
+  local sel="${1:-.image}"
+  printf '%s' "$RT_JSON" | jq -r "${sel}.hostPath // empty" 2>/dev/null
+}
+
+# Capture a screenshot straight to a file via `argent run screenshot --out`
+# (the CLI renders screenshot artifacts as a "Saved screenshot: <path>" message
+# rather than JSON, so --out is the deterministic path). Returns 0 and sets
+# SHOT_PATH when the file exists and exceeds the real-pixels floor.
+capture_screenshot() { # udid outfile
+  local udid="$1" out="$2" cmd
+  read -ra cmd <<< "${ARGENT_BIN:?}"
+  rm -f "$out"
+  timeout "$TOOL_TIMEOUT" "${cmd[@]}" run screenshot --udid "$udid" --out "$out" >/dev/null 2>&1
+  SHOT_RC=$?
+  [ -f "$out" ] || return 1
+  SHOT_SIZE="$(wc -c <"$out" | tr -d ' ')"
+  SHOT_PATH="$out"
+  [ "$SHOT_SIZE" -gt "$MIN_SHOT_BYTES" ]
+}

--- a/scripts/e2e-full/lib/common.sh
+++ b/scripts/e2e-full/lib/common.sh
@@ -96,19 +96,22 @@ _record() { # phase tool case status detail
 }
 
 pass() { # phase tool case [detail]
-  _record "$1" "$2" "$3" "pass" "${4:-}"
+  local phase="${1:-}" tool="${2:-}" case="${3:-}" detail="${4:-}"
+  _record "$phase" "$tool" "$case" "pass" "$detail"
   PASS_N=$((PASS_N + 1))
-  printf '%s\n' "  ${C_GRN}✓${C_RST} ${C_DIM}$2${C_RST} $3" >&2
+  printf '%s\n' "  ${C_GRN}✓${C_RST} ${C_DIM}$tool${C_RST} $case" >&2
 }
 fail() { # phase tool case detail
-  _record "$1" "$2" "$3" "fail" "${4:-}"
+  local phase="${1:-}" tool="${2:-}" case="${3:-}" detail="${4:-}"
+  _record "$phase" "$tool" "$case" "fail" "$detail"
   FAIL_N=$((FAIL_N + 1))
-  printf '%s\n' "  ${C_RED}✗${C_RST} $2 ${C_DIM}[$3]${C_RST} ${4:-}" >&2
+  printf '%s\n' "  ${C_RED}✗${C_RST} $tool ${C_DIM}[$case]${C_RST} $detail" >&2
 }
 skip() { # phase tool case reason
-  _record "$1" "$2" "$3" "skip" "${4:-}"
+  local phase="${1:-}" tool="${2:-}" case="${3:-}" detail="${4:-}"
+  _record "$phase" "$tool" "$case" "skip" "$detail"
   SKIP_N=$((SKIP_N + 1))
-  printf '%s\n' "  ${C_YEL}∼${C_RST} ${C_DIM}$2 ($3): ${4:-}${C_RST}" >&2
+  printf '%s\n' "  ${C_YEL}∼${C_RST} ${C_DIM}$tool ($case): $detail${C_RST}" >&2
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/e2e-full/lib/discover-tools.sh
+++ b/scripts/e2e-full/lib/discover-tools.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tool discovery + schema parsing.
+#
+# The whole harness is schema-driven off the CLI's own introspection so it never
+# drifts from the shipped tool set:
+#   - `argent tools`               -> the authoritative list of tool names
+#   - `argent tools describe <t>`  -> per-flag model (name / type / required / enum)
+#
+# The `describe` flag lines look like:
+#   --udid <value>     string (required)  Target device id ...
+#   --x <value>        number (required)  Normalized horizontal ...
+#   --button <value>   enum: "home" | "back" | ... (required)  Hardware button ...
+#   --scale <value>    number  Scale factor ...
+#
+# We parse those into a compact model file per tool under $E2E_WORK/tools/<t>.model,
+# one line per flag:  <name>\t<kind>\t<required 0|1>\t<enumvals csv>
+# kind ∈ string|number|boolean|enum|array|object|unknown
+
+: "${E2E_WORK:?E2E_WORK must be set}"
+TOOLS_DIR="$E2E_WORK/tools"
+mkdir -p "$TOOLS_DIR"
+
+# List all tool names (cached).
+list_tool_names() {
+  local cache="$E2E_WORK/tool-names.txt"
+  if [ ! -s "$cache" ]; then
+    argent_cli tools || true
+    printf '%s\n' "$CLI_OUT" \
+      | grep -oE '^  [a-z][a-z0-9-]+' \
+      | tr -d ' ' \
+      | sort -u > "$cache"
+  fi
+  cat "$cache"
+}
+
+# Parse one tool's describe output into a model file; echoes the model path.
+parse_tool_model() { # <tool>
+  local tool="$1"
+  local model="$TOOLS_DIR/$tool.model"
+  if [ -s "$model" ]; then printf '%s\n' "$model"; return 0; fi
+  argent_cli tools describe "$tool" || true
+  # Isolate the "Flags:" section and walk each "--flag" line.
+  printf '%s\n' "$CLI_OUT" | awk '
+    /^Flags:/ { inflags=1; next }
+    inflags && /^[[:space:]]*--/ {
+      line=$0
+      # flag name
+      match(line, /--[a-zA-Z0-9-]+/); name=substr(line, RSTART+2, RLENGTH-2)
+      req = (line ~ /\(required\)/) ? 1 : 0
+      kind="unknown"; enums=""
+      if (line ~ /enum:/) {
+        kind="enum"
+        # capture the quoted enum members
+        s=line
+        while (match(s, /"[^"]+"/)) {
+          v=substr(s, RSTART+1, RLENGTH-2)
+          enums = (enums=="") ? v : enums "," v
+          s=substr(s, RSTART+RLENGTH)
+        }
+      } else if (line ~ /\bnumber\b/) { kind="number" }
+      else if (line ~ /\bboolean\b/) { kind="boolean" }
+      else if (line ~ /\bstring\b/)  { kind="string" }
+      else if (line ~ /\barray\b/ || line ~ /\[\]/) { kind="array" }
+      else if (line ~ /\bobject\b/)  { kind="object" }
+      printf "%s\t%s\t%s\t%s\n", name, kind, req, enums
+    }
+    inflags && /^[[:space:]]*\(no parameters\)/ { }
+  ' > "$model"
+  printf '%s\n' "$model"
+}
+
+# Helpers over a parsed model file.
+model_required_flags() { awk -F'\t' '$3==1 {print $1}' "$1"; }              # names of required flags
+model_flag_kind()      { awk -F'\t' -v n="$2" '$1==n {print $2}' "$1"; }    # kind of flag $2
+model_enum_flags()     { awk -F'\t' '$2=="enum" {print $1}' "$1"; }         # names of enum flags
+model_enum_values()    { awk -F'\t' -v n="$2" '$1==n {print $4}' "$1"; }    # csv enum values of flag $2
+model_number_flags()   { awk -F'\t' '$2=="number" {print $1}' "$1"; }       # names of number flags
+model_flag_count()     { wc -l < "$1" | tr -d ' '; }

--- a/scripts/e2e-full/lib/report.py
+++ b/scripts/e2e-full/lib/report.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Aggregate the E2E JSONL log into a markdown report.
+
+Reads one JSON object per line: {phase, tool, case, status, detail}.
+Emits: run header, per-phase pass/fail/skip summary, a per-tool coverage
+matrix (was each tool validated? happy-path run?), and the full list of
+failures with the exact case so a release engineer can reproduce.
+"""
+import json
+import os
+import sys
+from collections import defaultdict, OrderedDict
+
+DEVICE_PHASES = {"android", "chromium", "rn"}
+
+
+def main() -> int:
+    path = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("E2E_JSONL", "")
+    rows = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+
+    version = os.environ.get("TGZ_VERSION", "?")
+    osname = os.environ.get("E2E_OS", "?")
+    binname = os.environ.get("ARGENT_BIN", "?")
+
+    total = defaultdict(int)
+    per_phase = defaultdict(lambda: defaultdict(int))
+    tools = OrderedDict()  # tool -> {"validation": status, "happy": status}
+    fails = []
+
+    for r in rows:
+        st = r.get("status", "?")
+        ph = r.get("phase", "?")
+        tool = r.get("tool", "?")
+        total[st] += 1
+        per_phase[ph][st] += 1
+        tools.setdefault(tool, {"validated": False, "happy": None})
+        if ph == "validation":
+            if st == "pass":
+                tools[tool]["validated"] = True
+        if ph in DEVICE_PHASES:
+            cur = tools[tool]["happy"]
+            # a single pass anywhere marks the tool happy-path covered
+            if st == "pass":
+                tools[tool]["happy"] = "pass"
+            elif st == "fail" and cur != "pass":
+                tools[tool]["happy"] = "fail"
+            elif st == "skip" and cur is None:
+                tools[tool]["happy"] = "skip"
+        if st == "fail":
+            fails.append(r)
+
+    out = []
+    w = out.append
+    w(f"# Argent full E2E report\n")
+    w(f"- **package:** `@swmansion/argent` v{version}")
+    w(f"- **os:** {osname}")
+    w(f"- **driver:** `{binname}`")
+    w(f"- **totals:** ✅ {total['pass']} pass · ❌ {total['fail']} fail · ∼ {total['skip']} skip"
+      f" ({sum(total.values())} cases)\n")
+
+    # Per-phase summary
+    w("## Per-phase\n")
+    w("| phase | pass | fail | skip |")
+    w("|---|---:|---:|---:|")
+    order = ["install", "introspection", "validation", "android", "chromium", "rn", "cleanup"]
+    seen = [p for p in order if p in per_phase] + [p for p in per_phase if p not in order]
+    for p in seen:
+        d = per_phase[p]
+        w(f"| {p} | {d['pass']} | {d['fail']} | {d['skip']} |")
+    w("")
+
+    # Coverage matrix
+    w("## Tool coverage\n")
+    w(f"{len(tools)} tools observed. `validated` = argument-schema rejection tests passed; "
+      "`happy-path` = a real device/app run (or why it was skipped).\n")
+    w("| tool | validated | happy-path |")
+    w("|---|:---:|:---:|")
+
+    def mark(v):
+        return {True: "✅", False: "—", None: "·", "pass": "✅", "fail": "❌", "skip": "∼"}.get(v, "?")
+
+    for tool in sorted(tools):
+        t = tools[tool]
+        w(f"| `{tool}` | {mark(t['validated'])} | {mark(t['happy'])} |")
+    w("")
+
+    # Failures
+    w("## Failures\n")
+    if not fails:
+        w("None. 🎉\n")
+    else:
+        for f in fails:
+            w(f"- **[{f.get('phase')}] `{f.get('tool')}` — {f.get('case')}**: "
+              f"{f.get('detail','').strip()}")
+        w("")
+
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/e2e-full/phases/00-install.sh
+++ b/scripts/e2e-full/phases/00-install.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Phase 0 — Install from the tgz (the whole point of "given ONLY a tgz").
+#
+# run-e2e.sh has already done the primary `npm install -g <tgz>` into the
+# sandbox prefix (that's what ARGENT_BIN drives). This phase asserts that
+# install produced a working CLI + bundled runtime, then exercises the
+# configuration lifecycle in throwaway workspaces: global init, local init,
+# uninstall, and a best-effort update.
+#
+# Everything is confined to the sandbox: npm_config_prefix -> $E2E_PREFIX,
+# HOME -> $E2E_HOME. Nothing touches the real machine.
+
+# Find a workspace config file that registers the argent MCP server. Editor
+# adapter selection is environment-dependent (which editors are "detected"), so
+# we assert the semantic outcome across all known config files rather than
+# pinning one path. Prints the first matching file (empty if none).
+_argent_mcp_in_ws() { # ws [grep-pattern]
+  local pat="${2:-@swmansion/argent}"
+  grep -rl "$pat" "$1" \
+    --include='*.json' --include='*.jsonc' --include='*.toml' --include='*.yaml' 2>/dev/null \
+    | grep -v -e '/node_modules/' -e 'skills-lock.json' -e 'package-lock.json' -e 'package.json' \
+    | head -1
+}
+
+# Path to the installed package inside the sandbox prefix.
+_pkg_dir() {
+  local d="$E2E_PREFIX/lib/node_modules/@swmansion/argent"
+  [ -d "$d" ] && { printf '%s\n' "$d"; return; }
+  # npm on some platforms nests bins differently; fall back to a find.
+  find "$E2E_PREFIX" -maxdepth 4 -type d -name argent -path '*@swmansion*' 2>/dev/null | head -1
+}
+
+run_phase() {
+  local P=install
+  local pkg; pkg="$(_pkg_dir)"
+
+  # --- the sandbox global install produced a working CLI --------------------
+  if argent_cli --version && [ "$CLI_OUT" = "$TGZ_VERSION" ]; then
+    pass "$P" npm-global "argent v$CLI_OUT on PATH"
+  else
+    fail "$P" npm-global "version '$CLI_OUT' != '$TGZ_VERSION' (install broken?)"
+  fi
+
+  if [ -n "$pkg" ] && [ -d "$pkg" ]; then
+    pass "$P" npm-global package-dir "$pkg"
+  else
+    fail "$P" npm-global package-dir "installed package dir not found under $E2E_PREFIX"
+    return 0
+  fi
+
+  # --- bundled native runtime is present + executable for THIS os ----------
+  local plat="linux"
+  case "$E2E_OS" in darwin) plat="darwin";; esac
+  # arm64 linux ships in a separate dir; pick whichever exists.
+  local simsrv=""
+  for cand in "$pkg/bin/$plat/simulator-server" "$pkg/bin/${plat}-arm64/simulator-server"; do
+    [ -f "$cand" ] && simsrv="$cand" && break
+  done
+  if [ -n "$simsrv" ] && [ -x "$simsrv" ]; then
+    pass "$P" bundle simulator-server "$(basename "$(dirname "$simsrv")")"
+  else
+    fail "$P" bundle simulator-server "missing/again-executable: $simsrv"
+  fi
+  # trace-processor assets (profiler) always shipped
+  [ -d "$pkg/assets/trace-processor" ] && pass "$P" bundle trace-processor || fail "$P" bundle trace-processor "assets/trace-processor missing"
+  # dylibs are macOS-only
+  if [ "$E2E_OS" = "darwin" ]; then
+    ls "$pkg"/dylibs/*.dylib >/dev/null 2>&1 && pass "$P" bundle dylibs || fail "$P" bundle dylibs "no dylibs in package"
+  else
+    skip "$P" bundle dylibs "macOS-only"
+  fi
+
+  # --- postinstall prints the init hint ------------------------------------
+  if [ -f "$pkg/scripts/postinstall.cjs" ]; then
+    local pout; pout="$(cd "$pkg" && ARGENT_SKIP_POSTINSTALL= node scripts/postinstall.cjs 2>&1)"
+    case "$pout" in *"argent init"*) pass "$P" postinstall init-hint;; *) fail "$P" postinstall init-hint "banner missing: $(printf '%s' "$pout" | head -1)";; esac
+  else
+    fail "$P" postinstall init-hint "postinstall.cjs not shipped"
+  fi
+
+  # --- global init in a throwaway workspace --------------------------------
+  local gws="$E2E_WORK/ws/global"
+  mkdir -p "$gws"; ( cd "$gws" && git init -q >/dev/null 2>&1 || true )
+  printf '{"name":"e2e-global-probe","private":true}\n' > "$gws/package.json"
+  pushd "$gws" >/dev/null
+  if argent_cli init --yes --global --no-telemetry --from "$E2E_TGZ"; then
+    pass "$P" init-global exit0
+  else
+    fail "$P" init-global exit0 "$(printf '%s' "$CLI_OUT" | tail -3 | tr '\n' ' ')"
+  fi
+  popd >/dev/null
+  # an argent MCP server registered in some editor config?
+  local gcfg; gcfg="$(_argent_mcp_in_ws "$gws")"
+  if [ -n "$gcfg" ]; then
+    pass "$P" init-global mcp-config "$(basename "$(dirname "$gcfg")")/$(basename "$gcfg")"
+  else
+    fail "$P" init-global mcp-config "no argent MCP config written under $gws"
+  fi
+  # skills synced?
+  [ -f "$gws/skills-lock.json" ] && pass "$P" init-global skills-lock || skip "$P" init-global skills-lock "no skills-lock.json"
+  # install record in sandbox HOME
+  [ -f "$E2E_HOME/.argent/config.json" ] && pass "$P" init-global home-config || skip "$P" init-global home-config "no ~/.argent/config.json"
+
+  # --- local (committable) init in a fresh npm project ---------------------
+  local lws="$E2E_WORK/ws/local"
+  mkdir -p "$lws"
+  printf '{"name":"e2e-local-probe","private":true,"version":"0.0.0"}\n' > "$lws/package.json"
+  pushd "$lws" >/dev/null
+  if argent_cli init --yes --local --no-telemetry --from "$E2E_TGZ"; then
+    pass "$P" init-local exit0
+  else
+    fail "$P" init-local exit0 "$(printf '%s' "$CLI_OUT" | tail -3 | tr '\n' ' ')"
+  fi
+  popd >/dev/null
+  # devDependency + a node-path MCP command (not the global `argent`)
+  if [ -d "$lws/node_modules/@swmansion/argent" ]; then
+    pass "$P" init-local devDependency
+  else
+    fail "$P" init-local devDependency "package not in $lws/node_modules"
+  fi
+  # local mode records mode:local and points MCP at the in-repo copy
+  if [ -f "$lws/.argent/install.json" ] && [ "$(jq -r '.mode' "$lws/.argent/install.json" 2>/dev/null)" = "local" ]; then
+    pass "$P" init-local install-record "mode=local"
+  else
+    fail "$P" init-local install-record "no local .argent/install.json"
+  fi
+  local lcfg; lcfg="$(_argent_mcp_in_ws "$lws" 'node_modules/@swmansion/argent')"
+  if [ -n "$lcfg" ]; then
+    pass "$P" init-local mcp-config "$(basename "$(dirname "$lcfg")")/$(basename "$lcfg") -> node_modules path"
+  else
+    # fall back: any argent MCP entry that launches via yarn/npx local resolution
+    lcfg="$(_argent_mcp_in_ws "$lws")"
+    [ -n "$lcfg" ] && pass "$P" init-local mcp-config "$(basename "$lcfg")" || fail "$P" init-local mcp-config "no local argent MCP config under $lws"
+  fi
+
+  # --- update: best-effort (needs network to reach the registry) -----------
+  # BEFORE any uninstall, while the driver is still installed. Acts on the local
+  # workspace install.
+  pushd "$lws" >/dev/null
+  if argent_cli update --yes; then
+    pass "$P" update "completed (rc=0)"
+  else
+    skip "$P" update "non-zero (likely offline/registry): $(printf '%s' "$CLI_OUT" | head -1)"
+  fi
+  popd >/dev/null
+
+  # --- uninstall LOCAL (safe: removes the devDependency + workspace config,
+  #     never the global driver the rest of the run depends on) --------------
+  pushd "$lws" >/dev/null
+  if argent_cli uninstall --yes --local; then pass "$P" uninstall-local exit0; else skip "$P" uninstall-local exit0 "$(printf '%s' "$CLI_OUT" | tail -2 | tr '\n' ' ')"; fi
+  popd >/dev/null
+  if [ ! -d "$lws/node_modules/@swmansion/argent" ] || [ ! -f "$lws/.argent/install.json" ]; then
+    pass "$P" uninstall-local config-removed
+  else
+    fail "$P" uninstall-local config-removed "local install still present under $lws"
+  fi
+
+  # --- uninstall GLOBAL, then restore the driver so downstream phases run ---
+  pushd "$gws" >/dev/null
+  if argent_cli uninstall --yes --global; then pass "$P" uninstall-global exit0; else skip "$P" uninstall-global exit0 "$(printf '%s' "$CLI_OUT" | tail -2 | tr '\n' ' ')"; fi
+  popd >/dev/null
+  local gcfg2; gcfg2="$(_argent_mcp_in_ws "$gws")"
+  if [ -z "$gcfg2" ]; then pass "$P" uninstall-global config-removed; else fail "$P" uninstall-global config-removed "argent MCP config remains: $gcfg2"; fi
+
+  # Restore the global driver (uninstall --global removes the sandbox bin that
+  # ARGENT_BIN points at). Fast: the tarball is local and npm caches it.
+  if [ ! -x "${ARGENT_BIN%% *}" ]; then
+    log "restoring sandbox driver after uninstall test"
+    npm install -g "$E2E_TGZ" --prefix "$E2E_PREFIX" --omit=optional >/dev/null 2>&1 || true
+  fi
+  if argent_cli --version >/dev/null 2>&1; then pass "$P" driver-restored; else fail "$P" driver-restored "argent not runnable after restore"; fi
+}

--- a/scripts/e2e-full/phases/00-install.sh
+++ b/scripts/e2e-full/phases/00-install.sh
@@ -14,8 +14,11 @@
 # adapter selection is environment-dependent (which editors are "detected"), so
 # we assert the semantic outcome across all known config files rather than
 # pinning one path. Prints the first matching file (empty if none).
+# The default pattern is the quoted server name, not the npm package name: a
+# global-mode init registers the MCP command as plain `argent` (the global bin),
+# so `@swmansion/argent` never appears in the written config.
 _argent_mcp_in_ws() { # ws [grep-pattern]
-  local pat="${2:-@swmansion/argent}"
+  local pat="${2:-\"argent\"}"
   grep -rl "$pat" "$1" \
     --include='*.json' --include='*.jsonc' --include='*.toml' --include='*.yaml' 2>/dev/null \
     | grep -v -e '/node_modules/' -e 'skills-lock.json' -e 'package-lock.json' -e 'package.json' \

--- a/scripts/e2e-full/phases/00-install.sh
+++ b/scripts/e2e-full/phases/00-install.sh
@@ -168,5 +168,5 @@ run_phase() {
     log "restoring sandbox driver after uninstall test"
     npm install -g "$E2E_TGZ" --prefix "$E2E_PREFIX" --omit=optional >/dev/null 2>&1 || true
   fi
-  if argent_cli --version >/dev/null 2>&1; then pass "$P" driver-restored; else fail "$P" driver-restored "argent not runnable after restore"; fi
+  if argent_cli --version >/dev/null 2>&1; then pass "$P" driver-restored ok; else fail "$P" driver-restored ok "argent not runnable after restore"; fi
 }

--- a/scripts/e2e-full/phases/10-introspection.sh
+++ b/scripts/e2e-full/phases/10-introspection.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Phase 1 — Introspection (offline, no device).
+#
+# Exercises the CLI surface itself and proves `argent tools describe` works for
+# EVERY tool (this is where all 70 tools first get a recorded case). Also
+# round-trips flags, the server lifecycle, and remote-link config — all against
+# the sandbox HOME.
+
+run_phase() {
+  local P=introspection
+
+  # --- help / version / unknown command ------------------------------------
+  if argent_cli --version && [ "$CLI_OUT" = "$TGZ_VERSION" ]; then
+    pass "$P" cli version
+  else
+    fail "$P" cli version "got '$CLI_OUT' want '$TGZ_VERSION'"
+  fi
+
+  argent_cli --help
+  case "$CLI_OUT" in *"Usage: argent"*) pass "$P" cli help;; *) fail "$P" cli help "no usage banner";; esac
+
+  argent_cli definitely-not-a-command
+  if [ $? -ne 0 ]; then pass "$P" cli unknown-command-exits-nonzero; else fail "$P" cli unknown-command-exits-nonzero "exited 0"; fi
+
+  # --- tool list: expect the full published set ----------------------------
+  local names n
+  names="$(list_tool_names)"
+  n="$(printf '%s\n' "$names" | grep -c .)"
+  if [ "$n" -ge 60 ]; then
+    pass "$P" tools "list ($n tools)"
+  else
+    fail "$P" tools "list ($n tools)" "suspiciously few tools"
+  fi
+
+  # --- describe EVERY tool (records a case per tool) ------------------------
+  local t model
+  while read -r t; do
+    [ -z "$t" ] && continue
+    model="$(parse_tool_model "$t")"
+    if [ -s "$model" ] || argent_cli tools describe "$t"; then
+      # a tool with no params is legitimate; require the describe call itself to succeed
+      if argent_cli tools describe "$t"; then
+        pass "$P" "$t" describe "$(model_flag_count "$model") flags"
+      else
+        fail "$P" "$t" describe "describe exited non-zero"
+      fi
+    fi
+  done <<< "$names"
+
+  # --- feature flags round-trip (uses a predefined flag name) --------------
+  argent_cli flags; [ $? -eq 0 ] && pass "$P" flags list || fail "$P" flags list "$CLI_OUT"
+  local PROBE_FLAG="disable-auto-screenshot"
+  if argent_cli enable "$PROBE_FLAG" --scope global; then
+    argent_cli flags
+    case "$CLI_OUT" in *"$PROBE_FLAG"*) pass "$P" flags enable;; *) fail "$P" flags enable "flag not shown after enable";; esac
+    argent_cli disable "$PROBE_FLAG" --scope global && pass "$P" flags disable || fail "$P" flags disable "$CLI_OUT"
+  else
+    fail "$P" flags enable "enable exited non-zero: $(printf '%s' "$CLI_OUT" | head -1)"
+  fi
+
+  # --- telemetry status -----------------------------------------------------
+  argent_cli telemetry status; [ $? -eq 0 ] && pass "$P" telemetry status || fail "$P" telemetry status "$CLI_OUT"
+
+  # --- server lifecycle (start/status/logs/stop) ---------------------------
+  # Start from a clean slate: kill any server auto-spawned by the calls above so
+  # we exercise an explicit `server start`.
+  argent_cli server stop >/dev/null 2>&1 || true
+  if argent_cli server start --detach --no-auth --port 0; then
+    pass "$P" server start
+  else
+    fail "$P" server start "$(printf '%s' "$CLI_OUT" | head -1)"
+  fi
+  local i ready=0
+  for i in $(seq 1 30); do server_running && { ready=1; break; }; sleep 1; done
+  [ "$ready" -eq 1 ] && pass "$P" server ready || fail "$P" server ready "status never reported healthy"
+
+  argent_cli server status --json
+  if printf '%s' "$CLI_OUT" | jq -e '.running==true' >/dev/null 2>&1; then
+    pass "$P" server status "port=$(printf '%s' "$CLI_OUT" | jq -r .port)"
+  else
+    fail "$P" server status "$(printf '%s' "$CLI_OUT" | head -1)"
+  fi
+  argent_cli server logs; [ $? -eq 0 ] && pass "$P" server logs || skip "$P" server logs "logs exited non-zero"
+
+  # Prove stop works, then bring one back for downstream phases.
+  if argent_cli server stop; then pass "$P" server stop; else fail "$P" server stop "$(printf '%s' "$CLI_OUT" | head -1)"; fi
+  ensure_server || warn "could not restart server after stop test"
+
+  # --- link / unlink round-trip (sandbox ~/.argent/link.json) --------------
+  # NB: setting a link overrides discovery; unset it immediately so downstream
+  # phases keep using ARGENT_TOOLS_URL.
+  if argent_cli link "http://127.0.0.1:${E2E_TOOLS_PORT}"; then
+    pass "$P" link set
+    if [ -f "$E2E_HOME/.argent/link.json" ]; then pass "$P" link persisted; else skip "$P" link persisted "no link.json"; fi
+    argent_cli unlink && pass "$P" link unset || fail "$P" link unset "$CLI_OUT"
+  else
+    fail "$P" link set "link exited non-zero: $(printf '%s' "$CLI_OUT" | head -1)"
+  fi
+
+  # leave the server running for downstream phases (validation reuses it)
+}

--- a/scripts/e2e-full/phases/20-validation.sh
+++ b/scripts/e2e-full/phases/20-validation.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Phase 2 — Argument-matrix validation (offline, no device).
+#
+# For EVERY tool, generates rejection cases straight from its parsed schema:
+#   - missing-required : omit all required flags            -> must reject
+#   - bad-enum         : junk value for each enum flag      -> must reject (that path)
+#   - bad-type         : string where a number is required  -> must reject (that path)
+#
+# Valid-typed dummies are filled for the *other* required flags so the single
+# intended violation is what trips the rejection. This is deterministic and
+# needs no hardware — it's the "every combination of arguments" guarantee at the
+# validation layer. Runs against the private tool-server started in phase 1.
+
+# Tools with no required flags that would actually EXECUTE (touch a device /
+# network / state) if called empty — excluded from missing-required here and
+# covered by the device tiers instead.
+_VAL_EXCLUDE_MISSING="list-devices stop-all-simulator-servers stop-metro native-devtools-status update-argent"
+
+# Build a JSON object with valid dummies for every required flag in a model,
+# then apply overrides "field=raw-json" pairs. Emits the JSON on stdout.
+_build_args() { # model [field:rawjson ...]
+  local model="$1"; shift
+  python3 - "$model" "$@" <<'PY'
+import json, sys
+model = sys.argv[1]
+overrides = {}
+for a in sys.argv[2:]:
+    k, v = a.split("=", 1)
+    overrides[k] = json.loads(v)
+obj = {}
+with open(model) as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        name, kind, req, enums = (line.split("\t") + ["", "", "", ""])[:4]
+        if req != "1":
+            continue
+        if kind == "number":
+            obj[name] = 1
+        elif kind == "boolean":
+            obj[name] = True
+        elif kind == "enum":
+            obj[name] = (enums.split(",")[0] if enums else "x")
+        elif kind == "array":
+            obj[name] = []
+        elif kind == "object":
+            obj[name] = {}
+        else:
+            obj[name] = "x"
+obj.update(overrides)
+print(json.dumps(obj))
+PY
+}
+
+run_phase() {
+  local P=validation
+  ensure_server || warn "no private server; validation still runs (client-side schema)"
+
+  local names t model
+  names="$(list_tool_names)"
+
+  while read -r t; do
+    [ -z "$t" ] && continue
+    model="$(parse_tool_model "$t")"
+    [ -s "$model" ] || { skip "$P" "$t" schema "no flags to validate"; continue; }
+
+    local reqs; reqs="$(model_required_flags "$model")"
+
+    # --- missing-required ---------------------------------------------------
+    if [ -n "$reqs" ]; then
+      local first_req; first_req="$(printf '%s\n' "$reqs" | head -1)"
+      # omit everything -> the first required flag must be flagged undefined
+      assert_reject "$P" "$t" missing-required '{}' "$first_req" "invalid_type"
+    else
+      case " $_VAL_EXCLUDE_MISSING " in
+        *" $t "*) : ;;  # device/stateful no-arg tool: covered elsewhere
+        *) skip "$P" "$t" missing-required "no required flags" ;;
+      esac
+    fi
+
+    # --- bad-enum (one case per enum flag) ---------------------------------
+    local ef
+    for ef in $(model_enum_flags "$model"); do
+      local args; args="$(_build_args "$model" "$ef=\"__not_a_valid_enum__\"")"
+      assert_reject "$P" "$t" "bad-enum:$ef" "$args" "$ef" "invalid_value"
+    done
+
+    # --- bad-type (first required number flag gets a string) ---------------
+    local nf
+    nf="$(model_number_flags "$model" | while read -r f; do
+            awk -F'\t' -v n="$f" '$1==n && $3==1{print n}' "$model"; done | head -1)"
+    if [ -z "$nf" ]; then nf="$(model_number_flags "$model" | head -1)"; fi
+    if [ -n "$nf" ]; then
+      local targs; targs="$(_build_args "$model" "$nf=\"not_a_number\"")"
+      assert_reject "$P" "$t" "bad-type:$nf" "$targs" "$nf" "invalid_type"
+    fi
+  done <<< "$names"
+}

--- a/scripts/e2e-full/phases/30-android.sh
+++ b/scripts/e2e-full/phases/30-android.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Phase 3 — Android device tier (Linux + macOS).
+#
+# Drives a happy-path of every tool that applies to an Android emulator. The
+# device is EITHER injected (E2E_ANDROID_SERIAL — e.g. a serial the device
+# allocator handed us on a shared machine, already booted) OR booted here from
+# E2E_ANDROID_AVD. If neither is available the whole tier is skipped with a
+# reason so the report still makes sense.
+
+# Verify a booted device with this serial is visible to the tool-server.
+_android_present() { # serial
+  run_tool list-devices '{}'
+  printf '%s' "$RT_JSON" | jq -e --arg s "$1" 'any(.devices[]?; .serial==$s or .udid==$s)' >/dev/null 2>&1
+}
+
+# Grab a screenshot to a file and assert it has real pixels. Sets SHOT_PATH.
+_shot_ok() { # phase udid case
+  local phase="$1" udid="$2" case="$3"
+  if capture_screenshot "$udid" "$E2E_WORK/android-$case.png"; then
+    pass "$phase" screenshot "$case (${SHOT_SIZE}B)"; return 0
+  else
+    fail "$phase" screenshot "$case" "size=${SHOT_SIZE:-0} rc=${SHOT_RC:-?} (blank framebuffer?)"; return 1
+  fi
+}
+
+run_phase() {
+  local P=android
+  ensure_server || { skip "$P" tier all "tool-server unavailable"; return 0; }
+
+  local DEV=""
+  if [ -n "${E2E_ANDROID_SERIAL:-}" ]; then
+    DEV="$E2E_ANDROID_SERIAL"
+    if _android_present "$DEV"; then
+      pass "$P" list-devices "injected serial $DEV present"
+    else
+      # not yet visible — try a boot-device against it in case the sim-server
+      # needs to attach; otherwise skip.
+      skip "$P" tier all "injected serial $DEV not visible to tool-server"; return 0
+    fi
+  elif [ -n "${E2E_ANDROID_AVD:-}" ]; then
+    log "booting AVD $E2E_ANDROID_AVD"
+    run_tool boot-device "{\"avdName\":\"$E2E_ANDROID_AVD\",\"bootTimeoutMs\":840000}"
+    if [ "$RT_RC" -eq 0 ] && printf '%s' "$RT_JSON" | jq -e '.booted==true' >/dev/null 2>&1; then
+      DEV="$(printf '%s' "$RT_JSON" | jq -r '.serial // .udid // empty')"
+      pass "$P" boot-device "booted $DEV"
+    else
+      fail "$P" boot-device "$(printf '%s' "$RT_OUT" | tr '\n' ' ' | cut -c1-160)"; return 0
+    fi
+  else
+    skip "$P" tier all "no Android device (set E2E_ANDROID_SERIAL or E2E_ANDROID_AVD)"; return 0
+  fi
+  local U="{\"udid\":\"$DEV\"}"
+
+  # --- discovery ------------------------------------------------------------
+  _shot_ok "$P" "$DEV" baseline || true
+  assert_field "$P" describe describe "$U" '(.description|length>0)' 'true'
+  assert_ok    "$P" await-screen-idle idle "$U"
+  assert_ok    "$P" await-ui-element exists-probe "{\"udid\":\"$DEV\",\"condition\":\"exists\",\"selector\":{\"text\":\"a\"},\"timeoutMs\":3000}"
+
+  # --- interaction ----------------------------------------------------------
+  assert_true "$P" gesture-tap tap    "{\"udid\":\"$DEV\",\"x\":0.5,\"y\":0.5}" '.tapped'
+  assert_true "$P" gesture-swipe swipe "{\"udid\":\"$DEV\",\"fromX\":0.5,\"fromY\":0.8,\"toX\":0.5,\"toY\":0.2}" '.swiped'
+  assert_ok   "$P" gesture-custom custom "{\"udid\":\"$DEV\",\"events\":[{\"type\":\"Down\",\"x\":0.5,\"y\":0.6},{\"type\":\"Move\",\"x\":0.5,\"y\":0.4},{\"type\":\"Up\",\"x\":0.5,\"y\":0.4}]}"
+  assert_true "$P" gesture-pinch pinch  "{\"udid\":\"$DEV\",\"centerX\":0.5,\"centerY\":0.5,\"startDistance\":0.1,\"endDistance\":0.4}" '.pinched'
+  assert_true "$P" gesture-rotate rotate2 "{\"udid\":\"$DEV\",\"centerX\":0.5,\"centerY\":0.5,\"radius\":0.2,\"startAngle\":0,\"endAngle\":90}" '.rotated'
+  assert_ok   "$P" button home   "{\"udid\":\"$DEV\",\"button\":\"home\"}"
+  assert_ok   "$P" button back   "{\"udid\":\"$DEV\",\"button\":\"back\"}"
+  assert_ok   "$P" rotate landscape "{\"udid\":\"$DEV\",\"orientation\":\"LandscapeLeft\"}"
+  assert_ok   "$P" rotate portrait  "{\"udid\":\"$DEV\",\"orientation\":\"Portrait\"}"
+  assert_ok   "$P" keyboard text "{\"udid\":\"$DEV\",\"text\":\"hello e2e\"}"
+  assert_ok   "$P" keyboard key  "{\"udid\":\"$DEV\",\"key\":\"enter\"}"
+  assert_ok   "$P" run-sequence seq "{\"udid\":\"$DEV\",\"steps\":[{\"tool\":\"button\",\"args\":{\"button\":\"home\"}},{\"tool\":\"gesture-tap\",\"args\":{\"x\":0.5,\"y\":0.5}}]}"
+
+  # --- url navigation -------------------------------------------------------
+  assert_true "$P" open-url url "{\"udid\":\"$DEV\",\"url\":\"https://example.com\"}" '.opened'
+
+  # --- screenshot-diff (two live captures) ----------------------------------
+  local b c
+  _shot_ok "$P" "$DEV" diff-baseline && b="$SHOT_PATH"
+  cp "$b" "$E2E_WORK/diff-base.png" 2>/dev/null || true
+  run_tool button "{\"udid\":\"$DEV\",\"button\":\"home\"}" >/dev/null 2>&1
+  _shot_ok "$P" "$DEV" diff-current && c="$SHOT_PATH"
+  if [ -n "${b:-}" ] && [ -n "${c:-}" ]; then
+    assert_ok "$P" screenshot-diff diff "{\"baselinePath\":\"$E2E_WORK/diff-base.png\",\"currentPath\":\"$c\"}"
+  else
+    skip "$P" screenshot-diff diff "could not capture two screenshots"
+  fi
+
+  # --- app lifecycle against a stock system app -----------------------------
+  local APP="com.android.settings"
+  assert_true "$P" launch-app  launch  "{\"udid\":\"$DEV\",\"bundleId\":\"$APP\"}" '.launched'
+  assert_true "$P" restart-app restart "{\"udid\":\"$DEV\",\"bundleId\":\"$APP\"}" '.restarted'
+
+  # --- state-only + platform-scoped ----------------------------------------
+  assert_ok "$P" dismiss-update dismiss "{\"hours\":1}"
+
+  # iOS-only tools: recorded as skips so coverage is explicit.
+  local iostool
+  for iostool in native-describe-screen native-devtools-status native-full-hierarchy \
+                 native-find-views native-view-at-point native-user-interactable-view-at-point \
+                 native-network-logs; do
+    skip "$P" "$iostool" happy-path "iOS-only (not applicable on Android)"
+  done
+  skip "$P" tv-remote happy-path "TV-only tier (skipped per scope)"
+  skip "$P" reinstall-app happy-path "covered in RN tier with the Bluesky apk"
+
+  # --- teardown for this device --------------------------------------------
+  # Only stop the sim-server if we booted the AVD ourselves; a device injected
+  # by the allocator is released by the caller.
+  if [ -z "${E2E_ANDROID_SERIAL:-}" ]; then
+    assert_ok "$P" stop-simulator-server stop "$U"
+  else
+    run_tool stop-simulator-server "$U" >/dev/null 2>&1 || true
+    skip "$P" stop-simulator-server stop "injected device released by caller"
+  fi
+}

--- a/scripts/e2e-full/phases/30-android.sh
+++ b/scripts/e2e-full/phases/30-android.sh
@@ -81,7 +81,7 @@ run_phase() {
   run_tool button "{\"udid\":\"$DEV\",\"button\":\"home\"}" >/dev/null 2>&1
   _shot_ok "$P" "$DEV" diff-current && c="$SHOT_PATH"
   if [ -n "${b:-}" ] && [ -n "${c:-}" ]; then
-    assert_ok "$P" screenshot-diff diff "{\"baselinePath\":\"$E2E_WORK/diff-base.png\",\"currentPath\":\"$c\"}"
+    assert_ok "$P" screenshot-diff diff "{\"udid\":\"$DEV\",\"baselinePath\":\"$E2E_WORK/diff-base.png\",\"currentPath\":\"$c\"}"
   else
     skip "$P" screenshot-diff diff "could not capture two screenshots"
   fi

--- a/scripts/e2e-full/phases/40-chromium.sh
+++ b/scripts/e2e-full/phases/40-chromium.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Phase 4 — Chromium / Electron tier (Linux + macOS).
+#
+# Generates a minimal Electron app, boots it through boot-device
+# (electronAppPath), and drives every Chromium/CDP tool. Electron ships as an
+# argent optionalDependency, so it's present after a sandbox install that kept
+# optional deps (run-e2e installs them when the chromium/rn phases are
+# selected). resolveLauncher() prefers <app>/node_modules/.bin/electron, so we
+# symlink the bundled binary in. Needs a display (DISPLAY or xvfb) on Linux.
+
+# Locate the electron launcher binary the sandbox install pulled in.
+_find_electron() {
+  find "$E2E_PREFIX" "$E2E_UNPACKED/.." -path '*/.bin/electron' 2>/dev/null | head -1
+}
+
+# Write the minimal Electron app into $E2E_WORK/electron-app and link electron.
+# Loads over http://127.0.0.1:$1 (not file://) so localStorage/sessionStorage
+# have a real, storable origin — file:// origins are opaque and throw.
+_gen_electron_app() { # electron-bin http-port  -> echoes app dir
+  local ebin="$1" httpport="$2" dir="$E2E_WORK/electron-app"
+  mkdir -p "$dir/node_modules/.bin"
+  ln -sf "$ebin" "$dir/node_modules/.bin/electron"
+  cat > "$dir/package.json" <<'JSON'
+{ "name": "argent-e2e-electron", "version": "0.0.0", "private": true, "main": "main.js" }
+JSON
+  cat > "$dir/main.js" <<JS
+const { app, BrowserWindow } = require("electron");
+app.commandLine.appendSwitch("disable-gpu");
+function createWindow() {
+  const win = new BrowserWindow({ width: 1024, height: 768, show: true,
+    webPreferences: { contextIsolation: true, nodeIntegration: false } });
+  win.loadURL("http://127.0.0.1:${httpport}/index.html");
+}
+app.whenReady().then(createWindow);
+app.on("window-all-closed", () => app.quit());
+JS
+  # A full-window canvas painted with random noise guarantees a large,
+  # incompressible PNG (well above the blank-framebuffer floor), with a button +
+  # input at known positions for the interaction tools.
+  cat > "$dir/index.html" <<'HTML'
+<!doctype html><html><head><meta charset="utf-8"><style>
+  html,body{margin:0;height:100%;overflow:auto}
+  #c{position:fixed;inset:0;z-index:0}
+  #b{position:absolute;left:45%;top:46%;width:10%;height:8%;font-size:20px;z-index:1}
+  #i{position:absolute;left:40%;top:60%;width:20%;z-index:1}
+</style></head><body>
+  <canvas id="c" width="1024" height="768"></canvas>
+  <button id="b" onclick="this.textContent='tapped'">Tap me</button>
+  <input id="i" placeholder="type here"/>
+  <div id="scrollpad" style="height:3000px"></div>
+  <script>
+    const cv = document.getElementById('c'), x = cv.getContext('2d');
+    const img = x.createImageData(cv.width, cv.height), d = img.data;
+    for (let i = 0; i < d.length; i += 4) { d[i]=Math.random()*255; d[i+1]=Math.random()*255; d[i+2]=Math.random()*255; d[i+3]=255; }
+    x.putImageData(img, 0, 0);
+  </script>
+</body></html>
+HTML
+  printf '%s\n' "$dir"
+}
+
+run_phase() {
+  local P=chromium
+  ensure_server || { skip "$P" tier all "tool-server unavailable"; return 0; }
+
+  # Display gate (Linux). macOS always has one.
+  if [ "$E2E_OS" = "linux" ] && [ -z "${DISPLAY:-}" ] && ! command -v xvfb-run >/dev/null 2>&1; then
+    skip "$P" tier all "no DISPLAY and no xvfb-run on Linux"; return 0
+  fi
+
+  local ebin; ebin="$(_find_electron)"
+  if [ -z "$ebin" ] || [ ! -e "$ebin" ]; then
+    skip "$P" tier all "electron not installed (run without --skip-install and with chromium selected)"; return 0
+  fi
+
+  local httpport; httpport="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+  local appdir; appdir="$(_gen_electron_app "$ebin" "$httpport")"
+  # Serve the fixture so the renderer has a real http origin (for storage).
+  ( cd "$appdir" && exec python3 -m http.server "$httpport" --bind 127.0.0.1 ) >/dev/null 2>&1 &
+  export E2E_HTTP_PID=$!
+  local port; port="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+  sleep 1
+
+  # electronArgs: --no-sandbox is required for Electron under many CI/root/Linux
+  # setups; disable-gpu keeps rendering deterministic.
+  run_tool boot-device "{\"electronAppPath\":\"$appdir\",\"electronPort\":$port,\"electronArgs\":[\"--no-sandbox\",\"--disable-gpu\"]}"
+  if [ "$RT_RC" -ne 0 ] || ! printf '%s' "$RT_JSON" | jq -e '.booted==true' >/dev/null 2>&1; then
+    fail "$P" boot-device "$(printf '%s' "$RT_OUT" | tr '\n' ' ' | cut -c1-180)"
+    skip "$P" tier remaining "electron did not boot"; return 0
+  fi
+  local DEV; DEV="$(printf '%s' "$RT_JSON" | jq -r '.id // .udid // .serial // empty')"
+  [ -z "$DEV" ] && DEV="chromium-cdp-$port"
+  export E2E_ELECTRON_PID="$(printf '%s' "$RT_JSON" | jq -r '.pid // empty')"
+  export E2E_ELECTRON_PORT="$port"
+  pass "$P" boot-device "electron $DEV (port $port)"
+
+  # --- discovery ------------------------------------------------------------
+  assert_true "$P" list-devices present "{}" "(any(.devices[]?; (.id//.udid//.serial)==\"$DEV\"))"
+  if capture_screenshot "$DEV" "$E2E_WORK/chromium-shot.png"; then
+    pass "$P" screenshot "shot (${SHOT_SIZE}B)"
+  else
+    fail "$P" screenshot "size=${SHOT_SIZE:-0} rc=${SHOT_RC:-?}"
+  fi
+  assert_field "$P" describe describe "{\"udid\":\"$DEV\"}" '(.description|length>0)' 'true'
+
+  # --- interaction ----------------------------------------------------------
+  assert_true "$P" gesture-tap tap    "{\"udid\":\"$DEV\",\"x\":0.5,\"y\":0.5}" '.tapped'
+  assert_true "$P" gesture-scroll scroll "{\"udid\":\"$DEV\",\"x\":0.5,\"y\":0.5,\"deltaY\":0.5}" '.scrolled'
+  assert_true "$P" gesture-drag drag   "{\"udid\":\"$DEV\",\"fromX\":0.4,\"fromY\":0.4,\"toX\":0.6,\"toY\":0.6}" '.dragged'
+  assert_ok   "$P" keyboard  text     "{\"udid\":\"$DEV\",\"text\":\"hello chromium\"}"
+  # navigate within the same http origin so storage tests below keep a storable
+  # origin (about:/data: origins are opaque and reject Web Storage).
+  assert_true "$P" open-url  url      "{\"udid\":\"$DEV\",\"url\":\"http://127.0.0.1:$httpport/index.html\"}" '.opened'
+
+  # --- tabs -----------------------------------------------------------------
+  # `list` always works; new/select/close need a multi-window/tab target, which
+  # a single-window Electron app doesn't provide — tolerate "Not supported".
+  assert_ok "$P" chromium-tabs list "{\"udid\":\"$DEV\",\"action\":\"list\"}"
+  run_tool chromium-tabs "{\"udid\":\"$DEV\",\"action\":\"new\",\"url\":\"about:blank\",\"label\":\"e2e-tab\"}"
+  if [ "$RT_RC" -eq 0 ]; then
+    pass "$P" chromium-tabs new
+    assert_ok "$P" chromium-tabs select "{\"udid\":\"$DEV\",\"action\":\"select\",\"tab\":\"e2e-tab\"}"
+    assert_ok "$P" chromium-tabs close  "{\"udid\":\"$DEV\",\"action\":\"close\",\"tab\":\"e2e-tab\"}"
+  else
+    case "$RT_OUT" in
+      *"Not supported"*|*"not supported"*)
+        skip "$P" chromium-tabs new "single-window Electron: tab creation not supported"
+        skip "$P" chromium-tabs select "no extra tab to select"
+        skip "$P" chromium-tabs close "no extra tab to close" ;;
+      *) fail "$P" chromium-tabs new "$(printf '%s' "$RT_OUT"|tr '\n' ' '|cut -c1-140)" ;;
+    esac
+  fi
+
+  # --- cookies --------------------------------------------------------------
+  assert_ok "$P" chromium-cookies set   "{\"udid\":\"$DEV\",\"action\":\"set\",\"name\":\"e2e\",\"value\":\"1\",\"url\":\"https://example.com\"}"
+  assert_ok "$P" chromium-cookies get   "{\"udid\":\"$DEV\",\"action\":\"get\"}"
+  assert_ok "$P" chromium-cookies delete "{\"udid\":\"$DEV\",\"action\":\"delete\",\"name\":\"e2e\",\"url\":\"https://example.com\"}"
+  assert_ok "$P" chromium-cookies clear "{\"udid\":\"$DEV\",\"action\":\"clear\"}"
+
+  # --- storage (local + session) -------------------------------------------
+  local store
+  for store in local session; do
+    assert_ok "$P" chromium-storage "set-$store"    "{\"udid\":\"$DEV\",\"store\":\"$store\",\"action\":\"set\",\"key\":\"e2e\",\"value\":\"v\"}"
+    assert_ok "$P" chromium-storage "get-$store"    "{\"udid\":\"$DEV\",\"store\":\"$store\",\"action\":\"get\",\"key\":\"e2e\"}"
+    assert_ok "$P" chromium-storage "remove-$store" "{\"udid\":\"$DEV\",\"store\":\"$store\",\"action\":\"remove\",\"key\":\"e2e\"}"
+    assert_ok "$P" chromium-storage "clear-$store"  "{\"udid\":\"$DEV\",\"store\":\"$store\",\"action\":\"clear\"}"
+  done
+
+  # --- teardown: kill the electron we spawned ------------------------------
+  if [ -n "${E2E_ELECTRON_PID:-}" ] && kill -0 "$E2E_ELECTRON_PID" 2>/dev/null; then
+    kill "$E2E_ELECTRON_PID" 2>/dev/null || true
+  else
+    # fall back: kill whatever holds the CDP port
+    local pid; pid="$(python3 -c "import subprocess,sys
+try:
+    out=subprocess.check_output(['bash','-lc','ss -ltnp 2>/dev/null | grep :$port || true']).decode()
+    import re; m=re.search(r'pid=(\d+)', out); print(m.group(1) if m else '')
+except Exception: print('')" 2>/dev/null)"
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+  fi
+  [ -n "${E2E_HTTP_PID:-}" ] && kill "$E2E_HTTP_PID" 2>/dev/null || true
+  pass "$P" teardown electron-stopped
+}

--- a/scripts/e2e-full/phases/50-rn-bluesky.sh
+++ b/scripts/e2e-full/phases/50-rn-bluesky.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Phase 5 — React-Native debugger / profiler / network tier.
+#
+# The deepest tier: drives the ~20 tools that only do anything against a running
+# React-Native app with a live Metro debugger. Target is the real Bluesky app
+# (Expo dev-client, Metro :8081, Android package xyz.blueskyweb.app).
+#
+# Heavily gated — needs (1) the Bluesky checkout, (2) an Android device, and
+# (3) the dev-client already built+installed on it. Anything missing → the whole
+# tier (or the failing sub-step) records a skip with a reason, so the report
+# still accounts for every tool.
+#
+# Env overrides:
+#   E2E_RN_DIR       default ~/dev/bluesky
+#   E2E_RN_PKG       default xyz.blueskyweb.app
+#   E2E_RN_PREBUILT  =1 to assume the dev-client is already installed (default;
+#                    building via `expo run:android` is too heavy to auto-run)
+#   E2E_METRO_PORT   default 8081
+
+_metro_ready() { curl -fsS -m 3 "http://127.0.0.1:${1}/status" 2>/dev/null | grep -q 'packager-status:running'; }
+
+run_phase() {
+  local P=rn
+  local RN_DIR="${E2E_RN_DIR:-$HOME_REAL/dev/bluesky}"
+  # HOME is sandboxed; resolve the real bluesky path from the invoking user.
+  [ -d "$RN_DIR" ] || RN_DIR="${E2E_RN_DIR:-/home/user/dev/bluesky}"
+  local PKG="${E2E_RN_PKG:-xyz.blueskyweb.app}"
+  local MPORT="${E2E_METRO_PORT:-8081}"
+
+  # All the RN-only tools, so we can blanket-skip them with one reason if gated.
+  local RN_TOOLS="debugger-connect debugger-status debugger-evaluate debugger-log-registry \
+    debugger-component-tree debugger-inspect-element debugger-reload-metro \
+    view-network-logs view-network-request-details \
+    react-profiler-start react-profiler-stop react-profiler-status react-profiler-analyze \
+    react-profiler-renders react-profiler-fiber-tree react-profiler-cpu-summary react-profiler-component-source \
+    profiler-load profiler-cpu-query profiler-commit-query profiler-stack-query profiler-combined-report \
+    native-profiler-start native-profiler-stop native-profiler-analyze"
+  _skip_all() { local t; for t in $RN_TOOLS; do skip "$P" "$t" happy-path "$1"; done; }
+
+  if [ ! -d "$RN_DIR" ]; then _skip_all "no RN app at $RN_DIR (set E2E_RN_DIR)"; return 0; fi
+  ensure_server || { _skip_all "tool-server unavailable"; return 0; }
+
+  local DEV="${E2E_ANDROID_SERIAL:-}"
+  if [ -z "$DEV" ]; then _skip_all "no Android device (set E2E_ANDROID_SERIAL)"; return 0; fi
+
+  # dev-client installed?
+  if ! adb -s "$DEV" shell pm list packages 2>/dev/null | grep -q "$PKG"; then
+    if [ "${E2E_RN_BUILD:-0}" = "1" ]; then
+      log "building Bluesky dev-client (expo run:android) — this is slow"
+      ( cd "$RN_DIR" && TOOL_TIMEOUT=0 ANDROID_SERIAL="$DEV" node_modules/.bin/expo run:android --device "$DEV" ) >/dev/null 2>&1 \
+        || { _skip_all "dev-client build failed"; return 0; }
+    else
+      _skip_all "$PKG not installed on $DEV (prebuild it, or set E2E_RN_BUILD=1)"; return 0
+    fi
+  fi
+
+  # --- start Metro ----------------------------------------------------------
+  if ! _metro_ready "$MPORT"; then
+    log "starting Metro in $RN_DIR"
+    local expo="$RN_DIR/node_modules/.bin/expo"
+    [ -x "$expo" ] || expo="npx --prefix $RN_DIR expo"
+    ( cd "$RN_DIR" && exec $expo start --dev-client --port "$MPORT" ) >/tmp/e2e-metro.log 2>&1 &
+    export E2E_METRO_PID=$!
+    local i
+    for i in $(seq 1 45); do _metro_ready "$MPORT" && break; sleep 2; done
+  fi
+  if _metro_ready "$MPORT"; then pass "$P" metro ready; else fail "$P" metro ready "Metro not up on :$MPORT"; _skip_all "Metro unavailable"; return 0; fi
+
+  # --- launch app + connect the debugger -----------------------------------
+  assert_true "$P" launch-app launch "{\"udid\":\"$DEV\",\"bundleId\":\"$PKG\"}" '.launched'
+  sleep 5  # let the JS runtime register with Metro
+
+  run_tool debugger-connect "{\"device_id\":\"$DEV\",\"port\":$MPORT}"
+  if [ "$RT_RC" -ne 0 ]; then
+    fail "$P" debugger-connect connect "$(printf '%s' "$RT_OUT"|tr '\n' ' '|cut -c1-160)"
+    _skip_all "debugger-connect failed"; return 0
+  fi
+  local LID; LID="$(printf '%s' "$RT_JSON" | jq -r '.logicalDeviceId // .device_id // empty')"
+  [ -z "$LID" ] && LID="$DEV"
+  pass "$P" debugger-connect "connected (logicalDeviceId=$LID)"
+  local D="\"device_id\":\"$LID\",\"port\":$MPORT"
+
+  # --- debugger chain -------------------------------------------------------
+  assert_ok    "$P" debugger-status status "{$D}"
+  assert_field "$P" debugger-evaluate eval "{$D,\"expression\":\"1+1\"}" '(.result|tostring)' '2'
+  assert_ok    "$P" debugger-log-registry logs "{$D}"
+  assert_ok    "$P" debugger-component-tree tree "{$D}"
+  assert_ok    "$P" debugger-inspect-element inspect "{$D,\"x\":0.5,\"y\":0.5}"
+  assert_ok    "$P" debugger-reload-metro reload "{$D}"
+  sleep 4  # reload drops the runtime; let it re-register
+
+  # --- network: trigger a fetch, then read the logs ------------------------
+  run_tool debugger-evaluate "{$D,\"expression\":\"fetch('https://example.com').then(()=>0)\"}" >/dev/null 2>&1
+  sleep 2
+  assert_ok "$P" view-network-logs netlogs "{$D,\"pageIndex\":\"latest\"}"
+  local RID; RID="$(printf '%s' "$RT_JSON" | jq -r '(.requests // .entries // [])[0].requestId // empty' 2>/dev/null)"
+  if [ -n "$RID" ]; then
+    assert_ok "$P" view-network-request-details netdetails "{$D,\"requestId\":\"$RID\"}"
+  else
+    skip "$P" view-network-request-details netdetails "no captured request id"
+  fi
+
+  # --- react profiler round-trip -------------------------------------------
+  run_tool react-profiler-start "{$D}"
+  if [ "$RT_RC" -eq 0 ]; then
+    pass "$P" react-profiler-start start
+    run_tool gesture-tap "{\"udid\":\"$DEV\",\"x\":0.5,\"y\":0.5}" >/dev/null 2>&1; sleep 1
+    run_tool gesture-swipe "{\"udid\":\"$DEV\",\"fromX\":0.5,\"fromY\":0.7,\"toX\":0.5,\"toY\":0.3}" >/dev/null 2>&1; sleep 1
+    assert_ok "$P" react-profiler-status  rp-status "{$D}"
+    assert_ok "$P" react-profiler-stop    rp-stop   "{$D}"
+    assert_ok "$P" react-profiler-analyze rp-analyze "{$D,\"project_root\":\"$RN_DIR\",\"platform\":\"android\"}"
+    assert_ok "$P" react-profiler-renders rp-renders "{$D}"
+    assert_ok "$P" react-profiler-fiber-tree rp-fiber "{$D}"
+    assert_ok "$P" react-profiler-cpu-summary rp-cpu "{$D}"
+    # profiler query tools operate on the loaded react session
+    assert_ok "$P" profiler-load load-list "{\"mode\":\"list\",\"device_id\":\"$DEV\"}"
+    assert_ok "$P" profiler-cpu-query cpu-top "{$D,\"mode\":\"top_functions\",\"top_n\":10}"
+    assert_ok "$P" profiler-commit-query commits "{$D,\"mode\":\"by_time_range\"}"
+    assert_ok "$P" profiler-stack-query stacks "{$D,\"mode\":\"thread_breakdown\"}"
+    assert_ok "$P" profiler-combined-report combined "{$D}"
+    # component-source needs a component name from the render list — best-effort
+    skip "$P" react-profiler-component-source rp-src "needs a specific component name (manual)"
+  else
+    for t in react-profiler-start react-profiler-status react-profiler-stop react-profiler-analyze \
+             react-profiler-renders react-profiler-fiber-tree react-profiler-cpu-summary react-profiler-component-source \
+             profiler-load profiler-cpu-query profiler-commit-query profiler-stack-query profiler-combined-report; do
+      skip "$P" "$t" happy-path "react-profiler-start failed: $(printf '%s' "$RT_OUT"|tr '\n' ' '|cut -c1-80)"
+    done
+  fi
+
+  # --- native profiler (Android perfetto) ----------------------------------
+  run_tool native-profiler-start "{\"device_id\":\"$DEV\",\"app_process\":\"$PKG\"}"
+  if [ "$RT_RC" -eq 0 ]; then
+    pass "$P" native-profiler-start np-start
+    run_tool gesture-swipe "{\"udid\":\"$DEV\",\"fromX\":0.5,\"fromY\":0.7,\"toX\":0.5,\"toY\":0.3}" >/dev/null 2>&1; sleep 3
+    assert_ok "$P" native-profiler-stop    np-stop   "{\"device_id\":\"$DEV\"}"
+    assert_ok "$P" native-profiler-analyze np-analyze "{\"device_id\":\"$DEV\"}"
+    assert_ok "$P" profiler-load load-native "{\"mode\":\"load_native\",\"device_id\":\"$DEV\",\"app_process\":\"$PKG\"}"
+  else
+    skip "$P" native-profiler-start  np-start   "start failed: $(printf '%s' "$RT_OUT"|tr '\n' ' '|cut -c1-80)"
+    skip "$P" native-profiler-stop   np-stop    "native profiler not started"
+    skip "$P" native-profiler-analyze np-analyze "native profiler not started"
+  fi
+  skip "$P" native-network-logs happy-path "iOS-only (not applicable on Android)"
+
+  # --- reinstall-app with the built Bluesky apk ----------------------------
+  local apk; apk="$(find "$RN_DIR/android/app/build/outputs/apk" -name '*.apk' 2>/dev/null | head -1)"
+  if [ -n "$apk" ]; then
+    assert_true "$P" reinstall-app reinstall "{\"udid\":\"$DEV\",\"bundleId\":\"$PKG\",\"appPath\":\"$apk\"}" '.reinstalled'
+  else
+    skip "$P" reinstall-app reinstall "no built apk under android/app/build/outputs/apk"
+  fi
+
+  # --- teardown -------------------------------------------------------------
+  assert_ok "$P" stop-metro stop "{}"
+}

--- a/scripts/e2e-full/phases/90-cleanup.sh
+++ b/scripts/e2e-full/phases/90-cleanup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Phase 90 — Cleanup. Best-effort teardown of everything the run spun up.
+# The sandbox dir itself is removed by run-e2e.sh (unless --keep).
+
+run_phase() {
+  local P=cleanup
+
+  # Stop any simulator-servers this run started (Android/iOS backends).
+  if [ -n "${ARGENT_TOOLS_URL:-}" ]; then
+    run_tool stop-all-simulator-servers '{}' >/dev/null 2>&1 && pass "$P" stop-all-simulator-servers teardown || skip "$P" stop-all-simulator-servers teardown "no server/none running"
+    run_tool stop-metro '{}' >/dev/null 2>&1 && pass "$P" stop-metro teardown || skip "$P" stop-metro teardown "no metro"
+  fi
+
+  # Kill any Electron we spawned (tracked by 40-chromium).
+  if [ -n "${E2E_ELECTRON_PID:-}" ] && kill -0 "$E2E_ELECTRON_PID" 2>/dev/null; then
+    kill "$E2E_ELECTRON_PID" 2>/dev/null || true
+    info "killed electron pid $E2E_ELECTRON_PID"
+  fi
+
+  # Kill the local http server backing the Electron fixture.
+  if [ -n "${E2E_HTTP_PID:-}" ] && kill -0 "$E2E_HTTP_PID" 2>/dev/null; then
+    kill "$E2E_HTTP_PID" 2>/dev/null || true
+  fi
+
+  # Stop Metro we started for the RN tier.
+  if [ -n "${E2E_METRO_PID:-}" ] && kill -0 "$E2E_METRO_PID" 2>/dev/null; then
+    kill "$E2E_METRO_PID" 2>/dev/null || true
+    info "killed metro pid $E2E_METRO_PID"
+  fi
+
+  # Stop our private tool-server.
+  argent_cli server stop >/dev/null 2>&1 && info "stopped private tool-server" || true
+
+  pass "$P" harness teardown-complete
+}

--- a/scripts/e2e-full/results/.gitignore
+++ b/scripts/e2e-full/results/.gitignore
@@ -1,0 +1,3 @@
+# Generated E2E run artifacts — never committed.
+*
+!.gitignore

--- a/scripts/e2e-full/run-e2e.sh
+++ b/scripts/e2e-full/run-e2e.sh
@@ -92,6 +92,19 @@ export E2E_TOOLS_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("12
 export HOME_REAL="$HOME"
 # Redirect argent state/config into the sandbox for the whole run.
 export HOME="$E2E_HOME"
+# Device state must stay visible through the sandbox HOME, or the android tier
+# false-fails on every gesture/screenshot: adb auth keys live in ~/.android, and
+# on macOS the emulator writes its gRPC discovery files (avd/running/pid_*.ini)
+# under ~/Library/Caches/TemporaryItems, which simulator-server resolves via
+# $HOME ("emulator not found among running emulators" otherwise). On Linux that
+# discovery uses XDG_RUNTIME_DIR, unaffected by the redirect. Both paths are
+# device state, not the argent/editor config this sandbox exists to isolate —
+# deliberately NOT ~/Library wholesale, which would expose real editor configs.
+[ -d "$HOME_REAL/.android" ] && ln -s "$HOME_REAL/.android" "$E2E_HOME/.android"
+if [ "$E2E_OS" = darwin ] && [ -d "$HOME_REAL/Library/Caches/TemporaryItems" ]; then
+  mkdir -p "$E2E_HOME/Library/Caches"
+  ln -s "$HOME_REAL/Library/Caches/TemporaryItems" "$E2E_HOME/Library/Caches/TemporaryItems"
+fi
 export PATH="$E2E_PREFIX/bin:$PATH"
 # Confine EVERY `npm install -g` (ours AND the ones `argent init/update` runs
 # internally) to the sandbox prefix — never the real system global.

--- a/scripts/e2e-full/run-e2e.sh
+++ b/scripts/e2e-full/run-e2e.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Full Argent E2E harness — top-level orchestrator.
+#
+# Starting from ONLY a `swmansion-argent-*.tgz`, this:
+#   0. installs from the tarball (global + local), runs init/uninstall/telemetry
+#   1. introspects the CLI (help, all 70 `tools describe`, flags, server, link)
+#   2. validates every tool's argument schema (missing/enum/type rejection)
+#   3. drives a happy-path of every applicable tool against real targets:
+#        - Android emulator      (Linux + Mac)
+#        - Chromium/Electron app (Linux + Mac)
+#        - React-Native debugger/profiler chain against Bluesky (Android)
+#
+# Everything runs under a sandbox HOME + npm prefix, so it never touches the
+# real machine's ~/.argent, MCP configs, or global packages. Results land in
+# scripts/e2e-full/results/ as a JSONL log + a markdown report; the process
+# exits non-zero if any hard assertion failed.
+#
+# Usage:
+#   run-e2e.sh [--tgz PATH] [--phase a,b,c] [--skip-install] [--system]
+#              [--android-serial S | --android-avd NAME] [--keep] [-h]
+#
+# Phases: install introspection validation android chromium rn
+#   (default: all that apply to this OS; iOS/tvOS/Vega are intentionally omitted)
+set -uo pipefail
+
+E2E_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$E2E_ROOT/../.." && pwd)"
+
+# --------------------------------------------------------------------------
+# Defaults / arg parsing
+# --------------------------------------------------------------------------
+TGZ=""
+PHASES=""
+SKIP_INSTALL=0
+SYSTEM_INSTALL=0
+KEEP=0
+export E2E_ANDROID_SERIAL="${E2E_ANDROID_SERIAL:-}"
+export E2E_ANDROID_AVD="${E2E_ANDROID_AVD:-}"
+
+usage() { sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tgz) TGZ="$2"; shift 2;;
+    --phase|--phases) PHASES="$2"; shift 2;;
+    --skip-install) SKIP_INSTALL=1; shift;;
+    --system) SYSTEM_INSTALL=1; shift;;
+    --android-serial) E2E_ANDROID_SERIAL="$2"; shift 2;;
+    --android-avd) E2E_ANDROID_AVD="$2"; shift 2;;
+    --keep) KEEP=1; shift;;
+    -h|--help) usage 0;;
+    *) echo "unknown arg: $1" >&2; usage 1;;
+  esac
+done
+
+# --------------------------------------------------------------------------
+# Locate the tgz (default: newest swmansion-argent-*.tgz at the repo root)
+# --------------------------------------------------------------------------
+if [ -z "$TGZ" ]; then
+  TGZ="$(ls -t "$REPO_ROOT"/swmansion-argent-*.tgz 2>/dev/null | head -1 || true)"
+fi
+if [ -z "$TGZ" ] || [ ! -f "$TGZ" ]; then
+  echo "No tgz found. Pass --tgz PATH or place swmansion-argent-*.tgz at $REPO_ROOT" >&2
+  exit 2
+fi
+TGZ="$(cd "$(dirname "$TGZ")" && pwd)/$(basename "$TGZ")"
+
+# --------------------------------------------------------------------------
+# Sandbox: private HOME, npm prefix, work dir. Nothing escapes here.
+# --------------------------------------------------------------------------
+export E2E_WORK="$(mktemp -d "${TMPDIR:-/tmp}/argent-e2e.XXXXXX")"
+export E2E_HOME="$E2E_WORK/home"
+export E2E_PREFIX="$E2E_WORK/prefix"
+export E2E_UNPACKED="$E2E_WORK/unpacked/package"
+mkdir -p "$E2E_HOME" "$E2E_PREFIX" "$E2E_WORK/unpacked" "$E2E_WORK/ws"
+export E2E_TGZ="$TGZ"
+export E2E_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+
+# Results
+RESULTS_DIR="$E2E_ROOT/results"
+mkdir -p "$RESULTS_DIR"
+TS="$(date +%Y%m%d-%H%M%S)"
+export E2E_JSONL="$RESULTS_DIR/e2e-$TS.jsonl"
+REPORT_MD="$RESULTS_DIR/report-$TS.md"
+: > "$E2E_JSONL"
+
+# Free port for our private tool-server
+export E2E_TOOLS_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+
+# Remember the real HOME (the RN tier looks for ~/dev/bluesky there) before we
+# repoint HOME at the sandbox.
+export HOME_REAL="$HOME"
+# Redirect argent state/config into the sandbox for the whole run.
+export HOME="$E2E_HOME"
+export PATH="$E2E_PREFIX/bin:$PATH"
+# Confine EVERY `npm install -g` (ours AND the ones `argent init/update` runs
+# internally) to the sandbox prefix — never the real system global.
+if [ "$SYSTEM_INSTALL" -eq 0 ]; then export npm_config_prefix="$E2E_PREFIX"; fi
+# Keep telemetry silent/off, and force non-interactive so @clack/prompts in
+# `argent init` never blocks on a spinner/TTY probe.
+export DO_NOT_TRACK=1
+export CI=1
+
+source "$E2E_ROOT/lib/common.sh"
+source "$E2E_ROOT/lib/discover-tools.sh"
+
+# --------------------------------------------------------------------------
+# Unpack the tarball (used for file-level install assertions + skip-install)
+# --------------------------------------------------------------------------
+tar xzf "$E2E_TGZ" -C "$E2E_WORK/unpacked"
+TGZ_VERSION="$(jq -r .version "$E2E_UNPACKED/package.json")"
+export TGZ_VERSION
+
+# --------------------------------------------------------------------------
+# Decide the default phase set for this OS if not specified.
+# --------------------------------------------------------------------------
+if [ -z "$PHASES" ]; then
+  case "$E2E_OS" in
+    linux)  PHASES="install,introspection,validation,android,chromium,rn";;
+    darwin) PHASES="install,introspection,validation,android,chromium,rn";;
+    *)      PHASES="install,introspection,validation";;
+  esac
+fi
+selected() { case ",$PHASES," in *",$1,"*) return 0;; *) return 1;; esac; }
+
+# --------------------------------------------------------------------------
+# Establish the argent CLI we drive with.
+#   default: real sandbox global install (also what phase 0 asserts)
+#   --skip-install: run the unpacked bundle directly (fast, offline phases only)
+# --------------------------------------------------------------------------
+if [ "$SKIP_INSTALL" -eq 1 ]; then
+  export ARGENT_BIN="node $E2E_UNPACKED/dist/cli.js"
+  read -ra ARGENT_CMD <<< "$ARGENT_BIN"
+  warn "skip-install: driving unpacked bundle; phase 'install' will be skipped"
+else
+  group "Sandbox install: npm i -g $(basename "$E2E_TGZ") --prefix \$E2E_PREFIX"
+  # Install optional deps (electron) only if a tier needs them; they add a slow
+  # network download and are irrelevant to the offline phases.
+  OMIT="--omit=optional"
+  if selected chromium || selected rn; then OMIT=""; fi
+  if [ "$SYSTEM_INSTALL" -eq 1 ]; then
+    warn "--system: installing to the REAL global prefix (release-machine mode)"
+    npm install -g "$E2E_TGZ" $OMIT 2>&1 | tail -20 >&2 || true
+    export ARGENT_BIN="$(command -v argent || echo "$E2E_PREFIX/bin/argent")"
+  else
+    npm install -g "$E2E_TGZ" --prefix "$E2E_PREFIX" $OMIT 2>&1 | tail -20 >&2 || true
+    export ARGENT_BIN="$E2E_PREFIX/bin/argent"
+  fi
+  read -ra ARGENT_CMD <<< "$ARGENT_BIN"
+  if [ ! -x "${ARGENT_CMD[0]}" ] && [ "${ARGENT_CMD[0]}" != "node" ]; then
+    err "argent binary not found at $ARGENT_BIN after install"
+    exit 3
+  fi
+fi
+log "Driving with: $ARGENT_BIN  (v${TGZ_VERSION})"
+log "Sandbox: $E2E_WORK"
+log "Results: $E2E_JSONL"
+
+# --------------------------------------------------------------------------
+# Run phases. Each phase file defines run_phase() and is executed in-process
+# so counters + env accumulate.
+# --------------------------------------------------------------------------
+run_one() { # phase-name file
+  local name="$1" file="$2"
+  group "PHASE: $name"
+  if [ ! -f "$file" ]; then warn "missing $file"; return; fi
+  # shellcheck disable=SC1090
+  source "$file"
+  run_phase || warn "phase $name returned non-zero (continuing)"
+}
+
+if [ "$SKIP_INSTALL" -eq 0 ] && selected install;      then run_one install       "$E2E_ROOT/phases/00-install.sh"; fi
+if selected introspection; then run_one introspection "$E2E_ROOT/phases/10-introspection.sh"; fi
+if selected validation;    then run_one validation    "$E2E_ROOT/phases/20-validation.sh"; fi
+if selected android;       then run_one android       "$E2E_ROOT/phases/30-android.sh"; fi
+if selected chromium;      then run_one chromium      "$E2E_ROOT/phases/40-chromium.sh"; fi
+if selected rn;            then run_one rn            "$E2E_ROOT/phases/50-rn-bluesky.sh"; fi
+
+run_one cleanup "$E2E_ROOT/phases/90-cleanup.sh"
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+group "Generating report"
+E2E_JSONL="$E2E_JSONL" TGZ_VERSION="$TGZ_VERSION" E2E_OS="$E2E_OS" ARGENT_BIN="$ARGENT_BIN" \
+  python3 "$E2E_ROOT/lib/report.py" "$E2E_JSONL" > "$REPORT_MD" || warn "report generation failed"
+cat "$REPORT_MD" >&2 || true
+
+TOTAL_FAIL=$(jq -s '[.[]|select(.status=="fail")]|length' "$E2E_JSONL")
+TOTAL_PASS=$(jq -s '[.[]|select(.status=="pass")]|length' "$E2E_JSONL")
+TOTAL_SKIP=$(jq -s '[.[]|select(.status=="skip")]|length' "$E2E_JSONL")
+
+if [ "$KEEP" -eq 1 ]; then
+  warn "--keep: leaving sandbox at $E2E_WORK"
+else
+  rm -rf "$E2E_WORK"
+fi
+
+group "DONE — pass:$TOTAL_PASS fail:$TOTAL_FAIL skip:$TOTAL_SKIP"
+echo "report: $REPORT_MD" >&2
+[ "$TOTAL_FAIL" -eq 0 ]


### PR DESCRIPTION
Now verified end-to-end on the real Mac: install/introspection/validation, the android tier (against a booted emulator), and the chromium tier all pass from a locally packed tgz; the rn tier auto-skips without `~/dev/bluesky` as designed.

## What this is

A release-gating end-to-end harness under `scripts/e2e-full/` that starts from **only a `swmansion-argent-*.tgz` bundle** and exercises the whole product: the install flow, every CLI command, all 70 tools' argument validation, and a happy-path run of every tool against real devices. Intended to be run on the real Linux box and the real Mac before a release.

Everything runs under a throwaway `HOME` + npm prefix, so it never touches the machine's real `~/.argent`, editor MCP configs, or global packages (safe on a shared box). It emits a JSONL log + a markdown coverage report and exits non-zero if any hard assertion fails.

## Phases

| phase | needs | covers |
|---|---|---|
| `install` | npm + network | `npm i -g <tgz>`, bundled binaries, `init` (global + `--local`), `update`, `uninstall`, telemetry, MCP-config generation |
| `introspection` | — | `--version/--help`, `tools describe` for **all 70** tools, feature flags, `server start/status/logs/stop`, `link/unlink` |
| `validation` | — | per tool: missing-required / bad-enum / bad-type rejection (schema-driven, no hardware) |
| `android` | Android emulator | happy-path of every touch/gesture/screenshot/app-lifecycle tool |
| `chromium` | Electron (bundled optional dep) + a display | boots a generated Electron app; drives CDP tools (scroll/drag/tabs/cookies/storage) |
| `rn` | `~/dev/bluesky` + Android device | debugger + react/native profiler + network chain against the real Bluesky app |

Tiers auto-skip with a recorded reason when prerequisites are missing. iOS / tvOS / Vega are intentionally out of scope for now.

## What I actually verified (real runs, Linux)

- **install** 18✓/0✗, **introspection** 85✓/0✗ (all 70 `tools describe`), **validation** 81✓/0✗, **chromium** 24✓/0✗ (real Electron app + CDP).
- Holistic run: **190✓ / 0✗ / 34∼, exit 0.** Failure-gate confirmed (non-zero on fail), `bash -n` clean on all files, all 72 android/rn JSON arg literals linted.

## What I did NOT verify live (please scrutinize)

- **`android` and `rn` tiers were never run against a live device.** The Android emulator would not stay up on my box (memory-constrained shared machine; QEMU threads hung seconds after boot across ~7 attempts). The code is complete and uses the same machinery the `chromium` tier exercised live, but it has **not** been proven end-to-end. This is the main reason for the "not certain how well it works" caveat.
- The RN tier's exact debugger/profiler arg shapes are derived from `tools describe`, not confirmed against a running Metro.

## Run it

```bash
bash scripts/e2e-full/run-e2e.sh                                   # everything applicable to this OS
bash scripts/e2e-full/run-e2e.sh --skip-install --phase introspection,validation   # fast offline core
bash scripts/e2e-full/run-e2e.sh --phase android --android-serial emulator-5554     # inject a device
```

