### PR TITLE
feat(flow): long-press directive

### DIFF
--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -20,17 +20,18 @@ Both run via `argent flow run <name>` — a fragment simply runs against whateve
 
 Beyond raw `tool:` steps and `echo:`, flows support declarative directives interpreted by the runner (they are **not** agent-callable tools). **Every directive hard-stops the flow on failure**; later steps are reported `skip`.
 
-| Directive   | YAML                                                                                                     | Meaning                                                                 |
-| ----------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `launch`    | `- launch: com.acme.app` or `- launch: { ios: …, android: … }`                                           | start the app from scratch (terminate + relaunch) and wait until ready  |
-| `tap`       | `- tap: Login` or `- tap: { x: 0.5, y: 0.57 }`                                                           | tap an element by selector (auto-waits), or a raw normalized point      |
-| `type`      | `- type: { into: email, text: "a@b.com" }`                                                               | focus a field, type, then press Enter to submit + dismiss the keyboard  |
-| `scroll-to` | `- scroll-to: "Order #1234"` (scrolls down) or `- scroll-to: { target: …, direction: right, within: … }` | momentum-free scroll until the target is visible                        |
-| `await`     | `- await: { visible: Home }`                                                                             | wait for a UI condition                                                 |
-| `wait`      | `- wait: 500`                                                                                            | pause for a fixed number of milliseconds (last resort — prefer `await`) |
-| `assert`    | `- assert: { visible: Welcome }`                                                                         | check a condition, hard-fail if it never holds                          |
-| `snapshot`  | `- snapshot: home` or `- snapshot: { name: home, maxMismatch: 0.5 }`                                     | diff a screenshot against a stored baseline                             |
-| `run`       | `- run: login`                                                                                           | execute a fragment's steps inline                                       |
+| Directive    | YAML                                                                                                     | Meaning                                                                 |
+| ------------ | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `launch`     | `- launch: com.acme.app` or `- launch: { ios: …, android: … }`                                           | start the app from scratch (terminate + relaunch) and wait until ready  |
+| `tap`        | `- tap: Login` or `- tap: { x: 0.5, y: 0.57 }`                                                           | tap an element by selector (auto-waits), or a raw normalized point      |
+| `long-press` | `- long-press: Row 3` or `- long-press: { on: <sel>, duration: 1200 }`                                   | press and hold an element (default 800ms; Chromium: mouse press-hold)   |
+| `type`       | `- type: { into: email, text: "a@b.com" }`                                                               | focus a field, type, then press Enter to submit + dismiss the keyboard  |
+| `scroll-to`  | `- scroll-to: "Order #1234"` (scrolls down) or `- scroll-to: { target: …, direction: right, within: … }` | momentum-free scroll until the target is visible                        |
+| `await`      | `- await: { visible: Home }`                                                                             | wait for a UI condition                                                 |
+| `wait`       | `- wait: 500`                                                                                            | pause for a fixed number of milliseconds (last resort — prefer `await`) |
+| `assert`     | `- assert: { visible: Welcome }`                                                                         | check a condition, hard-fail if it never holds                          |
+| `snapshot`   | `- snapshot: home` or `- snapshot: { name: home, maxMismatch: 0.5 }`                                     | diff a screenshot against a stored baseline                             |
+| `run`        | `- run: login`                                                                                           | execute a fragment's steps inline                                       |
 
 ### Selectors
 
