### PR TITLE
feat(flow): conditional when blocks

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -147,6 +147,24 @@ export function parseRunArgs(argv: string[]): {
   return out;
 }
 
+/**
+ * Render an echo step. Echo is narration, not a pass/fail step — one that RAN
+ * prints as a plain `› message` header with no index or glyph. A SKIPPED echo
+ * (its `when:` block didn't run, or a hard stop / cancellation reached it) must
+ * not print identically to one that ran, so it carries the skip glyph and its
+ * reason: one honest line per authored step, still unindexed so it keeps
+ * reading as narration rather than a numbered step. Returns undefined when
+ * there is no message to show.
+ */
+export function renderEchoLine(s: StepReport): string | undefined {
+  if (!s.message) return undefined;
+  if (s.status === "skip") {
+    const reason = s.reason ? ` — ${s.reason}` : "";
+    return `  ${STATUS_GLYPH.skip} › ${s.message}${reason}`;
+  }
+  return `  › ${s.message}`;
+}
+
 export function renderStepLine(s: StepReport, n: number, topFlow: string): string {
   const where = s.flow && s.flow !== topFlow ? ` [${s.flow}]` : "";
   const what = s.tool ?? s.target;
@@ -324,10 +342,11 @@ export function renderReport(report: FlowReport): string {
   // Number only real steps so echo narration doesn't leave gaps in the sequence.
   let n = 0;
   for (const s of report.steps) {
-    // Echo is narration, not a pass/fail step — render its message as a plain
-    // line with no index or status glyph so it reads as a header between steps.
+    // Echo is narration, not a pass/fail step — render it as a header between
+    // steps (a skipped one is marked so it can't be mistaken for having run).
     if (s.kind === "echo") {
-      if (s.message) lines.push(`  › ${s.message}`);
+      const line = renderEchoLine(s);
+      if (line) lines.push(line);
       continue;
     }
     n++;
@@ -418,7 +437,8 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     if (liveSteps === 0) console.log(`Flow "${flowName}"`);
     liveSteps++;
     if (s.kind === "echo") {
-      if (s.message) console.log(`  › ${s.message}`);
+      const line = renderEchoLine(s);
+      if (line) console.log(line);
       return;
     }
     liveIndex++;

--- a/packages/argent-cli/test/flow-render.test.ts
+++ b/packages/argent-cli/test/flow-render.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   renderReport,
   renderStepLine,
+  renderEchoLine,
   renderSummary,
   renderArtifactLines,
   type FlowReport,
@@ -71,7 +72,8 @@ describe("flow report rendering", () => {
     let n = 0;
     for (const s of report.steps) {
       if (s.kind === "echo") {
-        if (s.message) live.push(`  › ${s.message}`);
+        const line = renderEchoLine(s);
+        if (line) live.push(line);
         continue;
       }
       n++;
@@ -91,6 +93,57 @@ describe("flow report rendering", () => {
       warning: "baseline seeded",
     };
     expect(renderStepLine(step, 1, "checkout")).toBe("  ⚠  1 snapshot");
+  });
+
+  it("renders a skipped echo distinctly from one that ran", () => {
+    // A `when:` block that didn't run reports its echo as skipped. It must not
+    // print identically to an echo that executed, or the report lies about
+    // what happened.
+    const ran: StepReport = { index: 0, kind: "echo", status: "pass", message: "entering block" };
+    const skipped: StepReport = {
+      index: 1,
+      kind: "echo",
+      status: "skip",
+      reason: "when block skipped",
+      message: "entering block",
+    };
+    expect(renderEchoLine(ran)).toBe("  › entering block");
+    expect(renderEchoLine(skipped)).toBe("  · › entering block — when block skipped");
+    // The two must be visually distinguishable.
+    expect(renderEchoLine(ran)).not.toBe(renderEchoLine(skipped));
+  });
+
+  it("a hard-stopped echo (skip, no reason) still renders instead of vanishing", () => {
+    const stopped: StepReport = { index: 5, kind: "echo", status: "skip", message: "cleanup note" };
+    expect(renderEchoLine(stopped)).toBe("  · › cleanup note");
+  });
+
+  it("an echo without a message renders nothing", () => {
+    expect(renderEchoLine({ index: 0, kind: "echo", status: "pass" })).toBeUndefined();
+  });
+
+  it("a skipped echo appears in the buffered report as a marked line", () => {
+    const out = renderReport(
+      mkReport([
+        { index: 0, kind: "launch", status: "pass" },
+        {
+          index: 1,
+          kind: "when",
+          status: "skip",
+          reason: 'condition not met (visible "Promo") — block skipped (1 step)',
+          target: 'visible "Promo"',
+        },
+        {
+          index: 2,
+          kind: "echo",
+          status: "skip",
+          reason: "when block skipped",
+          message: "THIS MUST NOT RUN",
+        },
+      ])
+    );
+    expect(out).toContain("  · › THIS MUST NOT RUN — when block skipped");
+    expect(out).not.toContain("  › THIS MUST NOT RUN");
   });
 
   it("renderSummary carries the device only when asked (live tail)", () => {

--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -32,6 +32,7 @@ Beyond raw `tool:` steps and `echo:`, flows support declarative directives inter
 | `assert`     | `- assert: { visible: Welcome }`                                                                                                                                     | check a condition, hard-fail if it never holds                                                                                                                  |
 | `snapshot`   | `- snapshot: home` or `- snapshot: { name: home, maxMismatch: 0.5 }`                                                                                                 | diff a screenshot against a stored baseline                                                                                                                     |
 | `run`        | `- run: login`                                                                                                                                                       | execute another flow's steps inline (fragment or e2e)                                                                                                           |
+| `when`       | `- when: { visible: "What's new" }` + `steps: [...]`                                                                                                                 | run a guarded step block only when the condition holds (no else)                                                                                                |
 
 ### Selectors
 
@@ -159,6 +160,7 @@ The top-level is an object with `steps` (array) and — fragments only — `exec
 
 - `- echo: <message>` — a label printed during replay
 - `- tool: <name>` with optional `args:` — a raw tool call. A tool step may also carry `delayMs: <ms>` to sleep that long before it runs. (`await-ui-element` is an ordinary tool step; see _flow-add-step arguments_ and _Making flows resilient_ for when to gate a transition with one.)
+- **`when:` blocks** handle one-sided divergences (interstitials, coach marks): `- when: { visible: "What's new" }` with a sibling `steps: [...]` list runs the block only if the condition holds — checked once with the short assert grace (~1s), so a skipped block barely costs a clean run. Guards are one condition key (`exists`/`visible`/`hidden`/`text`, the await/assert shapes) or `platform: ios|android|chromium|vega`. **No else** (parse-rejected): a block exists to dismiss the divergence and reconverge, never to test two paths — two paths are two flows. Failures inside an entered block are real failures; a skipped block reports `skip` lines. Tap-if-present is a one-step block (`when: { visible: "Got it" }` + `steps: [tap: "Got it"]`); there is NO per-step `optional:` key — it is rejected at parse with a pointer to `when:`.
 
 The polished result of the example session above:
 

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -45,6 +45,15 @@ export interface DirectiveOutcome {
   reason?: string;
   /** The run was cancelled mid-step — reported as a skip, not a step failure. */
   aborted?: boolean;
+  /**
+   * The condition could not be evaluated — unknown, not false: the window
+   * never produced a trustworthy read (every fetch threw or returned a
+   * blind/degraded tree), or a `hidden` check ended on blind reads after the
+   * element had matched. Read by the `when:` guard probe, which must error
+   * rather than silently skip a block a broken tree source can't vouch for;
+   * a plain `assert` reports it as an ordinary failure.
+   */
+  indeterminate?: boolean;
 }
 
 /**
@@ -177,6 +186,25 @@ function axisFullyInside(
 // Playwright's web-first assertions, assert retries for a short grace window so
 // it absorbs that latency; a genuinely-false assertion still fails quickly.
 const DEFAULT_ASSERT_TIMEOUT_MS = 1000;
+
+/**
+ * Evaluate a `when:` block's UI guard — the same engine as `assert`, on the
+ * same assert grace window: a skipped block must not add an await-sized dead
+ * wait to every clean run. `ok` is "condition met"; `indeterminate`
+ * distinguishes an unreadable tree (the caller errors — unknown is not false)
+ * from a plainly unmet condition (the caller skips).
+ */
+export function probeWhenCondition(
+  env: ActionEnv,
+  cond: {
+    condition: WaitCondition;
+    selector: FlowSelector;
+    expectedText?: string;
+    textMatch?: TextMatchMode;
+  }
+): Promise<DirectiveOutcome> {
+  return waitForCondition(env, cond, DEFAULT_ASSERT_TIMEOUT_MS);
+}
 
 /**
  * The strict selectors a flow selector resolves through, in order. A loose
@@ -769,11 +797,35 @@ async function waitForCondition(
     }
   }
 
-  if (fetchError) return { ok: false, reason: `could not read the UI tree: ${fetchError}` };
-  if (step.condition === "hidden" && !everTrustedRead) {
+  // Unknown, not false: the window never produced a read we can trust —
+  // every fetch either threw or returned a blind tree (empty + degraded
+  // hint, or empty after the selector had matched). This is not specific to
+  // `hidden`: a probe that never got a trustworthy look at the screen cannot
+  // vouch for "condition false" for any condition. Conversely, once a trusted
+  // read exists, a transient fetch error on the trailing polls does NOT make
+  // the outcome unknown — the reads that succeeded already showed the
+  // condition false, and a last-poll blip must not flip a clean skip into a
+  // hard error.
+  if (!everTrustedRead) {
     return {
       ok: false,
-      reason: "could not confirm the element is hidden — the UI tree was empty or unreadable",
+      indeterminate: true,
+      reason: fetchError
+        ? `could not read the UI tree: ${fetchError}`
+        : "could not evaluate the condition — every read of the UI tree was empty or degraded",
+    };
+  }
+  // `hidden` with an evidence gap: the element matched on an earlier trusted
+  // read and every read since was blind or failed, so gone-ness can't be
+  // confirmed — also unknown, not false. (A trusted read WITHOUT a visible
+  // match would have satisfied `hidden` inside the loop; a final trusted
+  // read WITH one falls through to the determinate "still visible" below.)
+  if (step.condition === "hidden" && !lastMatches.some(isVisible)) {
+    return {
+      ok: false,
+      indeterminate: true,
+      reason:
+        "could not confirm the element is hidden — it was visible earlier, but the last UI reads were empty or unreadable",
     };
   }
   return {

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -48,10 +48,10 @@ export interface DirectiveOutcome {
   /**
    * The condition could not be evaluated — unknown, not false: the window
    * never produced a trustworthy read (every fetch threw or returned a
-   * blind/degraded tree), or a `hidden` check ended on blind reads after the
-   * element had matched. Read by the `when:` guard probe, which must error
-   * rather than silently skip a block a broken tree source can't vouch for;
-   * a plain `assert` reports it as an ordinary failure.
+   * blind/degraded tree), or a `hidden` check ended on a blind or failed
+   * read after the element had matched. Read by the `when:` guard probe,
+   * which must error rather than silently skip a block a broken tree source
+   * can't vouch for; a plain `assert` reports it as an ordinary failure.
    */
   indeterminate?: boolean;
 }
@@ -765,6 +765,10 @@ async function waitForCondition(
   let fetchError: string | undefined;
   let everMatched = false;
   let everTrustedRead = false;
+  // Whether the LAST completed read attempt was trusted — assigned on every
+  // pass through the loop (true on a trusted fetch, false on a blind one or a
+  // throw), so post-loop it describes the final poll.
+  let lastReadTrusted: boolean;
   let finalPoll = false;
 
   for (;;) {
@@ -777,6 +781,7 @@ async function waitForCondition(
       const blind =
         data.tree.children.length === 0 && Boolean(data.hint || data.should_restart || everMatched);
       everTrustedRead ||= !blind;
+      lastReadTrusted = !blind;
       if (
         !blind &&
         evaluateCondition(step.condition, step.expectedText, lastMatches, step.textMatch)
@@ -785,6 +790,9 @@ async function waitForCondition(
       }
     } catch (err) {
       fetchError = err instanceof Error ? err.message : String(err);
+      // A throw is as blind as an empty tree — `lastMatches` still holds the
+      // previous successful read, which must not pass for current evidence.
+      lastReadTrusted = false;
     }
     if (Date.now() >= deadline) {
       if (finalPoll) break;
@@ -805,7 +813,10 @@ async function waitForCondition(
   // read exists, a transient fetch error on the trailing polls does NOT make
   // the outcome unknown — the reads that succeeded already showed the
   // condition false, and a last-poll blip must not flip a clean skip into a
-  // hard error.
+  // hard error. (`hidden` is the one exception, handled below: there
+  // "condition false" means the element was VISIBLE, and the element leaving
+  // is exactly the transition `hidden` waits for — so visibility seen before
+  // the reads went dark cannot vouch for it still being on screen.)
   if (!everTrustedRead) {
     return {
       ok: false,
@@ -816,16 +827,18 @@ async function waitForCondition(
     };
   }
   // `hidden` with an evidence gap: the element matched on an earlier trusted
-  // read and every read since was blind or failed, so gone-ness can't be
+  // read and the FINAL read attempt was blind or threw, so gone-ness can't be
   // confirmed — also unknown, not false. (A trusted read WITHOUT a visible
-  // match would have satisfied `hidden` inside the loop; a final trusted
-  // read WITH one falls through to the determinate "still visible" below.)
-  if (step.condition === "hidden" && !lastMatches.some(isVisible)) {
+  // match would have satisfied `hidden` inside the loop, so a trusted final
+  // read implies it saw the element — that falls through to the determinate
+  // "still visible" below with `lastMatches` fresh from that read.)
+  if (step.condition === "hidden" && !lastReadTrusted) {
     return {
       ok: false,
       indeterminate: true,
-      reason:
-        "could not confirm the element is hidden — it was visible earlier, but the last UI reads were empty or unreadable",
+      reason: fetchError
+        ? `could not confirm the element is hidden — it was visible earlier, but the last UI read failed: ${fetchError}`
+        : "could not confirm the element is hidden — it was visible earlier, but the last UI reads were empty",
     };
   }
   return {
@@ -856,13 +869,11 @@ function assertReason(
         ? `element(s) matched ${sel} but none was visible (zero-area frame)`
         : `no element matched selector ${sel}`;
     case "hidden":
-      // No visible match on the final read means the deadline was spent on
-      // blind reads (blank trees the poll refuses to trust once the element
-      // has matched — see waitForCondition): the element may well be gone,
-      // but that can't be confirmed, so don't claim it was still on screen.
-      return matches.some(isVisible)
-        ? `an element matching ${sel} was still visible`
-        : `could not confirm the element is hidden — it was visible earlier, but the last UI reads returned an empty tree`;
+      // Reached only when the final read was trusted (waitForCondition
+      // returns indeterminate when it was blind or threw), and a trusted read
+      // without a visible match satisfies `hidden` inside the poll loop — so
+      // `matches` holds what that read saw: the element, still on screen.
+      return `an element matching ${sel} was still visible`;
     case "text": {
       const first = firstInReadingOrder(matches.filter(isVisible)) ?? firstInReadingOrder(matches);
       if (!first) return `no element matched selector ${sel}`;

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -187,6 +187,17 @@ function axisFullyInside(
 // it absorbs that latency; a genuinely-false assertion still fails quickly.
 const DEFAULT_ASSERT_TIMEOUT_MS = 1000;
 
+// Evidence-gap bound for `waitForCondition`'s post-timeout verdict: how far
+// behind the loop's exit the last TRUSTED read may lie before a determinate
+// "condition false" verdict stops being honest. Two poll intervals budgets
+// the worst genuine last-poll blip — up to one interval of sleep since the
+// last clean read, plus an interval's worth of latency for the deadline poll
+// and its back-to-back final retry both failing.
+// Anything longer means consecutive polls went dark, and a verdict narrated
+// from the reads before the darkness would describe a screen nobody saw at
+// the deadline.
+const CONDITION_DARK_TAIL_TOLERANCE_MS = POLL_INTERVAL_MS * 2;
+
 /**
  * Evaluate a `when:` block's UI guard — the same engine as `assert`, on the
  * same assert grace window: a skipped block must not add an await-sized dead
@@ -764,7 +775,10 @@ async function waitForCondition(
   let lastMatches: ReturnType<typeof findAll> = [];
   let fetchError: string | undefined;
   let everMatched = false;
-  let everTrustedRead = false;
+  // Date.now() of the most recent TRUSTED read — undefined until one lands.
+  // Post-loop it anchors the dark-tail measurement: how long the window's
+  // final stretch went without a trustworthy look at the screen.
+  let lastTrustedReadAt: number | undefined;
   // Whether the LAST completed read attempt was trusted — assigned on every
   // pass through the loop (true on a trusted fetch, false on a blind one or a
   // throw), so post-loop it describes the final poll.
@@ -780,7 +794,7 @@ async function waitForCondition(
       everMatched ||= lastMatches.length > 0;
       const blind =
         data.tree.children.length === 0 && Boolean(data.hint || data.should_restart || everMatched);
-      everTrustedRead ||= !blind;
+      if (!blind) lastTrustedReadAt = Date.now();
       lastReadTrusted = !blind;
       if (
         !blind &&
@@ -805,19 +819,32 @@ async function waitForCondition(
     }
   }
 
-  // Unknown, not false: the window never produced a read we can trust —
-  // every fetch either threw or returned a blind tree (empty + degraded
-  // hint, or empty after the selector had matched). This is not specific to
-  // `hidden`: a probe that never got a trustworthy look at the screen cannot
-  // vouch for "condition false" for any condition. Conversely, once a trusted
-  // read exists, a transient fetch error on the trailing polls does NOT make
-  // the outcome unknown — the reads that succeeded already showed the
-  // condition false, and a last-poll blip must not flip a clean skip into a
-  // hard error. (`hidden` is the one exception, handled below: there
-  // "condition false" means the element was VISIBLE, and the element leaving
-  // is exactly the transition `hidden` waits for — so visibility seen before
-  // the reads went dark cannot vouch for it still being on screen.)
-  if (!everTrustedRead) {
+  // Post-timeout verdict — unknown must not masquerade as false. Three tiers
+  // of evidence quality:
+  //
+  // 1. No trusted read in the whole window: every fetch either threw or
+  //    returned a blind tree (empty + degraded hint, or empty after the
+  //    selector had matched). A probe that never got a trustworthy look at
+  //    the screen cannot vouch for "condition false" for ANY condition.
+  // 2. Trusted reads existed but the window went dark at the end: the FINAL
+  //    read attempt was blind or threw AND the last trusted read lies more
+  //    than {@link CONDITION_DARK_TAIL_TOLERANCE_MS} behind the loop's exit.
+  //    The condition becoming true is exactly the transition being waited on,
+  //    so a "condition false" observation from before the reads went dark
+  //    says nothing about the deadline — a determinate verdict built from it
+  //    would let a dying tree source fake a clean report (and green-skip a
+  //    `when:` guard whose dismissal target may well be on screen). `hidden`
+  //    is held to a stricter bar: there "condition false" means the element
+  //    was VISIBLE, and the element leaving is the transition itself — so ANY
+  //    untrusted final read, however short the tail, leaves gone-ness
+  //    unconfirmable.
+  // 3. Dark tail within the tolerance — a genuine last-poll blip: trusted
+  //    reads showed the condition false until at most ~one poll interval
+  //    before the deadline, so they still describe the window and a transient
+  //    fetch error on the trailing poll must not flip a clean skip into a
+  //    hard error. The determinate verdict stands, with the failed final read
+  //    appended so the error is not silently dropped from the report.
+  if (lastTrustedReadAt === undefined) {
     return {
       ok: false,
       indeterminate: true,
@@ -826,30 +853,45 @@ async function waitForCondition(
         : "could not evaluate the condition — every read of the UI tree was empty or degraded",
     };
   }
-  // `hidden` with an evidence gap: the element matched on an earlier trusted
-  // read and the FINAL read attempt was blind or threw, so gone-ness can't be
-  // confirmed — also unknown, not false. (A trusted read WITHOUT a visible
-  // match would have satisfied `hidden` inside the loop, so a trusted final
-  // read implies it saw the element — that falls through to the determinate
-  // "still visible" below with `lastMatches` fresh from that read.)
-  if (step.condition === "hidden" && !lastReadTrusted) {
-    return {
-      ok: false,
-      indeterminate: true,
-      reason: fetchError
-        ? `could not confirm the element is hidden — it was visible earlier, but the last UI read failed: ${fetchError}`
-        : "could not confirm the element is hidden — it was visible earlier, but the last UI reads were empty",
-    };
+  if (!lastReadTrusted) {
+    // `hidden` with an evidence gap: the element matched on an earlier
+    // trusted read and the FINAL read attempt was blind or threw, so
+    // gone-ness can't be confirmed — no blip tolerance here (tier 2's
+    // stricter bar). (A trusted read WITHOUT a visible match would have
+    // satisfied `hidden` inside the loop, so a trusted final read implies it
+    // saw the element — that falls through to the determinate "still
+    // visible" below with `lastMatches` fresh from that read.)
+    if (step.condition === "hidden") {
+      return {
+        ok: false,
+        indeterminate: true,
+        reason: fetchError
+          ? `could not confirm the element is hidden — it was visible earlier, but the last UI read failed: ${fetchError}`
+          : "could not confirm the element is hidden — it was visible earlier, but the last UI reads were empty",
+      };
+    }
+    const darkTailMs = Date.now() - lastTrustedReadAt;
+    if (darkTailMs > CONDITION_DARK_TAIL_TOLERANCE_MS) {
+      return {
+        ok: false,
+        indeterminate: true,
+        reason: fetchError
+          ? `could not evaluate the condition — the UI tree was unreadable for the final ${darkTailMs}ms of the window: ${fetchError}`
+          : `could not evaluate the condition — the UI tree reads were empty or degraded for the final ${darkTailMs}ms of the window`,
+      };
+    }
   }
+  // Tier 3 (or a trusted final read): the verdict is determinate; a blip's
+  // failed final read is appended, not dropped.
+  const blipNote =
+    !lastReadTrusted && fetchError
+      ? ` (the final poll could not read the UI tree: ${fetchError})`
+      : "";
   return {
     ok: false,
-    reason: assertReason(
-      step.condition,
-      step.selector,
-      step.expectedText,
-      step.textMatch,
-      lastMatches
-    ),
+    reason:
+      assertReason(step.condition, step.selector, step.expectedText, step.textMatch, lastMatches) +
+      blipNote,
   };
 }
 

--- a/packages/tool-server/src/tools/flows/flow-device.ts
+++ b/packages/tool-server/src/tools/flows/flow-device.ts
@@ -2,6 +2,7 @@ import type { DeviceInfo, Registry, ToolContext } from "@argent/registry";
 import { FAILURE_CODES, FailureError } from "@argent/registry";
 import { resolveDevice } from "../../utils/device-info";
 import { invokeSubTool } from "../../utils/sub-invoke";
+import type { WhenPlatform } from "./flow-utils";
 
 /**
  * Device resolution + binding for the flow runner. Flows store no device id
@@ -10,7 +11,9 @@ import { invokeSubTool } from "../../utils/sub-invoke";
  * and injects it schema-aware into each step's tool args.
  */
 
-export type FlowPlatform = "ios" | "android" | "chromium" | "vega";
+// One platform set for the whole flows directory — see LAUNCH_PLATFORMS in
+// flow-utils, which this aliases via WhenPlatform.
+export type FlowPlatform = WhenPlatform;
 
 const DEVICE_BIND_KEYS = ["udid", "device_id"] as const;
 

--- a/packages/tool-server/src/tools/flows/flow-finish-recording.ts
+++ b/packages/tool-server/src/tools/flows/flow-finish-recording.ts
@@ -92,6 +92,17 @@ You can still edit the .yaml file directly afterwards to remove or reorder steps
         }
         case "wait":
           return `${n}. wait: ${step.ms}ms`;
+        case "when": {
+          // Mirror the await/assert rendering above — selectorLabel spelling,
+          // expected text included for text guards.
+          const cond =
+            step.condition.kind === "platform"
+              ? `platform ${step.condition.platform}`
+              : step.condition.condition === "text"
+                ? `text ${selectorLabel(step.condition.selector)} == "${step.condition.expectedText ?? ""}"`
+                : `${step.condition.condition} ${selectorLabel(step.condition.selector)}`;
+          return `${n}. when: ${cond} (${step.steps.length} steps)`;
+        }
         case "scroll-to":
           return `${n}. scroll-to: ${selectorLabel(step.target)} (${step.direction})`;
         case "snapshot":

--- a/packages/tool-server/src/tools/flows/flow-finish-recording.ts
+++ b/packages/tool-server/src/tools/flows/flow-finish-recording.ts
@@ -13,12 +13,32 @@ import {
   type FlowSavedTo,
   type FlowSelector,
 } from "./flow-utils";
+import type { TextMatchMode } from "../../utils/ui-tree-match";
 
 // Quote selectors in the step summary the way the flow FILE spells them
 // (`id`, bare string for loose, no internal `loose` flag) — the summary is what
 // gets read before hand-editing the YAML, so the spellings must agree.
 function selectorLabel(sel: FlowSelector): string {
   return JSON.stringify(selectorToYaml(sel));
+}
+
+// Render a text condition for the summary, one spelling for every step kind
+// that carries one (await/assert/when): the comparator is preserved — regex
+// patterns as `matches /…/`, exact text as `== "…"`, substrings as
+// `contains "…"` — and literals use JSON quoting so embedded quotes and
+// control characters stay unambiguous.
+function textConditionLabel(
+  sel: FlowSelector,
+  expectedText: string | undefined,
+  textMatch: TextMatchMode | undefined
+): string {
+  const selector = selectorLabel(sel);
+  const expected = expectedText ?? "";
+  return textMatch === "matches"
+    ? `text ${selector} matches /${expected}/`
+    : textMatch === "equals"
+      ? `text ${selector} == ${JSON.stringify(expected)}`
+      : `text ${selector} contains ${JSON.stringify(expected)}`;
 }
 
 const zodSchema = z.object({});
@@ -75,31 +95,26 @@ You can still edit the .yaml file directly afterwards to remove or reorder steps
           return `${n}. type: ${selectorLabel(step.into)} ← "${step.text}"`;
         case "await":
         case "assert": {
-          let tail: string;
-          if (step.condition !== "text") {
-            tail = `${step.condition} ${selectorLabel(step.selector)}`;
-          } else {
-            const selector = selectorLabel(step.selector);
-            const expected = step.expectedText ?? "";
-            tail =
-              step.textMatch === "matches"
-                ? `text ${selector} matches /${expected}/`
-                : step.textMatch === "equals"
-                  ? `text ${selector} == ${JSON.stringify(expected)}`
-                  : `text ${selector} contains ${JSON.stringify(expected)}`;
-          }
+          const tail =
+            step.condition === "text"
+              ? textConditionLabel(step.selector, step.expectedText, step.textMatch)
+              : `${step.condition} ${selectorLabel(step.selector)}`;
           return `${n}. ${step.kind}: ${tail}`;
         }
         case "wait":
           return `${n}. wait: ${step.ms}ms`;
         case "when": {
           // Mirror the await/assert rendering above — selectorLabel spelling,
-          // expected text included for text guards.
+          // same comparator tail for text guards.
           const cond =
             step.condition.kind === "platform"
               ? `platform ${step.condition.platform}`
               : step.condition.condition === "text"
-                ? `text ${selectorLabel(step.condition.selector)} == "${step.condition.expectedText ?? ""}"`
+                ? textConditionLabel(
+                    step.condition.selector,
+                    step.condition.expectedText,
+                    step.condition.textMatch
+                  )
                 : `${step.condition.condition} ${selectorLabel(step.condition.selector)}`;
           return `${n}. when: ${cond} (${step.steps.length} steps)`;
         }

--- a/packages/tool-server/src/tools/flows/flow-finish-recording.ts
+++ b/packages/tool-server/src/tools/flows/flow-finish-recording.ts
@@ -116,7 +116,9 @@ You can still edit the .yaml file directly afterwards to remove or reorder steps
                     step.condition.textMatch
                   )
                 : `${step.condition.condition} ${selectorLabel(step.condition.selector)}`;
-          return `${n}. when: ${cond} (${step.steps.length} steps)`;
+          // Pluralize like flow-run's skip reason so the two surfaces agree.
+          const count = step.steps.length;
+          return `${n}. when: ${cond} (${count} step${count === 1 ? "" : "s"})`;
         }
         case "scroll-to":
           return `${n}. scroll-to: ${selectorLabel(step.target)} (${step.direction})`;

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -103,7 +103,12 @@ export interface StepReport {
   index: number;
   kind: FlowStep["kind"];
   status: StepStatus;
-  /** Machine-readable explanation when the step did not pass. */
+  /**
+   * Machine-readable explanation of the outcome. Always set when the step did
+   * not pass; also set on some passing reports whose result is self-narrating —
+   * the `when:` guard marker (`condition met (…)`) and snapshot passes (diff
+   * percentage, baseline written/updated).
+   */
   reason?: string;
   /** Underlying tool id for `tool` steps. */
   tool?: string;

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -754,6 +754,9 @@ async function execSteps(
         status: "skip",
         flow: sourceFlow,
         target: stepTarget(step),
+        // Carry the echo's message so a skipped narration renders as a skip
+        // line rather than vanishing — matching reportBlockSkipped.
+        ...(step.kind === "echo" ? { message: step.message } : {}),
       });
       // A when block's literal steps are known — expand them so the report
       // keeps one line per authored step no matter where the stop landed.
@@ -769,6 +772,7 @@ async function execSteps(
         reason: "run aborted",
         flow: sourceFlow,
         target: stepTarget(step),
+        ...(step.kind === "echo" ? { message: step.message } : {}),
       });
       if (step.kind === "when") reportBlockSkipped(state, step.steps, sourceFlow, "run aborted");
       continue;

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -797,12 +797,12 @@ function describeWhenCondition(cond: WhenCondition): string {
 
 /**
  * Report every step of a `when:` block that will not run as skipped — so a
- * run where the block was skipped (unmet guard, hard stop, or cancellation)
- * produces the same report shape (one line per authored step) as a run where
- * it entered, and reports stay comparable run-to-run. Nested when blocks
- * expand (their literal steps are known); a `run:` composition stays one
- * line, matching how post-hard-stop skips report a fragment that was never
- * loaded.
+ * run where the block was skipped (unmet guard, errored guard, hard stop, or
+ * cancellation) produces the same report shape (one line per authored step)
+ * as a run where it entered, and reports stay comparable run-to-run. Nested
+ * when blocks expand (their literal steps are known); a `run:` composition
+ * stays one line, matching how post-hard-stop skips report a fragment that
+ * was never loaded.
  */
 function reportBlockSkipped(
   state: ExecState,
@@ -878,6 +878,7 @@ async function execWhenStep(
         target,
       });
       state.stopped = true;
+      reportBlockSkipped(state, step.steps, sourceFlow, "when guard errored");
       return;
     }
     met = probe.ok;

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -14,6 +14,7 @@ import {
   appIdForPlatform,
   assertSafeFlowName,
   chromiumLaunchSpec,
+  describeSelector,
   describeTextExpectation,
   getFlowPath,
   isE2eFlow,
@@ -23,7 +24,10 @@ import {
   type FlowSelector,
   type FlowStep,
   type Launch,
+  type WhenCondition,
+  LAUNCH_PLATFORMS,
 } from "./flow-utils";
+import type { TextMatchMode, WaitCondition } from "../../utils/ui-tree-match";
 import { sleepOrAbort } from "../../utils/timing";
 import { invokeSubTool } from "../../utils/sub-invoke";
 import { isUnmetUiWaitResult } from "../await-ui-element";
@@ -32,6 +36,7 @@ import {
   runDirective,
   invokeOnDevice,
   ABORTED_OUTCOME,
+  probeWhenCondition,
   type ActionEnv,
   type DirectiveOutcome,
 } from "./flow-actions";
@@ -69,7 +74,7 @@ const zodSchema = z.object({
       "Device id to run against (iOS UDID, Android/Vega serial, Chromium id). Auto-detected when omitted."
     ),
   platform: z
-    .enum(["ios", "android", "chromium", "vega"])
+    .enum(LAUNCH_PLATFORMS)
     .optional()
     .describe("Restrict auto-detection to this platform when several devices are booted."),
   updateBaselines: z
@@ -133,6 +138,11 @@ export interface FlowRunResult {
   device: string;
   executionPrerequisite: string;
   ok: boolean;
+  /**
+   * The run was cancelled mid-flight — set so a FAIL whose step statuses are
+   * all pass/skip is self-explanatory. Absent on completed runs.
+   */
+  aborted?: boolean;
   passed: number;
   failed: number;
   skipped: number;
@@ -420,6 +430,9 @@ holds; \`tap\`/\`long-press\` alternatively take a raw normalized point — bare
 condition; \`wait\` pauses for a fixed number of milliseconds; \`assert\` checks one now; \`snapshot\`
 diffs a screenshot against a stored baseline (a missing baseline fails the step — set updateBaselines
 to adopt the current screen); \`echo\` annotates; \`run\` executes a referenced fragment inline.
+A \`when:\` block (condition + \`steps:\`, no else) runs its steps only if the condition holds —
+checked once with the short assert grace — for one-sided divergences like interstitials and coach
+marks; a skipped block reports distinctly and failures inside an entered block are real failures.
 A flow that begins with a \`launch\` step is a self-contained e2e flow; one that doesn't runs against the
 device's current state. Device id is injected by the runner (flows store none) — pass \`device\` or
 \`platform\` to pick one, else the single booted device is used. For a Chromium e2e flow the \`launch\`
@@ -486,14 +499,19 @@ returns a notice with the prerequisite instead of running.`,
         ...(ctx?.emitProgress ? { onStepReport: ctx.emitProgress } : {}),
       };
 
+      let aborted: boolean;
       try {
         await execSteps(state, flow.steps, params.name, [params.name]);
       } finally {
+        // Sample the cancel flag before teardown: a client disconnect during
+        // status-bar restore / chromium teardown lands after every step
+        // already ran, and must not flip a finished run to FAIL.
+        aborted = state.signal?.aborted === true;
         if (state.pinned) await restoreStatusBar(device);
         if (resolved.booted) await teardownBootedChromium(registry, resolved.booted);
       }
 
-      return summarize(params.name, device.id, flow.executionPrerequisite, state.reports);
+      return summarize(params.name, device.id, flow.executionPrerequisite, state.reports, aborted);
     },
   };
 }
@@ -613,15 +631,14 @@ function summarize(
   flowName: string,
   deviceId: string,
   executionPrerequisite: string,
-  steps: StepReport[]
+  steps: StepReport[],
+  aborted: boolean
 ): FlowRunResult {
   let passed = 0;
   let failed = 0;
   let skipped = 0;
   let errored = 0;
-  let hasSkippedReport = false;
   for (const s of steps) {
-    hasSkippedReport ||= s.status === "skip";
     // Echo is narration, not a test step — counting it would let the summary
     // disagree with the renderers' step numbering (which skips echo too).
     if (s.kind === "echo") continue;
@@ -634,11 +651,13 @@ function summarize(
     flow: flowName,
     device: deviceId,
     executionPrerequisite,
-    // A skip is never a successful omission: the runner only emits skips after
-    // a hard stop or cancellation. The former already has a fail/error report;
-    // the latter may contain skips alone, so include them in the verdict or an
-    // aborted run would be reported as PASS.
-    ok: failed === 0 && errored === 0 && !hasSkippedReport,
+    // A cancelled run must never read as PASS — it may contain skips alone
+    // (no fail/error report), so the verdict folds the abort in directly. A
+    // skip by itself is NOT a failure: an unmet `when:` guard skips its block
+    // as a successful omission, and a hard stop already carries its own
+    // fail/error report.
+    ok: failed === 0 && errored === 0 && !aborted,
+    ...(aborted ? { aborted: true } : {}),
     passed,
     failed,
     skipped,
@@ -666,6 +685,30 @@ function selectorLabel(sel: FlowSelector): string {
   return parts.join(" ");
 }
 
+/**
+ * One template for rendering an await/assert/when-guard UI condition,
+ * parameterized by selector spelling — {@link selectorLabel} for report
+ * targets, `describeSelector` for reason strings — so the two surfaces share
+ * a single shape and cannot drift.
+ */
+function conditionLabel(
+  cond: {
+    condition: WaitCondition;
+    selector: FlowSelector;
+    expectedText?: string;
+    textMatch?: TextMatchMode;
+  },
+  renderSelector: (sel: FlowSelector) => string
+): string {
+  const sel = renderSelector(cond.selector);
+  // A text condition checks expectedText against the element the selector
+  // locates; the other conditions are about the selector itself.
+  if (cond.condition === "text") {
+    return `${sel} ${describeTextExpectation(cond.expectedText, cond.textMatch)}`;
+  }
+  return `${cond.condition} ${sel}`;
+}
+
 /** Display-only "what this step acts on" for {@link StepReport.target}. */
 function stepTarget(step: FlowStep): string | undefined {
   switch (step.kind) {
@@ -677,15 +720,12 @@ function stepTarget(step: FlowStep): string | undefined {
     case "type":
       return `into ${selectorLabel(step.into)}`;
     case "await":
-    case "assert": {
-      const sel = selectorLabel(step.selector);
-      // A text condition checks expectedText against the element the selector
-      // locates; the other conditions are about the selector itself.
-      if (step.condition === "text") {
-        return `${sel} ${describeTextExpectation(step.expectedText, step.textMatch)}`;
-      }
-      return `${step.condition} ${sel}`;
-    }
+    case "assert":
+      return conditionLabel(step, selectorLabel);
+    case "when":
+      return step.condition.kind === "platform"
+        ? `platform ${step.condition.platform}`
+        : conditionLabel(step.condition, selectorLabel);
     case "scroll-to": {
       const dir = step.direction !== "down" ? ` (${step.direction})` : "";
       return `${selectorLabel(step.target)}${dir}`;
@@ -715,6 +755,9 @@ async function execSteps(
         flow: sourceFlow,
         target: stepTarget(step),
       });
+      // A when block's literal steps are known — expand them so the report
+      // keeps one line per authored step no matter where the stop landed.
+      if (step.kind === "when") reportBlockSkipped(state, step.steps, sourceFlow);
       continue;
     }
     if (state.signal?.aborted) {
@@ -727,6 +770,7 @@ async function execSteps(
         flow: sourceFlow,
         target: stepTarget(step),
       });
+      if (step.kind === "when") reportBlockSkipped(state, step.steps, sourceFlow, "run aborted");
       continue;
     }
 
@@ -734,11 +778,136 @@ async function execSteps(
       await execRunStep(state, step, runStack);
       continue;
     }
+    if (step.kind === "when") {
+      await execWhenStep(state, step, sourceFlow, runStack);
+      continue;
+    }
 
     const report = await execLeafStep(state, step, index, sourceFlow);
     pushReport(state, report);
     if (report.status === "fail" || report.status === "error") state.stopped = true;
   }
+}
+
+/** A compact rendering of a when guard for report reasons. */
+function describeWhenCondition(cond: WhenCondition): string {
+  if (cond.kind === "platform") return `platform ${cond.platform}`;
+  return conditionLabel(cond, describeSelector);
+}
+
+/**
+ * Report every step of a `when:` block that will not run as skipped — so a
+ * run where the block was skipped (unmet guard, hard stop, or cancellation)
+ * produces the same report shape (one line per authored step) as a run where
+ * it entered, and reports stay comparable run-to-run. Nested when blocks
+ * expand (their literal steps are known); a `run:` composition stays one
+ * line, matching how post-hard-stop skips report a fragment that was never
+ * loaded.
+ */
+function reportBlockSkipped(
+  state: ExecState,
+  steps: FlowStep[],
+  sourceFlow: string,
+  reason?: string
+): void {
+  for (const step of steps) {
+    pushReport(state, {
+      index: state.reports.length,
+      kind: step.kind,
+      status: "skip",
+      reason,
+      // A `run:` line is attributed to the fragment it names, matching the
+      // executed marker in execRunStep; everything else belongs to the
+      // enclosing flow.
+      flow: step.kind === "run" ? step.flow : sourceFlow,
+      target: stepTarget(step),
+      ...(step.kind === "echo" ? { message: step.message } : {}),
+    });
+    if (step.kind === "when") reportBlockSkipped(state, step.steps, sourceFlow, reason);
+  }
+}
+
+/**
+ * Execute a `when:` block: evaluate the guard (a platform test is static; a UI
+ * condition probes with the short assert grace), then either expand the
+ * guarded steps inline — where failures are real failures, hard-stopping as
+ * usual — or report the whole block as skipped. An unreadable tree errors the
+ * step instead: "could not evaluate" is not "condition false", and silently
+ * skipping would let a broken tree source turn every guarded dismissal into a
+ * green no-op.
+ */
+async function execWhenStep(
+  state: ExecState,
+  step: Extract<FlowStep, { kind: "when" }>,
+  sourceFlow: string,
+  runStack: string[]
+): Promise<void> {
+  const index = state.reports.length;
+  const label = describeWhenCondition(step.condition);
+  const target = stepTarget(step);
+
+  let met: boolean;
+  if (step.condition.kind === "platform") {
+    // "ios-remote" is an iOS simulator driven through sim-remote — for a
+    // platform guard it IS ios. The parser deliberately rejects "ios-remote"
+    // as a guard spelling, so without this fold no guard could ever match on
+    // a remote sim and iOS-only blocks would silently skip there.
+    const platform = state.device.platform === "ios-remote" ? "ios" : state.device.platform;
+    met = platform === step.condition.platform;
+  } else {
+    const probe = await probeWhenCondition(state, step.condition);
+    if (probe.aborted) {
+      pushReport(state, {
+        index,
+        kind: "when",
+        status: "skip",
+        reason: "run aborted",
+        flow: sourceFlow,
+        target,
+      });
+      reportBlockSkipped(state, step.steps, sourceFlow, "run aborted");
+      return;
+    }
+    if (!probe.ok && probe.indeterminate) {
+      pushReport(state, {
+        index,
+        kind: "when",
+        status: "error",
+        reason: `could not evaluate when guard (${label}): ${probe.reason}`,
+        flow: sourceFlow,
+        target,
+      });
+      state.stopped = true;
+      return;
+    }
+    met = probe.ok;
+  }
+
+  if (!met) {
+    const n = step.steps.length;
+    pushReport(state, {
+      index,
+      kind: "when",
+      status: "skip",
+      reason: `condition not met (${label}) — block skipped (${n} step${n === 1 ? "" : "s"})`,
+      flow: sourceFlow,
+      target,
+    });
+    reportBlockSkipped(state, step.steps, sourceFlow, "when block skipped");
+    return;
+  }
+
+  // Marker for the block, then the guarded steps inline — same scope, same
+  // fragment attribution, failures hard-stop as anywhere else.
+  pushReport(state, {
+    index,
+    kind: "when",
+    status: "pass",
+    reason: `condition met (${label})`,
+    flow: sourceFlow,
+    target,
+  });
+  await execSteps(state, step.steps, sourceFlow, runStack);
 }
 
 async function execRunStep(

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -227,11 +227,35 @@ export type ScrollDirection = "up" | "down" | "left" | "right";
  */
 export type FlowSelector = Selector & { loose?: boolean };
 
+/**
+ * The platforms a `when: { platform: … }` condition can name — derived from
+ * {@link LAUNCH_PLATFORMS} so the parser's runtime check and this type cannot
+ * drift (flow-device's `FlowPlatform` is the same union, aliased there).
+ */
+export type WhenPlatform = (typeof LAUNCH_PLATFORMS)[number];
+
+/**
+ * The guard of a `when:` block. Either a UI condition — the await/assert
+ * condition-as-key shapes, evaluated at run time with the short assert grace
+ * (a skipped block must not add an await-sized dead wait to every clean run) —
+ * or `platform`, a static per-run test against the resolved device.
+ */
+export type WhenCondition =
+  | {
+      kind: "ui";
+      condition: WaitCondition;
+      selector: FlowSelector;
+      expectedText?: string;
+      textMatch?: TextMatchMode;
+    }
+  | { kind: "platform"; platform: WhenPlatform };
+
 export type FlowStep =
   | { kind: "tool"; name: string; args: Record<string, unknown>; delayMs?: number }
   | { kind: "echo"; message: string }
   | { kind: "launch"; app: Launch }
   | { kind: "run"; flow: string }
+  | { kind: "when"; condition: WhenCondition; steps: FlowStep[] }
   | { kind: "tap"; selector?: FlowSelector; x?: number; y?: number; times?: number }
   | { kind: "long-press"; selector?: FlowSelector; x?: number; y?: number; duration?: number }
   | { kind: "type"; into: FlowSelector; text: string; submit?: boolean }
@@ -370,10 +394,23 @@ type YamlScrollBody =
   | YamlSelector
   | { target: YamlSelector; direction?: ScrollDirection; within?: YamlSelector };
 
+/**
+ * A `when:` guard body: exactly one UI condition key (the await/assert shapes,
+ * no `timeout` — evaluation always uses the assert grace) or `{ platform }`.
+ */
+type YamlWhenBody =
+  | { exists: YamlSelector }
+  | { visible: YamlSelector }
+  | { hidden: YamlSelector }
+  | { text: { in: YamlSelector; contains: string } }
+  | { text: { in: YamlSelector; equals: string } }
+  | { platform: WhenPlatform };
+
 type YamlStep =
   | { echo: string }
   | { launch: Launch }
   | { run: string }
+  | { when: YamlWhenBody; steps: YamlStep[] }
   | { tool: string; args?: Record<string, unknown>; delayMs?: number }
   | { tap: TapBody }
   | { "long-press": YamlTarget | { on: YamlTarget; duration?: number } }
@@ -602,6 +639,19 @@ function toYamlStep(step: FlowStep): YamlStep {
       return { launch: step.app };
     case "run":
       return { run: step.flow };
+    case "when": {
+      const when: YamlWhenBody =
+        step.condition.kind === "platform"
+          ? { platform: step.condition.platform }
+          : (waitToYaml(
+              step.condition.condition,
+              step.condition.selector,
+              step.condition.expectedText,
+              step.condition.textMatch,
+              undefined
+            ) as YamlWhenBody);
+      return { when, steps: step.steps.map(toYamlStep) };
+    }
     case "tap": {
       // Canonical minimal spelling: the options form appears only when an
       // option is present (`times` is never stored as 1 — see parseTapTimes),
@@ -679,7 +729,15 @@ function toYamlStep(step: FlowStep): YamlStep {
 }
 
 function badEntry(raw: unknown, detail: string): never {
-  throw new FailureError(`Unrecognized flow entry (${detail}): ${JSON.stringify(raw)}`, {
+  // A cyclic YAML alias materializes as a cyclic object — JSON.stringify
+  // would throw and mask the validation message, so fall back to a marker.
+  let rendered: string;
+  try {
+    rendered = JSON.stringify(raw);
+  } catch {
+    rendered = "[cyclic entry]";
+  }
+  throw new FailureError(`Unrecognized flow entry (${detail}): ${rendered}`, {
     error_code: FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED,
     failure_stage: "flow_file_parse_step",
     failure_area: "tool_server",
@@ -859,16 +917,16 @@ type WaitFields = {
 };
 
 /**
- * Parse the body of an `await`/`assert` step into its condition + selector +
- * optional expected text. The condition is the key and its value is the
- * selector (`{ visible: "Home" }`, `{ text: { in, contains } }`). The `text`
- * check takes exactly one of `contains` (substring), `equals` (exact text), or
- * `matches` (JS regex, validated here so a bad pattern fails at parse, not
- * mid-run). `await` additionally accepts an optional `timeout` sibling key
- * (milliseconds); an `assert` carrying one is rejected rather than silently
- * ignored.
+ * Parse the body of an `await`/`assert` step (or a `when:` guard's UI
+ * condition) into its condition + selector + optional expected text. The
+ * condition is the key and its value is the selector (`{ visible: "Home" }`,
+ * `{ text: { in, contains } }`). The `text` check takes exactly one of
+ * `contains` (substring), `equals` (exact text), or `matches` (JS regex,
+ * validated here so a bad pattern fails at parse, not mid-run). `await`
+ * additionally accepts an optional `timeout` sibling key (milliseconds); an
+ * `assert` carrying one is rejected rather than silently ignored.
  */
-function parseWaitFields(raw: unknown, kind: "await" | "assert"): WaitFields {
+function parseWaitFields(raw: unknown, kind: "await" | "assert" | "when"): WaitFields {
   if (raw === null || typeof raw !== "object") {
     badEntry({ [kind]: raw }, `${kind} needs a condition (${WAIT_CONDITIONS.join(", ")})`);
   }
@@ -959,7 +1017,12 @@ function parseWaitFields(raw: unknown, kind: "await" | "assert"): WaitFields {
   return { condition, selector: parseSelector(b[condition], `${kind}.${condition}`), timeout };
 }
 
-const LAUNCH_PLATFORMS = ["ios", "android", "chromium", "vega"] as const;
+/**
+ * The platform set, spelled once: launch maps, `when: { platform }` guards
+ * ({@link WhenPlatform}), flow-device's `FlowPlatform`, and flow-run's
+ * `platform` param enum all derive from this tuple.
+ */
+export const LAUNCH_PLATFORMS = ["ios", "android", "chromium", "vega"] as const;
 
 // Keys a launch map accepts: the platforms plus the `native` shared-id shorthand.
 const LAUNCH_MAP_KEYS = ["native", ...LAUNCH_PLATFORMS] as const;
@@ -1031,6 +1094,7 @@ const STEP_DIRECTIVE_KEYS: readonly string[] = [
   "echo",
   "launch",
   "run",
+  "when",
   "tool",
   "tap",
   "long-press",
@@ -1193,8 +1257,103 @@ function parseLongPress(body: unknown, entry: unknown): FlowStep {
 
   return { kind: "long-press", ...parseTarget(body, "long-press") };
 }
-function fromYamlStep(raw: YamlStep): FlowStep {
+
+/**
+ * Parse a `when:` guard — exactly one condition key: a UI condition
+ * (exists|visible|hidden|text, the await/assert shapes) or `platform` (a
+ * static per-run test). No `timeout` sibling: the guard is always evaluated
+ * with the short assert grace, so a skipped block stays cheap on every clean
+ * run.
+ */
+function parseWhenCondition(raw: unknown): WhenCondition {
+  const conditionKeys = `${WAIT_CONDITIONS.join(", ")}, platform`;
+  if (raw === null || typeof raw !== "object") {
+    badEntry({ when: raw }, `when needs exactly one condition key (${conditionKeys})`);
+  }
+  const b = raw as Record<string, unknown>;
+  const present = [...WAIT_CONDITIONS, "platform"].filter((c) => c in b);
+  if (present.length !== 1) {
+    badEntry({ when: raw }, `when needs exactly one condition key (${conditionKeys})`);
+  }
+  if ("timeout" in b) {
+    badEntry(
+      { when: raw },
+      "when takes no timeout — the guard is evaluated with the short assert grace so a skipped block never adds a full await wait"
+    );
+  }
+  if (present[0] === "platform") {
+    if (Object.keys(b).length !== 1) {
+      badEntry({ when: raw }, "when.platform takes no other keys");
+    }
+    const p = b.platform;
+    if (typeof p !== "string" || !(LAUNCH_PLATFORMS as readonly string[]).includes(p)) {
+      badEntry({ when: raw }, `when.platform must be one of ${LAUNCH_PLATFORMS.join(", ")}`);
+    }
+    return { kind: "platform", platform: p as WhenPlatform };
+  }
+  // A when guard is the await/assert fields minus `timeout` (rejected above,
+  // so always undefined here) — spread the rest so a future WaitFields
+  // addition reaches when guards the same way it reaches await/assert.
+  const { timeout: _timeout, ...cond } = parseWaitFields(raw, "when");
+  return { kind: "ui", ...cond };
+}
+
+/**
+ * Nesting cap for `when` blocks — the parse-side analog of flow-run's
+ * MAX_RUN_DEPTH. `when` is the only step kind whose parse recurses into child
+ * steps, and the yaml library happily materializes a cyclic alias
+ * (`steps: &s … steps: *s`) as a cyclic object; without a cap that cycle
+ * escapes parseFlow as a raw RangeError instead of a structured parse error.
+ */
+const MAX_WHEN_DEPTH = 20;
+
+/**
+ * Parse a `when` step: `{ when: <condition>, steps: [<step>, …] }` — a guarded
+ * block whose steps run only when the condition holds. Deliberately no `else`:
+ * a when block exists to restore determinism (dismiss the interstitial, get
+ * back on the known path), so paths may only reconverge, never diverge.
+ */
+function parseWhenStep(raw: Record<string, unknown>, depth: number): FlowStep {
+  if (depth >= MAX_WHEN_DEPTH) {
+    badEntry(
+      raw,
+      `when blocks nest deeper than ${MAX_WHEN_DEPTH} levels — check for a cyclic YAML alias (\`steps: &s … steps: *s\`)`
+    );
+  }
+  if ("else" in raw) {
+    badEntry(
+      raw,
+      "when has no else — paths may only reconverge, never diverge; two genuinely different paths are two flows"
+    );
+  }
+  if (!Object.keys(raw).every((k) => k === "when" || k === "steps")) {
+    badEntry(raw, "a when step takes exactly { when: <condition>, steps: [...] }");
+  }
+  const condition = parseWhenCondition(raw.when);
+  if (!Array.isArray(raw.steps) || raw.steps.length === 0) {
+    badEntry(raw, "when needs a non-empty steps list to guard");
+  }
+  const steps = (raw.steps as unknown[]).map((s) => {
+    if (s !== null && typeof s === "object") return fromYamlStep(s as YamlStep, depth + 1);
+    return badEntry(s, "step must be an object");
+  });
+  return { kind: "when", condition, steps };
+}
+
+function fromYamlStep(raw: YamlStep, whenDepth = 0): FlowStep {
   const entry = raw as Record<string, unknown>;
+  // There is deliberately no per-step `optional:` — it would have to be
+  // re-plumbed into every action directive (and each future gesture
+  // directive), when a `when:` block already expresses it once for all of
+  // them. Rejected, not ignored: Maestro habits will produce it, and a
+  // silently-dropped `optional: true` leaves a step the author believes
+  // can't fail hard-stopping the flow.
+  if ("optional" in raw) {
+    badEntry(
+      raw,
+      "optional is not supported — guard the step with a when: block instead (`when: { visible: <target> }` + `steps:`)"
+    );
+  }
   const kinds = STEP_DIRECTIVE_KEYS.filter((k) => k in entry);
   if (kinds.length === 0) {
     const hint = Object.keys(entry)
@@ -1208,25 +1367,31 @@ function fromYamlStep(raw: YamlStep): FlowStep {
       `a step takes exactly one directive key, found ${kinds.map((k) => `\`${k}\``).join(", ")}`
     );
   }
-  // Only a `tool` step carries sibling keys (`args`, `delayMs`); every
+  // Only a `tool` step carries sibling keys (`args`, `delayMs`); every other
   // directive step is a single-key mapping — its options live INSIDE the
-  // value, so a sibling key is a mis-nested or misspelled option.
+  // value, so a sibling key is a mis-nested or misspelled option. A `when`
+  // step also carries siblings (`steps`, and the rejected `else`), but
+  // parseWhenStep validates them itself with pointed messages, so the generic
+  // check stays out of its way.
   const kind = kinds[0]!;
-  const siblings = kind === "tool" ? ["tool", "args", "delayMs"] : [kind];
-  const extras = Object.keys(entry).filter((k) => !siblings.includes(k));
-  if (extras.length > 0) {
-    badEntry(
-      raw,
-      `a \`${kind}\` step has ${describeUnknownKeys(extras, siblings)}` +
-        (kind === "tool"
-          ? " — a tool step takes only `tool`, `args`, `delayMs`"
-          : ` — step options go inside the \`${kind}:\` value, not beside it`)
-    );
+  if (kind !== "when") {
+    const siblings = kind === "tool" ? ["tool", "args", "delayMs"] : [kind];
+    const extras = Object.keys(entry).filter((k) => !siblings.includes(k));
+    if (extras.length > 0) {
+      badEntry(
+        raw,
+        `a \`${kind}\` step has ${describeUnknownKeys(extras, siblings)}` +
+          (kind === "tool"
+            ? " — a tool step takes only `tool`, `args`, `delayMs`"
+            : ` — step options go inside the \`${kind}:\` value, not beside it`)
+      );
+    }
   }
 
   if ("echo" in raw) return { kind: "echo", message: String(raw.echo) };
   if ("launch" in raw) return { kind: "launch", app: parseLaunch(raw.launch) };
   if ("run" in raw) return { kind: "run", flow: String(raw.run) };
+  if ("when" in raw) return parseWhenStep(entry, whenDepth);
 
   if ("tap" in raw) return parseTap((raw as { tap: unknown }).tap, raw);
 

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -397,14 +397,12 @@ type YamlScrollBody =
 /**
  * A `when:` guard body: exactly one UI condition key (the await/assert shapes,
  * no `timeout` — evaluation always uses the assert grace) or `{ platform }`.
+ * Deriving the UI arm from {@link YamlWaitCondition} keeps the two in lockstep:
+ * the guard is parsed by the same parseWaitFields as await/assert, so a
+ * condition shape added there is a when-guard shape too. `timeout` stays out
+ * by construction — the await step type adds it as a sibling key, not here.
  */
-type YamlWhenBody =
-  | { exists: YamlSelector }
-  | { visible: YamlSelector }
-  | { hidden: YamlSelector }
-  | { text: { in: YamlSelector; contains: string } }
-  | { text: { in: YamlSelector; equals: string } }
-  | { platform: WhenPlatform };
+type YamlWhenBody = YamlWaitCondition | { platform: WhenPlatform };
 
 type YamlStep =
   | { echo: string }
@@ -643,13 +641,13 @@ function toYamlStep(step: FlowStep): YamlStep {
       const when: YamlWhenBody =
         step.condition.kind === "platform"
           ? { platform: step.condition.platform }
-          : (waitToYaml(
+          : waitToYaml(
               step.condition.condition,
               step.condition.selector,
               step.condition.expectedText,
               step.condition.textMatch,
               undefined
-            ) as YamlWhenBody);
+            );
       return { when, steps: step.steps.map(toYamlStep) };
     }
     case "tap": {

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -11,6 +11,7 @@ import {
   type WaitCondition,
   type TextMatchMode,
 } from "../../utils/ui-tree-match";
+import { SECRET_PLACEHOLDER_MARKER } from "../../utils/secrets";
 
 const FLOWS_DIR_NAME = path.join(".argent", "flows");
 
@@ -1293,6 +1294,29 @@ function parseWhenCondition(raw: unknown): WhenCondition {
   // so always undefined here) — spread the rest so a future WaitFields
   // addition reaches when guards the same way it reaches await/assert.
   const { timeout: _timeout, ...cond } = parseWaitFields(raw, "when");
+  // `{{secret:NAME}}` resolves only inside the text-entry tools (a `type:`
+  // step), never in condition evaluation, so a guard carrying one tests for
+  // literal placeholder text that is never on screen: exists/visible/text
+  // guards are permanently false (the block silently skips every run) and a
+  // `hidden` guard is vacuously true (the block always runs). In an assert
+  // that mistake fails loudly on the first run; here the guard silently
+  // degenerates into a constant — the same silently-wrong class the per-step
+  // `optional:` rejection exists for, so it fails at parse too.
+  const { selector, expectedText } = cond;
+  for (const s of [
+    expectedText,
+    selector.text,
+    selector.textMatches,
+    selector.identifier,
+    selector.role,
+  ]) {
+    if (s !== undefined && s.includes(SECRET_PLACEHOLDER_MARKER)) {
+      badEntry(
+        { when: raw },
+        "when takes no {{secret:…}} placeholder — secrets resolve only in text-entry steps (`type:`), never in condition evaluation, so the guard tests literal placeholder text that is never on screen: permanently false (for `hidden`, vacuously true); use the literal on-screen text instead"
+      );
+    }
+  }
   return { kind: "ui", ...cond };
 }
 

--- a/packages/tool-server/test/flows/flow-hidden-blank-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-hidden-blank-reads.test.ts
@@ -6,9 +6,10 @@ import type { Registry } from "@argent/registry";
 import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
 
 // Serve the flow tree directly (flows hard-fail rather than degrade to the AX
-// tree). The mock scripts the reads: the element is visible on the first read,
-// then the tree blanks — the shape of a mid-navigation transition, where the
-// blind-read guard refuses to let an empty tree confirm `hidden`.
+// tree). The mock scripts the reads to shape evidence gaps: a trusted read
+// followed by blank trees or throws — the shapes where waitForCondition must
+// distinguish "condition false" from "could not look" (blind-read guard for
+// `hidden`, dark-tail rule for every condition).
 let currentFetch: () => DescribeTreeData;
 vi.mock("../../src/tools/flows/flow-tree", () => ({
   fetchFlowTree: vi.fn(async (): Promise<DescribeTreeData> => currentFetch()),
@@ -178,5 +179,141 @@ describe("hidden timeout diagnostics", () => {
     expect(result.ok).toBe(false);
     expect(result.steps[0].status).toBe("fail");
     expect(result.steps[0].reason).toMatch(/still visible/);
+  });
+});
+
+describe("dark-tail diagnostics (non-hidden conditions)", () => {
+  it("assert exists: reads going dark after one trusted read report indeterminate, not a stale verdict", async () => {
+    // Read 1: trusted, "Done" absent — the expected STARTING state of a
+    // wait, not evidence about the deadline. Reads 2+: the tree source dies
+    // for the rest of the window. A determinate "no element matched" here
+    // would narrate a screen nobody saw at the deadline and drop the fetch
+    // error entirely — the verdict must say the screen was unreadable, and
+    // say why.
+    let reads = 0;
+    currentFetch = () => {
+      if (reads++ === 0) {
+        return {
+          tree: screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]),
+          source: "native-devtools",
+        };
+      }
+      throw new Error("native devtools disconnected");
+    };
+
+    await writeFlow("dark-exists", {
+      executionPrerequisite: "",
+      steps: [{ kind: "assert", condition: "exists", selector: { text: "Done" } }],
+    });
+
+    const result = await run("dark-exists");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].status).toBe("fail");
+    expect(result.steps[0].reason).toMatch(/unreadable for the final \d+ms/i);
+    expect(result.steps[0].reason).toMatch(/native devtools disconnected/);
+    expect(result.steps[0].reason).not.toMatch(/no element matched/);
+  });
+
+  it("await exists: the same dark tail under an await window surfaces the fetch error", async () => {
+    let reads = 0;
+    currentFetch = () => {
+      if (reads++ === 0) {
+        return {
+          tree: screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]),
+          source: "native-devtools",
+        };
+      }
+      throw new Error("native devtools disconnected");
+    };
+
+    await writeFlow("dark-await", {
+      executionPrerequisite: "",
+      steps: [{ kind: "await", condition: "exists", selector: { text: "Done" }, timeout: 1000 }],
+    });
+
+    const result = await run("dark-await");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].status).toBe("fail");
+    expect(result.steps[0].reason).toMatch(/unreadable for the final \d+ms/i);
+    expect(result.steps[0].reason).toMatch(/native devtools disconnected/);
+    expect(result.steps[0].reason).not.toMatch(/no element matched/);
+  });
+
+  it("assert text: does not quote stale element text from before the reads went dark", async () => {
+    // Read 1 sees the banner saying "Loading"; then the source dies. Quoting
+    // `its text was "Loading"` at the deadline would present a first-poll
+    // snapshot as the state of a screen that was unreadable for essentially
+    // the whole window.
+    let reads = 0;
+    currentFetch = () => {
+      if (reads++ === 0) {
+        return {
+          tree: screen([
+            n({
+              identifier: "banner",
+              label: "Loading",
+              frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.1 },
+            }),
+          ]),
+          source: "native-devtools",
+        };
+      }
+      throw new Error("native devtools disconnected");
+    };
+
+    await writeFlow("dark-text", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "assert",
+          condition: "text",
+          selector: { identifier: "banner" },
+          expectedText: "Done",
+          textMatch: "contains",
+        },
+      ],
+    });
+
+    const result = await run("dark-text");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].status).toBe("fail");
+    expect(result.steps[0].reason).toMatch(/unreadable for the final \d+ms/i);
+    expect(result.steps[0].reason).toMatch(/native devtools disconnected/);
+    expect(result.steps[0].reason).not.toMatch(/Loading/);
+  });
+
+  it("keeps the determinate verdict — with the error appended — when only the final polls throw", async () => {
+    // The deliberate trailing tolerance: trusted reads showed "Done" absent
+    // until ~one poll before the 1s assert deadline, so a fetch error on the
+    // trailing polls is a blip, not doubt — the determinate reason stands.
+    // The failed final read is appended rather than silently dropped (main
+    // surfaced `could not read the UI tree: <err>` here; losing it was a
+    // report-quality regression).
+    let firstReadAt: number | undefined;
+    currentFetch = () => {
+      firstReadAt ??= Date.now();
+      if (Date.now() - firstReadAt >= 950) throw new Error("native devtools disconnected");
+      return {
+        tree: screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]),
+        source: "native-devtools",
+      };
+    };
+
+    await writeFlow("blip-exists", {
+      executionPrerequisite: "",
+      steps: [{ kind: "assert", condition: "exists", selector: { text: "Done" } }],
+    });
+
+    const result = await run("blip-exists");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].status).toBe("fail");
+    expect(result.steps[0].reason).toMatch(/no element matched/);
+    expect(result.steps[0].reason).toMatch(
+      /final poll could not read the UI tree: native devtools disconnected/
+    );
   });
 });

--- a/packages/tool-server/test/flows/flow-hidden-blank-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-hidden-blank-reads.test.ts
@@ -99,6 +99,39 @@ describe("hidden timeout diagnostics", () => {
     expect(result.steps[0].reason).not.toMatch(/still visible/);
   });
 
+  it("does not claim the element was still visible when the final reads threw", async () => {
+    // Same evidence gap as the blank-tree case, surfaced as a THROW: read 1
+    // is trusted and sees the spinner, then the tree source disconnects and
+    // every later fetch rejects. The stale read-1 match must not stand in as
+    // current evidence — the failure must say the check could not be
+    // confirmed (and why), not that the element was "still visible".
+    let reads = 0;
+    currentFetch = () => {
+      if (reads++ === 0) {
+        return {
+          tree: screen([
+            n({ identifier: "spinner", frame: { x: 0.4, y: 0.4, width: 0.2, height: 0.2 } }),
+          ]),
+          source: "native-devtools",
+        };
+      }
+      throw new Error("native devtools disconnected");
+    };
+
+    await writeFlow("dark-hidden", {
+      executionPrerequisite: "",
+      steps: [{ kind: "assert", condition: "hidden", selector: { identifier: "spinner" } }],
+    });
+
+    const result = await run("dark-hidden");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].status).toBe("fail");
+    expect(result.steps[0].reason).toMatch(/could not confirm/);
+    expect(result.steps[0].reason).toMatch(/native devtools disconnected/);
+    expect(result.steps[0].reason).not.toMatch(/still visible/);
+  });
+
   it("still reports a genuinely visible element as still visible", async () => {
     currentFetch = () => ({
       tree: screen([
@@ -113,6 +146,34 @@ describe("hidden timeout diagnostics", () => {
     });
 
     const result = await run("stuck-spinner");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].status).toBe("fail");
+    expect(result.steps[0].reason).toMatch(/still visible/);
+  });
+
+  it("reports still visible when a mid-window throw is followed by a trusted read", async () => {
+    // A blip that RECOVERS: read 2 throws, but every later read is trusted
+    // and still shows the spinner. The final read is honest evidence, so the
+    // determinate "still visible" verdict stands — indeterminacy is only for
+    // windows whose last look at the screen was blind or failed.
+    let reads = 0;
+    currentFetch = () => {
+      if (reads++ === 1) throw new Error("native devtools disconnected");
+      return {
+        tree: screen([
+          n({ identifier: "spinner", frame: { x: 0.4, y: 0.4, width: 0.2, height: 0.2 } }),
+        ]),
+        source: "native-devtools",
+      };
+    };
+
+    await writeFlow("blip-spinner", {
+      executionPrerequisite: "",
+      steps: [{ kind: "assert", condition: "hidden", selector: { identifier: "spinner" } }],
+    });
+
+    const result = await run("blip-spinner");
 
     expect(result.ok).toBe(false);
     expect(result.steps[0].status).toBe("fail");

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -675,7 +675,7 @@ describe("flow-finish-recording", () => {
               expectedText: "^Total: \\$\\d+\\.\\d{2}$",
               textMatch: "matches",
             },
-            steps: guarded,
+            steps: [...guarded, { kind: "echo", message: "and again" }],
           },
         ],
       })
@@ -684,9 +684,9 @@ describe("flow-finish-recording", () => {
     const result = await flowFinishRecordingTool.execute({}, {});
 
     expect(result.summary).toEqual([
-      '1. when: text {"id":"status"} contains "Ready \\"now\\"\\nnext" (1 steps)',
-      '2. when: text {"id":"status"} == "Ready" (1 steps)',
-      '3. when: text {"id":"total"} matches /^Total: \\$\\d+\\.\\d{2}$/ (1 steps)',
+      '1. when: text {"id":"status"} contains "Ready \\"now\\"\\nnext" (1 step)',
+      '2. when: text {"id":"status"} == "Ready" (1 step)',
+      '3. when: text {"id":"total"} matches /^Total: \\$\\d+\\.\\d{2}$/ (2 steps)',
     ]);
   });
 });

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -20,6 +20,7 @@ import {
   clearActiveProjectRoot,
   parseFlow,
   serializeFlow,
+  type FlowStep,
 } from "../../src/tools/flows/flow-utils";
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -627,6 +628,65 @@ describe("flow-finish-recording", () => {
       '2. assert: text {"id":"status"} == "Ready"',
       '3. assert: text {"id":"total"} matches /^Total: \\$\\d+\\.\\d{2}$/',
       '4. assert: text {"id":"legacy-status"} contains "Still running"',
+    ]);
+  });
+
+  it("renders when text guards with the same comparator spelling as await/assert", async () => {
+    const name = "when-text-guard-summary";
+    await flowStartRecordingTool.execute(
+      {},
+      { name, project_root: tmpDir, executionPrerequisite: PREREQ }
+    );
+
+    const guarded: FlowStep[] = [{ kind: "echo", message: "guarded" }];
+    await fs.writeFile(
+      path.join(tmpDir, ".argent", "flows", `${name}.yaml`),
+      serializeFlow({
+        executionPrerequisite: PREREQ,
+        steps: [
+          {
+            kind: "when",
+            condition: {
+              kind: "ui",
+              condition: "text",
+              selector: { identifier: "status" },
+              expectedText: 'Ready "now"\nnext',
+              textMatch: "contains",
+            },
+            steps: guarded,
+          },
+          {
+            kind: "when",
+            condition: {
+              kind: "ui",
+              condition: "text",
+              selector: { identifier: "status" },
+              expectedText: "Ready",
+              textMatch: "equals",
+            },
+            steps: guarded,
+          },
+          {
+            kind: "when",
+            condition: {
+              kind: "ui",
+              condition: "text",
+              selector: { identifier: "total" },
+              expectedText: "^Total: \\$\\d+\\.\\d{2}$",
+              textMatch: "matches",
+            },
+            steps: guarded,
+          },
+        ],
+      })
+    );
+
+    const result = await flowFinishRecordingTool.execute({}, {});
+
+    expect(result.summary).toEqual([
+      '1. when: text {"id":"status"} contains "Ready \\"now\\"\\nnext" (1 steps)',
+      '2. when: text {"id":"status"} == "Ready" (1 steps)',
+      '3. when: text {"id":"total"} matches /^Total: \\$\\d+\\.\\d{2}$/ (1 steps)',
     ]);
   });
 });

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -345,9 +345,61 @@ describe("when: execution", () => {
     const result = await run("blind");
 
     // "Could not evaluate" is not "condition false" — a broken tree source
-    // must not silently turn a guarded dismissal into a green no-op.
-    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["when:error", "echo:skip"]);
+    // must not silently turn a guarded dismissal into a green no-op. The
+    // guarded steps still expand: one skip line per authored step, same
+    // report shape as an unmet guard.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:error",
+      "tap:skip",
+      "echo:skip",
+    ]);
     expect(result.steps[0].reason).toMatch(/could not evaluate when guard/i);
