### PR TITLE
fix(tool-server): hard-kill (SIGKILL) timed-out iOS simctl calls so describe can't hang

### DIFF
--- a/packages/tool-server/src/utils/ax-prefs.ts
+++ b/packages/tool-server/src/utils/ax-prefs.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { SIMCTL_SPAWN_TIMEOUT_MS } from "./simctl-config";
+import { SIMCTL_KILL_SIGNAL, SIMCTL_SPAWN_TIMEOUT_MS } from "./simctl-config";
 
 const execFileAsync = promisify(execFile);
 
@@ -21,7 +21,7 @@ export async function ensureAutomationEnabled(udid: string): Promise<void> {
       "-bool",
       "true",
     ],
-    { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+    { timeout: SIMCTL_SPAWN_TIMEOUT_MS, killSignal: SIMCTL_KILL_SIGNAL }
   );
 }
 
@@ -48,7 +48,7 @@ export async function isEntitlementBypassActive(udid: string): Promise<boolean> 
       "com.apple.Accessibility",
       "IgnoreAXServerEntitlements",
     ],
-    { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+    { timeout: SIMCTL_SPAWN_TIMEOUT_MS, killSignal: SIMCTL_KILL_SIGNAL }
   )
     .then(({ stdout }) => stdout.trim() === "1")
     .catch(() => false);

--- a/packages/tool-server/src/utils/ios-devices.ts
+++ b/packages/tool-server/src/utils/ios-devices.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { SIMCTL_KILL_SIGNAL } from "./simctl-config";
 
 const execFileAsync = promisify(execFile);
 
@@ -32,6 +33,7 @@ export async function listIosSimulators(): Promise<IosSimulator[]> {
   try {
     const { stdout } = await execFileAsync("xcrun", ["simctl", "list", "devices", "--json"], {
       timeout: 10_000,
+      killSignal: SIMCTL_KILL_SIGNAL,
     });
     const data: SimctlOutput = JSON.parse(stdout);
     const out: IosSimulator[] = [];

--- a/packages/tool-server/src/utils/ios-host.ts
+++ b/packages/tool-server/src/utils/ios-host.ts
@@ -12,7 +12,7 @@ import {
   bootstrapDylibPathTvos,
   tcpInjectionDylibs,
 } from "@argent/native-devtools-ios";
-import { SIMCTL_SPAWN_TIMEOUT_MS } from "./simctl-config";
+import { SIMCTL_KILL_SIGNAL, SIMCTL_SPAWN_TIMEOUT_MS } from "./simctl-config";
 import { isTvOsSimulator } from "./ios-devices";
 import { ensureAutomationEnabled, isEntitlementBypassActive } from "./ax-prefs";
 import {
@@ -123,7 +123,7 @@ async function ensureAccessibilityEnabled(udid: string): Promise<void> {
           "-bool",
           "true",
         ],
-        { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+        { timeout: SIMCTL_SPAWN_TIMEOUT_MS, killSignal: SIMCTL_KILL_SIGNAL }
       )
     )
   );
@@ -148,7 +148,7 @@ async function setupNativeDevtoolsEnvLocal(udid: string, endpoint: IosEndpoint):
   const result = await execFileAsync(
     "xcrun",
     ["simctl", "spawn", udid, "launchctl", "getenv", "DYLD_INSERT_LIBRARIES"],
-    { encoding: "utf8", timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+    { encoding: "utf8", timeout: SIMCTL_SPAWN_TIMEOUT_MS, killSignal: SIMCTL_KILL_SIGNAL }
   ).catch((e) => ({ stdout: (e as NodeJS.ErrnoException & { stdout?: string }).stdout ?? "" }));
 
   const existing = (result.stdout ?? "").trim();
@@ -158,7 +158,7 @@ async function setupNativeDevtoolsEnvLocal(udid: string, endpoint: IosEndpoint):
     await execFileAsync(
       "xcrun",
       ["simctl", "spawn", udid, "launchctl", "setenv", "DYLD_INSERT_LIBRARIES", updated],
-      { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+      { timeout: SIMCTL_SPAWN_TIMEOUT_MS, killSignal: SIMCTL_KILL_SIGNAL }
     );
   }
 
@@ -177,7 +177,7 @@ async function setupNativeDevtoolsEnvLocal(udid: string, endpoint: IosEndpoint):
         "NATIVE_DEVTOOLS_IOS_CDP_PORT",
         String(endpoint.port),
       ],
-      { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+      { timeout: SIMCTL_SPAWN_TIMEOUT_MS, killSignal: SIMCTL_KILL_SIGNAL }
     );
   } else {
     await execFileAsync(
@@ -191,7 +191,7 @@ async function setupNativeDevtoolsEnvLocal(udid: string, endpoint: IosEndpoint):
         "NATIVE_DEVTOOLS_IOS_CDP_SOCKET",
         endpoint.socketPath,
       ],
-      { timeout: SIMCTL_SPAWN_TIMEOUT_MS }
+      { timeout: SIMCTL_SPAWN_TIMEOUT_MS, killSignal: SIMCTL_KILL_SIGNAL }
     );
   }
 
