### PR TITLE
fix(tool-server): resolve `ps` by absolute path so VVD dedup survives a sanitized PATH

### DIFF
--- a/packages/tool-server/src/utils/vega-cli.ts
+++ b/packages/tool-server/src/utils/vega-cli.ts
@@ -184,10 +184,17 @@ async function reapVegaGroup(child: ChildProcess): Promise<void> {
  * group kill is the primary mechanism; this is insurance).
  */
 async function collectDescendantPids(rootPid: number): Promise<number[]> {
-  const { stdout } = await execFileAsync(PS_BIN, ["-A", "-o", "pid=,ppid="], {
-    timeout: 1_500,
-    maxBuffer: 16 * 1024 * 1024,
-  });
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync(PS_BIN, ["-A", "-o", "pid=,ppid="], {
+      timeout: 1_500,
+      maxBuffer: 16 * 1024 * 1024,
+    }));
+  } catch {
+    // `ps` unavailable / timed out — honor the documented [] contract (the group
+    // kill is the primary mechanism; this walk is only insurance).
+    return [];
+  }
   const childrenByParent = new Map<number, number[]>();
   for (const line of stdout.split("\n")) {
     const m = line.trim().match(/^(\d+)\s+(\d+)$/);
@@ -218,10 +225,15 @@ async function collectDescendantPids(rootPid: number): Promise<number[]> {
  * itself). Used by reapLingeringGroupMembers; returns [] if `ps` is unavailable.
  */
 async function pgidMembers(pgid: number): Promise<number[]> {
-  const { stdout } = await execFileAsync(PS_BIN, ["-A", "-o", "pid=,pgid="], {
-    timeout: 1_500,
-    maxBuffer: 16 * 1024 * 1024,
-  });
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync(PS_BIN, ["-A", "-o", "pid=,pgid="], {
+      timeout: 1_500,
+      maxBuffer: 16 * 1024 * 1024,
+    }));
+  } catch {
+    return []; // `ps` unavailable / timed out — honor the documented [] contract.
+  }
   const members: number[] = [];
   for (const line of stdout.split("\n")) {
     const m = line.trim().match(/^(\d+)\s+(\d+)$/);

--- a/packages/tool-server/src/utils/vega-cli.ts
+++ b/packages/tool-server/src/utils/vega-cli.ts
@@ -12,7 +12,7 @@ import {
   type FailureSignal,
 } from "@argent/registry";
 import { formatSubprocessFailure } from "./subprocess-error";
-import { listRunningVvdConsolePorts } from "./vega-process";
+import { listRunningVvdConsolePorts, PS_BIN } from "./vega-process";
 
 const execFileAsync = promisify(execFile);
 
@@ -184,7 +184,7 @@ async function reapVegaGroup(child: ChildProcess): Promise<void> {
  * group kill is the primary mechanism; this is insurance).
  */
 async function collectDescendantPids(rootPid: number): Promise<number[]> {
-  const { stdout } = await execFileAsync("ps", ["-A", "-o", "pid=,ppid="], {
+  const { stdout } = await execFileAsync(PS_BIN, ["-A", "-o", "pid=,ppid="], {
     timeout: 1_500,
     maxBuffer: 16 * 1024 * 1024,
   });
@@ -218,7 +218,7 @@ async function collectDescendantPids(rootPid: number): Promise<number[]> {
  * itself). Used by reapLingeringGroupMembers; returns [] if `ps` is unavailable.
  */
 async function pgidMembers(pgid: number): Promise<number[]> {
-  const { stdout } = await execFileAsync("ps", ["-A", "-o", "pid=,pgid="], {
+  const { stdout } = await execFileAsync(PS_BIN, ["-A", "-o", "pid=,pgid="], {
     timeout: 1_500,
     maxBuffer: 16 * 1024 * 1024,
   });

--- a/packages/tool-server/src/utils/vega-process.ts
+++ b/packages/tool-server/src/utils/vega-process.ts
@@ -1,7 +1,16 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { existsSync } from "node:fs";
 
 const execFileAsync = promisify(execFile);
+
+// Absolute path to `ps`, resolved once. An MCP server launched from a GUI /
+// launchd context inherits a sanitized PATH that omits `/bin`, so a bare `"ps"`
+// spawn ENOENTs — the callers below swallow it, yielding an empty running-VVD set
+// that silently defeats the VVD adb-shadow dedup in list-devices (VVD listed
+// twice). Pin the canonical location; fall back to bare `"ps"` only if neither
+// exists, preserving PATH resolution for an atypical layout.
+export const PS_BIN = ["/bin/ps", "/usr/bin/ps"].find((p) => existsSync(p)) ?? "ps";
 
 /**
  * Running VVD discovery from the OS process table: the `vega-virtual-device`
@@ -86,7 +95,7 @@ export function parseVvdPids(psOutput: string): number[] {
  */
 export async function listRunningVvdConsolePorts(): Promise<Set<number>> {
   try {
-    const { stdout } = await execFileAsync("ps", [...PS_ARGS], {
+    const { stdout } = await execFileAsync(PS_BIN, [...PS_ARGS], {
       timeout: VVD_PS_PROBE_TIMEOUT_MS,
       maxBuffer: 16 * 1024 * 1024,
     });
@@ -104,7 +113,7 @@ export async function listRunningVvdConsolePorts(): Promise<Set<number>> {
 /** PIDs of all running VVD emulator processes (empty if none / `ps` unavailable). */
 export async function listRunningVvdPids(): Promise<number[]> {
   try {
-    const { stdout } = await execFileAsync("ps", [...PS_ARGS_WITH_PID], {
+    const { stdout } = await execFileAsync(PS_BIN, [...PS_ARGS_WITH_PID], {
       timeout: 5_000,
       maxBuffer: 16 * 1024 * 1024,
     });

--- a/packages/tool-server/test/list-devices.test.ts
+++ b/packages/tool-server/test/list-devices.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const execFileMock = vi.fn();
 
+// Production spawns `ps` by absolute path (PS_BIN); match on basename so the mock
+// fires regardless.
+const isPs = (cmd: string): boolean => cmd === "ps" || cmd.endsWith("/ps");
+
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   const { EventEmitter } = await import("node:events");
@@ -306,7 +310,7 @@ describe("list-devices", () => {
     execFileMock.mockImplementation((cmd: string, args: string[]) => {
       const vega = mockVegaVvd(cmd, args);
       if (vega) return vega;
-      if (cmd === "ps") return psWithVvds(5554); // VVD on console port 5554
+      if (isPs(cmd)) return psWithVvds(5554); // VVD on console port 5554
       if (cmd === "xcrun") return { stdout: simctlJson(), stderr: "" };
       if (cmd === "adb" && args[0] === "devices") {
         return { stdout: "List of devices attached\nemulator-5554\tdevice\n", stderr: "" };
@@ -332,7 +336,7 @@ describe("list-devices", () => {
     execFileMock.mockImplementation((cmd: string, args: string[]) => {
       const vega = mockVegaVvd(cmd, args);
       if (vega) return vega;
-      if (cmd === "ps") return psWithVvds(5554);
+      if (isPs(cmd)) return psWithVvds(5554);
       if (cmd === "xcrun") return { stdout: simctlJson(), stderr: "" };
       if (cmd === "adb" && args[0] === "devices") {
         // adb port = console + 1, so the `adb connect` serial is 127.0.0.1:5555.
@@ -356,7 +360,7 @@ describe("list-devices", () => {
     execFileMock.mockImplementation((cmd: string, args: string[]) => {
       const vega = mockVegaVvd(cmd, args);
       if (vega) return vega;
-      if (cmd === "ps") return psWithVvds(5556); // VVD on console port 5556
+      if (isPs(cmd)) return psWithVvds(5556); // VVD on console port 5556
       if (cmd === "xcrun") return { stdout: simctlJson(), stderr: "" };
       if (cmd === "adb" && args[0] === "devices") {
         return {
@@ -395,7 +399,7 @@ describe("list-devices", () => {
       if (cmd.endsWith("vega") && args[0] === "device" && args[1] === "list") {
         return { stdout: "Found the following device:\n", stderr: "" }; // no devices
       }
-      if (cmd === "ps") return { stdout: "/sbin/launchd\n", stderr: "" }; // no VVD process
+      if (isPs(cmd)) return { stdout: "/sbin/launchd\n", stderr: "" }; // no VVD process
       if (cmd === "xcrun") return { stdout: simctlJson(), stderr: "" };
       if (cmd === "adb" && args[0] === "devices") {
         return { stdout: "List of devices attached\nemulator-5554\tdevice\n", stderr: "" };
@@ -424,7 +428,7 @@ describe("list-devices", () => {
     execFileMock.mockImplementation((cmd: string, args: string[]) => {
       const vega = mockVegaVvd(cmd, args);
       if (vega) return vega;
-      if (cmd === "ps") return psWithVvds(5554);
+      if (isPs(cmd)) return psWithVvds(5554);
       if (cmd === "xcrun") return { stdout: simctlJson(), stderr: "" };
       if (cmd === "adb" && args[0] === "devices") {
         return { stdout: "List of devices attached\nemulator-5554\tdevice\n", stderr: "" };

--- a/packages/tool-server/test/vega-process.test.ts
+++ b/packages/tool-server/test/vega-process.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { existsSync } from "node:fs";
 import {
   parseVvdConsolePorts,
   parseVvdPids,
@@ -8,6 +9,7 @@ import {
   listRunningVvdPids,
   PS_ARGS,
   PS_ARGS_WITH_PID,
+  PS_BIN,
 } from "../src/utils/vega-process";
 
 const execFileAsync = promisify(execFile);
@@ -140,5 +142,31 @@ describe("listRunningVvdConsolePorts (real ps)", () => {
     const pids = await listRunningVvdPids();
     expect(Array.isArray(pids)).toBe(true);
     for (const p of pids) expect(Number.isInteger(p) && p > 0).toBe(true);
+  });
+});
+
+// Regression: under an MCP server's sanitized PATH (no /bin), a bare-name `ps`
+// spawn ENOENTs; the catch then yields an empty port set and the VVD adb-shadow
+// dedup no-ops, listing the VVD twice. An absolute `ps` path survives this.
+describe("PS_BIN (survives a sanitized PATH)", () => {
+  it("resolves to an existing absolute path on this host", () => {
+    expect(PS_BIN.startsWith("/")).toBe(true);
+    expect(existsSync(PS_BIN)).toBe(true);
+  });
+
+  it("spawns `ps` with PATH stripped of /bin and /usr/bin", async () => {
+    const savedPath = process.env.PATH;
+    process.env.PATH = "/nonexistent-dir";
+    try {
+      // Load-bearing: a bare "ps" would reject with ENOENT here, so a non-empty
+      // exit-0 result proves the absolute-path resolution is what survives.
+      const { stdout } = await execFileAsync(PS_BIN, [...PS_ARGS], {
+        maxBuffer: 16 * 1024 * 1024,
+      });
+      expect(stdout.split("\n").filter(Boolean).length).toBeGreaterThan(0);
+    } finally {
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
+    }
   });
 });

--- a/packages/tool-server/test/vega-process.test.ts
+++ b/packages/tool-server/test/vega-process.test.ts
@@ -149,12 +149,22 @@ describe("listRunningVvdConsolePorts (real ps)", () => {
 // spawn ENOENTs; the catch then yields an empty port set and the VVD adb-shadow
 // dedup no-ops, listing the VVD twice. An absolute `ps` path survives this.
 describe("PS_BIN (survives a sanitized PATH)", () => {
-  it("resolves to an existing absolute path on this host", () => {
-    expect(PS_BIN.startsWith("/")).toBe(true);
-    expect(existsSync(PS_BIN)).toBe(true);
+  // Every host CI runs on has /bin/ps or /usr/bin/ps, so PS_BIN resolves absolute
+  // here. But production deliberately falls back to bare "ps" when neither exists
+  // (Nix, a non-POSIX layout) to preserve PATH resolution — so assert the contract
+  // as a disjunction, not a hard "always absolute", and don't fail the intentional
+  // fallback path.
+  const psBinIsAbsolute = PS_BIN.startsWith("/");
+
+  it("is either an existing absolute path or the bare-`ps` PATH fallback", () => {
+    if (psBinIsAbsolute) expect(existsSync(PS_BIN)).toBe(true);
+    else expect(PS_BIN).toBe("ps");
   });
 
-  it("spawns `ps` with PATH stripped of /bin and /usr/bin", async () => {
+  // Only meaningful when PS_BIN is absolute: a bare "ps" is exactly what ENOENTs
+  // under a sanitized PATH, so asserting it survives there would contradict the
+  // fallback's intent. Skip rather than fail on a host without a canonical `ps`.
+  it.skipIf(!psBinIsAbsolute)("spawns `ps` with PATH stripped of /bin and /usr/bin", async () => {
     const savedPath = process.env.PATH;
     process.env.PATH = "/nonexistent-dir";
     try {


### PR DESCRIPTION
## What

A running Vega VVD registers a second adb transport (`emulator-<port>`), so it can surface in `list-devices` **twice** — once as `platform:"vega"` and once as `platform:"android"`. There's dedup logic (`resolveVvdShadowAdbSerials` + `filterVvdShadowsFromAndroid`) that drops the adb "shadow" row by matching the running VVD's console port — read from the process table via `ps` — against the adb serial's port.

That dedup was spawning a **bare `"ps"`**, which relies on `PATH`.

## Why it broke

An MCP server is frequently launched from a GUI / launchd context that inherits a **sanitized `PATH`** omitting `/bin`. There, `execFile("ps", …)` fails with `ENOENT`; the surrounding `catch` returns an empty port set, and the dedup silently no-ops — so the VVD shows up as two devices. It works fine from an interactive shell (where `/bin` is on `PATH`), which is why it doesn't reproduce in a terminal or in the existing tests.

Observed: `list-devices` returned both a phantom `platform:"android"` `emulator-5554` and the real `platform:"vega"` device for a single running VVD.

## Fix

Pin `ps` to its canonical absolute location, matching how the codebase already hardcodes `/bin/sh` (`android-binary.ts`, `vega-cli.ts`, `check-deps.ts`):

```ts
export const PS_BIN = ["/bin/ps", "/usr/bin/ps"].find((p) => existsSync(p)) ?? "ps";
```

Applied to all four `ps` spawn sites:
- `vega-process.ts` — `listRunningVvdConsolePorts`, `listRunningVvdPids`
- `vega-cli.ts` — `collectDescendantPids`, `pgidMembers` (same latent PATH fragility in the process-reaping paths)

The bare-`"ps"` fallback is retained only if neither canonical path exists, preserving `PATH` resolution for an atypical layout.

## Tests

- New regression test in `vega-process.test.ts` that strips `/bin` and `/usr/bin` from `PATH` and asserts the probe still spawns `ps` (a bare `"ps"` ENOENTs there — verified the test fails against the pre-fix code).
- Updated the `list-devices.test.ts` mock to match `ps` by basename, since production now passes an absolute path.
- `npm run build`, typecheck, lint (`--max-warnings 0`), and the full vega/list-devices suite (47 tests) all pass.

## Verification

End-to-end `list-devices.execute()` under a launchd-style minimal `PATH` now returns exactly **one** device (the Vega), with no android shadow. `PS_BIN` resolves to `/bin/ps` and reads the VVD's console port even with `/bin` removed from `PATH`.