+    expect(result.steps[1].reason).toBe("when guard errored");
+    expect(result.ok).toBe(false);
+  });
+
+  it("expands a nested when block when the guard errors", async () => {
+    currentTree = () => {
+      throw new Error("native devtools disconnected");
+    };
+    await writeFlow("blind-nested", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [
+            { kind: "tap", selector: { text: "Skip", loose: true } },
+            {
+              kind: "when",
+              condition: { kind: "platform", platform: "ios" },
+              steps: [{ kind: "echo", message: "nested" }],
+            },
+          ],
+        },
+        { kind: "echo", message: "never reached" },
+      ],
+    });
+
+    const result = await run("blind-nested");
+
+    // An errored guard reports the same shape as an unmet one — the block
+    // marker errors, then one skip line per authored step with the nested
+    // when's subtree expanded.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:error",
+      "tap:skip",
+      "when:skip",
+      "echo:skip",
+      "echo:skip",
+    ]);
+    expect(result.steps[2].reason).toBe("when guard errored");
+    expect(result.errored).toBe(1);
+    expect(result.skipped).toBe(2); // tap + nested when marker; echo is narration
     expect(result.ok).toBe(false);
   });
 
@@ -375,7 +427,11 @@ describe("when: execution", () => {
 
     const result = await run("degraded");
 
-    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["when:error", "echo:skip"]);
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:error",
+      "tap:skip",
+      "echo:skip",
+    ]);
     expect(result.steps[0].reason).toMatch(/could not evaluate when guard/i);
     expect(result.taps).toHaveLength(0);
     expect(result.ok).toBe(false);
