### PR TITLE
fix(flow): refuse invisible-only text selectors — record coordinates instead

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -4,6 +4,7 @@ import { FAILURE_CODES, FailureError } from "@argent/registry";
 import { stringify as yamlStringify, parse as yamlParse } from "yaml";
 import { CLIENT_FILE_MARKER, type ClientFileDirective } from "@argent/registry";
 import {
+  hasVisibleText,
   selectorFieldsSchema,
   selectorSchema,
   type Selector,
@@ -410,18 +411,20 @@ export function selectorToYaml(sel: FlowSelector): YamlSelector {
     );
   }
 
-  // A loose selector serializes to the bare-string spelling, which is parsed
-  // back through selectorSchema's non-empty `text` constraint. Guard the
-  // serialization boundary too: an empty (or runtime-invalid) text value
-  // would otherwise produce YAML that selectorToYaml's inverse rejects.
-  if (
-    sel.loose &&
-    sel.text !== undefined &&
-    (typeof sel.text !== "string" || sel.text.length === 0)
-  ) {
+  // Both spellings parse back through selectorSchema's visible-text
+  // constraint. Guard the serialization boundary too — for the strict map
+  // form as much as the bare string: an empty, runtime-invalid, or
+  // invisible-only text value (icon-font Private Use Area glyphs, zero-width
+  // characters) would otherwise produce YAML that DISPLAYS as an empty
+  // selector and that selectorToYaml's inverse rejects. Recorders never hit
+  // this (deriveSelector refuses invisible text and falls back to
+  // coordinates); a hand-built selector fails loudly instead of writing a
+  // flow no one can read or replay.
+  if (sel.text !== undefined && (typeof sel.text !== "string" || !hasVisibleText(sel.text))) {
     throw new Error(
-      "Cannot serialize loose flow selector: `text` must be a non-empty string so " +
-        "bare-string YAML can round-trip through selector validation."
+      "Cannot serialize flow selector: `text` must contain at least one visible character " +
+        "(icon-font/private-use and zero-width characters render as nothing). Select by " +
+        "identifier or role, or use a coordinate tap."
     );
   }
 

--- a/packages/tool-server/src/utils/ui-tree-match.ts
+++ b/packages/tool-server/src/utils/ui-tree-match.ts
@@ -24,11 +24,30 @@ import { chromiumCdpRef, type ChromiumCdpApi } from "../blueprints/chromium-cdp"
  * forms can replace `text` with another validated text constraint while still
  * reusing the canonical identifier/role validation.
  */
+/**
+ * True when `text` contains at least one visibly-rendered, font-independent
+ * character. Icon fonts expose their glyphs as Private Use Area code points
+ * (a tab-bar icon's label can be U+E163 — an icon, not text) and zero-width /
+ * format characters render as nothing: a text constraint made only of those
+ * displays as EMPTY in flow YAML, is meaningless outside the app's private
+ * font, and at replay matches an element no reader of the flow can predict.
+ * Strips Cf (format: zero-width space/joiners, BOM), Co (private use) and
+ * Cc (controls), then whitespace; visible = anything left.
+ */
+export function hasVisibleText(text: string): boolean {
+  return text.replace(/[\p{Cf}\p{Co}\p{Cc}]/gu, "").trim().length > 0;
+}
+
 export const selectorFieldsSchema = z
   .object({
     text: z
       .string()
       .min(1)
+      .refine(hasVisibleText, {
+        message:
+          "text must contain at least one visible character (icon-font/private-use and " +
+          "zero-width characters render as nothing) — select by identifier or role instead",
+      })
       .optional()
       .describe("Case-insensitive substring of the element's visible label or value."),
     identifier: z
@@ -448,7 +467,10 @@ export function deriveSelector(node: DescribeNode): Selector | null {
   // separately, so a joined "Volume 50%" would match nothing, not even the
   // node it was derived from. Label first — a value like "50%" is the
   // volatile part of a control, the label is the stabler replay anchor.
-  const text = [node.label, node.value].map((t) => t?.trim()).find(Boolean);
+  // Only visibly-rendered text counts as stable: icon-font labels are Private
+  // Use Area glyphs that serialize to invisible YAML (see hasVisibleText), so
+  // a node carrying only those falls through to role/coordinates.
+  const text = [node.label, node.value].map((t) => t?.trim()).find((t) => t && hasVisibleText(t));
   if (text) return { text };
   if (node.role && !GENERIC_ROLES.has(node.role.toLowerCase())) return { role: node.role };
   return null;

--- a/packages/tool-server/test/flows/flow-selector-matches.test.ts
+++ b/packages/tool-server/test/flows/flow-selector-matches.test.ts
@@ -167,9 +167,12 @@ describe("regex text selectors: parse/serialize", () => {
     }
   });
 
-  it("rejects empty loose text with a pointed round-trip error", () => {
+  it("rejects empty loose text with the visible-character error", () => {
+    // The empty-text guard is now shared with the strict map spelling and
+    // also refuses invisible-only text (icon-font PUA glyphs, zero-width) —
+    // see "rejects a text selector with no visible characters" in flow-tap.
     expect(() => selectorToYaml({ text: "", loose: true })).toThrow(
-      /`text` must be a non-empty string.*round-trip through selector validation/i
+      /`text` must contain at least one visible character/i
     );
   });
 

--- a/packages/tool-server/test/flows/flow-tap.test.ts
+++ b/packages/tool-server/test/flows/flow-tap.test.ts
@@ -120,6 +120,29 @@ describe("tap times: parse/serialize", () => {
     expect(serializeFlow({ executionPrerequisite: "", steps })).toContain("- tap: Photo");
   });
 
+  it("rejects a text selector with no visible characters, both at parse and at serialize", () => {
+    // The 0.15.0 QA repro: an icon-font tab bar exposed its Private Use Area
+    // glyph (U+E163) as the accessibility label; the recorder wrote
+    // `tap: { text: <PUA> }` — YAML that DISPLAYS as `text:` (empty) — and
+    // replay green-lit against it. Such selectors must be refused loudly.
+    expect(() => parseFlow('steps:\n  - tap: { text: "\\uE163" }\n')).toThrow(/visible character/i);
+    // Zero-width-only text is the same class; plain-empty already fails min(1).
+    expect(() => parseFlow('steps:\n  - tap: { text: "\\u200B" }\n')).toThrow(/visible character/i);
+    expect(() => parseFlow('steps:\n  - tap: { text: "" }\n')).toThrow();
+    // Serialization boundary guards the strict map spelling too — a hand-built
+    // selector can't write a flow file whose selector displays as empty.
+    expect(() =>
+      serializeFlow({
+        executionPrerequisite: "",
+        steps: [{ kind: "tap", selector: { text: "\uE163" } }],
+      })
+    ).toThrow(/visible character/i);
+    // Text that merely contains an icon glyph next to real text stays valid.
+    expect(parseFlow('steps:\n  - tap: { text: "\\uE163 Explore" }\n').steps).toEqual([
+      { kind: "tap", selector: { text: "\uE163 Explore" } },
+    ]);
+  });
+
   it("rejects selector fields alongside times with the nested-selector hint", () => {
     // zod would silently STRIP times from a selector map — this must be loud.
     expect(() => parseFlow('steps:\n  - tap: { text: "Test", times: 2 }\n')).toThrow(

--- a/packages/tool-server/test/utils/ui-tree-match.test.ts
+++ b/packages/tool-server/test/utils/ui-tree-match.test.ts
@@ -141,6 +141,28 @@ describe("ui-tree-match", () => {
     ).toEqual({ role: "AXButton" });
   });
 
+  it("deriveSelector refuses invisible-only text (icon-font PUA glyphs, zero-width chars)", () => {
+    const frame = { x: 0, y: 0, width: 0.1, height: 0.1 };
+    // The QA repro: an expo-router tab-bar icon whose accessibility label is
+    // the icon font's Private Use Area glyph (U+E163). Text-wise the node has
+    // "nothing stable to match on" — it must fall through, here to null.
+    expect(deriveSelector(node({ label: "\uE163", frame }))).toBeNull();
+    // Zero-width-only label (ZWSP survives trim(), renders as nothing).
+    expect(deriveSelector(node({ label: "\u200B\u200B", frame }))).toBeNull();
+    // Invisible label falls through to a visible VALUE...
+    expect(deriveSelector(node({ label: "\uE88A", value: "Home", frame }))).toEqual({
+      text: "Home",
+    });
+    // ...or to a specific role when no visible text exists at all.
+    expect(deriveSelector(node({ label: "\uE88A", role: "AXButton", frame }))).toEqual({
+      role: "AXButton",
+    });
+    // Visible text that merely CONTAINS an icon glyph stays usable.
+    expect(deriveSelector(node({ label: "\uE163 Explore", frame }))).toEqual({
+      text: "\uE163 Explore",
+    });
+  });
+
   it("deriveSelector derives text from the label alone — never the label+value join", () => {
     // matchNode compares a text selector against label and value individually,
     // so a selector derived from nodeText's join ("Volume 50%") would match no


### PR DESCRIPTION
## The bug (found in the 0.15.0 full-surface QA, on both the Android emulator and a physical S24)

Recording a `gesture-tap` on an icon-font tab-bar item wrote a flow step that displays as an **empty selector**, with the coordinates gone:

```yaml
steps:
  - tap:
      text:      # ← actually U+E163, an icon-font Private Use Area glyph
```

and `flow-execute` then **silently passed** against target `""`, tapping an element no reader of the flow can predict. Root cause (hexdump of the QA-recorded file: `ee 85 a3` = U+E163): icon fonts expose their glyph as the element's accessibility label; `deriveSelector` accepted any label that survived `trim()`, so a PUA code point counted as "stable text". This violated the rewrite's own documented contract — *"otherwise coordinates are kept with a warning"* — whose fallback path existed and worked, but never ran for this case.

## The fix — one predicate, three layers

`hasVisibleText()` (strip Unicode `Cf` format / `Co` private-use / `Cc` control, then trim; require something left):

1. **`deriveSelector`** — invisible-only label/value is not stable text; fall through to role, then to the recorder's existing kept-coordinates path.
2. **`selectorToYaml`** — the empty-text guard previously covered only the bare-string spelling; it now also rejects empty/invisible text on the strict `{text: …}` map form, so a hand-built selector fails loudly instead of writing an unreadable flow file.
3. **`selectorSchema`** — parse-side refinement, so flow files already recorded broken on 0.15.0 fail with an actionable message ("text must contain at least one visible character … select by identifier or role instead") instead of false-passing at replay. This also hardens the `await-ui-element` tool surface, which shares the schema.

Text that merely *contains* an icon glyph alongside real text ("⟨U+E163⟩ Explore") stays valid throughout.

## Verification

- Unit: `deriveSelector` PUA/ZWSP/mixed cases, serialize + parse rejection round-trips (explicit `\uXXXX` escapes, no invisible bytes in the test source).
- Full tool-server suite: **2667 passed**.
- **Live on the Pixel_9 emulator against the original QA repro** (my-app tab bar, same coordinates): recording now produces `tap: {x: 0.75, y: 0.947}` with the documented *"kept coordinates (brittle)"* warning — the role fallback was correctly caught by the existing resolves-to-a-different-element guard — replay passes 2/2 on the coordinate targets, and executing the old broken YAML now fails parse with the visible-character error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)