### PR TITLE
fix(ci): mark dtrace-provider external so the npm prerelease bundle builds

### DIFF
--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -536,6 +536,17 @@ fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
 // are declared in @swmansion/argent's dependencies so npm installs them
 // alongside the package; keep them external so the bundle resolves them from
 // node_modules/ at runtime.
+//
+// `dtrace-provider` MUST stay external. It is an OPTIONAL dependency of bunyan
+// (the tool-server event-log logger). bunyan loads it defensively as
+// `require('dtrace-provider' + '')` wrapped in try/catch — the `+ ''` is a
+// deliberate trick to hide the module from bundlers, and a failed require just
+// disables the (unused) DTrace USDT probes. esbuild constant-folds that string
+// back to a literal, defeating the trick, and then chokes on dtrace-provider's
+// own dynamic native binding require (`require('./src/build/'+build+'/…')`).
+// Keeping it external restores bunyan's intent: the published package never
+// declares dtrace-provider, so the runtime require misses and bunyan's
+// try/catch nulls it out — no DTrace probes, no functional impact.
 buildBundle({
   entry: TOOLS_ENTRY,
   out: OUT_FILE,
@@ -547,6 +558,7 @@ buildBundle({
     "electron",
     "@fails-components/webtransport",
     "@fails-components/webtransport-transport-http3-quiche",
+    "dtrace-provider",
   ],
 });
 


### PR DESCRIPTION
## Why

The **Publish prerelease to npm (next)** job has been red on `main` on *every* push since #367 (2+ days). It was not caused by any recent commit — it broke the moment the tool-server event log took on `bunyan`.

```
✘ [ERROR] Could not resolve require("./src/build/**/*/DTraceProviderBindings")
  node_modules/dtrace-provider/dtrace-provider.js:18:30
npm error command sh -c node scripts/bundle-tools.cjs   (build:bundles)
```

## Root cause

- `dtrace-provider` is an **optional** dependency of `bunyan`. It provides **DTrace USDT probes** — macOS/BSD kernel tracing we never fire.
- bunyan loads it defensively: `require('dtrace-provider' + '')` inside a `try/catch` (`bunyan.js:79`). The `+ ''` is a deliberate trick to hide the module from bundlers; a failed require just sets `dtrace = null` and bunyan works fine.
- **esbuild constant-folds `'dtrace-provider' + ''` back to a literal**, defeating the trick, pulls dtrace-provider into the graph, and then can't resolve *its* dynamic native-binding require (`require('./src/build/'+build+'/DTraceProviderBindings')`) → `build:bundles` aborts.
- **Bumping bunyan does not help:** `1.8.15` is the latest (last publish 2025-06-28) and effectively frozen; dtrace-provider remains an optionalDependency and there is no bunyan 2.x.

## Fix

Mark `dtrace-provider` **external** in the tool-server bundle — exactly how `tree-sitter` / `electron` / `@fails-components/webtransport` native deps are already handled. The published `@swmansion/argent` never declares bunyan/dtrace-provider, so the runtime `require("dtrace-provider")` misses and bunyan's `try/catch` nulls it out. **No DTrace probes were ever used → zero functional impact.**

Verified: `build:bundles` now succeeds; the built `dist/tool-server.cjs` contains an external `require("dtrace-provider")` and no `DTraceProviderBindings`.

## Note on scope

This branch originally also de-flaked the Android `await-ui-element` unit tests (real `adb` I/O via `isAndroidTv` per poll overrunning a tight `timeoutMs`). That was fixed independently on `main` by #429 (which mocks both `isAndroidTv` and `isTvOsSimulator`), so after rebasing this PR carries **only** the bundle fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)