@@ -408,7 +464,11 @@ describe("when: execution", () => {
 
     const result = await run("spinner-gone");
 
-    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["when:error", "echo:skip"]);
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:error",
+      "echo:skip",
+      "echo:skip",
+    ]);
     expect(result.steps[0].reason).toMatch(/could not confirm the element is hidden/i);
     expect(result.ok).toBe(false);
   });

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -63,11 +63,19 @@ function asRun(r: FlowRunResult | { notice: string }): FlowRunResult {
 }
 
 async function run(
-  name: string
+  name: string,
+  device: string = DEVICE,
+  signal?: AbortSignal
 ): Promise<FlowRunResult & { taps: Array<{ x: number; y: number }> }> {
   const taps: Array<{ x: number; y: number }> = [];
   const tool = createRunFlowTool(mockRegistry(taps));
-  const result = asRun(await tool.execute({}, { name, project_root: tmpDir, device: DEVICE }));
+  const result = asRun(
+    await tool.execute(
+      {},
+      { name, project_root: tmpDir, device },
+      (signal ? { signal } : undefined) as never
+    )
+  );
   return Object.assign(result, { taps });
 }
 
@@ -185,6 +193,63 @@ describe("when: parse/serialize", () => {
     expect(() => parseFlow("steps:\n  - await: { visible: X }\n    optional: false\n")).toThrow(
       /optional is not supported/i
     );
+  });
+
+  it("rejects a {{secret:…}} placeholder in a guard's expected text", () => {
+    // Placeholders resolve only in the text-entry tools; condition evaluation
+    // sees the literal placeholder, so the guard degenerates into a constant —
+    // permanently false here (vacuously true for hidden) — same silently-wrong
+    // class as optional:.
+    expect(() =>
+      parseFlow(
+        'steps:\n  - when: { text: { in: account, equals: "{{secret:USERNAME}}" } }\n    steps: [{ tap: A }]\n'
+      )
+    ).toThrow(/when takes no \{\{secret:…\}\} placeholder/i);
+    expect(() =>
+      parseFlow(
+        'steps:\n  - when: { text: { in: banner, contains: "{{secret:PROMO}}" } }\n    steps: [{ tap: A }]\n'
+      )
+    ).toThrow(/never in condition evaluation/i);
+  });
+
+  it("rejects a {{secret:…}} placeholder in a guard's selector", () => {
+    // Same degenerate-constant class as the expected-text case: the tree
+    // probe would look for the literal placeholder string on screen — and a
+    // hidden guard would flip the failure to always-run instead of never-run.
+    expect(() =>
+      parseFlow('steps:\n  - when: { exists: "{{secret:TOKEN}}" }\n    steps: [{ tap: A }]\n')
+    ).toThrow(/when takes no \{\{secret:…\}\} placeholder/i);
+    expect(() =>
+      parseFlow(
+        'steps:\n  - when: { visible: { id: "{{secret:TOKEN}}" } }\n    steps: [{ tap: A }]\n'
+      )
+    ).toThrow(/use the literal on-screen text instead/i);
+    expect(() =>
+      parseFlow('steps:\n  - when: { hidden: "{{secret:TOKEN}}" }\n    steps: [{ tap: A }]\n')
+    ).toThrow(/vacuously true/i);
+    expect(() =>
+      parseFlow(
+        'steps:\n  - when: { text: { in: "{{secret:FIELD}}", equals: ok } }\n    steps: [{ tap: A }]\n'
+      )
+    ).toThrow(/when takes no \{\{secret:…\}\} placeholder/i);
+  });
+
+  it("still parses a type: step carrying a placeholder (resolved by the keyboard tool)", () => {
+    const flow = parseFlow('steps:\n  - type: { into: password, text: "{{secret:PASSWORD}}" }\n');
+    expect(flow.steps).toEqual([
+      { kind: "type", into: { text: "password", loose: true }, text: "{{secret:PASSWORD}}" },
+    ]);
+  });
+
+  it("still parses assert: and await: conditions carrying a placeholder (they fail loudly at runtime)", () => {
+    // The rejection is when-only by design: an assert/await comparing the
+    // literal placeholder fails loudly on the first run, unlike a guard's
+    // silent degeneration. A refactor hoisting the check into parseWaitFields
+    // must trip this test.
+    expect(() =>
+      parseFlow('steps:\n  - assert: { text: { in: account, equals: "{{secret:USERNAME}}" } }\n')
+    ).not.toThrow();
+    expect(() => parseFlow('steps:\n  - await: { visible: "{{secret:TOKEN}}" }\n')).not.toThrow();
   });
 });
 
