### PR TITLE
fix(flow): error a no-windows iOS read instead of a false hidden pass

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-ios-tree.ts
+++ b/packages/tool-server/src/tools/flows/flow-ios-tree.ts
@@ -23,8 +23,9 @@ import {
  *
  * This lives under flows/ (not the describe layer) on purpose: it's a flow-only
  * concern, and the describe path is untouched. When native-devtools is
- * unavailable it throws rather than letting the caller degrade to the AX tree —
- * see `fetchFlowTree` for why a silent fallback would flip flow outcomes.
+ * unavailable — or the target returns no windows — it throws rather than
+ * degrade to the AX tree; see `fetchFlowTree` for why a silent fallback would
+ * flip flow outcomes.
  */
 
 // ── getFullHierarchy → DescribeNode adapter ──────────────────────────────────
@@ -264,7 +265,8 @@ const FULL_HIERARCHY_FIELDS = [
 /**
  * Query the raw UIView tree via native-devtools `getFullHierarchy` and adapt
  * it. Throws — with the reason — when native-devtools is unavailable / not yet
- * connected / errored: flows never degrade to the AX tree (see
+ * connected / errored, or when the resolved target returns no windows (a
+ * non-injectable or backgrounded app): flows never degrade to the AX tree (see
  * `fetchFlowTree`), so the caller's retry loop either rides out a transient
  * failure or surfaces this message as the step's failure reason.
  */
@@ -303,6 +305,19 @@ export async function queryFullHierarchyTree(
 
   if (rawResult.error) {
     throw new Error(`getFullHierarchy failed for ${target.bundleId}: ${rawResult.error}`);
+  }
+
+  // No windows is an untrustworthy read (non-injectable app, backgrounded, or a
+  // window not yet attached), not a blank screen — and an empty tree is the one
+  // thing a `hidden`/absent check accepts, so trusting it would false-pass.
+  // Key on raw windows, not flattened children: windows-but-no-leaves is a
+  // genuinely sparse, trusted screen.
+  if (!Array.isArray(rawResult.windows) || rawResult.windows.length === 0) {
+    throw new Error(
+      `getFullHierarchy returned no windows for ${target.bundleId} — the app is not injectable ` +
+        `(e.g. an Apple system app) or has no readable foreground window, so flows cannot resolve ` +
+        `selectors against its view hierarchy`
+    );
   }
 
   const { tree, screen } = adaptFullHierarchy(rawResult);

--- a/packages/tool-server/test/flows/flow-hidden-blank-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-hidden-blank-reads.test.ts
@@ -133,6 +133,35 @@ describe("hidden timeout diagnostics", () => {
     expect(result.steps[0].reason).not.toMatch(/still visible/);
   });
 
+  it("does not pass a hidden assert when the element was NEVER seen and the tree source is dark", async () => {
+    // The repro that motivated the flow-ios-tree no-windows guard: a
+    // non-injectable target (an Apple system app — library validation) yields a
+    // tree source that cannot read the hierarchy. The element is never seen at
+    // all, so `everMatched` never flips and the blind-read guard's
+    // everMatched-only backstop can't catch it. The source therefore throws on a
+    // no-windows read: every fetch rejects, so the assert reports the outage
+    // instead of taking an empty tree as proof the element is gone.
+    currentFetch = () => {
+      throw new Error(
+        "getFullHierarchy returned no windows for com.apple.Preferences — the app is not injectable"
+      );
+    };
+
+    await writeFlow("never-seen-hidden", {
+      executionPrerequisite: "",
+      steps: [{ kind: "assert", condition: "hidden", selector: { identifier: "General" } }],
+    });
+
+    const result = await run("never-seen-hidden");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].status).toBe("fail");
+    expect(result.steps[0].reason).toMatch(/could not read the UI tree/);
+    expect(result.steps[0].reason).toMatch(/not injectable/);
+    // Must NOT read as a confirmed-hidden pass.
+    expect(result.steps[0].reason).not.toMatch(/still visible/);
+  });
+
   it("still reports a genuinely visible element as still visible", async () => {
     currentFetch = () => ({
       tree: screen([

--- a/packages/tool-server/test/flows/flow-hidden-blank-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-hidden-blank-reads.test.ts
@@ -134,13 +134,18 @@ describe("hidden timeout diagnostics", () => {
   });
 
   it("does not pass a hidden assert when the element was NEVER seen and the tree source is dark", async () => {
-    // The repro that motivated the flow-ios-tree no-windows guard: a
-    // non-injectable target (an Apple system app — library validation) yields a
-    // tree source that cannot read the hierarchy. The element is never seen at
-    // all, so `everMatched` never flips and the blind-read guard's
-    // everMatched-only backstop can't catch it. The source therefore throws on a
-    // no-windows read: every fetch rejects, so the assert reports the outage
-    // instead of taking an empty tree as proof the element is gone.
+    // The runner's half of the no-windows fix: a `hidden` assert whose element
+    // is NEVER seen, so `everMatched` never flips and the blind-read guard's
+    // everMatched-only backstop can't catch it — the only defense is the tree
+    // source refusing the read. The rejecting fetch is SCRIPTED here (this
+    // file mocks fetchFlowTree wholesale; the message just mirrors
+    // flow-ios-tree's no-windows guard, which flow-ios-tree-no-windows.test.ts
+    // exercises at the unit level and flow-hidden-no-windows-e2e.test.ts
+    // end-to-end). What this case locks in is the caller's contract with that
+    // upstream throw: when every fetch rejects, the assert fails with the
+    // outage — the /not injectable/ check pins the fetch error's text landing
+    // in the step reason — instead of treating an unreadable screen as a
+    // no-match that satisfies `hidden`.
     currentFetch = () => {
       throw new Error(
         "getFullHierarchy returned no windows for com.apple.Preferences — the app is not injectable"

--- a/packages/tool-server/test/flows/flow-hidden-no-windows-e2e.test.ts
+++ b/packages/tool-server/test/flows/flow-hidden-no-windows-e2e.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { NativeAppState, NativeDevtoolsApi } from "../../src/blueprints/native-devtools";
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+import { serializeFlow } from "../../src/tools/flows/flow-utils";
+
+// End-to-end companion to flow-ios-tree-no-windows.test.ts: that file pins the
+// guard at the unit level (queryFullHierarchyTree throws on a no-windows read);
+// this one proves the guard is what stands between a non-injectable target and
+// a false green flow. Nothing on the tree path is mocked — the runner goes
+// through the REAL fetchFlowTree → queryFullHierarchyTree against a
+// native-devtools API whose getFullHierarchy returns `{ windows: [] }` (the
+// non-injectable / no-readable-foreground-window shape). Without the guard,
+// that payload adapts to an empty tree the poll loop treats as TRUSTED — the
+// element was never seen, so the blind-read guard's everMatched backstop
+// doesn't engage — and a `hidden` assert evaluates true against it: the exact
+// false pass the guard exists to prevent. Revert the guard and this test
+// fails; the unit file and this one gate the fix from both ends.
+
+const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
+const APP = "com.example.app";
+let tmpDir: string;
+
+function appState(bundleId: string): NativeAppState {
+  return {
+    bundleId,
+    applicationState: "active",
+    foregroundActiveSceneCount: 1,
+    foregroundInactiveSceneCount: 0,
+    backgroundSceneCount: 0,
+    unattachedSceneCount: 0,
+    isFrontmostCandidate: true,
+  };
+}
+
+/**
+ * Minimal NativeDevtoolsApi: one connected, foreground app whose
+ * `queryViewHierarchy` always reports no windows — the read the guard refuses.
+ */
+function nativeApi(): NativeDevtoolsApi {
+  return {
+    listConnectedBundleIds: () => [APP],
+    getAppState: async (id: string) => appState(id),
+    requiresAppRestart: async () => false,
+    queryViewHierarchy: async () => ({ windows: [] }),
+  } as unknown as NativeDevtoolsApi;
+}
+
+// The native-devtools service resolution is the only seam faked here; the
+// registry's tool surface is inert (the flow has no launch or tool steps).
+function mockRegistry(api: NativeDevtoolsApi): Registry {
+  return {
+    resolveService: async () => api,
+    invokeTool: async () => ({ ok: true }),
+    getTool: () => undefined,
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: Parameters<typeof serializeFlow>[0]): Promise<void> {
+  const dir = path.join(tmpDir, ".argent", "flows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.yaml`), serializeFlow(yaml), "utf8");
+}
+
+function asRun(r: FlowRunResult | { notice: string }): FlowRunResult {
+  if (!("steps" in r)) throw new Error(`expected a run result, got notice: ${r.notice}`);
+  return r;
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-no-windows-"));
+});
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("hidden assert against a no-windows target (end-to-end)", () => {
+  it("fails with the guard's no-windows reason instead of false-passing", async () => {
+    await writeFlow("no-windows-hidden", {
+      executionPrerequisite: "",
+      steps: [{ kind: "assert", condition: "hidden", selector: { identifier: "General" } }],
+    });
+
+    const result = asRun(
+      await createRunFlowTool(mockRegistry(nativeApi())).execute(
+        {},
+        { name: "no-windows-hidden", project_root: tmpDir, device: DEVICE }
+      )
+    );
+
+    // Every poll's fetch rejects with the guard's message, so the assert never
+    // gets a trusted read and must report the outage, quoting the guard.
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].status).toBe("fail");
+    expect(result.steps[0].reason).toMatch(/could not read the UI tree/);
+    expect(result.steps[0].reason).toMatch(/returned no windows for com\.example\.app/);
+    expect(result.steps[0].reason).toMatch(/not injectable/);
+  });
+});

--- a/packages/tool-server/test/flows/flow-ios-tree-no-windows.test.ts
+++ b/packages/tool-server/test/flows/flow-ios-tree-no-windows.test.ts
@@ -64,6 +64,23 @@ function windowSpanning() {
   };
 }
 
+/** A window whose subtree is pure scaffolding — no identifier, label, semantic
+ * role, or first responder anywhere — so the flatten emits zero leaves. */
+function windowBare() {
+  return {
+    className: "UIWindow",
+    frame: { x: 0, y: 0, width: 400, height: 800 },
+    windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+    children: [
+      {
+        className: "UIView",
+        windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+        children: [],
+      },
+    ],
+  };
+}
+
 describe("queryFullHierarchyTree — untrusted (no windows) reads", () => {
   it("throws when the target returns an empty windows array", async () => {
     const registry = registryFor(nativeApi(() => ({ windows: [] })));
@@ -82,6 +99,16 @@ describe("queryFullHierarchyTree — untrusted (no windows) reads", () => {
     const { tree, source } = await queryFullHierarchyTree(registry, IOS_DEVICE);
     expect(source).toBe("native-devtools");
     expect(tree.children.length).toBeGreaterThan(0);
+  });
+
+  // The guard keys on the raw `windows` array, not the flattened child count:
+  // windows-present-but-zero-leaves is a genuinely sparse, trusted screen, so
+  // it must resolve (letting a `hidden` assert pass) rather than throw.
+  it("resolves an empty trusted tree when windows are present but flatten to no leaves", async () => {
+    const registry = registryFor(nativeApi(() => ({ windows: [windowBare()] })));
+    const { tree, source } = await queryFullHierarchyTree(registry, IOS_DEVICE);
+    expect(source).toBe("native-devtools");
+    expect(tree.children.length).toBe(0);
   });
 
   it("still throws on an explicit getFullHierarchy error (unchanged)", async () => {

--- a/packages/tool-server/test/flows/flow-ios-tree-no-windows.test.ts
+++ b/packages/tool-server/test/flows/flow-ios-tree-no-windows.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import type { DeviceInfo, Registry } from "@argent/registry";
+import type { NativeAppState, NativeDevtoolsApi } from "../../src/blueprints/native-devtools";
+import { queryFullHierarchyTree } from "../../src/tools/flows/flow-ios-tree";
+
+// A getFullHierarchy read that returns no windows is the signal of an untrusted
+// read — a non-injectable target (an Apple system app the frontmost resolver
+// still picked), a backgrounded app, or a window that has not attached yet.
+// The flow tree source must THROW there rather than hand back an empty tree:
+// an empty tree is the one thing a `hidden`/absent check accepts as satisfied,
+// so degrading to it turns a non-injectable target into a false green pass.
+
+const IOS_DEVICE = {
+  id: "00000000-0000-0000-0000-0000000000ab",
+  platform: "ios",
+} as unknown as DeviceInfo;
+
+const APP = "com.example.app";
+
+function appState(bundleId: string): NativeAppState {
+  return {
+    bundleId,
+    applicationState: "active",
+    foregroundActiveSceneCount: 1,
+    foregroundInactiveSceneCount: 0,
+    backgroundSceneCount: 0,
+    unattachedSceneCount: 0,
+    isFrontmostCandidate: true,
+  };
+}
+
+/**
+ * Minimal NativeDevtoolsApi: one connected, foreground app; `queryViewHierarchy`
+ * returns whatever `hierarchy` yields (called with the resolved bundleId).
+ */
+function nativeApi(hierarchy: () => unknown, bundleId = APP): NativeDevtoolsApi {
+  return {
+    listConnectedBundleIds: () => [bundleId],
+    getAppState: async (id: string) => appState(id),
+    requiresAppRestart: async () => false,
+    queryViewHierarchy: async () => hierarchy(),
+  } as unknown as NativeDevtoolsApi;
+}
+
+function registryFor(api: NativeDevtoolsApi): Registry {
+  return {
+    resolveService: async () => api,
+  } as unknown as Registry;
+}
+
+function windowSpanning() {
+  return {
+    className: "UIWindow",
+    frame: { x: 0, y: 0, width: 400, height: 800 },
+    windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+    children: [
+      {
+        className: "RCTView",
+        identifier: "root",
+        windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+        children: [],
+      },
+    ],
+  };
+}
+
+describe("queryFullHierarchyTree — untrusted (no windows) reads", () => {
+  it("throws when the target returns an empty windows array", async () => {
+    const registry = registryFor(nativeApi(() => ({ windows: [] })));
+    await expect(queryFullHierarchyTree(registry, IOS_DEVICE)).rejects.toThrow(
+      /returned no windows for com\.example\.app/i
+    );
+  });
+
+  it("throws when the payload carries no windows field at all", async () => {
+    const registry = registryFor(nativeApi(() => ({})));
+    await expect(queryFullHierarchyTree(registry, IOS_DEVICE)).rejects.toThrow(/no windows/i);
+  });
+
+  it("returns a tree when windows are present", async () => {
+    const registry = registryFor(nativeApi(() => ({ windows: [windowSpanning()] })));
+    const { tree, source } = await queryFullHierarchyTree(registry, IOS_DEVICE);
+    expect(source).toBe("native-devtools");
+    expect(tree.children.length).toBeGreaterThan(0);
+  });
+
+  it("still throws on an explicit getFullHierarchy error (unchanged)", async () => {
+    const registry = registryFor(nativeApi(() => ({ error: "hierarchy walk failed" })));
+    await expect(queryFullHierarchyTree(registry, IOS_DEVICE)).rejects.toThrow(
+      /getFullHierarchy failed.*hierarchy walk failed/i
+    );
+  });
+});


### PR DESCRIPTION
## Problem
On iOS, a flow `assert hidden` (and an unmet `when` guard) could pass /
green-skip against a screen where the element was plainly visible — whenever the
target's view hierarchy can't be read. A flow that launches a non-injectable app
(e.g. an Apple system app, where library validation blocks injection) runs to
exit 0 with a false pass while `describe` still shows the element on screen.

## Root cause
`queryFullHierarchyTree` returned an empty tree as a *successful* read when
`getFullHierarchy` yields no windows, and the iOS source never sets a
degraded-read hint. The runner's blind-read guard then falls back to
`everMatched` alone, so an element that was *never seen* leaves the empty tree
"trusted" — and an empty tree is exactly what a `hidden`/absent check accepts as
satisfied.

## Fix
Throw on a no-windows read instead of adapting it to an empty tree — consistent
with the existing unavailable / requiresAppRestart guards. The caller's retry
loop rides out a transient blank; a persistent one surfaces as the step's
failure (`assert` fails, `when` guard errors) with an actionable reason, never a
false pass. Keys on raw `windows`, not the flattened child count, so a genuinely
sparse screen (windows present, no matching leaves) still resolves to "not
found".

## Tests
- New `flow-ios-tree-no-windows.test.ts`: throws on empty / missing windows,
  returns a tree when windows are present, still throws on an explicit RPC error.
- `flow-hidden-blank-reads.test.ts`: adds the never-seen case (element never
  matched + dark source) → `hidden` fails with the outage reason, not a pass.
