### PR TITLE
fix(tool-server): stop unix native-devtools listen from crashing the process

### DIFF
--- a/packages/tool-server/src/blueprints/native-devtools.ts
+++ b/packages/tool-server/src/blueprints/native-devtools.ts
@@ -567,7 +567,19 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
       // written — lands on our listener.
       await host.startProxy(udid, endpoint.port!);
     } else {
-      server.listen(socketPath);
+      // Mirror the TCP branch above (and ax-service's startListener): attach an
+      // error handler so a bind failure — EEXIST from a stale socket a crashed
+      // run left behind (the pre-unlink above covers the common case) or
+      // EADDRINUSE from a concurrent instance racing on the same per-UDID path —
+      // rejects into the watcher-retry path instead of surfacing as an unhandled
+      // 'error' event that crashes the entire tool-server.
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(socketPath, () => {
+          server.off("error", reject);
+          resolve();
+        });
+      });
     }
 
     // Tolerate ensureEnv failure: throwing here would leak `server` — the

--- a/packages/tool-server/test/blueprints/native-devtools-factory-cleanup.test.ts
+++ b/packages/tool-server/test/blueprints/native-devtools-factory-cleanup.test.ts
@@ -62,6 +62,10 @@ const UDID = "FACTORY1-1111-1111-1111-111111111111";
 const device: DeviceInfo = { id: UDID, platform: "ios", kind: "simulator" };
 const SOCKET_PATH = `/tmp/argent-nd-${UDID.slice(0, 8)}.sock`;
 
+const UDID_BIND = "FACTORY2-2222-2222-2222-222222222222";
+const deviceBind: DeviceInfo = { id: UDID_BIND, platform: "ios", kind: "simulator" };
+const SOCKET_PATH_BIND = `/tmp/argent-nd-${UDID_BIND.slice(0, 8)}.sock`;
+
 beforeEach(() => {
   execFileMock.mockReset();
   vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -72,6 +76,16 @@ afterEach(() => {
     fs.unlinkSync(SOCKET_PATH);
   } catch {
     /* expected when dispose already unlinked */
+  }
+  try {
+    fs.rmdirSync(SOCKET_PATH_BIND);
+  } catch {
+    /* only present for the bind-failure test */
+  }
+  try {
+    fs.unlinkSync(SOCKET_PATH_BIND);
+  } catch {
+    /* ignore */
   }
   vi.restoreAllMocks();
 });
@@ -146,5 +160,23 @@ describe("nativeDevtoolsBlueprint factory — failure tolerance", () => {
     expect(setenvCallCount).toBe(1);
 
     await instance.dispose();
+  });
+
+  it("rejects instead of crashing when the unix socket cannot be bound", async () => {
+    // All simctl calls succeed so ensureEnv is not the source of failure —
+    // the listen bind is.
+    execFileMock.mockImplementation(() => ({ stdout: "", stderr: "" }));
+
+    // Occupy the per-UDID socket path with a directory. The factory's pre-unlink
+    // can't remove it (EISDIR, swallowed) and `server.listen(socketPath)` then
+    // emits an 'error' (EADDRINUSE). Before the fix the unix branch had no error
+    // handler, so this surfaced as an unhandled 'error' event that crashed the
+    // entire tool-server process. It must now reject the factory instead, which
+    // the registry turns into a retryable ServiceInitializationError.
+    fs.mkdirSync(SOCKET_PATH_BIND);
+
+    await expect(
+      nativeDevtoolsBlueprint.factory({}, deviceBind, { device: deviceBind })
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the **real multi-user crash source** surfaced by the new 0.16.0 tool-server crash telemetry (PR #494).

Analyzing `toolserver:stop reason=crash` in PostHog (project Argent, 30d): 936 crashes / 48 users, 0 unclassified. Ranked by **users** (not events), the widespread bug is fingerprint **`dc063fe2`** — `EADDRINUSE` + `EEXIST` at `crash_phase=startup`, across ~14 users. (The 774-crash `a0517e9a` loop is a single machine tight-looping on an occupied HTTP port — high volume, one user — tracked separately.)

## Root cause

The native-devtools socket server's **unix branch** did a bare `server.listen(socketPath)` with **no `'error'` handler** — unlike the TCP branch immediately above it and unlike `ax-service.ts`'s `startListener`, both of which wrap listen in a promise with `server.once("error", reject)`.

So a bind failure — `EEXIST` from a stale `/tmp/argent-nd-<UDID>.sock` a crashed run left behind, or `EADDRINUSE` from a concurrent instance racing on the same per-UDID path (see the multi-agent socket-contention case) — fired an unhandled `'error'` EventEmitter event. Node rethrows that as an uncaught exception, taking down the **entire tool-server** (every device's service with it). That is exactly the `EADDRINUSE`/`EEXIST`-at-startup signature of `dc063fe2`.

## Fix

Wrap the unix listen in the same promise + error-handler pattern the TCP branch already uses, so a bind failure **rejects out of the factory**. The registry catches that and turns it into a retryable `ServiceInitializationError` (`packages/registry/src/registry.ts`) instead of a process crash. The existing pre-unlink (a few lines above) still clears the common stale-socket case, and the watcher retries on its next poll.

```diff
-      server.listen(socketPath);
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(socketPath, () => {
+          server.off("error", reject);
+          resolve();
+        });
+      });
```

## Testing

- **New regression test** (`native-devtools-factory-cleanup.test.ts`): occupies the per-UDID socket path with a directory so the bind deterministically fails, and asserts the factory **rejects** rather than emitting an unhandled `'error'`.
- Full tool-server suite: **2727 tests green**; typecheck + eslint clean.
- **Live A/B against the compiled `dist`** (the shipped surface; this crash path is pure JS, before any native binary is touched):
  - Buggy build → `uncaughtException EADDRINUSE` → **process exits 42** (crash reproduced).
  - Fixed build → **handled rejection, process survives, exit 0**.

## Scope note

This PR targets `dc063fe2` (the genuine multi-user defect). The single-machine `a0517e9a` restart loop on the tool-server's own HTTP port is environmental (a contested fixed port on one host) and would need port-selection/back-off changes to the main `app.listen` path; it is intentionally out of scope here.