@@ -311,6 +376,52 @@ describe("when: execution", () => {
     expect(result.ok).toBe(false);
   });
 
+  it("expands a when block skipped by a hard stop — one line per authored step, no abort", async () => {
+    // The hard-stop test above places an echo after the failure; here a when
+    // BLOCK sits there instead, so the stopped-run branch must expand the
+    // block's authored steps rather than collapse it to one line. And a hard
+    // stop is not a cancellation: `aborted` stays unset and the skip lines
+    // carry no "run aborted" reason.
+    currentTree = () =>
+      screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+    await writeFlow("hard-stop-when", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "assert",
+          condition: "visible",
+          selector: { text: "No such button", loose: true },
+        },
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [
+            { kind: "tap", selector: { text: "Skip", loose: true } },
+            { kind: "echo", message: "inside" },
+          ],
+        },
+      ],
+    });
+
+    const result = await run("hard-stop-when");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "assert:fail",
+      "when:skip",
+      "tap:skip",
+      "echo:skip",
+    ]);
+    expect(result.steps[1].reason).toBeUndefined();
+    expect(result.steps[3].message).toBe("inside");
+    expect(result.taps).toHaveLength(0);
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBeUndefined();
+  });
+
   it("evaluates a platform guard statically against the resolved device", async () => {
     await writeFlow("per-platform", {
       executionPrerequisite: "",
@@ -337,6 +448,119 @@ describe("when: execution", () => {
       "tool:skip",
     ]);
     expect(result.steps[2].reason).toMatch(/platform android/);
+    expect(result.ok).toBe(true);
+  });
+
+  it("folds ios-remote to ios: a platform guard matches on a remote simulator", async () => {
+    // A `remote:`-prefixed udid resolves as platform "ios-remote" (shape-based,
+    // see classifyDevice), a spelling the parser deliberately rejects in
+    // guards — execWhenStep folds it to "ios" at evaluation time. Without the
+    // fold no guard could ever match on a remote sim: every
+    // `when: { platform: ios }` block would silently skip there while the run
+    // stays green — the same silent-no-op class the indeterminate-guard
+    // handling exists to prevent. This test pins the fold at runtime.
+    currentTree = () =>
+      screen([n({ label: "Skip", frame: { x: 0.4, y: 0.8, width: 0.2, height: 0.1 } })]);
+    await writeFlow("remote-sim", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: { kind: "platform", platform: "ios" },
+          steps: [{ kind: "tap", selector: { text: "Skip", loose: true } }],
+        },
+        {
+          kind: "when",
+          condition: { kind: "platform", platform: "android" },
+          steps: [{ kind: "tool", name: "button", args: { button: "back" } }],
+        },
+      ],
+    });
+
+    const result = await run("remote-sim", `remote:${DEVICE}`);
+
+    // The run really targeted the remote-prefixed id (platform "ios-remote"),
+    // not a local iOS udid — so entering the ios block below IS the fold.
+    expect(result.device).toBe(`remote:${DEVICE}`);
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:pass",
+      "tap:pass",
+      "when:skip",
+      "tool:skip",
+    ]);
+    expect(result.steps[0].reason).toMatch(/condition met \(platform ios\)/);
+    expect(result.steps[2].reason).toMatch(/platform android/);
+    expect(result.taps).toHaveLength(1);
+    expect(result.ok).toBe(true);
+  });
+
+  it("matches a platform guard positively on an android device and skips the ios block", async () => {
+    // The inverse orientation of the iOS-udid test above: an android serial
+    // (any id that is not a UUID / remote: / chromium-cdp- / amazon- shape
+    // resolves as android) must ENTER the android block. Pins that guard
+    // matching works from a non-iOS device too, not only as
+    // ios-matches / android-skips seen from an iOS udid.
+    currentTree = () =>
+      screen([n({ label: "Allow", frame: { x: 0.4, y: 0.8, width: 0.2, height: 0.1 } })]);
+    await writeFlow("android-run", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: { kind: "platform", platform: "android" },
+          steps: [{ kind: "tap", selector: { text: "Allow", loose: true } }],
+        },
+        {
+          kind: "when",
+          condition: { kind: "platform", platform: "ios" },
+          steps: [{ kind: "echo", message: "ios only" }],
+        },
+      ],
+    });
+
+    const result = await run("android-run", "emulator-5554");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:pass",
+      "tap:pass",
+      "when:skip",
+      "echo:skip",
+    ]);
+    expect(result.steps[0].reason).toMatch(/condition met \(platform android\)/);
+    expect(result.steps[2].reason).toMatch(/platform ios/);
+    expect(result.taps).toHaveLength(1);
+    expect(result.ok).toBe(true);
+  });
+
+  it("matches a platform guard positively on a vega device", async () => {
+    // Vega resolves by the amazon- serial prefix. Touch directives are
+    // rejected upfront on vega (it is remote-driven), so the guarded step is
+    // an echo — the guard entering at all is what's under test.
+    await writeFlow("vega-run", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: { kind: "platform", platform: "vega" },
+          steps: [{ kind: "echo", message: "vega only" }],
+        },
+        {
+          kind: "when",
+          condition: { kind: "platform", platform: "ios" },
+          steps: [{ kind: "echo", message: "ios only" }],
+        },
+      ],
+    });
+
+    const result = await run("vega-run", "amazon-4a27df03c9777152");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:pass",
+      "echo:pass",
+      "when:skip",
+      "echo:skip",
+    ]);
+    expect(result.steps[0].reason).toMatch(/condition met \(platform vega\)/);
     expect(result.ok).toBe(true);
   });
 