@@ -60,7 +61,7 @@ For a custom poll interval or bundleId, drop to an explicit `- tool: await-ui-el
 
 ### TV targets (Vega)
 
-A Vega (Fire TV) device is remote-driven — there is no touch input, so the touch directives (`tap`, `type`, `scroll-to`) fail on it with guidance. Drive focus with `tool: tv-remote` steps and type with `tool: keyboard` instead; everything else (`launch`, `await`, `assert`, `wait`, `snapshot`, `echo`, `run`, selectors) works unchanged — the tree comes from the on-device automation toolkit, which attaches at app launch (the `launch` step waits for it, so a leading `launch` also guarantees selectors resolve).
+A Vega (Fire TV) device is remote-driven — there is no touch input, so the touch directives (`tap`, `long-press`, `type`, `scroll-to`) fail on it with guidance. Drive focus with `tool: tv-remote` steps and type with `tool: keyboard` instead; everything else (`launch`, `await`, `assert`, `wait`, `snapshot`, `echo`, `run`, selectors) works unchanged — the tree comes from the on-device automation toolkit, which attaches at app launch (the `launch` step waits for it, so a leading `launch` also guarantees selectors resolve).
 
 ```yaml
 steps:

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -62,7 +62,7 @@ export const ABORTED_OUTCOME: DirectiveOutcome = {
 /** The selector-acting steps {@link runDirective} handles. */
 export type DirectiveStep = Extract<
   FlowStep,
-  { kind: "tap" | "type" | "await" | "assert" | "scroll-to" }
+  { kind: "tap" | "long-press" | "type" | "await" | "assert" | "scroll-to" }
 >;
 
 /** Dispatch a tool with the run's resolved device id bound into its args. */
@@ -538,14 +538,17 @@ function offscreenHint(sel: FlowSelector): string {
   return `no visible element matched selector ${describeSelector(sel)} — if it is off-screen, add a scroll-to step before this one`;
 }
 
-/** Execute one selector-acting directive (`tap` / `type` / `await` / `assert` / `scroll-to`). */
+/** Execute one selector-acting directive (`tap` / `long-press` / `type` / `await` / `assert` / `scroll-to`). */
 export async function runDirective(env: ActionEnv, step: DirectiveStep): Promise<DirectiveOutcome> {
   // Vega is remote-driven — there is no touch input, so the touch directives
   // can never act on it. Fail upfront with authoring guidance instead of a
   // low-level gesture dispatch error after the selector resolves.
   if (
     env.device.platform === "vega" &&
-    (step.kind === "tap" || step.kind === "type" || step.kind === "scroll-to")
+    (step.kind === "tap" ||
+      step.kind === "long-press" ||
+      step.kind === "type" ||
+      step.kind === "scroll-to")
   ) {
     return {
       ok: false,
@@ -555,6 +558,8 @@ export async function runDirective(env: ActionEnv, step: DirectiveStep): Promise
   switch (step.kind) {
     case "tap":
       return runTap(env, step);
+    case "long-press":
+      return runLongPress(env, step);
     case "type":
       return runType(env, step);
     case "await":
@@ -592,6 +597,54 @@ async function runTap(
     return { ok: false, reason: "tap needs a selector or x/y coordinates" };
   }
   await invokeOnDevice(env, "gesture-tap", point);
+  return { ok: true };
+}
+
+/**
+ * Long-press defaults comfortably past both platforms' recognizers — iOS
+ * UILongPressGestureRecognizer's 500ms minimum and Android's ~400ms
+ * long-press timeout (RN's Pressable uses 500ms) — without dragging every
+ * step out.
+ */
+const DEFAULT_LONG_PRESS_MS = 800;
+
+/**
+ * Press-and-hold on an element: resolve the selector (same settle + auto-wait
+ * as tap), then hold at the frame centre for `duration` ms. Touch platforms
+ * dispatch ONE `gesture-custom` train (Down, then Up delayed by the duration)
+ * so the hold length is exact; Chromium has no touch, so the closest honest
+ * mapping is a mouse press-hold-release (`gesture-drag` with from == to) —
+ * apps implementing pointer-based long-press respond, anything else sees a
+ * slow click. A desktop context menu is a *right*-click, deliberately not
+ * aliased here.
+ */
+async function runLongPress(
+  env: ActionEnv,
+  step: { selector: FlowSelector; duration?: number }
+): Promise<DirectiveOutcome> {
+  const frame = await waitForFrame(env, step.selector);
+  if (frame === "aborted") return ABORTED_OUTCOME;
+  if (!frame) {
+    return { ok: false, reason: offscreenHint(step.selector) };
+  }
+  const point = getDescribeTapPoint(frame);
+  const duration = step.duration ?? DEFAULT_LONG_PRESS_MS;
+  if (env.device.platform === "chromium") {
+    await invokeOnDevice(env, "gesture-drag", {
+      fromX: point.x,
+      fromY: point.y,
+      toX: point.x,
+      toY: point.y,
+      durationMs: duration,
+    });
+  } else {
+    await invokeOnDevice(env, "gesture-custom", {
+      events: [
+        { type: "Down", x: point.x, y: point.y, delayMs: 0 },
+        { type: "Up", x: point.x, y: point.y, delayMs: duration },
+      ],
+    });
+  }
   return { ok: true };
 }
 

--- a/packages/tool-server/src/tools/flows/flow-finish-recording.ts
+++ b/packages/tool-server/src/tools/flows/flow-finish-recording.ts
@@ -70,6 +70,8 @@ You can still edit the .yaml file directly afterwards to remove or reorder steps
           return `${n}. run: ${step.flow}`;
         case "tap":
           return `${n}. tap: ${step.selector ? selectorLabel(step.selector) : `(${step.x}, ${step.y})`}`;
+        case "long-press":
+          return `${n}. long-press: ${selectorLabel(step.selector)}`;
         case "type":
           return `${n}. type: ${selectorLabel(step.into)} ← "${step.text}"`;
         case "await":

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -384,8 +384,9 @@ export function createRunFlowTool(
     id: "flow-execute",
     description: `Run a saved flow from the .argent/flows/ directory.
 Steps run in order: \`launch\` starts an app from scratch (terminate + relaunch) and waits until it is
-ready; \`tool\` calls dispatch through the registry; \`tap\`/\`type\` resolve a selector to an element and
-act on it; \`scroll-to\` scrolls (momentum-free) until a target is visible; \`await\` waits for a UI
+ready; \`tool\` calls dispatch through the registry; \`tap\`/\`long-press\`/\`type\` resolve a selector to an
+element and act on it (\`long-press: { on, duration }\` presses and holds); \`scroll-to\` scrolls
+(momentum-free) until a target is visible; \`await\` waits for a UI
 condition; \`wait\` pauses for a fixed number of milliseconds; \`assert\` checks one now; \`snapshot\`
 diffs a screenshot against a stored baseline (a missing baseline fails the step — set updateBaselines
 to adopt the current screen); \`echo\` annotates; \`run\` executes a referenced fragment inline.
@@ -640,6 +641,8 @@ function stepTarget(step: FlowStep): string | undefined {
       if (step.selector) return selectorLabel(step.selector);
       if (step.x !== undefined && step.y !== undefined) return `(${step.x}, ${step.y})`;
       return undefined;
+    case "long-press":
+      return selectorLabel(step.selector);
     case "type":
       return `into ${selectorLabel(step.into)}`;
     case "await":
@@ -769,6 +772,7 @@ async function execLeafStep(
     }
 
     case "tap":
+    case "long-press":
     case "type":
     case "await":
     case "assert":

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -231,6 +231,7 @@ export type FlowStep =
   | { kind: "launch"; app: Launch }
   | { kind: "run"; flow: string }
   | { kind: "tap"; selector?: FlowSelector; x?: number; y?: number }
+  | { kind: "long-press"; selector: FlowSelector; duration?: number }
   | { kind: "type"; into: FlowSelector; text: string; submit?: boolean }
   | {
       kind: "await";
@@ -343,6 +344,7 @@ type YamlStep =
   | { run: string }
   | { tool: string; args?: Record<string, unknown>; delayMs?: number }
   | { tap: TapBody }
+  | { "long-press": YamlSelector | { on: YamlSelector; duration?: number } }
   | { type: { into: YamlSelector; text: string; submit?: boolean } }
   | { await: YamlWaitCondition & { timeout?: number } }
   | { assert: YamlWaitCondition }
@@ -441,6 +443,12 @@ function toYamlStep(step: FlowStep): YamlStep {
         ? selectorToYaml(step.selector)
         : { x: step.x!, y: step.y! };
       return { tap: body };
+    }
+    case "long-press": {
+      const sel = selectorToYaml(step.selector);
+      return {
+        "long-press": step.duration !== undefined ? { on: sel, duration: step.duration } : sel,
+      };
     }
     case "type": {
       const body: { into: YamlSelector; text: string; submit?: boolean } = {
@@ -787,6 +795,7 @@ const STEP_DIRECTIVE_KEYS: readonly string[] = [
   "run",
   "tool",
   "tap",
+  "long-press",
   "type",
   "await",
   "assert",
@@ -794,6 +803,52 @@ const STEP_DIRECTIVE_KEYS: readonly string[] = [
   "scroll-to",
   "snapshot",
 ];
+
+/**
+ * Parse a `long-press` body: a selector (bare = loose, map = strict) or the
+ * options form `{ on: <selector>, duration?: <ms> }` — nesting the selector
+ * under `on` so an option key can never be mistaken for — or silently
+ * stripped from — a selector field. No coordinate form: a point long-press is
+ * the `tool: gesture-custom` escape hatch.
+ */
+function parseLongPress(body: unknown, entry: unknown): FlowStep {
+  const obj = body !== null && typeof body === "object" ? (body as Record<string, unknown>) : {};
+
+  if (obj.on !== undefined || obj.duration !== undefined) {
+    if (
+      obj.text !== undefined ||
+      obj.id !== undefined ||
+      obj.identifier !== undefined ||
+      obj.role !== undefined
+    ) {
+      badEntry(
+        entry,
+        'the long-press options form takes a nested selector — e.g. long-press: { on: { text: "Row" }, duration: 1200 }'
+      );
+    }
+    if (!Object.keys(obj).every((k) => k === "on" || k === "duration")) {
+      badEntry(entry, "the long-press options form accepts only { on, duration }");
+    }
+    if (obj.on === undefined) {
+      badEntry(entry, 'long-press needs a target — e.g. long-press: { on: "Row", duration: 1200 }');
+    }
+    const step: FlowStep = { kind: "long-press", selector: parseSelector(obj.on, "long-press.on") };
+    if (obj.duration !== undefined) {
+      // Like `await.timeout`: reject non-finite values (YAML `.inf` parses to
+      // Infinity), which would hold the press forever.
+      if (typeof obj.duration !== "number" || !Number.isFinite(obj.duration) || obj.duration <= 0) {
+        badEntry(
+          entry,
+          "long-press.duration needs a positive number of milliseconds (e.g. `duration: 1200`)"
+        );
+      }
+      step.duration = obj.duration;
+    }
+    return step;
+  }
+
+  return { kind: "long-press", selector: parseSelector(body, "long-press") };
+}
 
 function fromYamlStep(raw: YamlStep): FlowStep {
   const entry = raw as Record<string, unknown>;
@@ -856,6 +911,10 @@ function fromYamlStep(raw: YamlStep): FlowStep {
       return { kind: "tap", x: obj.x, y: obj.y };
     }
     return { kind: "tap", selector: parseSelector(body, "tap") };
+  }
+
+  if ("long-press" in raw) {
+    return parseLongPress((raw as { "long-press": unknown })["long-press"], raw);
   }
 
   if ("type" in raw) {

--- a/packages/tool-server/test/flows/flow-long-press.test.ts
+++ b/packages/tool-server/test/flows/flow-long-press.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
+
+// Serve the flow tree directly: flows resolve selectors against the platform's
+// full-hierarchy source and hard-fail rather than degrade to the AX tree, so
+// these unit tests stub the tree fetch itself.
+let currentTree: () => DescribeNode;
+vi.mock("../../src/tools/flows/flow-tree", () => ({
+  fetchFlowTree: vi.fn(
+    async (): Promise<DescribeTreeData> => ({
+      tree: currentTree(),
+      source: "native-devtools",
+    })
+  ),
+}));
+
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+import { serializeFlow, parseFlow } from "../../src/tools/flows/flow-utils";
+
+const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
+let tmpDir: string;
+
+function n(partial: Partial<DescribeNode> & { frame: DescribeNode["frame"] }): DescribeNode {
+  return { role: "AXOther", children: [], ...partial };
+}
+
+function screen(children: DescribeNode[]): DescribeNode {
+  return n({ role: "AXWindow", frame: { x: 0, y: 0, width: 1, height: 1 }, children });
+}
+
+/** Registry that records every gesture tool invocation's args. */
+function mockRegistry(calls: Array<{ tool: string; args: Record<string, unknown> }>): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string, args: Record<string, unknown>) => {
+      if (id === "list-devices") return { devices: [] };
+      calls.push({ tool: id, args });
+      return { ok: true };
+    }),
+    getTool: vi.fn(() => ({ inputSchema: { properties: { udid: {} } } })),
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: Parameters<typeof serializeFlow>[0]): Promise<void> {
+  const dir = path.join(tmpDir, ".argent", "flows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.yaml`), serializeFlow(yaml), "utf8");
+}
+
+function asRun(r: FlowRunResult | { notice: string }): FlowRunResult {
+  if (!("steps" in r)) throw new Error(`expected a run result, got notice: ${r.notice}`);
+  return r;
+}
+
+async function run(
+  name: string
+): Promise<FlowRunResult & { calls: Array<{ tool: string; args: Record<string, unknown> }> }> {
+  const calls: Array<{ tool: string; args: Record<string, unknown> }> = [];
+  const tool = createRunFlowTool(mockRegistry(calls));
+  const result = asRun(await tool.execute({}, { name, project_root: tmpDir, device: DEVICE }));
+  return Object.assign(result, { calls });
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-long-press-"));
+  currentTree = () => screen([]);
+});
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("long-press: parse/serialize", () => {
+  it("round-trips all three spellings", () => {
+    const flow = {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "long-press" as const, selector: { text: "Row 3", loose: true } },
+        { kind: "long-press" as const, selector: { identifier: "row-3" } },
+        { kind: "long-press" as const, selector: { text: "Row 3", loose: true }, duration: 1200 },
+      ],
+    };
+    expect(parseFlow(serializeFlow(flow)).steps).toEqual(flow.steps);
+  });
+
+  it("parses the options form with the usual selector sugar", () => {
+    const steps = parseFlow(
+      "steps:\n" +
+        '  - long-press: { on: "Row 3", duration: 1200 }\n' +
+        "  - long-press: { on: { text: Row } }\n" // no options — canonicalizes away
+    ).steps;
+    expect(steps).toEqual([
+      { kind: "long-press", selector: { text: "Row 3", loose: true }, duration: 1200 },
+      { kind: "long-press", selector: { text: "Row" } },
+    ]);
+  });
+
+  it("rejects malformed bodies", () => {
+    expect(() => parseFlow('steps:\n  - long-press: { text: "Row", duration: 900 }\n')).toThrow(
+      /options form takes a nested selector/i
+    );
+    expect(() => parseFlow("steps:\n  - long-press: { on: A, foo: 1 }\n")).toThrow(
+      /accepts only \{ on, duration \}/i
+    );
+    expect(() => parseFlow("steps:\n  - long-press: { duration: 900 }\n")).toThrow(
+      /needs a target/i
+    );
+    for (const bad of ["0", "-5", '"900"', ".inf"]) {
+      expect(() => parseFlow(`steps:\n  - long-press: { on: A, duration: ${bad} }\n`)).toThrow(
+        /duration needs a positive number of milliseconds/i
+      );
+    }
+  });
+});
+
+describe("long-press: execution", () => {
+  it("dispatches one Down/delayed-Up gesture-custom train on touch platforms", async () => {
+    currentTree = () =>
+      screen([n({ label: "Row 3", frame: { x: 0.1, y: 0.4, width: 0.8, height: 0.1 } })]);
+    await writeFlow("press", {
+      executionPrerequisite: "",
+      steps: [{ kind: "long-press", selector: { text: "Row 3", loose: true }, duration: 1200 }],
+    });
+
+    const result = await run("press");
+
+    expect(result.ok).toBe(true);
+    expect(result.calls).toEqual([
+      {
+        tool: "gesture-custom",
+        args: {
+          udid: DEVICE,
+          events: [
+            { type: "Down", x: 0.5, y: 0.45, delayMs: 0 },
+            { type: "Up", x: 0.5, y: 0.45, delayMs: 1200 },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("holds for the 800ms default when no duration is given", async () => {
+    currentTree = () =>
+      screen([n({ label: "Row 3", frame: { x: 0.1, y: 0.4, width: 0.8, height: 0.1 } })]);
+    await writeFlow("press-default", {
+      executionPrerequisite: "",
+      steps: [{ kind: "long-press", selector: { text: "Row 3", loose: true } }],
+    });
+
+    const result = await run("press-default");
+
+    const events = result.calls[0]!.args.events as Array<{ type: string; delayMs: number }>;
+    expect(events[1]).toMatchObject({ type: "Up", delayMs: 800 });
+  });
+
+  it("maps to a mouse press-hold-release (gesture-drag, from == to) on chromium", async () => {
+    currentTree = () =>
+      screen([n({ label: "Row 3", frame: { x: 0.1, y: 0.4, width: 0.8, height: 0.1 } })]);
+    await writeFlow("press-chromium", {
+      executionPrerequisite: "",
+      steps: [{ kind: "long-press", selector: { text: "Row 3", loose: true }, duration: 900 }],
+    });
+
+    const calls: Array<{ tool: string; args: Record<string, unknown> }> = [];
+    const tool = createRunFlowTool(mockRegistry(calls));
+    const result = asRun(
+      await tool.execute(
+        {},
+        { name: "press-chromium", project_root: tmpDir, device: "chromium-cdp-9222" }
+      )
+    );
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([
+      {
+        tool: "gesture-drag",
+        args: {
+          udid: "chromium-cdp-9222",
+          fromX: 0.5,
+          fromY: 0.45,
+          toX: 0.5,
+          toY: 0.45,
+          durationMs: 900,
+        },
+      },
+    ]);
+  });
+
+  it("fails with the scroll-to hint when the target never appears", async () => {
+    currentTree = () => screen([]);
+    await writeFlow("press-missing", {
+      executionPrerequisite: "",
+      steps: [{ kind: "long-press", selector: { text: "Row 3", loose: true } }],
+    });
+
+    const result = await run("press-missing");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0]).toMatchObject({ kind: "long-press", status: "fail" });
+    expect(result.steps[0].reason).toMatch(/add a scroll-to step/i);
+    expect(result.calls).toHaveLength(0);
+  }, 15000);
+});

--- a/packages/tool-server/test/flows/flow-progress.test.ts
+++ b/packages/tool-server/test/flows/flow-progress.test.ts
@@ -159,6 +159,7 @@ describe("flow progress streaming (ctx.emitProgress)", () => {
         { kind: "tool", name: "boom", args: {} },
         { kind: "tap", selector: { text: "Clear logs", loose: true } },
         { kind: "tap", x: 0.5, y: 0.25 },
+        { kind: "long-press", selector: { text: "Row 3", loose: true }, duration: 1200 },
         {
           kind: "assert",
           condition: "hidden",
@@ -186,6 +187,7 @@ describe("flow progress streaming (ctx.emitProgress)", () => {
       undefined,
       '"Clear logs"',
       "(0.5, 0.25)",
+      '"Row 3"',
       'hidden "] outer Touchable"',
       'id=total contains "Total"',
       '"Nested touchables" (up)',


### PR DESCRIPTION

Press-and-hold on an element — context menus, reorder activation — with
the same resolution behavior as `tap` (settled tree, auto-wait, no
auto-scroll) and the same options shape: a bare/strict selector, or
`long-press: { on: <selector>, duration: <ms> }` with the selector
nested under `on` so option keys never mix with selector fields.

The default 800ms clears both platforms' recognizers (iOS 500ms,
Android ~400ms). Touch platforms dispatch one `gesture-custom` train
(`Down`, then `Up` delayed by the duration) so the hold length is
exact; Chromium maps to a mouse press-hold-release (`gesture-drag`,
from == to) — a desktop context menu is a right-click and is
deliberately not aliased. Vega rejects upfront with the other touch
directives. No coordinate form: a point long-press stays the
`gesture-custom` escape hatch.
