### PR TITLE
feat(flow): multi-tap via tap times and gesture-tap clickCount

### DIFF
--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -23,7 +23,7 @@ Beyond raw `tool:` steps and `echo:`, flows support declarative directives inter
 | Directive    | YAML                                                                                                     | Meaning                                                                 |
 | ------------ | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `launch`     | `- launch: com.acme.app` or `- launch: { ios: …, android: … }`                                           | start the app from scratch (terminate + relaunch) and wait until ready  |
-| `tap`        | `- tap: Login` or `- tap: { x: 0.5, y: 0.57 }`                                                           | tap an element by selector (auto-waits), or a raw normalized point      |
+| `tap`        | `- tap: Login`, `- tap: { x: 0.5, y: 0.57 }`, `- tap: { on: Login, times: 2 }`                           | tap by selector (auto-waits) or raw point; `times: 2` = double-tap      |
 | `long-press` | `- long-press: Row 3` or `- long-press: { on: <sel>, duration: 1200 }`                                   | press and hold an element (default 800ms; Chromium: mouse press-hold)   |
 | `type`       | `- type: { into: email, text: "a@b.com" }`                                                               | focus a field, type, then press Enter to submit + dismiss the keyboard  |
 | `scroll-to`  | `- scroll-to: "Order #1234"` (scrolls down) or `- scroll-to: { target: …, direction: right, within: … }` | momentum-free scroll until the target is visible                        |

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -577,11 +577,14 @@ export async function runDirective(env: ActionEnv, step: DirectiveStep): Promise
 /**
  * Tap either an element (resolve a selector → frame, auto-waiting) or a raw
  * normalized point. Coordinate taps are the fallback for elements with no
- * stable selector (e.g. an unlabeled view).
+ * stable selector (e.g. an unlabeled view). `times` rides the gesture-tap
+ * tool's `clickCount`: one resolution, one dispatched multi-tap gesture —
+ * never N separate calls, whose RPC gaps could fall outside the OS
+ * double-tap window.
  */
 async function runTap(
   env: ActionEnv,
-  target: { selector?: FlowSelector; x?: number; y?: number }
+  target: { selector?: FlowSelector; x?: number; y?: number; times?: number }
 ): Promise<DirectiveOutcome> {
   let point: { x: number; y: number };
   if (target.selector) {
@@ -596,7 +599,10 @@ async function runTap(
   } else {
     return { ok: false, reason: "tap needs a selector or x/y coordinates" };
   }
-  await invokeOnDevice(env, "gesture-tap", point);
+  await invokeOnDevice(env, "gesture-tap", {
+    ...point,
+    ...(target.times !== undefined ? { clickCount: target.times } : {}),
+  });
   return { ok: true };
 }
 

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -222,15 +222,24 @@ If a step was recorded by mistake, edit the .yaml file directly to remove it.`,
         typeof strippedArgs.bundleId === "string" &&
         Object.keys(strippedArgs).length === 1;
 
+      // A multi-tap (`clickCount: 2` = double-tap) must survive the rewrite as
+      // `times`, or replay would silently fire a single tap for a recorded
+      // double. Bounds match the tool's clickCount; 1 is the default (absent).
+      const cc = args.clickCount;
+      const tapTimes =
+        isTap && typeof cc === "number" && Number.isInteger(cc) && cc >= 2 && cc <= 10
+          ? { times: cc }
+          : {};
+
       let step: FlowStep;
       let warning: string | undefined;
       if (captured?.selector) {
-        step = { kind: "tap", selector: captured.selector };
+        step = { kind: "tap", selector: captured.selector, ...tapTimes };
         warning = captured.warning;
       } else if (isTap) {
         // No stable selector — keep a coordinate tap, but still as a `tap:`
         // directive so every tap reads uniformly.
-        step = { kind: "tap", x: args.x as number, y: args.y as number };
+        step = { kind: "tap", x: args.x as number, y: args.y as number, ...tapTimes };
         warning = captured?.warning;
       } else if (isLaunch) {
         step = { kind: "launch", app: strippedArgs.bundleId as string };

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -230,7 +230,7 @@ export type FlowStep =
   | { kind: "echo"; message: string }
   | { kind: "launch"; app: Launch }
   | { kind: "run"; flow: string }
-  | { kind: "tap"; selector?: FlowSelector; x?: number; y?: number }
+  | { kind: "tap"; selector?: FlowSelector; x?: number; y?: number; times?: number }
   | { kind: "long-press"; selector: FlowSelector; duration?: number }
   | { kind: "type"; into: FlowSelector; text: string; submit?: boolean }
   | {
@@ -312,8 +312,17 @@ export function chromiumLaunchSpec(
  */
 type YamlSelector = string | (Omit<Selector, "identifier"> & { id?: string });
 
-/** A tap targets an element (selector, possibly a bare string) or a raw point. */
-type TapBody = YamlSelector | { x: number; y: number };
+/**
+ * A tap targets an element (selector, possibly a bare string) or a raw point.
+ * The options form nests the selector under `on` so option keys never mix
+ * with selector fields: `{ on: <selector>, times: 2 }` is a double-tap
+ * (`on` carries the usual bare-string-loose / map-strict sugar). A coordinate
+ * body takes `times` directly — it is already an options-shaped map.
+ */
+type TapBody =
+  | YamlSelector
+  | { x: number; y: number; times?: number }
+  | { on: YamlSelector; times?: number };
 
 /**
  * The condition of an `await`/`assert` step. The condition is the key, not a
@@ -439,9 +448,15 @@ function toYamlStep(step: FlowStep): YamlStep {
     case "run":
       return { run: step.flow };
     case "tap": {
-      const body: TapBody = step.selector
-        ? selectorToYaml(step.selector)
-        : { x: step.x!, y: step.y! };
+      // Canonical minimal spelling: the options form appears only when an
+      // option is present (`times` is never stored as 1 — see parseTapTimes),
+      // so a plain tap always round-trips to the plain selector/point body.
+      if (step.selector) {
+        const sel = selectorToYaml(step.selector);
+        return { tap: step.times !== undefined ? { on: sel, times: step.times } : sel };
+      }
+      const body: { x: number; y: number; times?: number } = { x: step.x!, y: step.y! };
+      if (step.times !== undefined) body.times = step.times;
       return { tap: body };
     }
     case "long-press": {
@@ -850,6 +865,86 @@ function parseLongPress(body: unknown, entry: unknown): FlowStep {
   return { kind: "long-press", selector: parseSelector(body, "long-press") };
 }
 
+/**
+ * Parse `times` on a tap body: an integer tap count dispatched as ONE
+ * multi-tap gesture (2 = double-tap; the OS may recognize it as such — N
+ * *independent* taps are N tap steps). `times: 1` is the default and
+ * normalizes to absent, keeping parse/serialize exact inverses. The cap
+ * matches the gesture-tap tool's clickCount bound.
+ */
+function parseTapTimes(raw: unknown, entry: unknown): number | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1 || raw > 10) {
+    badEntry(entry, "tap.times must be an integer between 1 and 10 (2 = double-tap)");
+  }
+  return raw === 1 ? undefined : raw;
+}
+
+/**
+ * Parse a `tap` body — one of three forms:
+ * - a selector (bare string = loose, map = strict),
+ * - a raw point `{ x, y, times? }`,
+ * - the options form `{ on: <selector>, times? }`, which nests the selector
+ *   under `on` so an option key can never be mistaken for — or silently
+ *   stripped from — a selector field.
+ */
+function parseTap(body: unknown, entry: unknown): FlowStep {
+  const obj = body !== null && typeof body === "object" ? (body as Record<string, unknown>) : {};
+
+  // A tap targets either an element (selector) or a raw point (x/y) — a body
+  // mixing both is ambiguous (which wins?) and rejected rather than silently
+  // resolved one way.
+  if (obj.x !== undefined || obj.y !== undefined) {
+    if (
+      obj.on !== undefined ||
+      obj.text !== undefined ||
+      obj.id !== undefined ||
+      obj.identifier !== undefined ||
+      obj.role !== undefined
+    ) {
+      badEntry(entry, "tap takes a selector or x/y coordinates, not both");
+    }
+    if (typeof obj.x !== "number" || typeof obj.y !== "number") {
+      badEntry(entry, "a coordinate tap needs numeric x and y");
+    }
+    // A stray key would be silently dropped otherwise — a misspelled option
+    // must fail loudly, like everywhere else in the parser.
+    if (!Object.keys(obj).every((k) => k === "x" || k === "y" || k === "times")) {
+      badEntry(entry, "a coordinate tap takes only { x, y, times }");
+    }
+    const step: FlowStep = { kind: "tap", x: obj.x, y: obj.y };
+    const times = parseTapTimes(obj.times, entry);
+    if (times !== undefined) step.times = times;
+    return step;
+  }
+
+  if (obj.on !== undefined || obj.times !== undefined) {
+    if (
+      obj.text !== undefined ||
+      obj.id !== undefined ||
+      obj.identifier !== undefined ||
+      obj.role !== undefined
+    ) {
+      badEntry(
+        entry,
+        'the tap options form takes a nested selector — e.g. tap: { on: { text: "Photo" }, times: 2 }'
+      );
+    }
+    if (!Object.keys(obj).every((k) => k === "on" || k === "times")) {
+      badEntry(entry, "the tap options form accepts only { on, times }");
+    }
+    if (obj.on === undefined) {
+      badEntry(entry, 'tap with times needs a target — e.g. tap: { on: "Photo", times: 2 }');
+    }
+    const step: FlowStep = { kind: "tap", selector: parseSelector(obj.on, "tap.on") };
+    const times = parseTapTimes(obj.times, entry);
+    if (times !== undefined) step.times = times;
+    return step;
+  }
+
+  return { kind: "tap", selector: parseSelector(body, "tap") };
+}
+
 function fromYamlStep(raw: YamlStep): FlowStep {
   const entry = raw as Record<string, unknown>;
   const kinds = STEP_DIRECTIVE_KEYS.filter((k) => k in entry);
@@ -885,33 +980,7 @@ function fromYamlStep(raw: YamlStep): FlowStep {
   if ("launch" in raw) return { kind: "launch", app: parseLaunch(raw.launch) };
   if ("run" in raw) return { kind: "run", flow: String(raw.run) };
 
-  if ("tap" in raw) {
-    const body = (raw as { tap: unknown }).tap;
-    const obj = body !== null && typeof body === "object" ? (body as Record<string, unknown>) : {};
-    // A misspelled selector field or coordinate would silently fall through
-    // (a stripped key, or a selector parse where a point was meant).
-    if (body !== null && typeof body === "object" && !Array.isArray(body)) {
-      rejectUnknownKeys(raw, obj, [...SELECTOR_KEYS, "x", "y"], "tap");
-    }
-    // A tap targets either an element (selector) or a raw point (x/y) — a body
-    // mixing both is ambiguous (which wins?) and rejected rather than silently
-    // resolved one way.
-    if (obj.x !== undefined || obj.y !== undefined) {
-      if (
-        obj.text !== undefined ||
-        obj.id !== undefined ||
-        obj.identifier !== undefined ||
-        obj.role !== undefined
-      ) {
-        badEntry(raw, "tap takes a selector or x/y coordinates, not both");
-      }
-      if (typeof obj.x !== "number" || typeof obj.y !== "number") {
-        badEntry(raw, "a coordinate tap needs numeric x and y");
-      }
-      return { kind: "tap", x: obj.x, y: obj.y };
-    }
-    return { kind: "tap", selector: parseSelector(body, "tap") };
-  }
+  if ("tap" in raw) return parseTap((raw as { tap: unknown }).tap, raw);
 
   if ("long-press" in raw) {
     return parseLongPress((raw as { "long-press": unknown })["long-press"], raw);

--- a/packages/tool-server/src/tools/gesture-tap/index.ts
+++ b/packages/tool-server/src/tools/gesture-tap/index.ts
@@ -13,6 +13,17 @@ const zodSchema = z.object({
     .describe("Target device id from `list-devices` (iOS UDID, Android serial, or Chromium id)."),
   x: z.number().describe("Normalized horizontal position 0.0–1.0 (left=0, right=1), not pixels"),
   y: z.number().describe("Normalized vertical position 0.0–1.0 (top=0, bottom=1), not pixels"),
+  clickCount: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .optional()
+    .describe(
+      "Number of taps/clicks dispatched as ONE multi-tap gesture (2 = double-tap / double-click). " +
+        "The taps land inside the OS double-tap window; on Chromium each click carries an escalating " +
+        "CDP clickCount so dblclick actually fires. Default 1."
+    ),
 });
 
 type Params = z.infer<typeof zodSchema>;
@@ -29,20 +40,37 @@ const capability: ToolCapability = {
   chromium: { app: true },
 };
 
-async function tapChromium(api: ChromiumCdpApi, x: number, y: number): Promise<void> {
+// One press-release is 50ms; taps in a multi-tap gesture are 100ms apart —
+// comfortably inside the OS double-tap window (~300ms on both platforms and
+// in Chromium's click counter), which separate tool calls could not guarantee.
+const TAP_HOLD_MS = 50;
+const MULTI_TAP_GAP_MS = 100;
+
+async function tapChromium(
+  api: ChromiumCdpApi,
+  x: number,
+  y: number,
+  clickCount: number
+): Promise<void> {
   const vp = api.getViewport();
   const pxX = Math.max(0, Math.min(vp.width, x * vp.width));
   const pxY = Math.max(0, Math.min(vp.height, y * vp.height));
   await api.dispatchMouseEvent({ type: "mouseMoved", x: pxX, y: pxY });
-  await api.dispatchMouseEvent({ type: "mousePressed", x: pxX, y: pxY, clickCount: 1 });
-  await sleep(50);
-  await api.dispatchMouseEvent({ type: "mouseReleased", x: pxX, y: pxY, clickCount: 1 });
+  // The browser's click counter drives dblclick: each press carries the
+  // running count (1, then 2, …), the way a real mouse reports it.
+  for (let i = 1; i <= clickCount; i++) {
+    if (i > 1) await sleep(MULTI_TAP_GAP_MS);
+    await api.dispatchMouseEvent({ type: "mousePressed", x: pxX, y: pxY, clickCount: i });
+    await sleep(TAP_HOLD_MS);
+    await api.dispatchMouseEvent({ type: "mouseReleased", x: pxX, y: pxY, clickCount: i });
+  }
 }
 
 export const gestureTapTool: ToolDefinition<Params, Result> = {
   id: "gesture-tap",
   description: `Press the device screen (iOS simulator, Android emulator, or Chromium app) at normalized coordinates: x and y are fractions of screen width and height in 0.0–1.0 (not pixels).
 Sends a Down event followed by an Up event at the same point. For Chromium, this dispatches a CDP mouse-press/release on the renderer.
+Set clickCount: 2 for a double-tap / double-click — the taps are dispatched as one gesture with proper click counting, which two separate tap calls cannot guarantee.
 Use when you need to tap a button, link, or any tappable element on the screen.
 Returns { tapped: true, timestampMs }. Fails if the simulator-server / emulator backend / Chromium CDP is not reachable for the given device.
 Before tapping, determine the correct coordinates by using discovery tools — pick by platform: iOS / Android use \`describe\`, \`native-describe-screen\`, or \`debugger-component-tree\`; Chromium uses \`describe\` (the DOM walker), since the native and RN-specific discovery tools don't apply. More information in \`argent-device-interact\` skill`,
@@ -60,29 +88,33 @@ Before tapping, determine the correct coordinates by using discovery tools — p
   async execute(services, params) {
     const device = resolveDevice(params.udid);
     const timestampMs = Date.now();
+    const clickCount = params.clickCount ?? 1;
     if (device.platform === "chromium") {
       const chromium = services.chromium as ChromiumCdpApi;
-      await tapChromium(chromium, params.x, params.y);
+      await tapChromium(chromium, params.x, params.y, clickCount);
       return { tapped: true, timestampMs };
     }
     const api = services.simulatorServer as SimulatorServerApi;
-    sendCommand(api, {
-      cmd: "touch",
-      type: "Down",
-      x: params.x,
-      y: params.y,
-      second_x: null,
-      second_y: null,
-    });
-    await sleep(50);
-    sendCommand(api, {
-      cmd: "touch",
-      type: "Up",
-      x: params.x,
-      y: params.y,
-      second_x: null,
-      second_y: null,
-    });
+    for (let i = 1; i <= clickCount; i++) {
+      if (i > 1) await sleep(MULTI_TAP_GAP_MS);
+      sendCommand(api, {
+        cmd: "touch",
+        type: "Down",
+        x: params.x,
+        y: params.y,
+        second_x: null,
+        second_y: null,
+      });
+      await sleep(TAP_HOLD_MS);
+      sendCommand(api, {
+        cmd: "touch",
+        type: "Up",
+        x: params.x,
+        y: params.y,
+        second_x: null,
+        second_y: null,
+      });
+    }
     return { tapped: true, timestampMs };
   },
 };

