### PR TITLE
fix(debugger): collapse a device's two ids onto one debugger instance

### DIFF
--- a/packages/tool-server/src/blueprints/js-runtime-debugger.ts
+++ b/packages/tool-server/src/blueprints/js-runtime-debugger.ts
@@ -9,6 +9,7 @@ import { discoverMetro } from "../utils/debugger/discovery";
 import { classifyDevice } from "../utils/device-info";
 import { proxyStart } from "../utils/sim-remote";
 import { selectTarget } from "../utils/debugger/target-selection";
+import { rememberDeviceAlias, forgetDeviceAlias } from "../utils/debugger/device-alias";
 import { CDPClient, type ConsoleAPICalledParams } from "../utils/debugger/cdp-client";
 import { createSourceResolver, type SourceResolver } from "../utils/debugger/source-resolver";
 import { SourceMapsRegistry } from "../utils/debugger/source-maps";
@@ -258,6 +259,13 @@ export const jsRuntimeDebuggerBlueprint: ServiceBlueprint<JsRuntimeDebuggerApi, 
       consoleSocketUrl: consoleServer.url,
     };
 
+    // Both ids for this device are known here for the first (and only) time:
+    // `deviceId` is what the caller connected with, `logicalDeviceId` is what
+    // Metro echoed back. Record the alias so a later tool that forwards the
+    // logicalDeviceId canonicalizes back to this instance instead of opening a
+    // second connection. See utils/debugger/device-alias.ts.
+    rememberDeviceAlias(api.logicalDeviceId, deviceId);
+
     const events = new TypedEventEmitter<ServiceEvents>();
 
     cdp.events.on("disconnected", (error) => {
@@ -276,6 +284,7 @@ export const jsRuntimeDebuggerBlueprint: ServiceBlueprint<JsRuntimeDebuggerApi, 
     return {
       api,
       dispose: async () => {
+        forgetDeviceAlias(api.logicalDeviceId);
         await consoleServer.close();
         logWriter.close();
         await cdp.disconnect();

--- a/packages/tool-server/src/tools/debugger/debugger-component-tree.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-component-tree.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { canonicalDeviceId } from "../../utils/debugger/device-alias";
 import * as crypto from "node:crypto";
 import type { ToolDefinition } from "@argent/registry";
 import { RN_ONLY_TOOL_CAPABILITY } from "./debugger-service-ref";
@@ -489,7 +490,7 @@ const zodSchema = z.object({
   device_id: z
     .string()
     .describe(
-      "Device logicalDeviceId from debugger-connect (iOS simulator UDID or Android logicalDeviceId)."
+      "Device id from list-devices — the SAME id you passed to debugger-connect (iOS simulator UDID or Android serial)."
     ),
   onScreenOnly: z
     .boolean()
@@ -544,7 +545,7 @@ Use when you need tap coordinates for a React Native UI element. Returns a compa
   // for DOM-tree discovery on Chromium.
   capability: RN_ONLY_TOOL_CAPABILITY,
   services: (params) => ({
-    debugger: `JsRuntimeDebugger:${params.port}:${params.device_id}`,
+    debugger: `JsRuntimeDebugger:${params.port}:${canonicalDeviceId(params.device_id)}`,
   }),
   async execute(services, params) {
     const api = services.debugger as JsRuntimeDebuggerApi;
@@ -576,7 +577,7 @@ Use when you need tap coordinates for a React Native UI element. Returns a compa
     const deviceLine = [
       `device: ${api.deviceName}`,
       `app: ${api.appName}`,
-      ...(api.logicalDeviceId ? [`udid: ${api.logicalDeviceId}`] : []),
+      ...(api.logicalDeviceId ? [`logicalDeviceId: ${api.logicalDeviceId}`] : []),
     ].join(" | ");
 
     return `[${deviceLine}]\n${tree}`;

--- a/packages/tool-server/src/tools/debugger/debugger-connect.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-connect.ts
@@ -11,7 +11,7 @@ const zodSchema = z.object({
   device_id: z
     .string()
     .describe(
-      "Device id: iOS simulator UDID, Android logicalDeviceId returned by Metro, Vega serial (amazon-...), or Chromium device id (chromium-cdp-<port>) from list-devices. When a logicalDeviceId is returned, forward it as device_id to all subsequent debugger-* calls to pin them to this device; when none is returned (Vega), keep passing the id you connected with."
+      "Device id from list-devices: iOS simulator UDID, Android serial, Vega serial (amazon-...), or Chromium device id (chromium-cdp-<port>). Pass this SAME id as device_id to every subsequent debugger-* call to pin them to this device. The returned logicalDeviceId is informational (Metro's own per-connection handle, absent on Vega); you do not switch to it — forwarding it still resolves here, but the list-devices id is the stable one."
     ),
 });
 

--- a/packages/tool-server/src/tools/debugger/debugger-evaluate.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-evaluate.ts
@@ -8,7 +8,7 @@ const zodSchema = z.object({
   device_id: z
     .string()
     .describe(
-      "Device id from debugger-connect (iOS simulator UDID, Android logicalDeviceId, Vega serial, or Chromium device id)."
+      "Device id from list-devices — the SAME id you passed to debugger-connect (iOS simulator UDID, Android serial, Vega serial, or Chromium device id). The logicalDeviceId debugger-connect returns also resolves here, but prefer the stable list-devices id."
     ),
   expression: z.string().describe("JavaScript expression to evaluate in the app runtime"),
 });

--- a/packages/tool-server/src/tools/debugger/debugger-inspect-element.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-inspect-element.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { canonicalDeviceId } from "../../utils/debugger/device-alias";
 import * as crypto from "node:crypto";
 import type { ToolDefinition } from "@argent/registry";
 import type { JsRuntimeDebuggerApi } from "../../blueprints/js-runtime-debugger";
@@ -126,7 +127,7 @@ const zodSchema = z.object({
   device_id: z
     .string()
     .describe(
-      "Device logicalDeviceId from debugger-connect (iOS simulator UDID or Android logicalDeviceId)."
+      "Device id from list-devices — the SAME id you passed to debugger-connect (iOS simulator UDID or Android serial)."
     ),
   x: z.coerce.number().describe("Logical X coordinate on device screen"),
   y: z.coerce.number().describe("Logical Y coordinate on device screen"),
@@ -191,7 +192,7 @@ Use when you need the source file and line for a component at a tap coordinate. 
   // out of scope for this port.
   capability: RN_ONLY_TOOL_CAPABILITY,
   services: (params) => ({
-    debugger: `JsRuntimeDebugger:${params.port}:${params.device_id}`,
+    debugger: `JsRuntimeDebugger:${params.port}:${canonicalDeviceId(params.device_id)}`,
   }),
   async execute(services, params) {
     const api = services.debugger as JsRuntimeDebuggerApi;

--- a/packages/tool-server/src/tools/debugger/debugger-log-registry.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-log-registry.ts
@@ -16,7 +16,7 @@ const zodSchema = z.object({
   device_id: z
     .string()
     .describe(
-      "Device id from debugger-connect (iOS simulator UDID, Android logicalDeviceId, Vega serial, or Chromium device id)."
+      "Device id from list-devices — the SAME id you passed to debugger-connect (iOS simulator UDID, Android serial, Vega serial, or Chromium device id). The logicalDeviceId debugger-connect returns also resolves here, but prefer the stable list-devices id."
     ),
 });
 

--- a/packages/tool-server/src/tools/debugger/debugger-reload-metro.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-reload-metro.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { canonicalDeviceId } from "../../utils/debugger/device-alias";
 import { FAILURE_CODES, FailureError, type ToolDefinition } from "@argent/registry";
 import type { JsRuntimeDebuggerApi } from "../../blueprints/js-runtime-debugger";
 import { DISABLE_LOGBOX_SCRIPT } from "../../utils/debugger/scripts/disable-logbox";
@@ -9,7 +10,7 @@ const zodSchema = z.object({
   device_id: z
     .string()
     .describe(
-      "Device logicalDeviceId from debugger-connect (iOS simulator UDID or Android logicalDeviceId)."
+      "Device id from list-devices — the SAME id you passed to debugger-connect (iOS simulator UDID or Android serial)."
     ),
 });
 
@@ -35,7 +36,7 @@ Use when you want to apply code changes or reset JS state. Returns { reloaded, p
   // want that on Chromium later, it deserves its own tool.
   capability: RN_ONLY_TOOL_CAPABILITY,
   services: (params) => ({
-    debugger: `JsRuntimeDebugger:${params.port}:${params.device_id}`,
+    debugger: `JsRuntimeDebugger:${params.port}:${canonicalDeviceId(params.device_id)}`,
   }),
   async execute(services, _params) {
     const api = services.debugger as JsRuntimeDebuggerApi;

--- a/packages/tool-server/src/tools/debugger/debugger-service-ref.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-service-ref.ts
@@ -1,6 +1,7 @@
 import type { ServiceRef, ToolCapability } from "@argent/registry";
 import { CHROMIUM_ID_PREFIX, resolveDevice } from "../../utils/device-info";
 import { chromiumJsRuntimeDebuggerRef } from "../../blueprints/chromium-js-runtime-debugger";
+import { canonicalDeviceId } from "../../utils/debugger/device-alias";
 
 /**
  * Capability matrix shared by every debugger-* tool that has been ported to
@@ -71,14 +72,19 @@ export const RN_ONLY_TOOL_CAPABILITY: ToolCapability = {
  * passing 8081 by default in the tools' zodSchemas does no harm.
  */
 export function debuggerServiceRef(params: { port: number; device_id?: string }): ServiceRef {
+  // Collapse a forwarded logicalDeviceId back onto the id its device was
+  // connected with, so it resolves to the one open debugger instance rather
+  // than minting a second URN. A no-op for the stable connect id and for
+  // Chromium ids (never aliased). See utils/debugger/device-alias.ts.
+  const deviceId = canonicalDeviceId(params.device_id);
   // Only branch into the Chromium blueprint when the device_id explicitly
   // matches the Chromium shape. The Metro path is the default — it has to
   // tolerate undefined / empty / malformed ids the same way the original
   // template-literal implementation did, because tests and older callers
   // expect a Metro URN to come back even when device_id is missing.
-  if (params.device_id && params.device_id.startsWith(CHROMIUM_ID_PREFIX)) {
-    const device = resolveDevice(params.device_id);
+  if (deviceId && deviceId.startsWith(CHROMIUM_ID_PREFIX)) {
+    const device = resolveDevice(deviceId);
     return chromiumJsRuntimeDebuggerRef(device);
   }
-  return `JsRuntimeDebugger:${params.port}:${params.device_id}`;
+  return `JsRuntimeDebugger:${params.port}:${deviceId}`;
 }

--- a/packages/tool-server/src/tools/debugger/debugger-status.ts
+++ b/packages/tool-server/src/tools/debugger/debugger-status.ts
@@ -8,7 +8,7 @@ const zodSchema = z.object({
   device_id: z
     .string()
     .describe(
-      "Device id from debugger-connect (iOS simulator UDID, Android logicalDeviceId, Vega serial, or Chromium device id)."
+      "Device id from list-devices — the SAME id you passed to debugger-connect (iOS simulator UDID, Android serial, Vega serial, or Chromium device id). The logicalDeviceId debugger-connect returns also resolves here, but prefer the stable list-devices id."
     ),
 });
 

--- a/packages/tool-server/src/tools/network/network-logs.ts
+++ b/packages/tool-server/src/tools/network/network-logs.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import bytesUtil from "bytes";
+import { canonicalDeviceId } from "../../utils/debugger/device-alias";
 import type { ServiceRef, ToolDefinition } from "@argent/registry";
 import type { NetworkInspectorApi } from "../../blueprints/network-inspector";
 import { DEBUGGER_TOOL_CAPABILITY } from "../debugger/debugger-service-ref";
@@ -103,7 +104,11 @@ const zodSchema = z.object({
     .number()
     .default(8081)
     .describe("Metro server port (RN only; ignored on Chromium)"),
-  device_id: z.string().describe("Device UDID (logicalDeviceId)."),
+  device_id: z
+    .string()
+    .describe(
+      "Device id from list-devices (iOS simulator UDID or Android serial) — the same id used with debugger-connect."
+    ),
   pageIndex: z
     .union([z.coerce.number().int().nonnegative(), z.literal("latest")])
     .default("latest")
@@ -129,7 +134,7 @@ Fails if the app is not connected (RN) or the device is not reachable (Chromium)
     if (device.platform === "chromium") {
       return { chromium: chromiumCdpRef(device) };
     }
-    return { inspector: `NetworkInspector:${params.port}:${params.device_id}` };
+    return { inspector: `NetworkInspector:${params.port}:${canonicalDeviceId(params.device_id)}` };
   },
   async execute(services, params) {
     // Chromium: read the server-side CDP Network recording (no in-app injection).

--- a/packages/tool-server/src/tools/network/network-request.ts
+++ b/packages/tool-server/src/tools/network/network-request.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ServiceRef, ToolDefinition } from "@argent/registry";
+import { canonicalDeviceId } from "../../utils/debugger/device-alias";
 import { DEBUGGER_TOOL_CAPABILITY } from "../debugger/debugger-service-ref";
 import type { NetworkInspectorApi } from "../../blueprints/network-inspector";
 import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-cdp";
@@ -45,7 +46,11 @@ const MAX_BODY_SIZE = 1000;
 
 const zodSchema = z.object({
   port: z.coerce.number().default(8081).describe("Metro server port"),
-  device_id: z.string().describe("Device UDID (logicalDeviceId)."),
+  device_id: z
+    .string()
+    .describe(
+      "Device id from list-devices (iOS simulator UDID or Android serial) — the same id used with debugger-connect."
+    ),
   requestId: z.string().describe("The requestId from view-network-logs to get full details for"),
   includeBody: z.coerce
     .boolean()
@@ -121,7 +126,7 @@ Returns an error message string if the requestId is not found — use view-netwo
     if (device.platform === "chromium") {
       return { chromium: chromiumCdpRef(device) };
     }
-    return { inspector: `NetworkInspector:${params.port}:${params.device_id}` };
+    return { inspector: `NetworkInspector:${params.port}:${canonicalDeviceId(params.device_id)}` };
   },
   async execute(services, params) {
     // Chromium: build details from the server-side CDP Network recording, and

--- a/packages/tool-server/src/tools/profiler/react/react-profiler-start.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-start.ts
@@ -26,6 +26,7 @@ import {
   type ProfilerSessionOwner,
 } from "../../../utils/react-profiler/session-ownership";
 import { RN_ONLY_TOOL_CAPABILITY } from "../../debugger/debugger-service-ref";
+import { canonicalDeviceId } from "../../../utils/debugger/device-alias";
 import {
   bootstrapFailureMessage,
   type BootstrapResult,
@@ -62,7 +63,7 @@ const zodSchema = z.object({
   device_id: z
     .string()
     .describe(
-      "Device logicalDeviceId from debugger-connect (iOS simulator UDID or Android logicalDeviceId)."
+      "Device id from list-devices — the SAME id you passed to debugger-connect (iOS simulator UDID or Android serial)."
     ),
   sample_interval_us: z.coerce
     .number()
@@ -116,8 +117,11 @@ Fails if the Hermes runtime is not reachable or the Metro CDP connection cannot 
     capability: RN_ONLY_TOOL_CAPABILITY,
     services: () => ({}),
     async execute(_services, params) {
-      const jsdUrn = `${JS_RUNTIME_DEBUGGER_NAMESPACE}:${params.port}:${params.device_id}`;
-      const psUrn = `${REACT_PROFILER_SESSION_NAMESPACE}:${params.port}:${params.device_id}`;
+      // Canonicalize a forwarded logicalDeviceId to the connect id so the
+      // profiler session and its debugger dependency reuse the open connection.
+      const deviceId = canonicalDeviceId(params.device_id);
+      const jsdUrn = `${JS_RUNTIME_DEBUGGER_NAMESPACE}:${params.port}:${deviceId}`;
+      const psUrn = `${REACT_PROFILER_SESSION_NAMESPACE}:${params.port}:${deviceId}`;
       const ignore = () => {};
 
       async function disposeAndWait() {

--- a/packages/tool-server/src/tools/profiler/react/react-profiler-stop.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-stop.ts
@@ -19,13 +19,14 @@ import {
   RESOLVE_FIBER_META_SCRIPT,
 } from "../../../utils/react-profiler/scripts";
 import { RN_ONLY_TOOL_CAPABILITY } from "../../debugger/debugger-service-ref";
+import { canonicalDeviceId } from "../../../utils/debugger/device-alias";
 
 const zodSchema = z.object({
   port: z.coerce.number().default(8081).describe("Metro server port"),
   device_id: z
     .string()
     .describe(
-      "Device logicalDeviceId from debugger-connect (iOS simulator UDID or Android logicalDeviceId)."
+      "Device id from list-devices — the SAME id you passed to debugger-connect (iOS simulator UDID or Android serial)."
     ),
 });
 
@@ -167,7 +168,7 @@ Fails if no active profiling session exists or the CDP connection was lost durin
     capability: RN_ONLY_TOOL_CAPABILITY,
     services: () => ({}),
     async execute(_services, params) {
-      const psUrn = `${REACT_PROFILER_SESSION_NAMESPACE}:${params.port}:${params.device_id}`;
+      const psUrn = `${REACT_PROFILER_SESSION_NAMESPACE}:${params.port}:${canonicalDeviceId(params.device_id)}`;
       const snapshot = registry.getSnapshot();
       const entry = snapshot.services.get(psUrn);
 

--- a/packages/tool-server/src/utils/debugger/device-alias.ts
+++ b/packages/tool-server/src/utils/debugger/device-alias.ts
@@ -1,0 +1,64 @@
+/**
+ * Collapses the two ids that name the SAME device onto one canonical id, so the
+ * debugger service is cached once instead of twice.
+ *
+ * A device is reached through two different id namespaces:
+ *   - the stable id the caller connects with — an iOS UDID / Android serial /
+ *     Vega serial from `list-devices`;
+ *   - the `logicalDeviceId` Metro's inspector-proxy echoes back for that
+ *     connection, an opaque per-connection handle.
+ *
+ * These are different strings, and the debugger service is cached by its URN,
+ * which embeds `device_id` verbatim (`JsRuntimeDebugger:<port>:<device_id>`).
+ * Metro never sees the UDID, so the logicalDeviceId is not derivable from it —
+ * there is nothing to join on synchronously. Without an alias, a caller that
+ * connects with a UDID and then forwards the returned logicalDeviceId (as the
+ * old docs told it to) would mint a second URN, and thus a second CDPClient, a
+ * second console-log server, and a split log file, all for one device.
+ *
+ * The alias is learned as a side effect of a successful connect — the one place
+ * both ids are known at once — and consumed synchronously when the next tool
+ * builds its service ref. No Metro round-trip on the hot path, so the tools'
+ * `services()` callbacks stay synchronous.
+ *
+ * A logicalDeviceId is unique per Metro connection, so the map is 1:1 and never
+ * mis-collapses two distinct devices. A stale entry (device reconnected, Metro
+ * issued a fresh logicalDeviceId) is harmless: the caller is handed the new
+ * logicalDeviceId, so the old key is simply never looked up again — and it is
+ * cleared on dispose anyway.
+ */
+const logicalIdToConnectId = new Map<string, string>();
+
+/**
+ * Record that `logicalDeviceId` names the same device the caller connected with
+ * as `connectDeviceId`. No-op when the two are equal (e.g. Chromium, where the
+ * logicalDeviceId IS the device id) or when there is no logicalDeviceId (Vega).
+ */
+export function rememberDeviceAlias(
+  logicalDeviceId: string | undefined,
+  connectDeviceId: string
+): void {
+  if (!logicalDeviceId || logicalDeviceId === connectDeviceId) return;
+  logicalIdToConnectId.set(logicalDeviceId, connectDeviceId);
+}
+
+/**
+ * Rewrite a `device_id` to the id its device was connected with, so a forwarded
+ * logicalDeviceId resolves to the already-open debugger instance. Unknown ids
+ * (the stable connect id itself, Chromium ids, anything not aliased) pass
+ * through unchanged, so this is safe to call at every URN-building site.
+ */
+export function canonicalDeviceId(deviceId: string | undefined): string | undefined {
+  if (!deviceId) return deviceId;
+  return logicalIdToConnectId.get(deviceId) ?? deviceId;
+}
+
+/** Drop a learned alias when its debugger connection is disposed. */
+export function forgetDeviceAlias(logicalDeviceId: string | undefined): void {
+  if (logicalDeviceId) logicalIdToConnectId.delete(logicalDeviceId);
+}
+
+/** Test-only: clear all learned aliases. */
+export function resetDeviceAliases(): void {
+  logicalIdToConnectId.clear();
+}

--- a/packages/tool-server/test/metro/device-alias.test.ts
+++ b/packages/tool-server/test/metro/device-alias.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  rememberDeviceAlias,
+  canonicalDeviceId,
+  forgetDeviceAlias,
+  resetDeviceAliases,
+} from "../../src/utils/debugger/device-alias";
+import { debuggerServiceRef } from "../../src/tools/debugger/debugger-service-ref";
+
+const IOS_UDID = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA";
+const LOGICAL_ID = "8a44101d";
+const CHROMIUM_ID = "chromium-cdp-19222";
+
+describe("device-alias — canonicalizing a forwarded logicalDeviceId", () => {
+  beforeEach(() => resetDeviceAliases());
+
+  it("passes an unknown id through unchanged", () => {
+    expect(canonicalDeviceId(IOS_UDID)).toBe(IOS_UDID);
+    expect(canonicalDeviceId(LOGICAL_ID)).toBe(LOGICAL_ID);
+    expect(canonicalDeviceId(undefined)).toBeUndefined();
+  });
+
+  it("maps a learned logicalDeviceId back to the id its device connected with", () => {
+    rememberDeviceAlias(LOGICAL_ID, IOS_UDID);
+    expect(canonicalDeviceId(LOGICAL_ID)).toBe(IOS_UDID);
+    // the connect id itself is still a no-op
+    expect(canonicalDeviceId(IOS_UDID)).toBe(IOS_UDID);
+  });
+
+  it("never records a self-alias (Chromium, where logicalDeviceId === device id)", () => {
+    rememberDeviceAlias(CHROMIUM_ID, CHROMIUM_ID);
+    expect(canonicalDeviceId(CHROMIUM_ID)).toBe(CHROMIUM_ID);
+  });
+
+  it("ignores a missing logicalDeviceId (Vega / legacy inspector)", () => {
+    rememberDeviceAlias(undefined, IOS_UDID);
+    expect(canonicalDeviceId(IOS_UDID)).toBe(IOS_UDID);
+  });
+
+  it("drops the alias on forget so a reconnect is not shadowed", () => {
+    rememberDeviceAlias(LOGICAL_ID, IOS_UDID);
+    forgetDeviceAlias(LOGICAL_ID);
+    expect(canonicalDeviceId(LOGICAL_ID)).toBe(LOGICAL_ID);
+  });
+});
+
+describe("debuggerServiceRef — collapses a forwarded logicalDeviceId onto one URN", () => {
+  beforeEach(() => resetDeviceAliases());
+
+  it("keys the service by the connect id whether called with the UDID or the logicalDeviceId", () => {
+    const connectRef = debuggerServiceRef({ port: 8081, device_id: IOS_UDID });
+    expect(connectRef).toBe(`JsRuntimeDebugger:8081:${IOS_UDID}`);
+
+    // After connect learns Metro's handle, a later call that forwards it must
+    // resolve to the SAME URN — otherwise a second CDP connection is opened.
+    rememberDeviceAlias(LOGICAL_ID, IOS_UDID);
+    const forwardedRef = debuggerServiceRef({ port: 8081, device_id: LOGICAL_ID });
+    expect(forwardedRef).toBe(connectRef);
+  });
+
+  it("does not disturb Chromium routing", () => {
+    const ref = debuggerServiceRef({ port: 8081, device_id: CHROMIUM_ID });
+    expect(ref).toMatchObject({ urn: expect.stringContaining(CHROMIUM_ID) });
+  });
+});


### PR DESCRIPTION
## The problem

A device is reached through **two id namespaces** that name the same thing but are different strings:

- the **stable id** the caller connects with — an iOS UDID / Android serial / Vega serial from `list-devices`;
- the **`logicalDeviceId`** Metro's inspector-proxy echoes back for that connection (an opaque per-connection handle).

`logicalDeviceId` is not derived by Argent — it is echoed verbatim from Metro (`js-runtime-debugger.ts`), and Metro never sees the UDID, so there is **nothing to join on synchronously**.

The debugger service is cached by its URN, which embeds `device_id` verbatim:

```
JsRuntimeDebugger:<port>:<device_id>
```

`debugger-connect` took the UDID, returned the logicalDeviceId, and its description told callers to *"forward it as device_id to all subsequent debugger-\* calls."* Following that instruction produced a **different URN** → a **second `JsRuntimeDebugger` instance** → a second `CDPClient`, a second console-log server, and a split log file — **all for one device**. The second attach also kicks the first off Metro's single-debugger-per-target proxy. Nothing deduplicated them.

It only *looked* fine because with a single device on a Metro port, `selectTarget`'s single-device fallback quietly connects anyway; the split surfaces as "the debugger randomly drops" and logs landing in the wrong bucket.

Secondary damage the same split caused:
- `classifyDevice()` is shape-based and was fed the logicalDeviceId → an iOS device's forwarded id classified as **Android** in the capability gate + telemetry.
- The docs asserted *"iOS simulator UDID, Android logicalDeviceId"* as if a UDID were the iOS logicalDeviceId — the repo's own test says the opposite.
- `debugger-component-tree` printed the logicalDeviceId under a `udid:` label — teaching callers the wrong name.

## The fix — synchronous, within the existing `services()` design

- **Learn an alias** `logicalDeviceId → connect-id` as a side effect of a successful connect (the one place both ids are known at once; see `utils/debugger/device-alias.ts`), and **canonicalize `device_id` through it at every URN-building site**. A forwarded logicalDeviceId now resolves to the already-open instance; unknown ids (the connect id itself, Chromium ids) pass through unchanged, so it is safe to call everywhere. **No Metro round-trip on the hot path — `services()` stays synchronous.** The alias is 1:1 (a logicalDeviceId is unique per connection) and is cleared on dispose.
- **Rewrite the `device_id` docs** across `debugger-*`, `network-*`, and `react-profiler-*`: pass the **same list-devices id you connected with**; the returned logicalDeviceId is informational (forwarding it still resolves, via the alias). Removes the instruction that caused the double instance and the false "UDID = logicalDeviceId" wording.
- **Fix the `debugger-component-tree` header** (`udid:` → `logicalDeviceId:`).

Covered call sites (all that embed `device_id` into a Metro URN): `debuggerServiceRef` (connect/evaluate/status/log-registry), `debugger-reload-metro`, `debugger-component-tree`, `debugger-inspect-element`, `react-profiler-start` (+ its session URN), `react-profiler-stop`, `network-logs`, `network-request`.

## Verification

**Live**, against a real iOS sim + Metro (my-app, RN 0.81.5), driving the branch tool-server directly:

| step | result | URNs instantiated |
|---|---|---|
| `debugger-connect { device_id: <UDID> }` | returns `logicalDeviceId: d52ad36b…` | `JsRuntimeDebugger:8081:<UDID>` |
| `debugger-evaluate { device_id: d52ad36b… }` (forward the logicalDeviceId) | `42` ✅ | **no new URN — reused** |
| counterfactual: `debugger-evaluate { device_id: some-unaliased-id }` | `42` ✅ | **`JsRuntimeDebugger:8081:some-unaliased-id` — a distinct 2nd instance** (the pre-fix behavior, reproduced) |
| `debugger-component-tree { device_id: <UDID> }` | header reads `logicalDeviceId: d52ad36b…` ✅ | reused |

**Unit** — new `test/metro/device-alias.test.ts` covers the alias (learn / canonicalize / self-alias no-op / missing-id / forget) and that `debuggerServiceRef` yields the same URN whether called with the UDID or the forwarded logicalDeviceId. Full tool-server suite green (2726 tests).

## Not in scope

Renaming the `device_id` param to `udid` (or vice-versa) — that is a breaking MCP wire change. This PR is additive: a forwarded logicalDeviceId keeps working, it just no longer opens a second connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)