### PR TITLE
feat(screenshot-diff): support full-image comparisons

### DIFF
--- a/packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts
@@ -111,12 +111,17 @@ const HORIZONTAL_TEXT_MERGE_MAX_GAP = 120;
 // still report the dominant RGB channel.
 const UNIFORM_BRIGHTNESS_DELTA_TOLERANCE = 4;
 
-export async function diffPngFiles(options: {
+type TopMaskPolicy = "none" | "status-bar";
+
+export interface DiffPngFilesOptions {
   baselinePath: string;
   currentPath: string;
   outputDir: string;
-}): Promise<PngDiffResult> {
-  const settings = resolveDiffSettings();
+  topMask?: TopMaskPolicy;
+}
+
+export async function diffPngFiles(options: DiffPngFilesOptions): Promise<PngDiffResult> {
+  const settings = resolveDiffSettings(options.topMask ?? "status-bar");
 
   const [decodedBaseline, decodedCurrent] = await Promise.all([
     decodePngFile(options.baselinePath),
@@ -197,10 +202,10 @@ export async function diffPngFiles(options: {
   });
 }
 
-function resolveDiffSettings(): DiffSettings {
+function resolveDiffSettings(topMask: TopMaskPolicy): DiffSettings {
   return {
     thresholdSquared: DEFAULT_THRESHOLD * DEFAULT_THRESHOLD * MAX_RGB_DISTANCE_SQUARED,
-    ignoreTopNormalizedY: DEFAULT_IGNORE_TOP_NORMALIZED_Y,
+    ignoreTopNormalizedY: topMask === "none" ? 0 : DEFAULT_IGNORE_TOP_NORMALIZED_Y,
     joinGapPixels: DEFAULT_REGION_MERGE_DISTANCE,
     contextDiffScale: DEFAULT_CONTEXT_DIFF_SCALE,
   };

--- a/packages/tool-server/test/screenshot-diff.test.ts
+++ b/packages/tool-server/test/screenshot-diff.test.ts
@@ -204,7 +204,12 @@ describe("diffPngFiles", () => {
       ...rectPixels(4, 20, 4, 4, { r: 255, g: 0, b: 0 }),
     ]);
 
-    const result = await diffPngFiles({ baselinePath, currentPath, outputDir: dir });
+    const result = await diffPngFiles({
+      baselinePath,
+      currentPath,
+      outputDir: dir,
+      topMask: "status-bar",
+    });
 
     expect(result.regions).toEqual([
       expect.objectContaining({
@@ -216,6 +221,60 @@ describe("diffPngFiles", () => {
     expect(readRgb(diff, 0, 0)).toEqual({ r: 247, g: 247, b: 247 });
     expect(readRgb(diff, 4, 17)).toEqual({ r: 255, g: 220, b: 0 });
     expect(readRgb(diff, 5, 21)).toEqual({ r: 0, g: 200, b: 0 });
+  });
+
+  it("compares the full image when the top mask is disabled", async () => {
+    const dir = await makeTempDir();
+    const baselinePath = path.join(dir, "baseline.png");
+    const currentPath = path.join(dir, "current.png");
+    await writePng(baselinePath, 12, 100, { r: 20, g: 20, b: 20 });
+    await writePng(
+      currentPath,
+      12,
+      100,
+      { r: 20, g: 20, b: 20 },
+      rectPixels(0, 0, 12, 6, { r: 240, g: 240, b: 240 })
+    );
+
+    const result = await diffPngFiles({
+      baselinePath,
+      currentPath,
+      outputDir: dir,
+      topMask: "none",
+    });
+
+    expect(result).toMatchObject({
+      differentPixels: 72,
+      mismatchPercentage: 6,
+      regions: [
+        expect.objectContaining({
+          bounds: { x: 0, y: 0, width: 12, height: 6 },
+          pixelCount: 72,
+        }),
+      ],
+    });
+    expect(analyzeScreenshotTextChangesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ ignoreTopPixels: 0 })
+    );
+  });
+
+  it("does not mask an entire one-row image when the top mask is disabled", async () => {
+    const dir = await makeTempDir();
+    const baselinePath = path.join(dir, "baseline.png");
+    const currentPath = path.join(dir, "current.png");
+    await writePng(baselinePath, 2, 1, { r: 0, g: 0, b: 0 });
+    await writePng(currentPath, 2, 1, { r: 255, g: 255, b: 255 });
+
+    const masked = await diffPngFiles({ baselinePath, currentPath, outputDir: dir });
+    const unmasked = await diffPngFiles({
+      baselinePath,
+      currentPath,
+      outputDir: dir,
+      topMask: "none",
+    });
+
+    expect(masked).toMatchObject({ differentPixels: 0, mismatchPercentage: 0 });
+    expect(unmasked).toMatchObject({ differentPixels: 2, mismatchPercentage: 100 });
   });
 
   it("colors changed pixels green when they brightened and red when they darkened", async () => {


### PR DESCRIPTION

## Summary

- Add an explicit top-mask policy to the shared PNG differ.
- Preserve status-bar masking by default while allowing isolated image regions to compare every row.
- Add real-PNG regressions for top-band changes and one-row images.

This prepares the differ for cropped comparisons without changing existing callers.

## Testing

- Screenshot-diff tests
- Tool-server build