--- a/packages/tool-server/src/tools/run-sequence/index.ts
+++ b/packages/tool-server/src/tools/run-sequence/index.ts
@@ -96,7 +96,7 @@ a prior tap), use individual tool calls instead.
 
 Allowed tools and their args (udid is auto-injected, do NOT include it in args):
 
-  gesture-tap:    { x: number, y: number }                                                                              [ios/android/chromium]
+  gesture-tap:    { x: number, y: number, clickCount?: number }                                                        [ios/android/chromium]
   gesture-swipe:  { fromX: number, fromY: number, toX: number, toY: number, durationMs?: number }                       [ios/android]
   gesture-scroll: { x: number, y: number, deltaX?: number, deltaY?: number, durationMs?: number }                       [chromium only]
   gesture-drag:   { fromX: number, fromY: number, toX: number, toY: number, durationMs?: number }                       [chromium only]

--- a/packages/tool-server/test/flows/flow-record-tap.test.ts
+++ b/packages/tool-server/test/flows/flow-record-tap.test.ts
@@ -120,6 +120,22 @@ describe("flow-add-step tap selector capture", () => {
     expect(await recordedSteps()).toEqual([{ kind: "tap", selector: { text: "Volume" } }]);
   });
 
+  it("carries a recorded clickCount into the tap step's times", async () => {
+    // A recorded double-tap must not silently replay as a single tap.
+    setTree([n({ label: "Photo", frame: { x: 0.3, y: 0.5, width: 0.4, height: 0.06 } })]);
+
+    const tool = createFlowAddStepTool(mockRegistry());
+    await tool.execute(
+      {},
+      {
+        command: "gesture-tap",
+        args: JSON.stringify({ udid: DEVICE, x: 0.5, y: 0.52, clickCount: 2 }),
+      }
+    );
+
+    expect(await recordedSteps()).toEqual([{ kind: "tap", selector: { text: "Photo" }, times: 2 }]);
+  });
+
   it("keeps coordinates when the selector would retarget to another element", async () => {
     // Two "Add" labels: replay's selectorToFrame ranking (exact → smallest
     // frame) elects the smaller node at the top, not the tapped one — so the

--- a/packages/tool-server/test/flows/flow-tap.test.ts
+++ b/packages/tool-server/test/flows/flow-tap.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
+
+// Serve the flow tree directly: flows resolve selectors against the platform's
+// full-hierarchy source and hard-fail rather than degrade to the AX tree, so
+// these unit tests stub the tree fetch itself.
+let currentTree: () => DescribeNode;
+vi.mock("../../src/tools/flows/flow-tree", () => ({
+  fetchFlowTree: vi.fn(
+    async (): Promise<DescribeTreeData> => ({
+      tree: currentTree(),
+      source: "native-devtools",
+    })
+  ),
+}));
+
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+import { serializeFlow, parseFlow } from "../../src/tools/flows/flow-utils";
+
+const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
+let tmpDir: string;
+
+function n(partial: Partial<DescribeNode> & { frame: DescribeNode["frame"] }): DescribeNode {
+  return { role: "AXOther", children: [], ...partial };
+}
+
+function screen(children: DescribeNode[]): DescribeNode {
+  return n({ role: "AXWindow", frame: { x: 0, y: 0, width: 1, height: 1 }, children });
+}
+
+/** Registry that records every gesture tool invocation's args. */
+function mockRegistry(calls: Array<{ tool: string; args: Record<string, unknown> }>): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string, args: Record<string, unknown>) => {
+      if (id === "list-devices") return { devices: [] };
+      calls.push({ tool: id, args });
+      return { ok: true };
+    }),
+    getTool: vi.fn(() => ({ inputSchema: { properties: { udid: {} } } })),
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: Parameters<typeof serializeFlow>[0]): Promise<void> {
+  const dir = path.join(tmpDir, ".argent", "flows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.yaml`), serializeFlow(yaml), "utf8");
+}
+
+function asRun(r: FlowRunResult | { notice: string }): FlowRunResult {
+  if (!("steps" in r)) throw new Error(`expected a run result, got notice: ${r.notice}`);
+  return r;
+}
+
+async function run(
+  name: string
+): Promise<FlowRunResult & { calls: Array<{ tool: string; args: Record<string, unknown> }> }> {
+  const calls: Array<{ tool: string; args: Record<string, unknown> }> = [];
+  const tool = createRunFlowTool(mockRegistry(calls));
+  const result = asRun(await tool.execute({}, { name, project_root: tmpDir, device: DEVICE }));
+  return Object.assign(result, { calls });
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-gestures-"));
+  currentTree = () => screen([]);
+});
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("tap times: parse/serialize", () => {
+  it("round-trips the options form and the coordinate form", () => {
+    const flow = {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "tap" as const, selector: { text: "Photo", loose: true }, times: 2 },
+        { kind: "tap" as const, selector: { identifier: "map" }, times: 3 },
+        { kind: "tap" as const, x: 0.5, y: 0.5, times: 2 },
+        { kind: "tap" as const, selector: { text: "Plain", loose: true } },
+      ],
+    };
+    expect(parseFlow(serializeFlow(flow)).steps).toEqual(flow.steps);
+  });
+
+  it("serializes the canonical minimal spelling", () => {
+    const yaml = serializeFlow({
+      executionPrerequisite: "",
+      steps: [
+        { kind: "tap", selector: { text: "Photo", loose: true }, times: 2 },
+        { kind: "tap", selector: { text: "Plain", loose: true } },
+      ],
+    });
+    // Options form only when an option is present; plain taps stay bare.
+    expect(yaml).toContain("on: Photo");
+    expect(yaml).toContain("times: 2");
+    expect(yaml).toContain("- tap: Plain");
+  });
+
+  it("parses `on` with the usual selector sugar; a bare on-form canonicalizes away", () => {
+    const steps = parseFlow(
+      "steps:\n" +
+        '  - tap: { on: "Photo", times: 2 }\n' + // bare inside on = loose
+        "  - tap: { on: { text: Photo }, times: 2 }\n" + // map inside on = strict
+        '  - tap: { on: "Photo" }\n' // no options — plain loose tap
+    ).steps;
+    expect(steps).toEqual([
+      { kind: "tap", selector: { text: "Photo", loose: true }, times: 2 },
+      { kind: "tap", selector: { text: "Photo" }, times: 2 },
+      { kind: "tap", selector: { text: "Photo", loose: true } },
+    ]);
+  });
+
+  it("normalizes times: 1 to absent (round-trip stays inverse)", () => {
+    const steps = parseFlow('steps:\n  - tap: { on: "Photo", times: 1 }\n').steps;
+    expect(steps).toEqual([{ kind: "tap", selector: { text: "Photo", loose: true } }]);
+    expect(serializeFlow({ executionPrerequisite: "", steps })).toContain("- tap: Photo");
+  });
+
+  it("rejects selector fields alongside times with the nested-selector hint", () => {
+    // zod would silently STRIP times from a selector map — this must be loud.
+    expect(() => parseFlow('steps:\n  - tap: { text: "Test", times: 2 }\n')).toThrow(
+      /options form takes a nested selector/i
+    );
+  });
+
+  it("rejects malformed options forms", () => {
+    expect(() => parseFlow("steps:\n  - tap: { times: 2 }\n")).toThrow(/needs a target/i);
+    expect(() => parseFlow("steps:\n  - tap: { on: A, foo: 1 }\n")).toThrow(
+      /accepts only \{ on, times \}/i
+    );
+    expect(() => parseFlow("steps:\n  - tap: { on: A, x: 0.5, y: 0.5 }\n")).toThrow(
+      /selector or x\/y coordinates, not both/i
+    );
+  });
+
+  it("validates the times value on both forms", () => {
+    for (const bad of ["0", "11", "1.5", '"2"']) {
+      expect(() => parseFlow(`steps:\n  - tap: { on: A, times: ${bad} }\n`)).toThrow(
+        /times must be an integer between 1 and 10/i
+      );
+    }
+    expect(() => parseFlow("steps:\n  - tap: { x: 0.5, y: 0.5, times: 0 }\n")).toThrow(
+      /times must be an integer between 1 and 10/i
+    );
+  });
+});
+
+describe("tap times: execution", () => {
+  it("resolves the selector once and dispatches one multi-tap gesture", async () => {
+    currentTree = () =>
+      screen([n({ label: "Photo", frame: { x: 0.4, y: 0.4, width: 0.2, height: 0.2 } })]);
+    await writeFlow("double", {
+      executionPrerequisite: "",
+      steps: [{ kind: "tap", selector: { text: "Photo", loose: true }, times: 2 }],
+    });
+
+    const result = await run("double");
+
+    expect(result.ok).toBe(true);
+    expect(result.calls).toEqual([
+      { tool: "gesture-tap", args: { udid: DEVICE, x: 0.5, y: 0.5, clickCount: 2 } },
+    ]);
+  });
+
+  it("sends no clickCount for a plain tap", async () => {
+    currentTree = () =>
+      screen([n({ label: "Photo", frame: { x: 0.4, y: 0.4, width: 0.2, height: 0.2 } })]);
+    await writeFlow("single", {
+      executionPrerequisite: "",
+      steps: [{ kind: "tap", selector: { text: "Photo", loose: true } }],
+    });
+
+    const result = await run("single");
+
+    expect(result.ok).toBe(true);
+    expect(result.calls[0]!.args).not.toHaveProperty("clickCount");
+  });
+
+  it("dispatches clickCount on a coordinate multi-tap", async () => {
+    await writeFlow("coord", {
+      executionPrerequisite: "",
+      steps: [{ kind: "tap", x: 0.3, y: 0.7, times: 3 }],
+    });
+
+    const result = await run("coord");
+
+    expect(result.ok).toBe(true);
+    expect(result.calls).toEqual([
+      { tool: "gesture-tap", args: { udid: DEVICE, x: 0.3, y: 0.7, clickCount: 3 } },
+    ]);
+  });
+});