@@ -232,6 +232,8 @@ function parseUIKitApplicationBundleIds(stdout: string): Set<string> {
 async function listRunningUIKitApplicationBundleIds(udid: string): Promise<Set<string>> {
   const { stdout } = await execFileAsync("xcrun", ["simctl", "spawn", udid, "launchctl", "list"], {
     encoding: "utf8",
+    timeout: SIMCTL_SPAWN_TIMEOUT_MS,
+    killSignal: SIMCTL_KILL_SIGNAL,
   });
   return parseUIKitApplicationBundleIds(stdout);
 }

--- a/packages/tool-server/src/utils/simctl-config.ts
+++ b/packages/tool-server/src/utils/simctl-config.ts
@@ -5,3 +5,20 @@
  * CoreSimulatorService blocking simctl forever, so the watcher's backoff
  * would never fire). */
 export const SIMCTL_SPAWN_TIMEOUT_MS = 10_000;
+
+/** Kill signal for timed-out `xcrun simctl` invocations.
+ *
+ * Node's `execFile` `timeout` sends its `killSignal` (default `SIGTERM`) once and
+ * never escalates. A `simctl` process blocked on a wedged CoreSimulatorService
+ * ignores `SIGTERM`, so the parent keeps awaiting past the deadline and the
+ * timeout that `SIMCTL_SPAWN_TIMEOUT_MS` promises never actually fires (observed:
+ * a `describe` call hung ~24 min against a stuck simulator until the tool-server
+ * was killed). `SIGKILL` reaps the child at the timeout boundary so callers'
+ * budgets hold.
+ *
+ * `simctl` is a single-process XPC client — the real work runs under the
+ * simulator's `launchd_sim`, not as a child of `simctl` — so killing the direct
+ * child settles the promise; the orphaned in-sim process is the simulator's to
+ * reap. Mirrors `ADB_KILL_SIGNAL` in `adb.ts`, which fixed the same class of
+ * hang for the Android surface. */
+export const SIMCTL_KILL_SIGNAL = "SIGKILL" as const;

--- a/packages/tool-server/test/ios-simctl-hardening.test.ts
+++ b/packages/tool-server/test/ios-simctl-hardening.test.ts
@@ -5,8 +5,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // `killSignal` once and never escalates; with the default SIGTERM a `simctl`
 // process blocked on a wedged CoreSimulatorService ignores the signal and the
 // await hangs past the deadline — the failure mode that hung a real `describe`
-// call for ~24 minutes. These tests pin every describe-path `xcrun simctl`
-// invocation to `killSignal: "SIGKILL"` + a finite `timeout` so it can't regress.
+// call for ~24 minutes. These tests pin every *bounded* describe-path `xcrun
+// simctl` invocation to `killSignal: "SIGKILL"` + a finite `timeout` so it can't
+// regress — across all three describe-path modules (ax-prefs, ios-devices, and
+// ios-host via the exported `localIosHost`).
+//
+// The long-lived ax-service daemon spawn (`spawnAxDaemonLocal` /
+// `localIosHost.spawnAxDaemon`) is deliberately NOT asserted here: it runs for
+// up to `--timeout 3600` serving RPC, so a 10s exec `timeout` would SIGKILL it
+// mid-session. Its hang is bounded elsewhere — `waitForDaemonConnection(…, 10s)`
+// in ax-service — not by an exec deadline. So these tests never invoke it.
 type ExecOptions = { timeout?: number; killSignal?: string } | undefined;
 const calls: Array<{ cmd: string; args: readonly string[]; options: ExecOptions }> = [];
 
@@ -30,8 +38,25 @@ vi.mock("node:child_process", async () => {
   };
 });
 
+// `setupNativeDevtoolsEnvLocal` resolves the injection dylib path before any
+// simctl call, and that resolver hard-requires a macOS host. Stub the three
+// bootstrap-path getters so this cross-platform test can reach the simctl
+// getenv/setenv spawns it is meant to guard.
+vi.mock("@argent/native-devtools-ios", async () => {
+  const actual = await vi.importActual<typeof import("@argent/native-devtools-ios")>(
+    "@argent/native-devtools-ios"
+  );
+  return {
+    ...actual,
+    bootstrapDylibPath: () => "/fake/bootstrap.dylib",
+    bootstrapDylibPathTcp: () => "/fake/bootstrap-tcp.dylib",
+    bootstrapDylibPathTvos: () => "/fake/bootstrap-tvos.dylib",
+  };
+});
+
 import { ensureAutomationEnabled, isEntitlementBypassActive } from "../src/utils/ax-prefs";
 import { listIosSimulators } from "../src/utils/ios-devices";