@@ -534,16 +758,18 @@ describe("when: execution", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("keeps a clean skip when trusted reads showed a non-hidden condition false and only trailing reads throw", async () => {
-    // The trailing-blip tolerance for every condition except `hidden`: the
-    // trusted first read already showed "What's new" absent, so a last-poll
-    // disconnect is a blip, not doubt — the skip stays clean and the run green.
-    let reads = 0;
+  it("keeps a clean skip when trusted reads showed a non-hidden condition false and only the final polls throw", async () => {
+    // The trailing-blip tolerance for every condition except `hidden`:
+    // trusted reads showed "What's new" absent until ~one poll before the
+    // 1s guard deadline, so a disconnect on the trailing polls is a blip,
+    // not doubt — the skip stays clean and the run green. (Appending the
+    // failed-read note is an assert/await report feature; the when skip
+    // reason carries only the guard label.)
+    let firstReadAt: number | undefined;
     currentTree = () => {
-      if (reads++ === 0) {
-        return screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
-      }
-      throw new Error("native devtools disconnected");
+      firstReadAt ??= Date.now();
+      if (Date.now() - firstReadAt >= 950) throw new Error("native devtools disconnected");
+      return screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
     };
     await writeFlow("blip-skip", {
       executionPrerequisite: "",
@@ -571,6 +797,50 @@ describe("when: execution", () => {
     expect(result.steps[0].reason).toMatch(/condition not met/);
     expect(result.taps).toHaveLength(0);
     expect(result.ok).toBe(true);
+  });
+
+  it("errors — not skips — a guard whose reads go dark for the tail of the window", async () => {
+    // The unbounded dark tail: one trusted read shows "What's new" absent,
+    // then the tree source dies for the REST of the 1s window. That early
+    // read is the expected starting state of a wait, not evidence about the
+    // deadline — a determinate "condition not met" skip here would let a
+    // dying tree source turn a guarded dismissal into a silent green no-op
+    // while the dialog may well be on screen. Unknown is not false: error.
+    let reads = 0;
+    currentTree = () => {
+      if (reads++ === 0) {
+        return screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+      }
+      throw new Error("native devtools disconnected");
+    };
+    await writeFlow("dark-tail-guard", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [{ kind: "tap", selector: { text: "Skip", loose: true } }],
+        },
+        { kind: "echo", message: "never reached" },
+      ],
+    });
+
+    const result = await run("dark-tail-guard");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:error",
+      "tap:skip",
+      "echo:skip",
+    ]);
+    expect(result.steps[0].reason).toMatch(/could not evaluate when guard/i);
+    expect(result.steps[0].reason).toMatch(/unreadable for the final \d+ms/i);
+    expect(result.steps[0].reason).toMatch(/native devtools disconnected/);
+    expect(result.taps).toHaveLength(0);
+    expect(result.ok).toBe(false);
   });
 
   it("streams every when-related report line to the live progress consumer", async () => {
@@ -661,5 +931,141 @@ describe("when: as tap-if-present", () => {
     ]);
     expect(result.taps).toHaveLength(0);
     expect(result.ok).toBe(true);
+  });
+});
+
+describe("when: run cancellation", () => {
+  // Same abort injection as flow-abort.test.ts: trip an AbortController from
+  // inside the mocked tree fetch, landing the cancellation deterministically
+  // inside a poll (no timer races).
+
+  it("skips the block with the abort reason — not a determinate skip — when the guard probe is cancelled", async () => {
+    const controller = new AbortController();
+    // The guard's target is absent and the cancellation lands inside the
+    // probe's first tree read. ABORTED_OUTCOME carries no `indeterminate`, so
+    // without execWhenStep's dedicated probe.aborted branch the cancelled
+    // probe would fall through to met=false and claim the determinate
+    // "condition not met (...) — block skipped" for a screen it never
+    // finished reading — the assertions below pin the abort reason instead.
+    currentTree = () => {
+      controller.abort();
+      return screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+    };
+    await writeFlow("cancelled-guard", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [
+            { kind: "tap", selector: { text: "Skip", loose: true } },
+            { kind: "echo", message: "inside" },
+          ],
+        },
+        { kind: "echo", message: "after block" },
+      ],
+    });
+
+    const result = await run("cancelled-guard", DEVICE, controller.signal);
+
+    // The block marker + every authored step skip with the uniform abort
+    // reason, and the guarded tap never dispatches.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:skip",
+      "tap:skip",
+      "echo:skip",
+      "echo:skip",
+    ]);
+    expect(result.steps[0].reason).toBe("run aborted");
+    expect(result.steps[0].reason).not.toMatch(/condition not met/);
+    expect(result.steps[1].reason).toBe("run aborted");
+    expect(result.taps).toHaveLength(0);
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBe(true);
+  });
+
+  it("expands a when block — nested block included — when the run was cancelled before it", async () => {
+    const controller = new AbortController();
+    // The tap's target never appears; the run is cancelled on the third tree
+    // read, while the tap's auto-wait is still polling. The when block after
+    // it then hits the pre-step abort guard: one skip line for the marker AND
+    // one per authored step, with the nested when's subtree expanded.
+    let reads = 0;
+    currentTree = () => {
+      reads++;
+      if (reads >= 3) controller.abort();
+      return screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+    };
+    await writeFlow("aborted-before-when", {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "tap", selector: { text: "Checkout", loose: true } },
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [
+            { kind: "tap", selector: { text: "Skip", loose: true } },
+            {
+              kind: "when",
+              condition: { kind: "platform", platform: "ios" },
+              steps: [{ kind: "echo", message: "nested" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await run("aborted-before-when", DEVICE, controller.signal);
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "tap:skip",
+      "when:skip",
+      "tap:skip",
+      "when:skip",
+      "echo:skip",
+    ]);
+    expect(result.steps.map((s) => s.reason)).toEqual(Array(5).fill("run aborted"));
+    // The skipped nested echo keeps its message, matching reportBlockSkipped.
+    expect(result.steps[4].message).toBe("nested");
+    expect(result.taps).toHaveLength(0);
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBe(true);
+  });
+
+  it("leaves the aborted field unset on a clean green run", async () => {
+    // Control for the cancellation cases: summarize spreads the flag in only
+    // when the signal tripped (`...(aborted ? { aborted: true } : {})`), so a
+    // completed run must not carry the key at all.
+    currentTree = () =>
+      screen([n({ label: "Got it", frame: { x: 0.4, y: 0.8, width: 0.2, height: 0.1 } })]);
+    await writeFlow("green-run", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "Got it", loose: true },
+          },
+          steps: [{ kind: "tap", selector: { text: "Got it", loose: true } }],
+        },
+        { kind: "echo", message: "after" },
+      ],
+    });
+
+    const result = await run("green-run");
+
+    expect(result.ok).toBe(true);
+    expect(result.aborted).toBeUndefined();
+    expect("aborted" in result).toBe(false);
   });
 });

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -112,6 +112,17 @@ describe("when: parse/serialize", () => {
           },
           steps: [{ kind: "echo" as const, message: "sale banner up" }],
         },