--- a/packages/tool-server/test/flows/flow-utils.test.ts
+++ b/packages/tool-server/test/flows/flow-utils.test.ts
@@ -617,7 +617,7 @@ describe("parseFlow", () => {
 
     it("rejects an unknown key on a selector map", () => {
       expect(() => parseFlow("steps:\n  - tap: { text: Save, roel: button }\n")).toThrow(
-        /tap has unknown key `roel` \(did you mean `role`\?\)/
+        /tap: selector has unknown key `roel` \(did you mean `role`\?\)/
       );
       expect(() => parseFlow("steps:\n  - await: { visible: { txt: Save } }\n")).toThrow(
         /await.visible: selector has unknown key `txt` \(did you mean `text`\?\)/
@@ -643,7 +643,7 @@ describe("parseFlow", () => {
 
     it("rejects a stray key on a coordinate tap", () => {
       expect(() => parseFlow("steps:\n  - tap: { x: 0.5, y: 0.5, why: 0.6 }\n")).toThrow(
-        /tap has unknown key `why`/
+        /a coordinate tap takes only \{ x, y, times \}/
       );
     });
 

--- a/packages/tool-server/test/tools/gesture-tap.test.ts
+++ b/packages/tool-server/test/tools/gesture-tap.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture the touch-event train the tool sends to the simulator-server — the
+// multi-tap contract (N Down/Up pairs, one gesture) lives entirely in it.
+interface TouchCmd {
+  cmd: string;
+  type: "Down" | "Move" | "Up";
+  x: number;
+  y: number;
+}
+const sent: TouchCmd[] = [];
+vi.mock("../../src/utils/simulator-client", () => ({
+  sendCommand: (_api: unknown, cmd: TouchCmd) => {
+    sent.push(cmd);
+  },
+}));
+
+import { gestureTapTool } from "../../src/tools/gesture-tap";
+
+const touchServices = { simulatorServer: {} } as never;
+
+beforeEach(() => {
+  sent.length = 0;
+});
+
+describe("gesture-tap", () => {
+  it("dispatches a single Down/Up pair by default", async () => {
+    await gestureTapTool.execute(touchServices, { udid: "X", x: 0.5, y: 0.5 });
+    expect(sent.map((e) => e.type)).toEqual(["Down", "Up"]);
+  });
+
+  it("dispatches clickCount Down/Up pairs as ONE gesture on touch platforms", async () => {
+    await gestureTapTool.execute(touchServices, { udid: "X", x: 0.4, y: 0.6, clickCount: 3 });
+    expect(sent.map((e) => e.type)).toEqual(["Down", "Up", "Down", "Up", "Down", "Up"]);
+    // Every tap lands on the same point — a multi-tap, not a gesture path.
+    expect(sent.every((e) => e.x === 0.4 && e.y === 0.6)).toBe(true);
+  });
+
+  it("escalates the CDP clickCount per click on chromium so dblclick fires", async () => {
+    const mouse: Array<{ type: string; clickCount?: number }> = [];
+    const chromium = {
+      getViewport: () => ({ width: 1000, height: 800 }),
+      dispatchMouseEvent: vi.fn(async (e: { type: string; clickCount?: number }) => {
+        mouse.push(e);
+      }),
+    };
+    await gestureTapTool.execute({ chromium } as never, {
+      udid: "chromium-cdp-9222",
+      x: 0.5,
+      y: 0.5,
+      clickCount: 2,
+    });
+    // The browser's click counter drives dblclick: presses carry 1, then 2.
+    expect(mouse.map((e) => `${e.type}:${e.clickCount ?? ""}`)).toEqual([
+      "mouseMoved:",
+      "mousePressed:1",
+      "mouseReleased:1",
+      "mousePressed:2",
+      "mouseReleased:2",
+    ]);
+  });
+});


### PR DESCRIPTION
Flows can now express double-taps declaratively:

```yaml
- tap: { on: Login, times: 2 }          # selector double-tap
- tap: { x: 0.5, y: 0.57, times: 2 }    # coordinate double-tap
```

The selector nests under `on` so option keys never share a map with selector fields — zod would silently strip them; mixing errors with a hint instead. `times: 1` normalizes to absent and the serializer emits the minimal spelling, keeping parse/serialize exact inverses.

The taps dispatch as **one gesture** via `gesture-tap`'s new `clickCount` (1–10): N Down/Up pairs ~100 ms apart on touch, escalating CDP `clickCount` per click on Chromium (what makes `dblclick` actually fire) — never N separate calls whose RPC gaps could miss the OS double-tap window.

The recorder carries a recorded `clickCount` into `times`, so a recorded double-tap can't silently replay as a single tap.
