### PR TITLE
feat(flow): indent nested steps in reports by block depth

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -29,6 +29,12 @@ export interface StepReport {
   message?: string;
   /** Human-readable step target (selector / snapshot name), set by the runner. */
   target?: string;
+  /**
+   * Nesting depth: absent/0 at top level, +1 inside each block directive
+   * (`when:` guarded steps, `run:` fragment steps). Renderers indent by it; a
+   * pre-depth tool-server sends none and the report renders flat, as before.
+   */
+  depth?: number;
   /** Baseline key stem (`<name>__<platform>-WxH`) on artifact-bearing snapshot steps. */
   snapshotKey?: string;
   /**
@@ -60,6 +66,26 @@ const STATUS_GLYPH: Record<StepReport["status"], string> = {
   error: "✗",
   skip: "·",
 };
+
+/**
+ * Display cap on the nesting indent — not a producer bound. The tool-server's
+ * run-chain and per-file when-nesting limits accumulate, so legitimate depth
+ * can exceed this; such steps keep the maximum indent rather than flattening.
+ * Depth also arrives over the wire, so the clamp doubles as a guard: a buggy
+ * or malicious server must not drive `repeat()` with a huge (multi-GB string)
+ * or negative (throwing) count.
+ */
+const MAX_RENDER_DEPTH = 20;
+
+/**
+ * Indentation for a step's nesting depth, applied to the label so the
+ * glyph/number columns stay aligned. Absent depth (a pre-depth tool-server)
+ * renders flat.
+ */
+function stepIndent(depth: number | undefined): string {
+  if (typeof depth !== "number" || !Number.isInteger(depth) || depth <= 0) return "";
+  return "  ".repeat(Math.min(depth, MAX_RENDER_DEPTH));
+}
 
 function printHelp(): void {
   console.log(`Usage: argent flow <subcommand> [options]
@@ -158,11 +184,12 @@ export function parseRunArgs(argv: string[]): {
  */
 export function renderEchoLine(s: StepReport): string | undefined {
   if (!s.message) return undefined;
+  const indent = stepIndent(s.depth);
   if (s.status === "skip") {
     const reason = s.reason ? ` — ${s.reason}` : "";
-    return `  ${STATUS_GLYPH.skip} › ${s.message}${reason}`;
+    return `  ${STATUS_GLYPH.skip} ${indent}› ${s.message}${reason}`;
   }
-  return `  › ${s.message}`;
+  return `  ${indent}› ${s.message}`;
 }
 
 export function renderStepLine(s: StepReport, n: number, topFlow: string): string {
@@ -171,7 +198,17 @@ export function renderStepLine(s: StepReport, n: number, topFlow: string): strin
   const label = what ? `${s.kind} ${what}` : s.kind;
   const reason = s.reason ? ` — ${s.reason}` : "";
   const glyph = s.status === "pass" && s.warning ? "⚠" : STATUS_GLYPH[s.status];
-  return `  ${glyph} ${String(n).padStart(2)} ${label}${where}${reason}`;
+  return `  ${glyph} ${String(n).padStart(2)} ${stepIndent(s.depth)}${label}${where}${reason}`;
+}
+
+/**
+ * A line printed under a step (warning, artifact path), padded so it sits
+ * under the step's label: the width of renderStepLine's `  ✓ NN ` prefix —
+ * which grows with the step number past 99 — then the step's depth indent.
+ * Shared by the buffered and live renderers so the two can't drift.
+ */
+export function renderUnderStepLine(s: StepReport, n: number, text: string): string {
+  return `${" ".repeat(5 + Math.max(2, String(n).length))}${stepIndent(s.depth)}${text}`;
 }
 
 export function renderSummary(report: FlowReport, opts: { withDevice?: boolean } = {}): string {
@@ -351,10 +388,10 @@ export function renderReport(report: FlowReport): string {
     }
     n++;
     lines.push(renderStepLine(s, n, report.flow));
-    if (s.warning) lines.push(`       ⚠ ${s.warning}`);
+    if (s.warning) lines.push(renderUnderStepLine(s, n, `⚠ ${s.warning}`));
     if (s.artifacts && typeof s.artifacts === "object") {
       for (const [k, v] of Object.entries(s.artifacts)) {
-        if (typeof v === "string") lines.push(`       ${k}: ${v}`);
+        if (typeof v === "string") lines.push(renderUnderStepLine(s, n, `${k}: ${v}`));
       }
     }
   }
@@ -443,7 +480,7 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     }
     liveIndex++;
     console.log(renderStepLine(s, liveIndex, flowName));
-    if (s.warning) console.log(`       ⚠ ${s.warning}`);
+    if (s.warning) console.log(renderUnderStepLine(s, liveIndex, `⚠ ${s.warning}`));
   };
 
   let report: FlowReport;

--- a/packages/argent-cli/test/flow-render.test.ts
+++ b/packages/argent-cli/test/flow-render.test.ts
@@ -5,6 +5,7 @@ import {
   renderEchoLine,
   renderSummary,
   renderArtifactLines,
+  renderUnderStepLine,
   type FlowReport,
   type StepReport,
 } from "../src/flow.js";
@@ -144,6 +145,101 @@ describe("flow report rendering", () => {
     );
     expect(out).toContain("  · › THIS MUST NOT RUN — when block skipped");
     expect(out).not.toContain("  › THIS MUST NOT RUN");
+  });
+
+  it("indents step and echo labels by depth, keeping the glyph/number columns", () => {
+    const tap: StepReport = {
+      index: 2,
+      kind: "tap",
+      status: "pass",
+      target: '"Dismiss"',
+      depth: 1,
+    };
+    expect(renderStepLine(tap, 3, "checkout")).toBe('  ✓  3   tap "Dismiss"');
+    expect(renderStepLine({ ...tap, depth: 2 }, 3, "checkout")).toBe('  ✓  3     tap "Dismiss"');
+    // Absent depth (a pre-depth tool-server) and explicit 0 both render flat.
+    expect(renderStepLine({ ...tap, depth: undefined }, 3, "checkout")).toBe(
+      '  ✓  3 tap "Dismiss"'
+    );
+    expect(renderStepLine({ ...tap, depth: 0 }, 3, "checkout")).toBe('  ✓  3 tap "Dismiss"');
+
+    const echo: StepReport = {
+      index: 3,
+      kind: "echo",
+      status: "pass",
+      message: "inside",
+      depth: 1,
+    };
+    expect(renderEchoLine(echo)).toBe("    › inside");
+    const skippedEcho: StepReport = {
+      ...echo,
+      status: "skip",
+      reason: "when block skipped",
+      depth: 2,
+    };
+    expect(renderEchoLine(skippedEcho)).toBe("  ·     › inside — when block skipped");
+  });
+
+  it("clamps a hostile wire depth instead of throwing or exploding", () => {
+    // depth arrives over the wire: a negative value must not throw
+    // (String.repeat rejects it) and a huge one must not allocate a huge line.
+    const tap: StepReport = { index: 0, kind: "tap", status: "pass", target: '"A"', depth: -3 };
+    expect(renderStepLine(tap, 1, "f")).toBe('  ✓  1 tap "A"');
+    expect(renderStepLine({ ...tap, depth: 1.5 }, 1, "f")).toBe('  ✓  1 tap "A"');
+    // The cap clamps, it does not discard: legitimate depth can exceed it
+    // (the producer's run-chain and when-nesting limits accumulate), so a
+    // too-deep step keeps the maximum indent rather than snapping back flat.
+    const atCap = renderStepLine({ ...tap, depth: 20 }, 1, "f");
+    expect(atCap).toBe(`  ✓  1 ${"  ".repeat(20)}tap "A"`);
+    expect(renderStepLine({ ...tap, depth: 21 }, 1, "f")).toBe(atCap);
+    expect(renderStepLine({ ...tap, depth: 1e9 }, 1, "f")).toBe(atCap);
+  });
+
+  it("buffered report shifts under-step lines (warnings, artifacts) with the step", () => {
+    const out = renderReport(
+      mkReport([
+        {
+          index: 0,
+          kind: "when",
+          status: "pass",
+          reason: 'condition met (visible "Promo")',
+          target: 'visible "Promo"',
+        },
+        {
+          index: 1,
+          kind: "snapshot",
+          status: "fail",
+          reason: "diff 2.10% > 1%",
+          target: '"home"',
+          depth: 1,
+          warning: "baseline seeded",
+          artifacts: { baseline: "/tmp/b.png" },
+        },
+      ])
+    );
+    expect(out).toContain('  ✗  2   snapshot "home" — diff 2.10% > 1%');
+    expect(out).toContain("         ⚠ baseline seeded");
+    expect(out).toContain("         baseline: /tmp/b.png");
+  });
+
+  it("the live tail's warning line (renderUnderStepLine) shifts with depth too", () => {
+    // The live path prints warnings through the same helper as the buffered
+    // renderer — pin the helper so the two can't drift apart.
+    const step: StepReport = { index: 0, kind: "snapshot", status: "pass", depth: 1 };
+    expect(renderUnderStepLine(step, 3, "⚠ baseline seeded")).toBe("         ⚠ baseline seeded");
+    expect(renderUnderStepLine({ ...step, depth: undefined }, 3, "⚠ w")).toBe("       ⚠ w");
+  });
+
+  it("under-step lines stay under the label when the step number grows past 99", () => {
+    // padStart(2) widens the number column at 100+; the under-step pad must
+    // widen with it, at any depth.
+    for (const n of [9, 99, 100, 1000]) {
+      for (const depth of [undefined, 1]) {
+        const step: StepReport = { index: 0, kind: "snapshot", status: "pass", depth };
+        const labelCol = renderStepLine(step, n, "f").indexOf("snapshot");
+        expect(renderUnderStepLine(step, n, "⚠ w").indexOf("⚠")).toBe(labelCol);
+      }
+    }
   });
 
   it("renderSummary carries the device only when asked (live tail)", () => {

--- a/packages/argent-mcp/src/content.ts
+++ b/packages/argent-mcp/src/content.ts
@@ -225,6 +225,12 @@ export type FlowStepResult = {
   /** Human-readable step target (selector / snapshot name), set by the runner. */
   target?: string;
   /**
+   * Nesting depth: absent/0 at top level, +1 inside each block directive
+   * (`when:` guarded steps, `run:` fragment steps). The label is indented by
+   * it; a pre-depth tool-server sends none and the report renders flat.
+   */
+  depth?: number;
+  /**
    * Snapshot-step artifacts keyed by role (baseline/current/diff). Values are
    * artifact handles on current tool-servers; treated as untrusted wire data
    * here, so anything else renders as text or is skipped.
@@ -252,6 +258,22 @@ const STATUS_GLYPH: Record<string, string> = {
   error: "✗",
   skip: "·",
 };
+
+/**
+ * Display cap on the nesting indent — not a producer bound. The tool-server's
+ * run-chain and per-file when-nesting limits accumulate, so legitimate depth
+ * can exceed this; such steps keep the maximum indent rather than flattening.
+ * Depth is also untrusted wire data, so the clamp doubles as a guard: a buggy
+ * or malicious server must not drive `repeat()` with a huge (multi-GB string)
+ * or negative (throwing) count.
+ */
+const MAX_RENDER_DEPTH = 20;
+
+/** Indentation for a step's nesting depth; absent/invalid depth renders flat. */
+function stepIndent(depth: unknown): string {
+  if (typeof depth !== "number" || !Number.isInteger(depth) || depth <= 0) return "";
+  return "  ".repeat(Math.min(depth, MAX_RENDER_DEPTH));
+}
 
 function stepLabel(step: FlowStepResult): string {
   if (step.kind === "echo") return step.message ?? "";
@@ -293,7 +315,10 @@ export async function flowRunToMcpContent(
     const reason = step.reason ?? step.error;
     const suffix = reason ? ` — ${reason}` : "";
     const warning = step.warning ? ` ⚠ ${step.warning}` : "";
-    blocks.push({ type: "text", text: `[${num}] ${glyph}${stepLabel(step)}${suffix}${warning}` });
+    blocks.push({
+      type: "text",
+      text: `[${num}] ${glyph}${stepIndent(step.depth)}${stepLabel(step)}${suffix}${warning}`,
+    });
 
     // Surface a step's own content (e.g. a screenshot) only when it actually
     // returned one.
@@ -304,7 +329,7 @@ export async function flowRunToMcpContent(
     // Snapshot steps carry artifacts instead of a result — list their paths,
     // and inline the annotated diff image when the assertion failed.
     if (isRecord(step.artifacts)) {
-      blocks.push(...(await stepArtifactBlocks(step.artifacts, step.status, ctx)));
+      blocks.push(...(await stepArtifactBlocks(step.artifacts, step.status, ctx, step.depth)));
     }
   }
 
@@ -328,12 +353,14 @@ export async function flowRunToMcpContent(
  * tool-server paths (or filenames) without pulling the bytes over the wire —
  * the same economy flow-visual.ts applies by omitting artifacts on a clean
  * pass. A legacy string[] (pre-handle tool-servers) renders its paths as
- * plain text.
+ * plain text. Lines shift with the step's depth indent so they stay attached
+ * to a nested step's label, matching the CLI renderer.
  */
 async function stepArtifactBlocks(
   artifacts: Record<string, unknown>,
   status: string | undefined,
-  ctx?: ContentContext
+  ctx?: ContentContext,
+  depth?: number
 ): Promise<ContentBlock[]> {
   const failed = status === "fail" || status === "error";
   const entries: [string, string][] = [];
@@ -356,9 +383,10 @@ async function stepArtifactBlocks(
     }
   }
 
+  const indent = stepIndent(depth);
   const blocks: ContentBlock[] =
     entries.length > 0
-      ? [{ type: "text", text: entries.map(([k, v]) => `  ${k}: ${v}`).join("\n") }]
+      ? [{ type: "text", text: entries.map(([k, v]) => `  ${indent}${k}: ${v}`).join("\n") }]
       : [];
   if (diffImage) blocks.push(diffImage);
   return blocks;

--- a/packages/argent-mcp/test/content.test.ts
+++ b/packages/argent-mcp/test/content.test.ts
@@ -317,6 +317,63 @@ describe("flowRunToMcpContent", () => {
     });
   });
 
+  it("indents step labels by nesting depth, clamping hostile wire values", async () => {
+    const input: FlowExecuteResult = {
+      flow: "f",
+      steps: [
+        { index: 0, kind: "when", status: "pass", target: 'visible "Promo"' },
+        { index: 1, kind: "tap", status: "pass", target: '"Dismiss"', depth: 1 },
+        { index: 2, kind: "echo", status: "pass", message: "deep note", depth: 2 },
+        // Wire data is untrusted: a negative depth must not throw and a huge
+        // one must not allocate a huge line.
+        { index: 3, kind: "tap", status: "pass", target: '"A"', depth: -2 },
+        { index: 4, kind: "tap", status: "pass", target: '"B"', depth: 1e9 },
+        // The cap clamps, it does not discard: legitimate depth can exceed it
+        // (the producer's run-chain and when-nesting limits accumulate), so a
+        // too-deep step keeps the maximum indent rather than snapping flat.
+        { index: 5, kind: "tap", status: "pass", target: '"C"', depth: 20 },
+        { index: 6, kind: "tap", status: "pass", target: '"D"', depth: 21 },
+      ],
+    };
+    const blocks = await flowRunToMcpContent(input);
+    const texts = blocks
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+
+    expect(texts).toContain('[1] ✓ when visible "Promo"');
+    expect(texts).toContain('[2] ✓   tap "Dismiss"');
+    expect(texts).toContain("[3] ✓     deep note");
+    expect(texts).toContain('[4] ✓ tap "A"');
+    const cap = "  ".repeat(20);
+    expect(texts).toContain(`[5] ✓ ${cap}tap "B"`);
+    expect(texts).toContain(`[6] ✓ ${cap}tap "C"`);
+    expect(texts).toContain(`[7] ✓ ${cap}tap "D"`);
+  });
+
+  it("shifts snapshot artifact lines with the step's depth, matching the CLI renderer", async () => {
+    const input: FlowExecuteResult = {
+      flow: "f",
+      steps: [
+        {
+          index: 0,
+          kind: "snapshot",
+          status: "fail",
+          reason: "diff 2.10% > 1%",
+          target: '"home"',
+          depth: 1,
+          artifacts: { baseline: "/tmp/b.png" },
+        },
+      ],
+    };
+    const blocks = await flowRunToMcpContent(input);
+    const artifactText = blocks.find(
+      (b): b is { type: "text"; text: string } => b.type === "text" && b.text.includes("baseline:")
+    );
+    // Two-space prefix, then the step's indent — under the indented label,
+    // not left of it.
+    expect(artifactText?.text).toBe("    baseline: /tmp/b.png");
+  });
+
   it("renders the new report shape: status glyphs, reasons, directive kinds, and summary", async () => {
     const input: FlowExecuteResult = {
       flow: "checkout",

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -136,6 +136,14 @@ export interface StepReport {
   snapshotKey?: string;
   /** Snapshot-step artifacts (baseline/current/diff) as materializable handles. */
   artifacts?: SnapshotArtifacts;
+  /**
+   * Nesting depth for display: omitted at top level, +1 inside each block
+   * directive's expanded steps (a `when:` block's guarded steps, a `run:`
+   * fragment's steps). Renderers indent by it without knowing which directives
+   * nest — the report is a flat list with no block-end marker, so depth cannot
+   * be reconstructed downstream.
+   */
+  depth?: number;
 }
 
 export interface FlowRunResult {
@@ -506,7 +514,11 @@ returns a notice with the prerequisite instead of running.`,
 
       let aborted: boolean;
       try {
-        await execSteps(state, flow.steps, params.name, [params.name]);
+        await execSteps(state, flow.steps, {
+          flow: params.name,
+          runStack: [params.name],
+          depth: 0,
+        });
       } finally {
         // Sample the cancel flag before teardown: a client disconnect during
         // status-bar restore / chromium teardown lands after every step
@@ -742,13 +754,36 @@ function stepTarget(step: FlowStep): string | undefined {
   }
 }
 
+/**
+ * Where a list of steps executes: the fragment they are attributed to
+ * (StepReport.flow), the `run:` chain for the cycle/depth guards, and the
+ * nesting depth block directives accumulate for display. Threaded as one value
+ * so a new block directive only has to hand its children {@link childScope}.
+ */
+interface StepScope {
+  flow: string;
+  runStack: string[];
+  depth: number;
+}
+
+/** The scope a block directive's children execute in — one level deeper. */
+function childScope(
+  scope: StepScope,
+  overrides: Partial<Omit<StepScope, "depth">> = {}
+): StepScope {
+  return { ...scope, ...overrides, depth: scope.depth + 1 };
+}
+
+/**
+ * The depth stamp for a report — omitted at top level, so a flow with no block
+ * directives produces a report byte-identical to the pre-depth shape.
+ */
+function depthOf(scope: StepScope): Pick<StepReport, "depth"> {
+  return scope.depth ? { depth: scope.depth } : {};
+}
+
 /** Execute a list of steps, appending reports to state. Honors hard-stop + abort. */
-async function execSteps(
-  state: ExecState,
-  steps: FlowStep[],
-  sourceFlow: string,
-  runStack: string[]
-): Promise<void> {
+async function execSteps(state: ExecState, steps: FlowStep[], scope: StepScope): Promise<void> {
   for (const step of steps) {
     const index = state.reports.length;
 
@@ -757,15 +792,16 @@ async function execSteps(
         index,
         kind: step.kind,
         status: "skip",
-        flow: sourceFlow,
+        flow: scope.flow,
         target: stepTarget(step),
+        ...depthOf(scope),
         // Carry the echo's message so a skipped narration renders as a skip
         // line rather than vanishing — matching reportBlockSkipped.
         ...(step.kind === "echo" ? { message: step.message } : {}),
       });
       // A when block's literal steps are known — expand them so the report
       // keeps one line per authored step no matter where the stop landed.
-      if (step.kind === "when") reportBlockSkipped(state, step.steps, sourceFlow);
+      if (step.kind === "when") reportBlockSkipped(state, step.steps, childScope(scope));
       continue;
     }
     if (state.signal?.aborted) {
@@ -775,24 +811,27 @@ async function execSteps(
         kind: step.kind,
         status: "skip",
         reason: "run aborted",
-        flow: sourceFlow,
+        flow: scope.flow,
         target: stepTarget(step),
+        ...depthOf(scope),
         ...(step.kind === "echo" ? { message: step.message } : {}),
       });
-      if (step.kind === "when") reportBlockSkipped(state, step.steps, sourceFlow, "run aborted");
+      if (step.kind === "when") {
+        reportBlockSkipped(state, step.steps, childScope(scope), "run aborted");
+      }
       continue;
     }
 
     if (step.kind === "run") {
-      await execRunStep(state, step, runStack);
+      await execRunStep(state, step, scope);
       continue;
     }
     if (step.kind === "when") {
-      await execWhenStep(state, step, sourceFlow, runStack);
+      await execWhenStep(state, step, scope);
       continue;
     }
 
-    const report = await execLeafStep(state, step, index, sourceFlow);
+    const report = await execLeafStep(state, step, index, scope);
     pushReport(state, report);
     if (report.status === "fail" || report.status === "error") state.stopped = true;
   }
@@ -807,16 +846,17 @@ function describeWhenCondition(cond: WhenCondition): string {
 /**
  * Report every step of a `when:` block that will not run as skipped — so a
  * run where the block was skipped (unmet guard, errored guard, hard stop, or
- * cancellation) produces the same report shape (one line per authored step)
- * as a run where it entered, and reports stay comparable run-to-run. Nested
- * when blocks expand (their literal steps are known); a `run:` composition
- * stays one line, matching how post-hard-stop skips report a fragment that
- * was never loaded.
+ * cancellation) produces the same report shape (one line per authored step,
+ * at the same depth) as a run where it entered, and reports stay comparable
+ * run-to-run. Nested when blocks expand (their literal steps are known); a
+ * `run:` composition stays one line, matching how post-hard-stop skips report
+ * a fragment that was never loaded. `scope` is the scope the steps would have
+ * executed in — already the block's child scope, not the marker's.
  */
 function reportBlockSkipped(
   state: ExecState,
   steps: FlowStep[],
-  sourceFlow: string,
+  scope: StepScope,
   reason?: string
 ): void {
   for (const step of steps) {
@@ -828,11 +868,12 @@ function reportBlockSkipped(
       // A `run:` line is attributed to the fragment it names, matching the
       // executed marker in execRunStep; everything else belongs to the
       // enclosing flow.
-      flow: step.kind === "run" ? step.flow : sourceFlow,
+      flow: step.kind === "run" ? step.flow : scope.flow,
       target: stepTarget(step),
+      ...depthOf(scope),
       ...(step.kind === "echo" ? { message: step.message } : {}),
     });
-    if (step.kind === "when") reportBlockSkipped(state, step.steps, sourceFlow, reason);
+    if (step.kind === "when") reportBlockSkipped(state, step.steps, childScope(scope), reason);
   }
 }
 
@@ -848,12 +889,15 @@ function reportBlockSkipped(
 async function execWhenStep(
   state: ExecState,
   step: Extract<FlowStep, { kind: "when" }>,
-  sourceFlow: string,
-  runStack: string[]
+  scope: StepScope
 ): Promise<void> {
   const index = state.reports.length;
   const label = describeWhenCondition(step.condition);
   const target = stepTarget(step);
+  // The marker sits at the enclosing depth; the guarded steps one deeper —
+  // whether they execute or report as skipped.
+  const marker = { index, kind: "when", flow: scope.flow, target, ...depthOf(scope) } as const;
+  const inner = childScope(scope);
 
   let met: boolean;
   if (step.condition.kind === "platform") {
@@ -866,28 +910,18 @@ async function execWhenStep(
   } else {
     const probe = await probeWhenCondition(state, step.condition);
     if (probe.aborted) {
-      pushReport(state, {
-        index,
-        kind: "when",
-        status: "skip",
-        reason: "run aborted",
-        flow: sourceFlow,
-        target,
-      });
-      reportBlockSkipped(state, step.steps, sourceFlow, "run aborted");
+      pushReport(state, { ...marker, status: "skip", reason: "run aborted" });
+      reportBlockSkipped(state, step.steps, inner, "run aborted");
       return;
     }
     if (!probe.ok && probe.indeterminate) {
       pushReport(state, {
-        index,
-        kind: "when",
+        ...marker,
         status: "error",
         reason: `could not evaluate when guard (${label}): ${probe.reason}`,
-        flow: sourceFlow,
-        target,
       });
       state.stopped = true;
-      reportBlockSkipped(state, step.steps, sourceFlow, "when guard errored");
+      reportBlockSkipped(state, step.steps, inner, "when guard errored");
       return;
     }
     met = probe.ok;
@@ -896,47 +930,44 @@ async function execWhenStep(
   if (!met) {
     const n = step.steps.length;
     pushReport(state, {
-      index,
-      kind: "when",
+      ...marker,
       status: "skip",
       reason: `condition not met (${label}) — block skipped (${n} step${n === 1 ? "" : "s"})`,
-      flow: sourceFlow,
-      target,
     });
-    reportBlockSkipped(state, step.steps, sourceFlow, "when block skipped");
+    reportBlockSkipped(state, step.steps, inner, "when block skipped");
     return;
   }
 
-  // Marker for the block, then the guarded steps inline — same scope, same
-  // fragment attribution, failures hard-stop as anywhere else.
-  pushReport(state, {
-    index,
-    kind: "when",
-    status: "pass",
-    reason: `condition met (${label})`,
-    flow: sourceFlow,
-    target,
-  });
-  await execSteps(state, step.steps, sourceFlow, runStack);
+  // Marker for the block, then the guarded steps inline — same fragment
+  // attribution, one level deeper, failures hard-stop as anywhere else.
+  pushReport(state, { ...marker, status: "pass", reason: `condition met (${label})` });
+  await execSteps(state, step.steps, inner);
 }
 
 async function execRunStep(
   state: ExecState,
   step: Extract<FlowStep, { kind: "run" }>,
-  runStack: string[]
+  scope: StepScope
 ): Promise<void> {
   const index = state.reports.length;
   const target = step.flow;
 
   const fail = (reason: string): void => {
-    pushReport(state, { index, kind: "run", status: "error", flow: target, reason });
+    pushReport(state, {
+      index,
+      kind: "run",
+      status: "error",
+      flow: target,
+      reason,
+      ...depthOf(scope),
+    });
     state.stopped = true;
   };
 
-  if (runStack.includes(target)) {
-    return fail(`cyclic flow reference: ${[...runStack, target].join(" → ")}`);
+  if (scope.runStack.includes(target)) {
+    return fail(`cyclic flow reference: ${[...scope.runStack, target].join(" → ")}`);
   }
-  if (runStack.length >= MAX_RUN_DEPTH) {
+  if (scope.runStack.length >= MAX_RUN_DEPTH) {
     return fail("max run depth exceeded");
   }
 
@@ -949,18 +980,29 @@ async function execRunStep(
     return fail(`could not load fragment "${target}": ${errMsg(err)}`);
   }
 
-  // Marker for the composition point, then expand the fragment's steps inline.
-  pushReport(state, { index, kind: "run", status: "pass", flow: target });
-  await execSteps(state, fragment.steps, target, [...runStack, target]);
+  // Marker for the composition point, then expand the fragment's steps inline,
+  // one level deeper, attributed to the fragment.
+  pushReport(state, { index, kind: "run", status: "pass", flow: target, ...depthOf(scope) });
+  await execSteps(
+    state,
+    fragment.steps,
+    childScope(scope, { flow: target, runStack: [...scope.runStack, target] })
+  );
 }
 
 async function execLeafStep(
   state: ExecState,
   step: FlowStep,
   index: number,
-  sourceFlow: string
+  scope: StepScope
 ): Promise<StepReport> {
-  const base = { index, kind: step.kind, flow: sourceFlow, target: stepTarget(step) } as const;
+  const base = {
+    index,
+    kind: step.kind,
+    flow: scope.flow,
+    target: stepTarget(step),
+    ...depthOf(scope),
+  } as const;
   const { registry, ctx, device, signal } = state;
 
   switch (step.kind) {

--- a/packages/tool-server/test/flows/flow-composition.test.ts
+++ b/packages/tool-server/test/flows/flow-composition.test.ts
@@ -80,6 +80,45 @@ describe("flow composition (run:)", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("stamps nesting depth on expanded fragment steps (omitted at top level)", async () => {
+    await writeFlow("inner", {
+      executionPrerequisite: "",
+      steps: [{ kind: "echo", message: "deepest" }],
+    });
+    await writeFlow("login", {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "tool", name: "tap", args: { x: 0.5 } },
+        { kind: "run", flow: "inner" },
+      ],
+    });
+    await writeFlow("main", {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "run", flow: "login" },
+        { kind: "echo", message: "done" },
+      ],
+    });
+
+    const runFlow = createRunFlowTool(mockRegistry());
+    const result = asRun(
+      await runFlow.execute({}, { name: "main", project_root: tmpDir, device: DEVICE })
+    );
+
+    // Each run marker sits at its enclosing depth; the fragment it expands runs
+    // one deeper. Top-level steps omit the field entirely, so a flow with no
+    // block directives reports byte-identically to the pre-depth shape.
+    expect(result.steps.map((s) => `${s.kind}:${s.depth ?? 0}`)).toEqual([
+      "run:0",
+      "tool:1",
+      "run:1",
+      "echo:2",
+      "echo:0",
+    ]);
+    expect(result.steps[0].depth).toBeUndefined();
+    expect(result.steps[4].depth).toBeUndefined();
+  });
+
   it("expands a referenced e2e flow inline, launch step and all", async () => {
     await writeFlow("other-e2e", {
       executionPrerequisite: "",
@@ -119,6 +158,14 @@ describe("flow composition (run:)", () => {
     );
     const errored = result.steps.find((s) => s.status === "error");
     expect(errored?.reason).toMatch(/cyclic/i);
+    // The cycle is detected two fragments down; its error marker keeps that
+    // depth (the fail() path stamps depthOf(scope) like the success marker),
+    // so the error line renders inside the block that caused it.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}:${s.depth ?? 0}`)).toEqual([
+      "run:pass:0",
+      "run:pass:1",
+      "run:error:2",
+    ]);
   });
 
   it("executes a leading launch step from scratch (restart-app) and reports it", async () => {

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -334,6 +334,117 @@ describe("when: execution", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("stamps nesting depth identically whether a block enters or skips", async () => {
+    // Depth is display metadata for the renderers' indentation. Two invariants:
+    // top-level steps omit the field entirely (a flat flow's report stays
+    // byte-identical to the pre-depth shape), and a skipped block reports the
+    // same depths as an entered one, so runs stay comparable run-to-run.
+    await writeFlow("depths", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [
+            { kind: "tap", selector: { text: "Skip", loose: true } },
+            {
+              kind: "when",
+              condition: { kind: "platform", platform: "ios" },
+              steps: [{ kind: "echo", message: "nested" }],
+            },
+          ],
+        },
+        { kind: "echo", message: "after block" },
+      ],
+    });
+
+    currentTree = () =>
+      screen([
+        n({ label: "What's new", frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.2 } }),
+        n({ label: "Skip", frame: { x: 0.4, y: 0.8, width: 0.2, height: 0.1 } }),
+      ]);
+    const entered = await run("depths");
+    expect(entered.steps.map((s) => `${s.kind}:${s.status}:${s.depth ?? 0}`)).toEqual([
+      "when:pass:0",
+      "tap:pass:1",
+      "when:pass:1",
+      "echo:pass:2",
+      "echo:pass:0",
+    ]);
+    // Top level omits the field, not depth: 0.
+    expect(entered.steps[0].depth).toBeUndefined();
+    expect(entered.steps[4].depth).toBeUndefined();
+
+    currentTree = () =>
+      screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+    const skipped = await run("depths");
+    expect(skipped.steps.map((s) => `${s.kind}:${s.status}:${s.depth ?? 0}`)).toEqual([
+      "when:skip:0",
+      "tap:skip:1",
+      "when:skip:1",
+      "echo:skip:2",
+      "echo:pass:0",
+    ]);
+    expect(skipped.steps.map((s) => `${s.kind}:${s.depth ?? 0}`)).toEqual(
+      entered.steps.map((s) => `${s.kind}:${s.depth ?? 0}`)
+    );
+    // The skip path, too, omits the field at top level rather than emitting 0
+    // (the ?? 0 maps above cannot tell the two apart).
+    expect(skipped.steps[0].depth).toBeUndefined();
+    expect(skipped.steps[4].depth).toBeUndefined();
+  });
+
+  it("stamps depth on a run: inside a when block — expanded entered, one line skipped", async () => {
+    await writeFlow("dismiss", {
+      executionPrerequisite: "",
+      steps: [{ kind: "tap", selector: { text: "Skip", loose: true } }],
+    });
+    await writeFlow("run-in-when", {
+      executionPrerequisite: "",
+      steps: [
+        {
+          kind: "when",
+          condition: {
+            kind: "ui",
+            condition: "visible",
+            selector: { text: "What's new", loose: true },
+          },
+          steps: [{ kind: "run", flow: "dismiss" }],
+        },
+        { kind: "echo", message: "after block" },
+      ],
+    });
+
+    currentTree = () =>
+      screen([
+        n({ label: "What's new", frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.2 } }),
+        n({ label: "Skip", frame: { x: 0.4, y: 0.8, width: 0.2, height: 0.1 } }),
+      ]);
+    const entered = await run("run-in-when");
+    // when marker at top level, run marker one deep, the fragment's steps two.
+    expect(entered.steps.map((s) => `${s.kind}:${s.status}:${s.depth ?? 0}`)).toEqual([
+      "when:pass:0",
+      "run:pass:1",
+      "tap:pass:2",
+      "echo:pass:0",
+    ]);
+
+    currentTree = () =>
+      screen([n({ label: "Home", frame: { x: 0, y: 0, width: 1, height: 0.1 } })]);
+    const skipped = await run("run-in-when");
+    // A skipped block's run: line stays single (the fragment is never loaded),
+    // at the block's child depth via reportBlockSkipped.
+    expect(skipped.steps.map((s) => `${s.kind}:${s.status}:${s.depth ?? 0}`)).toEqual([
+      "when:skip:0",
+      "run:skip:1",
+      "echo:pass:0",
+    ]);
+  });
+
   it("treats a failure inside an entered block as a real failure (hard stop)", async () => {
     currentTree = () =>
       screen([n({ label: "What's new", frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.2 } })]);
@@ -415,6 +526,9 @@ describe("when: execution", () => {
       "tap:skip",
       "echo:skip",
     ]);
+    // The hard-stop expansion keeps the block's depths: marker at top level
+    // (field omitted), authored steps one deeper — same as an executed block.
+    expect(result.steps.map((s) => s.depth)).toEqual([undefined, undefined, 1, 1]);
     expect(result.steps[1].reason).toBeUndefined();
     expect(result.steps[3].message).toBe("inside");
     expect(result.taps).toHaveLength(0);
@@ -639,6 +753,9 @@ describe("when: execution", () => {
       "echo:skip",
       "echo:skip",
     ]);
+    // The errored-guard expansion keeps the entered-block depths: marker and
+    // trailing echo at top level (field omitted), authored steps one deeper.
+    expect(result.steps.map((s) => s.depth)).toEqual([undefined, 1, 1, 2, undefined]);
     expect(result.steps[2].reason).toBe("when guard errored");
     expect(result.errored).toBe(1);
     expect(result.skipped).toBe(2); // tap + nested when marker; echo is narration
@@ -1033,6 +1150,9 @@ describe("when: run cancellation", () => {
       "echo:skip",
     ]);
     expect(result.steps.map((s) => s.reason)).toEqual(Array(5).fill("run aborted"));
+    // Abort skips keep the block's depths — top-level markers omit the field,
+    // authored steps sit one deeper — same shape as a clean run.
+    expect(result.steps.map((s) => s.depth)).toEqual([undefined, undefined, 1, 1, 2]);
     // The skipped nested echo keeps its message, matching reportBlockSkipped.
     expect(result.steps[4].message).toBe("nested");
     expect(result.taps).toHaveLength(0);


### PR DESCRIPTION
Flow reports rendered every step flat, hiding which steps ran inside a `when:` block or a `run:` fragment. The tool-server now stamps `StepReport.depth` (+1 per block directive, omitted at top level) and the CLI/MCP renderers indent step labels and under-step lines by it:

```
  ✓  1 launch
  ✓  2 when visible "What's new" — condition met
  ✓  3   tap "Skip"
  ✓  4   run dismiss [dismiss]
  ✓  5     tap "OK" [dismiss]
```

Invariants:

- **Wire-compatible both ways** — a flow with no block directives reports byte-identical to the pre-depth shape; a pre-depth server renders flat as before.
- **Skipped ≡ entered** — skipped/errored/aborted blocks report the same depths as entered ones, keeping reports comparable run-to-run.
- **Untrusted wire data** — renderers clamp depth (display cap, not a producer bound): hostile values render flat or at the cap, never throw or allocate huge strings.

Also fixes a pre-existing bug: under-step warning/artifact lines now stay aligned past 99 steps.

Tests pin depth on every producer path (entered/skipped/errored/aborted blocks, `run:` success/failure markers, `run:`-in-`when:`) and renderer alignment incl. the clamp boundary.