+        {
+          kind: "when" as const,
+          condition: {
+            kind: "ui" as const,
+            condition: "text" as const,
+            selector: { identifier: "total" },
+            expectedText: "^Total: \\$\\d+$",
+            textMatch: "matches" as const,
+          },
+          steps: [{ kind: "echo" as const, message: "total rendered" }],
+        },
       ],
     };
     expect(parseFlow(serializeFlow(flow)).steps).toEqual(flow.steps);

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -251,6 +251,9 @@ describe("when: execution", () => {
     ]);
     expect(result.steps[0].reason).toMatch(/condition not met .*block skipped \(2 steps\)/);
     expect(result.steps[1].reason).toBe("when block skipped");
+    // The skipped nested echo keeps its message so the renderer marks it
+    // skipped rather than printing it as if it had run.
+    expect(result.steps[3].message).toBe("nested");
     expect(result.taps).toHaveLength(0);
     expect(result.ok).toBe(true);
   });
@@ -290,6 +293,10 @@ describe("when: execution", () => {
       "assert:fail",
       "echo:skip",
     ]);
+    // The trailing top-level echo is skipped by the hard stop but keeps its
+    // message, so the renderer can mark it skipped instead of dropping the
+    // line (or, worse, printing it as if it had run).
+    expect(result.steps[2].message).toBe("never reached");
     expect(result.ok).toBe(false);
   });
 

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -473,6 +473,88 @@ describe("when: execution", () => {
     expect(result.ok).toBe(false);
   });
 