+import { localIosHost } from "../src/utils/ios-host";
 
 beforeEach(() => {
   calls.length = 0;
@@ -66,6 +91,46 @@ describe("iOS simctl calls are hard-killed on timeout (SIGKILL, not SIGTERM)", (
     await listIosSimulators();
     const simctl = xcrunCalls();
     expect(simctl.length).toBeGreaterThan(0);
+    for (const c of simctl) {
+      expect(c.options?.killSignal).toBe("SIGKILL");
+      expect(typeof c.options?.timeout).toBe("number");
+    }
+  });
+
+  // The ios-host.ts describe-path sites — reached via the exported `localIosHost`
+  // rather than the internal functions. This is the block that guards
+  // `listRunningUIKitApplicationBundleIds` (the call this fix added a
+  // previously-missing timeout+kill to) and the six other ios-host simctl spawns.
+  it("localIosHost.bootstrapAx (ensureAutomationEnabled + entitlement probe) passes killSignal SIGKILL", async () => {
+    await localIosHost.bootstrapAx("UDID-HOST-1");
+    const simctl = xcrunCalls();
+    expect(simctl.length).toBeGreaterThan(0);
+    for (const c of simctl) {
+      expect(c.options?.killSignal).toBe("SIGKILL");
+      expect(typeof c.options?.timeout).toBe("number");
+    }
+  });
+
+  it("localIosHost.listRunningBundleIds (launchctl list) passes killSignal SIGKILL + a finite timeout", async () => {
+    await localIosHost.listRunningBundleIds("UDID-HOST-2");
+    const simctl = xcrunCalls();
+    // Exactly the `simctl spawn … launchctl list` call this fix hardened.
+    expect(simctl.some((c) => c.args.includes("launchctl") && c.args.includes("list"))).toBe(true);
+    for (const c of simctl) {
+      expect(c.options?.killSignal).toBe("SIGKILL");
+      expect(typeof c.options?.timeout).toBe("number");
+    }
+  });
+
+  it("localIosHost.setupNativeDevtoolsEnv (getenv/setenv + ensureAccessibilityEnabled) passes killSignal SIGKILL", async () => {
+    await localIosHost.setupNativeDevtoolsEnv("UDID-HOST-3", {
+      transport: "unix",
+      socketPath: "/tmp/argent-hardening-test.sock",
+    });
+    const simctl = xcrunCalls();
+    // Covers the launchctl getenv/setenv spawns plus the two
+    // ensureAccessibilityEnabled `defaults write` spawns.
+    expect(simctl.length).toBeGreaterThan(1);
     for (const c of simctl) {
       expect(c.options?.killSignal).toBe("SIGKILL");
       expect(typeof c.options?.timeout).toBe("number");

--- a/packages/tool-server/test/ios-simctl-hardening.test.ts
+++ b/packages/tool-server/test/ios-simctl-hardening.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture the options object handed to every `execFile` call so we can assert
+// the timeout is backed by a SIGKILL. Node's `execFile` `timeout` only sends its
+// `killSignal` once and never escalates; with the default SIGTERM a `simctl`
+// process blocked on a wedged CoreSimulatorService ignores the signal and the
+// await hangs past the deadline — the failure mode that hung a real `describe`
+// call for ~24 minutes. These tests pin every describe-path `xcrun simctl`
+// invocation to `killSignal: "SIGKILL"` + a finite `timeout` so it can't regress.
+type ExecOptions = { timeout?: number; killSignal?: string } | undefined;
+const calls: Array<{ cmd: string; args: readonly string[]; options: ExecOptions }> = [];
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFile: (
+      cmd: string,
+      args: readonly string[],
+      opts: unknown,
+      cb?: (err: Error | null, out: { stdout: string; stderr: string }) => void
+    ) => {
+      const callback = typeof opts === "function" ? opts : cb!;
+      const options = (typeof opts === "function" ? undefined : opts) as ExecOptions;
+      calls.push({ cmd, args, options });
+      // `simctl list devices --json` must parse; everything else can be empty.
+      const isListJson = args.includes("list") && args.includes("--json");
+      callback(null, { stdout: isListJson ? '{"devices":{}}' : "", stderr: "" });
+    },
+  };
+});
+
+import { ensureAutomationEnabled, isEntitlementBypassActive } from "../src/utils/ax-prefs";
+import { listIosSimulators } from "../src/utils/ios-devices";
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+function xcrunCalls() {
+  return calls.filter((c) => c.cmd === "xcrun" && c.args[0] === "simctl");
+}
+
+describe("iOS simctl calls are hard-killed on timeout (SIGKILL, not SIGTERM)", () => {
+  it("ensureAutomationEnabled passes killSignal SIGKILL + a finite timeout", async () => {
+    await ensureAutomationEnabled("UDID-1");
+    const simctl = xcrunCalls();
+    expect(simctl.length).toBeGreaterThan(0);
+    for (const c of simctl) {
+      expect(c.options?.killSignal).toBe("SIGKILL");
+      expect(typeof c.options?.timeout).toBe("number");
+    }
+  });
+
+  it("isEntitlementBypassActive passes killSignal SIGKILL + a finite timeout", async () => {
+    await isEntitlementBypassActive("UDID-2");
+    const simctl = xcrunCalls();
+    expect(simctl.length).toBeGreaterThan(0);
+    for (const c of simctl) {
+      expect(c.options?.killSignal).toBe("SIGKILL");
+      expect(typeof c.options?.timeout).toBe("number");
+    }
+  });
+
+  it("listIosSimulators (the isTvOsSimulator/describe probe) passes killSignal SIGKILL", async () => {
+    await listIosSimulators();
+    const simctl = xcrunCalls();
+    expect(simctl.length).toBeGreaterThan(0);
+    for (const c of simctl) {
+      expect(c.options?.killSignal).toBe("SIGKILL");
+      expect(typeof c.options?.timeout).toBe("number");
+    }
+  });
+});


### PR DESCRIPTION
## What happened

An iOS `describe` call hung for **~24 minutes** on the benchmark host, logging the incoming request and then going completely silent until the tool-server was killed.

The iOS `describe` path shells out to `xcrun simctl` for nearly every step — `isTvOsSimulator` (`simctl list`), the ax-service bootstrap (`simctl spawn defaults …`), and the native-devtools env setup (`simctl spawn launchctl …`). Every one is guarded by `execFileAsync(…, { timeout: 10_000 })`, so on paper each is bounded to 10s.

The problem is in Node itself: **`execFile`'s `timeout` sends its `killSignal` (default `SIGTERM`) exactly once and never escalates to `SIGKILL`.** When CoreSimulatorService wedges (which rapid clone/boot/delete churn induces), the `simctl` child ignores SIGTERM, its stdio never closes, and the promise never settles — so the "10-second timeout" never actually fires. There is no outer deadline on the `describe` tool to catch it, so the call hangs until the process is killed.

## Why this is the root cause (not a guess)

- **Static elimination:** every JS-level guard on the describe path (ax-service's 10s connect/query timers, native-devtools' 5s RPC timers) *would* have fired and let `describe` return — and it never returned. That leaves only an `execFileAsync` whose OS-level kill failed to settle the promise.
- **Server logs:** the hung process logged the POST, then nothing for 24 min until the kill — the exact signature of a stuck subprocess await with no error thrown.
- **Existing precedent:** `adb.ts` already fixes this identical class of bug for Android via `ADB_KILL_SIGNAL = "SIGKILL"` (see its comment: "Node's execFile default kill signal is SIGTERM, which an `adb` process blocked on a hung daemon can ignore — leaving the parent waiting past the deadline"). The same fix was simply never applied to the `simctl` path.
- **Deterministic repro:** `execFileAsync('sh', ['-c', 'trap "" TERM; …'], { timeout: 2000 })` never settles; adding `killSignal: "SIGKILL"` makes it reject at ~2006ms. Reproduces both the hang and the fix.

## The fix

- Add `SIMCTL_KILL_SIGNAL = "SIGKILL"` to `simctl-config.ts` and pass it alongside the timeout on every describe-path `simctl` invocation (`ax-prefs.ts`, `ios-devices.ts`, `ios-host.ts`), mirroring `ADB_KILL_SIGNAL`.
- Add the missing `timeout` + kill signal to `listRunningUIKitApplicationBundleIds`, which had **no timeout at all** (a latent forever-hang on the `native-devtools-status` path).
- Add `test/ios-simctl-hardening.test.ts` pinning every describe-path `xcrun simctl` call to `killSignal: SIGKILL` + a finite timeout.

## Verification

- `tsc --noEmit` clean (src + tests).
- Full tool-server suite: **2670/2670 pass**.
- Confirmed the new test is a real guard: stripping the flag makes it fail, restoring makes it pass.

## Scope note

This fixes the **proven** describe / native-devtools path. The same latent hang exists in other `simctl` call sites (`boot-device`, `launch-app`, `screenshot`, etc.) that use `execFileAsync` with the default signal — extending SIGKILL to the whole `simctl` surface is a reasonable follow-up but was kept out of this PR to stay scoped to the reported hang.

One caveat: if `simctl` is ever stuck in true uninterruptible kernel state, even SIGKILL can't reap it until the syscall returns; the fully robust version would detach the await from the child via an independent deadline. SIGKILL matches the `adb` precedent and handles the realistic CoreSimulator-wedge case.