### PR TITLE
fix(ios-profiler): stop native-profiler-stop being aborted mid-packaging

### DIFF
--- a/packages/tool-server/src/tools/profiler/native-profiler/native-profiler-stop.ts
+++ b/packages/tool-server/src/tools/profiler/native-profiler/native-profiler-stop.ts
@@ -79,6 +79,8 @@ function registerTrace(store: ArtifactStore, traceFile: string): Promise<Artifac
 export const nativeProfilerStopTool: ToolDefinition<z.infer<typeof zodSchema>, StopResult> = {
   id: "native-profiler-stop",
   capability,
+  // Packaging plus the export passes routinely exceed the 30s fetch timeout.
+  longRunning: true,
   description: `Stop native profiling and export trace data.
 iOS: sends SIGINT to xctrace, waits for packaging, then exports CPU, hangs, and leaks XML.
 Android: sends SIGTERM to the perfetto daemon, polls /proc/<pid>, then \`adb pull\`s the .pftrace.

--- a/packages/tool-server/src/tools/profiler/native-profiler/platforms/ios.ts
+++ b/packages/tool-server/src/tools/profiler/native-profiler/platforms/ios.ts
@@ -72,7 +72,8 @@ const MAX_START_ATTEMPTS = 2;
 const RETRY_DELAY_MS = 1_200;
 const COLD_START_SIGNATURE = "Cannot find process matching name:";
 
-const STOP_GRACE_MS = 30_000;
+// Ceiling, not a fixed wait — 30s SIGTERM'd xctrace mid-package.
+const STOP_GRACE_MS = 300_000;
 const STOP_TERM_MS = 5_000;
 const STOP_KILL_MS = 5_000;
 

--- a/packages/tool-server/test/ios-instruments/stop-recovery.test.ts
+++ b/packages/tool-server/test/ios-instruments/stop-recovery.test.ts
@@ -192,6 +192,10 @@ describe("native-profiler-stop recovery branch", () => {
     expect(api.recordingTimedOut).toBe(false);
   });
 
+  it("is declared longRunning so the MCP fetch timeout can't abort a slow stop", () => {
+    expect(nativeProfilerStopTool.longRunning).toBe(true);
+  });
+
   it("falls through to the unrecoverable error when no recovery flag is set", async () => {
     const api = await buildSession();
     api.traceFile = FAKE_TRACE; // a stale traceFile alone must not trigger recovery


### PR DESCRIPTION
## Problem

`native-profiler-stop` fails with `No active native profiling session found. Call native-profiler-start first.` while xctrace is still recording — #248, #250, #330. Those were closed on the 0.12.1 `--all-processes` workaround (#380), which fixed trace finalization but not this.

The tool isn't declared `longRunning`, so the MCP adapter applies its per-request timeout:

```js
fetchTimeoutMs: meta?.longRunning ? null : FETCH_TIMEOUT_MS,   // mcp-server.ts:222
```

A stop that runs past 30s is aborted and retried (`MAX_RETRIES = 4`). The retry runs against the session state the first call has already cleared, hits the `!api.profilingActive` branch and throws. The message points at session tracking; the actual failure is the timeout.

Every failed stop I have logs for lands at 30–34s: `durationMs: 33639` in [#330](https://github.com/software-mansion/argent/issues/330), and 30276 / 30605 / 31019 / 31914 locally.

Stop can't fit in 30s on Xcode 26.4+. Since #380 the capture is host-wide rather than app-scoped, so the bundle is much larger — ~55MB per 10s of recording here, 385MB for 90s — and xctrace needs ~22s to package even the 10s case before the four export passes start.

`STOP_GRACE_MS` has the same problem from the other side: at 30s xctrace is SIGTERM'd mid-package, and the bundle it leaves behind fails to export.

## Fix

Declare the tool `longRunning`, and raise `STOP_GRACE_MS` to 300s. The grace is a ceiling rather than a fixed wait — a fast package still returns as soon as xctrace exits — so this only changes captures that were previously killed.

With both applied a 90s capture stops and exports cleanly in ~2–4 min, and a 40s capture returns inline.

## Note

The abort-and-retry sequence is inferred rather than captured directly. What's observed: `MAX_RETRIES = 4`, the uniform ~30s durations, and `tool-server.log` showing the `did not respond to SIGINT` warning — written after the throw site — logged 184ms *before* the failure was returned. One execution can't produce that ordering.

## Testing

- `npm run build` and eslint clean on changed files
- `npm test -w @argent/tool-server` — 2727 tests / 273 files pass
- Verified on Xcode 26.5 / iOS 26.5 simulator against a bridgeless RN app: start → interact → stop → analyze now returns a populated report with `errors: {}`