+  it("errors a hidden guard whose later reads throw after the element matched", async () => {
+    // The same evidence gap as the blind-read case, surfaced as a THROW: read
+    // 1 is trusted and sees the spinner, then the tree source disconnects and
+    // every later fetch rejects. The visible match left over from read 1 must
+    // not stand in as current evidence and turn the guard into a determinate
+    // "condition not met" skip — gone-ness is unconfirmable, so error.
+    let reads = 0;
+    currentTree = () => {
+      if (reads++ === 0) {
+        return screen([
+          n({ label: "Spinner", frame: { x: 0.4, y: 0.4, width: 0.2, height: 0.2 } }),
+        ]);
+      }
+      throw new Error("native devtools disconnected");
+    };
+    await writeFlow("spinner-dark", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "hidden",
+            selector: { text: "Spinner", loose: true },
+          },
+          steps: [{ kind: "echo", message: "cleanup" }],
+        },
+        { kind: "echo", message: "never reached" },
+      ],
+    });
+
+    const result = await run("spinner-dark");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:error",
+      "echo:skip",
+      "echo:skip",
+    ]);
+    expect(result.steps[0].reason).toMatch(/could not confirm the element is hidden/i);
+    expect(result.steps[0].reason).toMatch(/native devtools disconnected/);
+    expect(result.ok).toBe(false);
+  });
+
+  it("keeps a clean skip when trusted reads showed a non-hidden condition false and only trailing reads throw", async () => {
+    // The trailing-blip tolerance for every condition except `hidden`: the
+    // trusted first read already showed "What's new" absent, so a last-poll
+    // disconnect is a blip, not doubt — the skip stays clean and the run green.
+    let reads = 0;
+    currentTree = () => {
+      if (reads++ === 0) {
+        return screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+      }
+      throw new Error("native devtools disconnected");
+    };
+    await writeFlow("blip-skip", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [{ kind: "tap", selector: { text: "Skip", loose: true } }],
+        },
+        { kind: "echo", message: "after block" },
+      ],
+    });
+
+    const result = await run("blip-skip");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:skip",
+      "tap:skip",
+      "echo:pass",
+    ]);
+    expect(result.steps[0].reason).toMatch(/condition not met/);
+    expect(result.taps).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+
   it("streams every when-related report line to the live progress consumer", async () => {
     // All when reports go through pushReport — the progress stream and the
     // final report must contain the same lines.

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -1,0 +1,505 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
+
+// Serve the flow tree directly: flows resolve selectors against the platform's
+// full-hierarchy source and hard-fail rather than degrade to the AX tree, so
+// these unit tests stub the tree fetch itself. `currentHint` flags the read as
+// degraded — an empty tree + hint is a blind read the guard must not trust.
+let currentTree: () => DescribeNode;
+let currentHint: string | undefined;
+vi.mock("../../src/tools/flows/flow-tree", () => ({
+  fetchFlowTree: vi.fn(
+    async (): Promise<DescribeTreeData> => ({
+      tree: currentTree(),
+      source: "native-devtools",
+      ...(currentHint !== undefined ? { hint: currentHint } : {}),
+    })
+  ),
+}));
+
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+import { serializeFlow, parseFlow } from "../../src/tools/flows/flow-utils";
+
+const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
+let tmpDir: string;
+
+function n(partial: Partial<DescribeNode> & { frame: DescribeNode["frame"] }): DescribeNode {
+  return { role: "AXOther", children: [], ...partial };
+}
+
+function screen(children: DescribeNode[]): DescribeNode {
+  return n({ role: "AXWindow", frame: { x: 0, y: 0, width: 1, height: 1 }, children });
+}
+
+function mockRegistry(taps: Array<{ x: number; y: number }>): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string, args: Record<string, unknown>) => {
+      if (id === "list-devices") return { devices: [] };
+      if (id === "gesture-tap") {
+        taps.push({ x: args.x as number, y: args.y as number });
+        return { tapped: true };
+      }
+      return { ok: true };
+    }),
+    getTool: vi.fn((id: string) =>
+      id === "gesture-tap" ? { inputSchema: { properties: { udid: {} } } } : undefined
+    ),
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: Parameters<typeof serializeFlow>[0]): Promise<void> {
+  const dir = path.join(tmpDir, ".argent", "flows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.yaml`), serializeFlow(yaml), "utf8");
+}
+
+function asRun(r: FlowRunResult | { notice: string }): FlowRunResult {
+  if (!("steps" in r)) throw new Error(`expected a run result, got notice: ${r.notice}`);
+  return r;
+}
+
+async function run(
+  name: string
+): Promise<FlowRunResult & { taps: Array<{ x: number; y: number }> }> {
+  const taps: Array<{ x: number; y: number }> = [];
+  const tool = createRunFlowTool(mockRegistry(taps));
+  const result = asRun(await tool.execute({}, { name, project_root: tmpDir, device: DEVICE }));
+  return Object.assign(result, { taps });
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-when-"));
+  currentTree = () => screen([]);
+  currentHint = undefined;
+});
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("when: parse/serialize", () => {
+  it("round-trips ui and platform guards and nested blocks", () => {
+    const flow = {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when" as const,
+          condition: {
+            kind: "ui" as const,
+            condition: "visible" as const,
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [
+            { kind: "tap" as const, selector: { text: "Skip", loose: true } },
+            {
+              kind: "when" as const,
+              condition: { kind: "platform" as const, platform: "android" as const },
+              steps: [{ kind: "tool" as const, name: "button", args: { button: "back" } }],
+            },
+          ],
+        },
+        {
+          kind: "when" as const,
+          condition: {
+            kind: "ui" as const,
+            condition: "text" as const,
+            selector: { identifier: "banner" },
+            expectedText: "Sale",
+            textMatch: "contains" as const,
+          },
+          steps: [{ kind: "echo" as const, message: "sale banner up" }],
+        },
+      ],
+    };
+    expect(parseFlow(serializeFlow(flow)).steps).toEqual(flow.steps);
+  });
+
+  it("rejects an else branch with the design rationale", () => {
+    expect(() =>
+      parseFlow(
+        "steps:\n  - when: { visible: X }\n    steps:\n      - tap: Skip\n    else:\n      - tap: Other\n"
+      )
+    ).toThrow(/when has no else/i);
+  });
+
+  it("rejects unknown sibling keys and a missing/empty steps list", () => {
+    expect(() =>
+      parseFlow("steps:\n  - when: { visible: X }\n    steps: [{ tap: A }]\n    retries: 2\n")
+    ).toThrow(/takes exactly \{ when: <condition>, steps: \[\.\.\.\] \}/i);
+    expect(() => parseFlow("steps:\n  - when: { visible: X }\n")).toThrow(/non-empty steps list/i);
+    expect(() => parseFlow("steps:\n  - when: { visible: X }\n    steps: []\n")).toThrow(
+      /non-empty steps list/i
+    );
+  });
+
+  it("requires exactly one condition key and no timeout", () => {
+    expect(() => parseFlow("steps:\n  - when: {}\n    steps: [{ tap: A }]\n")).toThrow(
+      /exactly one condition key \(exists, visible, hidden, text, platform\)/i
+    );
+    expect(() =>
+      parseFlow("steps:\n  - when: { visible: X, hidden: Y }\n    steps: [{ tap: A }]\n")
+    ).toThrow(/exactly one condition key/i);
+    expect(() =>
+      parseFlow("steps:\n  - when: { visible: X, timeout: 5000 }\n    steps: [{ tap: A }]\n")
+    ).toThrow(/when takes no timeout/i);
+  });
+
+  it("validates the platform guard value", () => {
+    expect(() =>
+      parseFlow("steps:\n  - when: { platform: windows }\n    steps: [{ tap: A }]\n")
+    ).toThrow(/when\.platform must be one of ios, android, chromium, vega/i);
+    expect(() =>
+      parseFlow("steps:\n  - when: { platform: ios, foo: 1 }\n    steps: [{ tap: A }]\n")
+    ).toThrow(/no other keys/i);
+  });
+
+  it("rejects a cyclic YAML alias on when steps with a structured error", () => {
+    // The yaml library materializes `steps: *s` as a cyclic object; without
+    // the depth cap the parser would recurse forever and escape as a raw
+    // RangeError instead of a flow parse error.
+    expect(() => parseFlow("steps: &s\n  - when: { visible: X }\n    steps: *s\n")).toThrow(
+      /nest deeper than 20 levels/i
+    );
+  });
+
+  it("rejects a per-step optional key, pointing at when:", () => {
+    // No silent drop: an ignored `optional: true` would leave a step the
+    // author believes can't fail hard-stopping the flow.
+    expect(() => parseFlow("steps:\n  - tap: A\n    optional: true\n")).toThrow(
+      /optional is not supported — guard the step with a when: block/i
+    );
+    expect(() => parseFlow("steps:\n  - await: { visible: X }\n    optional: false\n")).toThrow(
+      /optional is not supported/i
+    );
+  });
+});
+
+describe("when: execution", () => {
+  it("runs the guarded steps when the condition holds, then continues", async () => {
+    currentTree = () =>
+      screen([
+        n({ label: "What's new", frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.2 } }),
+        n({ label: "Skip", frame: { x: 0.4, y: 0.8, width: 0.2, height: 0.1 } }),
+      ]);
+    await writeFlow("dismiss", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [{ kind: "tap", selector: { text: "Skip", loose: true } }],
+        },
+        { kind: "echo", message: "after block" },
+      ],
+    });
+
+    const result = await run("dismiss");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:pass",
+      "tap:pass",
+      "echo:pass",
+    ]);
+    expect(result.steps[0].reason).toMatch(/condition met \(visible text="What's new"\)/);
+    expect(result.taps).toHaveLength(1);
+    expect(result.ok).toBe(true);
+  });
+
+  it("skips the whole block — one line per authored step — when the condition is unmet", async () => {
+    currentTree = () =>
+      screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+    await writeFlow("clean-run", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [
+            { kind: "tap", selector: { text: "Skip", loose: true } },
+            {
+              kind: "when",
+              condition: { kind: "platform", platform: "ios" },
+              steps: [{ kind: "echo", message: "nested" }],
+            },
+          ],
+        },
+        { kind: "echo", message: "after block" },
+      ],
+    });
+
+    const result = await run("clean-run");
+
+    // The block marker + every guarded step (nested when expanded) skip; the
+    // flow continues and stays green.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:skip",
+      "tap:skip",
+      "when:skip",
+      "echo:skip",
+      "echo:pass",
+    ]);
+    expect(result.steps[0].reason).toMatch(/condition not met .*block skipped \(2 steps\)/);
+    expect(result.steps[1].reason).toBe("when block skipped");
+    expect(result.taps).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+
+  it("treats a failure inside an entered block as a real failure (hard stop)", async () => {
+    currentTree = () =>
+      screen([n({ label: "What's new", frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.2 } })]);
+    await writeFlow("bad-dismiss", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          // The asserted element never exists — the step must FAIL, not skip.
+          // An assert fails at the short grace; a tap on a missing element
+          // would burn the full action retry budget for the same hard stop.
+          steps: [
+            {
+              kind: "assert",
+              condition: "visible",
+              selector: { text: "No such button", loose: true },
+            },
+          ],
+        },
+        { kind: "echo", message: "never reached" },
+      ],
+    });
+
+    const result = await run("bad-dismiss");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:pass",
+      "assert:fail",
+      "echo:skip",
+    ]);
+    expect(result.ok).toBe(false);
+  });
+
+  it("evaluates a platform guard statically against the resolved device", async () => {
+    await writeFlow("per-platform", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: { kind: "platform", platform: "ios" },
+          steps: [{ kind: "echo", message: "ios only" }],
+        },
+        {
+          kind: "when",
+          condition: { kind: "platform", platform: "android" },
+          steps: [{ kind: "tool", name: "button", args: { button: "back" } }],
+        },
+      ],
+    });
+
+    const result = await run("per-platform"); // DEVICE is an iOS UDID
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:pass",
+      "echo:pass",
+      "when:skip",
+      "tool:skip",
+    ]);
+    expect(result.steps[2].reason).toMatch(/platform android/);
+    expect(result.ok).toBe(true);
+  });
+
+  it("errors the when step when the guard cannot be evaluated (unreadable tree)", async () => {
+    currentTree = () => {
+      throw new Error("native devtools disconnected");
+    };
+    await writeFlow("blind", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [{ kind: "tap", selector: { text: "Skip", loose: true } }],
+        },
+        { kind: "echo", message: "never reached" },
+      ],
+    });
+
+    const result = await run("blind");
+
+    // "Could not evaluate" is not "condition false" — a broken tree source
+    // must not silently turn a guarded dismissal into a green no-op.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["when:error", "echo:skip"]);
+    expect(result.steps[0].reason).toMatch(/could not evaluate when guard/i);
+    expect(result.ok).toBe(false);
+  });
+
+  it("errors — not skips — when every read in the window is blind (empty tree + hint)", async () => {
+    // A detached tree source (e.g. Vega toolkit) surfaces as SUCCESSFUL
+    // fetches returning an empty tree with a degraded-read hint. That is not
+    // evidence the condition is false, for any condition kind.
+    currentTree = () => screen([]);
+    currentHint = "automation toolkit not attached — relaunch the app";
+    await writeFlow("degraded", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "Got it", loose: true },
+          },
+          steps: [{ kind: "tap", selector: { text: "Got it", loose: true } }],
+        },
+        { kind: "echo", message: "never reached" },
+      ],
+    });
+
+    const result = await run("degraded");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["when:error", "echo:skip"]);
+    expect(result.steps[0].reason).toMatch(/could not evaluate when guard/i);
+    expect(result.taps).toHaveLength(0);
+    expect(result.ok).toBe(false);
+  });
+
+  it("errors a hidden guard that ends on blind reads after the element matched", async () => {
+    // First read: trusted, element visible. Every later read: empty tree,
+    // blind because the selector had matched. Gone-ness can't be confirmed —
+    // unknown must not be treated as "condition false".
+    let reads = 0;
+    currentTree = () =>
+      reads++ === 0
+        ? screen([n({ label: "Spinner", frame: { x: 0.4, y: 0.4, width: 0.2, height: 0.2 } })])
+        : screen([]);
+    await writeFlow("spinner-gone", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "hidden",
+            selector: { text: "Spinner", loose: true },
+          },
+          steps: [{ kind: "echo", message: "cleanup" }],
+        },
+        { kind: "echo", message: "never reached" },
+      ],
+    });
+
+    const result = await run("spinner-gone");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["when:error", "echo:skip"]);
+    expect(result.steps[0].reason).toMatch(/could not confirm the element is hidden/i);
+    expect(result.ok).toBe(false);
+  });
+
+  it("streams every when-related report line to the live progress consumer", async () => {
+    // All when reports go through pushReport — the progress stream and the
+    // final report must contain the same lines.
+    currentTree = () =>
+      screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+    await writeFlow("stream", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [
+            { kind: "tap", selector: { text: "Skip", loose: true } },
+            { kind: "echo", message: "inside" },
+          ],
+        },
+        { kind: "echo", message: "after block" },
+      ],
+    });
+
+    const events: unknown[] = [];
+    const tool = createRunFlowTool(mockRegistry([]));
+    const ctx = {
+      emitProgress: (e: unknown) => {
+        events.push(e);
+      },
+    } as unknown as Parameters<typeof tool.execute>[2];
+    const result = asRun(
+      await tool.execute({}, { name: "stream", project_root: tmpDir, device: DEVICE }, ctx)
+    );
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:skip",
+      "tap:skip",
+      "echo:skip",
+      "echo:pass",
+    ]);
+    expect(events).toEqual(result.steps);
+  });
+});
+
+describe("when: as tap-if-present", () => {
+  const coachMark = (): Parameters<typeof writeFlow>[1] => ({
+    executionPrerequisite: "",
+    steps: [
+      {
+        kind: "when",
+        condition: { kind: "ui", condition: "visible", selector: { text: "Got it", loose: true } },
+        steps: [{ kind: "tap", selector: { text: "Got it", loose: true } }],
+      },
+      { kind: "echo", message: "after" },
+    ],
+  });
+
+  it("taps when the target is visible", async () => {
+    currentTree = () =>
+      screen([n({ label: "Got it", frame: { x: 0.4, y: 0.8, width: 0.2, height: 0.1 } })]);
+    await writeFlow("coach-mark", coachMark());
+
+    const result = await run("coach-mark");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:pass",
+      "tap:pass",
+      "echo:pass",
+    ]);
+    expect(result.taps).toHaveLength(1);
+    expect(result.ok).toBe(true);
+  });
+
+  it("skips — and keeps the run green — when the target is absent", async () => {
+    currentTree = () =>
+      screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+    await writeFlow("no-coach-mark", coachMark());
+
+    const result = await run("no-coach-mark");
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "when:skip",
+      "tap:skip",
+      "echo:pass",
+    ]);
+    expect(result.taps).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION

