### PR TITLE
feat(flow): allow to compose all flows via `run:`

### DIFF
--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -11,7 +11,7 @@ Flows store **no device id**: the runner binds a device (the single booted one, 
 
 **Two flow types**
 
-- **e2e** — begins with a `launch:` step, which starts that app from scratch (terminate + relaunch), so the flow controls its own start state. No `executionPrerequisite`. May `run:` fragments; cannot itself be a `run:` target. Record one by adding a `restart-app` of the app under test as the **first** step — it is captured as the `launch` step.
+- **e2e** — begins with a `launch:` step, which starts that app from scratch (terminate + relaunch), so the flow controls its own start state. No `executionPrerequisite`. May `run:` other flows, and (on iOS/Android) may itself be a `run:` target — when nested, its `launch` runs inline, restarting the app for that sub-scenario. **Chromium is the exception:** the runner boots one Electron app per run (the top-level flow's), so a nested chromium e2e flow's `launch` can't boot its own instance and fails the run — keep chromium e2e flows top-level. Record one by adding a `restart-app` of the app under test as the **first** step — it is captured as the `launch` step.
 - **fragment** — doesn't begin with a launch; runs against the device's current state. May declare an `executionPrerequisite` (a documented entry-state contract). Invoked from other flows via a `run:` step, or directly by you at any time.
 
 Both run via `argent flow run <name>` — a fragment simply runs against whatever is on screen (its prerequisite is printed as a reminder). Only e2e flows are meaningful CI/suite entries, since only they give a deterministic verdict from a clean start.
@@ -31,7 +31,7 @@ Beyond raw `tool:` steps and `echo:`, flows support declarative directives inter
 | `wait`       | `- wait: 500`                                                                                            | pause for a fixed number of milliseconds (last resort — prefer `await`) |
 | `assert`     | `- assert: { visible: Welcome }`                                                                         | check a condition, hard-fail if it never holds                          |
 | `snapshot`   | `- snapshot: home` or `- snapshot: { name: home, maxMismatch: 0.5 }`                                     | diff a screenshot against a stored baseline                             |
-| `run`        | `- run: login`                                                                                           | execute a fragment's steps inline                                       |
+| `run`        | `- run: login`                                                                                           | execute another flow's steps inline (fragment or e2e)                   |
 
 ### Selectors
 

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -7,7 +7,6 @@ import {
   getRecordingSession,
   appendStepToActiveFlow,
   parseFlow,
-  isE2eFlow,
   assertSafeFlowName,
   describeSelector,
   type FlowSavedTo,
@@ -123,14 +122,14 @@ const RUN_TARGET_COMMAND = "flow-execute";
 
 /**
  * For a recorded `flow-execute` call, decide whether to record it as a
- * `run: <name>` directive. Returns the fragment name to compose, or a warning
+ * `run: <name>` directive. Returns the flow name to compose, or a warning
  * explaining why the raw `flow-execute` step was kept.
  *
- * `run:` only composes **fragments** (no `launch`) resolved as **siblings** of
- * the recording in its `.argent/flows` dir (host-resolved composition, design
- * §12). So we keep the raw step when the target is an e2e flow, can't be
- * resolved as a sibling, or the recording is remote (the host can't read the
- * client's sibling files to validate).
+ * `run:` composes any sibling flow — fragment or e2e — resolved in the
+ * recording's `.argent/flows` dir (host-resolved composition, design §12). An
+ * e2e target's `launch` simply runs inline. So we keep the raw step only when
+ * the target can't be resolved as a sibling, or the recording is remote (the
+ * host can't read the client's sibling files to validate).
  */
 async function captureRunTarget(
   session: RecordingSession | null,
@@ -149,13 +148,10 @@ async function captureRunTarget(
     assertSafeFlowName(name);
     // Resolve against the recording's own flows dir (the running flow-execute
     // may have mutated the active-project-root global), not getFlowsDir().
+    // Parsing validates the sibling exists and is a well-formed flow; a failure
+    // falls through to keeping the raw step.
     const fragPath = path.join(path.dirname(session.filePath), `${name}.yaml`);
-    const fragment = parseFlow(await fs.readFile(fragPath, "utf8"));
-    if (isE2eFlow(fragment)) {
-      return {
-        warning: `"${name}" is an e2e flow (starts with a launch step); only fragments compose via run: — kept the raw flow-execute step`,
-      };
-    }
+    parseFlow(await fs.readFile(fragPath, "utf8"));
     return { flow: name };
   } catch (err) {
     return {

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -306,11 +306,33 @@ async function treeSourceGate(
  * against the CDP service directly, not via `launch-app` — the chromium launch
  * value is an app *path*, which `launch-app`'s bundleId grammar rejects (and
  * its chromium handler is this same viewport refresh anyway).
+ *
+ * Chromium boots exactly one app for the whole run, so only the first launch is
+ * real; a second one (always a nested e2e flow pulled in via `run:`) can't boot
+ * its own instance and is rejected rather than silently passing against the
+ * already-launched app (see `state.chromiumLaunched`).
  */
 async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcome> {
   const { registry, device, signal } = state;
 
   if (device.platform === "chromium") {
+    // Only the top-level flow's leading launch is honored: the runner boots that
+    // app (or attaches to a pinned one) before step 1, and `chromiumBootSpec`
+    // only ever consults the top-level flow. Any later launch — a nested e2e
+    // flow's own launch — would run against the already-launched (wrong) app
+    // while booting nothing, so fail loudly instead of passing a no-op. The
+    // first launch still works, keeping a plain chromium e2e flow usable.
+    if (state.chromiumLaunched) {
+      return {
+        ok: false,
+        reason:
+          `chromium launches only the top-level flow's app, once per run — a nested launch can't ` +
+          `boot its own instance and would run against the already-launched app. Nested chromium ` +
+          `e2e flows aren't supported: run this flow at the top level, or drop its launch step to ` +
+          `make it a fragment.`,
+      };
+    }
+    state.chromiumLaunched = true;
     if (state.chromiumBooted) {
       // already booted + fronted; just settle
       if (!(await sleepOrAbort(POST_LAUNCH_SETTLE_MS, signal))) return ABORTED_OUTCOME;
@@ -367,6 +389,12 @@ interface ExecState extends ActionEnv {
   pinned: boolean;
   /** True when the runner booted the chromium app for this run (and owns its teardown). */
   chromiumBooted: boolean;
+  /**
+   * True once a chromium `launch` step has run. Chromium boots one app per run
+   * (the top-level flow's), so a later launch — a nested e2e flow's own — is
+   * rejected instead of silently passing against the already-launched app.
+   */
+  chromiumLaunched: boolean;
   /** Live progress hook: receives every report the moment it is appended. */
   onStepReport?: (report: StepReport) => void;
 }
@@ -453,6 +481,7 @@ returns a notice with the prerequisite instead of running.`,
         stopped: false,
         pinned: statusBarPinned,
         chromiumBooted: resolved.booted !== null,
+        chromiumLaunched: false,
         ...(ctx?.emitProgress ? { onStepReport: ctx.emitProgress } : {}),
       };
 
@@ -739,12 +768,6 @@ async function execRunStep(
     fragment = parseFlow(await fs.readFile(fragPath, "utf8"));
   } catch (err) {
     return fail(`could not load fragment "${target}": ${errMsg(err)}`);
-  }
-
-  if (isE2eFlow(fragment)) {
-    return fail(
-      `"${target}" is an e2e flow (starts with a launch step); only fragments can be run from another flow`
-    );
   }
 
   // Marker for the composition point, then expand the fragment's steps inline.

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -263,9 +263,8 @@ export type FlowFile = {
 /**
  * A flow is end-to-end iff it BEGINS by launching an app — its first step
  * (ignoring `echo` narration) is a `launch`. Such a flow controls its own
- * start state, so it is the natural standalone/suite entry point, must not
- * declare an `executionPrerequisite`, and cannot be composed via `run:`.
- * Everything else is a fragment.
+ * start state, so it is the natural standalone/suite entry point and must not
+ * declare an `executionPrerequisite`. Everything else is a fragment.
  */
 export function isE2eFlow(flow: FlowFile): boolean {
   const first = flow.steps.find((s) => s.kind !== "echo");

--- a/packages/tool-server/test/flows/flow-chromium-boot.test.ts
+++ b/packages/tool-server/test/flows/flow-chromium-boot.test.ts
@@ -54,6 +54,15 @@ async function writeFlow(yaml: string): Promise<string> {
   return file;
 }
 
+// A run: target must be a sibling named `<name>.yaml` (the runner resolves it
+// against the parent flow's directory), so write it next to `parent` under a
+// caller-chosen name.
+async function writeSiblingFlow(parent: string, name: string, yaml: string): Promise<void> {
+  const file = path.join(path.dirname(parent), `${name}.yaml`);
+  await fs.writeFile(file, yaml, "utf8");
+  writtenFiles.push(file);
+}
+
 function asRun(r: FlowRunResult | { notice: string }): FlowRunResult {
   if (!("steps" in r)) throw new Error(`expected a FlowRunResult, got a notice: ${r.notice}`);
   return r;
@@ -180,6 +189,87 @@ describe("flow-execute chromium boot", () => {
     expect(refreshViewport).toHaveBeenCalled();
     expect(result.ok).toBe(true);
     expect(result.steps[0]).toMatchObject({ kind: "launch", status: "pass" });
+  });
+
+  it("errors a nested e2e flow's launch (chromium boots only the top-level app) and keeps the first working", async () => {
+    // Parent chromium e2e flow that runs a nested chromium e2e flow. Chromium
+    // boots exactly one app for the run (the parent's), so the nested launch
+    // can't boot its own instance — it must fail loudly, not silently pass
+    // against the already-launched app. The parent's own launch still works.
+    const parent = await writeFlow(
+      "steps:\n  - launch: { chromium: ./app-a }\n  - run: nested-chromium\n"
+    );
+    await writeSiblingFlow(
+      parent,
+      "nested-chromium",
+      "steps:\n  - launch: { chromium: ./app-b }\n  - echo: should never run\n"
+    );
+    const registry = makeRegistry();
+
+    const result = await runFlow(registry, {
+      name: "parent-chromium",
+      project_root: PROJECT_ROOT,
+      flow_file: parent,
+    });
+
+    // Only the parent's app booted — the nested launch never spawned a second
+    // instance.
+    expect(bootElectronApp).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(false);
+    // parent launch passes; run marker passes; nested launch errors; the rest skip.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "launch:pass",
+      "run:pass",
+      "launch:error",
+      "echo:skip",
+    ]);
+    const nestedLaunch = result.steps[2];
+    expect(nestedLaunch.flow).toBe("nested-chromium");
+    expect(nestedLaunch.reason).toMatch(/chromium launches only the top-level flow's app/i);
+
+    // The one booted instance is still torn down cleanly on the failing run.
+    expect(killChromiumByPort).toHaveBeenCalledWith(12345, 4242);
+  });
+
+  it("still honors the first launch when a fragment run:s an e2e flow (the common composition)", async () => {
+    // Fragment B (no leading launch) that run:s e2e flow A (launch + setup).
+    // A's launch is the FIRST launch of the run, so the once-per-run guard does
+    // not fire — it attaches to the pinned instance and passes. Only a *second*
+    // launch is rejected. Uses a pinned device: a fragment top-level means the
+    // runner boots nothing itself, so an already-running instance is required.
+    const fragmentB = await writeFlow("steps:\n  - run: setup-a\n  - echo: B after A\n");
+    await writeSiblingFlow(
+      fragmentB,
+      "setup-a",
+      "steps:\n  - launch: { chromium: ./app }\n  - echo: A setup done\n"
+    );
+    const registry = makeRegistry();
+    const refreshViewport = vi.fn(async () => ({ width: 800, height: 600 }));
+    (registry.resolveService as any).mockImplementation(async () => ({
+      refreshViewport,
+      cdp: { send: vi.fn(async () => ({})) },
+    }));
+
+    const result = await runFlow(registry, {
+      name: "fragment-b",
+      project_root: PROJECT_ROOT,
+      flow_file: fragmentB,
+      device: "chromium-cdp-9999",
+    });
+
+    // Fragment top-level: the runner never boots (nor tears down) an instance;
+    // A's launch attaches to the pinned one instead.
+    expect(bootElectronApp).not.toHaveBeenCalled();
+    expect(killChromiumByPort).not.toHaveBeenCalled();
+    expect(refreshViewport).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(true);
+    // run marker, then A's launch (honored) + echo, then B's trailing echo.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "run:pass",
+      "launch:pass",
+      "echo:pass",
+      "echo:pass",
+    ]);
   });
 
   it("errors the launch step (and skips the rest) when the pinned instance is unreachable", async () => {

--- a/packages/tool-server/test/flows/flow-composition.test.ts
+++ b/packages/tool-server/test/flows/flow-composition.test.ts
@@ -80,10 +80,13 @@ describe("flow composition (run:)", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("rejects running an e2e flow as a fragment", async () => {
+  it("expands a referenced e2e flow inline, launch step and all", async () => {
     await writeFlow("other-e2e", {
       executionPrerequisite: "",
-      steps: [{ kind: "launch", app: "com.acme.app" }],
+      steps: [
+        { kind: "launch", app: "com.acme.app" },
+        { kind: "echo", message: "in nested e2e" },
+      ],
     });
     await writeFlow("main", {
       executionPrerequisite: "",
@@ -93,9 +96,14 @@ describe("flow composition (run:)", () => {
     const result = asRun(
       await runFlow.execute({}, { name: "main", project_root: tmpDir, device: DEVICE })
     );
-    expect(result.steps[0]).toMatchObject({ kind: "run", status: "error" });
-    expect(result.steps[0].reason).toMatch(/e2e flow/i);
-    expect(result.ok).toBe(false);
+    // run marker, then the nested e2e's launch + echo expanded inline.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "run:pass",
+      "launch:pass",
+      "echo:pass",
+    ]);
+    expect(result.steps[1].flow).toBe("other-e2e");
+    expect(result.ok).toBe(true);
   });
 
   it("detects a cyclic run reference", async () => {

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -418,7 +418,7 @@ describe("flow-add-step", () => {
     expect(parseFlow(result.flowFile).steps).toEqual([{ kind: "run", flow: "login" }]);
   });
 
-  it("keeps the raw flow-execute step when the target is an e2e flow", async () => {
+  it("records a run: directive when the target is an e2e flow", async () => {
     const registry = createMockRegistry({
       "flow-execute": { result: { ok: true, steps: [] } },
     });
@@ -435,17 +435,8 @@ describe("flow-add-step", () => {
       }
     );
 
-    expect(result.message).toMatch(/e2e flow/i);
-    // The raw fallback keeps `device` (flow-execute's device param isn't a
-    // udid/device_id key, so it survives stripping) — exactly the
-    // non-portability that the run: rewrite avoids.
-    expect(parseFlow(result.flowFile).steps).toEqual([
-      {
-        kind: "tool",
-        name: "flow-execute",
-        args: { name: "other-e2e", project_root: tmpDir, device: "ABC" },
-      },
-    ]);
+    // e2e flows now compose via run: just like fragments — their launch runs inline.
+    expect(parseFlow(result.flowFile).steps).toEqual([{ kind: "run", flow: "other-e2e" }]);
   });
 
   it("keeps the raw flow-execute step when the target is not a sibling", async () => {


### PR DESCRIPTION

## Summary

`run:` accepted **fragments only** — an e2e flow (one starting with `launch:`)
was rejected as a `run:` target. This lifts that: an e2e flow can now be nested
via `run:`, its `launch` running inline (a real terminate + relaunch on native).
Composition becomes uniform — any flow can be a reusable building block.

## What changed

- **`flow-run.ts`**: dropped the `isE2eFlow` rejection in `execRunStep`; cycle /
  `MAX_RUN_DEPTH` guards still bound recursion.
- **`flow-add-step.ts`**: the recorder now captures a recorded `flow-execute` of
  an e2e sibling as a portable `run: <name>` directive (was: raw `tool:` step).
- **`flow-utils.ts`, `argent-create-flow/SKILL.md`**: updated docs/skill that
  said e2e flows can't be `run:` targets.

## Known limitation — Chromium

Chromium `launch` boots an Electron app from a *path*, wired to the top-level
flow only — so a nested **chromium** e2e flow doesn't boot its own app. Native
nesting is correct; chromium nested e2e is unsupported.

## Testing

Rewrote the two affected tests (composition + recorder). Full flows suite green
(349 tests); `tsc --noEmit` clean.