## What

A `when:` block runs a step list only when one condition holds — a UI
condition (`exists`/`visible`/`hidden`/`text`, the await/assert shapes)
or a static `platform` test. **No else**, by design: a block exists to
restore determinism (dismiss an interstitial, reconverge), never to
test two paths. Tap-if-present is a one-step block:
`when: { visible: "Got it" }` + `steps: [tap: "Got it"]`.

No per-step `optional:` — `when:` covers every directive once. The key
is rejected at parse with a pointer to `when:`, not silently dropped (a
Maestro habit that would leave a "can't fail" step hard-stopping the
flow).

## How

- The guard reuses the assert engine at the 1s grace (`timeout` is a
parse error), so a skipped block barely costs a clean run.
- Verdicts are evidence-based: no trustworthy read in the window →
indeterminate → the step **errors** ("could not evaluate" is not
"condition false"); a transient read failure after trusted reads showed
the condition false stays a clean skip.
- `platform` folds `ios-remote` into `ios` — the parser rejects that
spelling, so the fold is the only way a guard matches a remote sim.
- A skipped block reports one line per authored step, same shape for
unmet guard, hard stop, or cancellation; everything goes through
`pushReport`, so when lines stream live. Failures inside an entered
block hard-stop as usual.
- Results carry an explicit `aborted` flag; `ok` keys off
fail/error/cancel, not skip lines.
- Nesting is capped at 20, so a cyclic YAML alias is a structured parse
error, not a stack overflow.

## Testing

`vitest` 2546 pass (17 when-specific); `tsc --noEmit` (tool-server,
argent-mcp, argent-cli), eslint, prettier clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
