### PR TITLE
fix(tool-server): defer to an existing server on EADDRINUSE instead of crash-looping

### DIFF
--- a/packages/telemetry/src/events.ts
+++ b/packages/telemetry/src/events.ts
@@ -175,7 +175,10 @@ export interface CliRunFailProps extends FailureTelemetryProps {
 export type ToolserverStartProps = Record<string, never>;
 
 export interface ToolserverStopProps extends FailureTelemetryProps {
-  reason: "idle" | "signal" | "crash";
+  // "deferred": a redundant instance lost the port bind (EADDRINUSE) to a
+  // healthy argent peer and exited cleanly in its favor — kept distinct from
+  // "signal" so a supervisor relaunch loop over deferrals stays identifiable.
+  reason: "idle" | "signal" | "crash" | "deferred";
   uptime_ms: number;
   total_tool_calls: number;
   // Crash-only diagnostics (see crash-diagnostics.ts). All anonymous: a coded

--- a/packages/telemetry/src/sanitize.ts
+++ b/packages/telemetry/src/sanitize.ts
@@ -244,7 +244,7 @@ export const ALLOWED: ValidatorMap = {
   },
   "toolserver:start": {},
   "toolserver:stop": {
-    reason: oneOf(["idle", "signal", "crash"] as const),
+    reason: oneOf(["idle", "signal", "crash", "deferred"] as const),
     uptime_ms: DURATION_MS,
     total_tool_calls: COUNT,
     ...FAILURE_SIGNAL,

--- a/packages/telemetry/test/sanitize.test.ts
+++ b/packages/telemetry/test/sanitize.test.ts
@@ -388,6 +388,22 @@ describe("sanitize", () => {
     });
   });
 
+  it("passes the 'deferred' stop reason through", () => {
+    // Emitted by a redundant tool-server instance that lost the port bind to a
+    // healthy peer and exited cleanly; must not be scrubbed to undefined.
+    expect(
+      sanitize("toolserver:stop", {
+        reason: "deferred",
+        uptime_ms: 950,
+        total_tool_calls: 0,
+      })
+    ).toEqual({
+      reason: "deferred",
+      uptime_ms: 950,
+      total_tool_calls: 0,
+    });
+  });
+
   it("allows static failure signal fields on crash stop events", () => {
     expect(
       sanitize("toolserver:stop", {

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import * as http from "node:http";
 import { homedir } from "node:os";
 import { isFlagEnabled } from "@argent/configuration-core";
 import { FAILURE_CODES, attachRegistryLogger, type FailureSignal } from "@argent/registry";
@@ -85,6 +86,34 @@ function initializeStdioTimestampWrapper(): void {
     stream.write = ((chunk: string | Uint8Array, ...rest: unknown[]) =>
       orig(`[${new Date().toISOString()}] ${chunk}`, ...(rest as []))) as typeof stream.write;
   }
+}
+
+/**
+ * Probe whether a healthy argent tool-server is already listening on
+ * `host:port`. Used to tell a redundant/overlapping instance (which lost the
+ * bind with EADDRINUSE) that the port is owned by a live peer, so it can defer
+ * cleanly instead of crash-looping.
+ *
+ * An argent tool-server answers `GET /tools` with 200 (the tools JSON) or, when
+ * an auth token is configured, 401 — either proves a live argent peer. No token
+ * is sent: reachability + argent-shaped response is all we need. A wedged peer
+ * that never answers within the timeout resolves `false`, so we still surface a
+ * genuinely stuck port as a crash rather than deferring to a dead server.
+ */
+export function probeArgentToolServer(host: string, port: number, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.request({ host, port, path: "/tools", method: "GET", timeout: timeoutMs }, (res) => {
+      const isArgentPeer = res.statusCode === 200 || res.statusCode === 401;
+      res.resume(); // drain the response so the socket can close
+      resolve(isArgentPeer);
+    });
+    req.on("error", () => resolve(false)); // connection refused / reset / non-HTTP
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
 }
 
 export function start(): void {
@@ -480,14 +509,26 @@ export function start(): void {
           /* swallow */
         }
       });
-      // A bind failure (EADDRINUSE from a stale server still holding the port,
-      // EACCES on a privileged port) is the socket half of the startup
-      // restart-loop population this diagnostics work exists to surface. Route it
-      // through crashShutdown so `err.code` is captured as error_syscall on a
-      // reason:"crash" stop instead of exiting silently with no telemetry at all.
-      // `listening` is still false here (the listen callback never ran), so the
-      // crash is correctly phased as "startup"; crashShutdown handles teardown,
-      // telemetry drain, and exit.
+      // Bind failure handling. EACCES (privileged port) and other errors are
+      // genuine faults → crashShutdown, which captures `err.code` as
+      // error_syscall on a reason:"crash" stop and handles teardown + telemetry
+      // drain + exit.
+      //
+      // EADDRINUSE is special: it means another server already owns HOST:PORT.
+      // Unconditionally crashing feeds a supervisor respawn → re-bind → crash
+      // loop — the 0.16.0 crash telemetry's `toolserver_bind` population (one
+      // machine alone: 785 crashes, ~1s uptime, 0 tool calls served, never
+      // serving anything). If a healthy argent tool-server already answers on
+      // the port, this instance is redundant, so shut down cleanly (exit 0) and
+      // defer to the existing one instead of looping. Only when nothing healthy
+      // owns the port (a foreign holder, or a wedged peer) do we still crash, so
+      // a genuinely stuck port stays visible.
+      const bindSignal: FailureSignal = {
+        error_code: FAILURE_CODES.ARGENT_UNCLASSIFIED_FAILURE,
+        failure_stage: "toolserver_bind",
+        failure_area: "tool_server",
+        error_kind: "crash",
+      };
       server.on("error", (err: NodeJS.ErrnoException) => {
         eventLog?.error({
           type: "tool_server.bind_failed",
@@ -495,24 +536,38 @@ export function start(): void {
           host: HOST,
           port: PORT,
           failureSignal: {
-            error_code: FAILURE_CODES.ARGENT_UNCLASSIFIED_FAILURE,
-            failure_stage: "toolserver_bind",
-            failure_area: "tool_server",
-            error_kind: "crash",
+            error_code: bindSignal.error_code,
+            failure_stage: bindSignal.failure_stage,
+            failure_area: bindSignal.failure_area,
+            error_kind: bindSignal.error_kind,
           },
         });
         const code = err.code ? `${err.code}: ` : "";
-        crashShutdown(
-          `Failed to bind ${HOST}:${PORT}`,
-          `${code}${err.message}`,
-          {
-            error_code: FAILURE_CODES.ARGENT_UNCLASSIFIED_FAILURE,
-            failure_stage: "toolserver_bind",
-            failure_area: "tool_server",
-            error_kind: "crash",
-          },
-          err
-        );
+        const crashBind = () =>
+          crashShutdown(`Failed to bind ${HOST}:${PORT}`, `${code}${err.message}`, bindSignal, err);
+
+        if (err.code === "EADDRINUSE") {
+          void probeArgentToolServer(HOST, PORT).then((isArgentPeer) => {
+            if (!isArgentPeer) {
+              crashBind();
+              return;
+            }
+            process.stderr.write(
+              `Another argent tool-server already owns ${HOST}:${PORT}; deferring to it (redundant instance).\n`
+            );
+            eventLog?.info({
+              type: "tool_server.deferred_to_existing",
+              msg: `Deferred to an existing tool-server on ${HOST}:${PORT}.`,
+              host: HOST,
+              port: PORT,
+            });
+            // Clean stop (not a crash): removes this redundant instance from the
+            // reason:"crash" restart-loop population.
+            void shutdown?.(0);
+          });
+          return;
+        }
+        crashBind();
       });
       // Bolt the per-Chromium-device WebSocket upgrade handler onto the live
       // server. Must happen AFTER `listen()` so the http.Server instance

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -1,5 +1,4 @@
 import * as path from "node:path";
-import * as http from "node:http";
 import { homedir } from "node:os";
 import { isFlagEnabled } from "@argent/configuration-core";
 import { FAILURE_CODES, attachRegistryLogger, type FailureSignal } from "@argent/registry";
@@ -17,6 +16,7 @@ import {
 import { createHttpApp } from "./http";
 import { attachRegistryEventLogger, createToolServerEventLog } from "./event-log";
 import { createRegistry } from "./utils/setup-registry";
+import { probeArgentToolServer } from "./utils/probe-argent-tool-server";
 import { startSimulatorWatcher } from "./utils/simulator-watcher";
 import { startUpdateChecker } from "./utils/update-checker";
 import { createPreviewWindowManager } from "./utils/preview-window";
@@ -88,41 +88,6 @@ function initializeStdioTimestampWrapper(): void {
   }
 }
 
-/**
- * Probe whether a healthy argent tool-server is already listening on
- * `host:port`. Used to tell a redundant/overlapping instance (which lost the
- * bind with EADDRINUSE) that the port is owned by a live peer, so it can defer
- * cleanly instead of crash-looping.
- *
- * An argent tool-server answers `GET /tools` with 200 (the tools JSON) or, when
- * an auth token is configured, 401 — either proves a live argent peer. No token
- * is sent: reachability + argent-shaped response is all we need. A wedged peer
- * that never answers within the timeout resolves `false`, so we still surface a
- * genuinely stuck port as a crash rather than deferring to a dead server.
- */
-export function probeArgentToolServer(
-  host: string,
-  port: number,
-  timeoutMs = 500
-): Promise<boolean> {
-  return new Promise((resolve) => {
-    const req = http.request(
-      { host, port, path: "/tools", method: "GET", timeout: timeoutMs },
-      (res) => {
-        const isArgentPeer = res.statusCode === 200 || res.statusCode === 401;
-        res.resume(); // drain the response so the socket can close
-        resolve(isArgentPeer);
-      }
-    );
-    req.on("error", () => resolve(false)); // connection refused / reset / non-HTTP
-    req.on("timeout", () => {
-      req.destroy();
-      resolve(false);
-    });
-    req.end();
-  });
-}
-
 export function start(): void {
   initializeStdioTimestampWrapper();
 
@@ -137,7 +102,7 @@ export function start(): void {
   // crash arriving mid-shutdown would be swallowed by the re-entrancy guard and
   // the in-flight shutdown(0) would exit 0, hiding the crash from supervisors.
   let finalExitCode = 0;
-  let shutdownReason: "idle" | "signal" | "crash" = "signal";
+  let shutdownReason: "idle" | "signal" | "crash" | "deferred" = "signal";
   let shutdownFailureSignal: FailureSignal | null = null;
   // Anonymous crash detail (class name, syscall, stack fingerprint, phase),
   // merged into the final toolserver:stop only on a real crash. Left null on
@@ -537,21 +502,25 @@ export function start(): void {
         error_kind: "crash",
       };
       server.on("error", (err: NodeJS.ErrnoException) => {
-        eventLog?.error({
-          type: "tool_server.bind_failed",
-          msg: `Tool server failed to bind ${HOST}:${PORT}.`,
-          host: HOST,
-          port: PORT,
-          failureSignal: {
-            error_code: bindSignal.error_code,
-            failure_stage: bindSignal.failure_stage,
-            failure_area: bindSignal.failure_area,
-            error_kind: bindSignal.error_kind,
-          },
-        });
         const code = err.code ? `${err.code}: ` : "";
-        const crashBind = () =>
+        // The crash-tagged bind_failed event is emitted only on the legs that
+        // actually crash — a clean deferral must not count as a bind crash in
+        // the event log any more than in the stop-reason telemetry.
+        const crashBind = () => {
+          eventLog?.error({
+            type: "tool_server.bind_failed",
+            msg: `Tool server failed to bind ${HOST}:${PORT}.`,
+            host: HOST,
+            port: PORT,
+            failureSignal: {
+              error_code: bindSignal.error_code,
+              failure_stage: bindSignal.failure_stage,
+              failure_area: bindSignal.failure_area,
+              error_kind: bindSignal.error_kind,
+            },
+          });
           crashShutdown(`Failed to bind ${HOST}:${PORT}`, `${code}${err.message}`, bindSignal, err);
+        };
 
         if (err.code === "EADDRINUSE") {
           void probeArgentToolServer(HOST, PORT).then((isArgentPeer) => {
@@ -569,7 +538,11 @@ export function start(): void {
               port: PORT,
             });
             // Clean stop (not a crash): removes this redundant instance from the
-            // reason:"crash" restart-loop population.
+            // reason:"crash" restart-loop population. Stamped "deferred" (not the
+            // default "signal") so a supervisor that relaunches on ANY exit still
+            // shows up in the stop-reason telemetry as a deferral loop rather
+            // than blending into ordinary SIGINT/SIGTERM churn.
+            shutdownReason = "deferred";
             void shutdown?.(0);
           });
           return;

--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -100,13 +100,20 @@ function initializeStdioTimestampWrapper(): void {
  * that never answers within the timeout resolves `false`, so we still surface a
  * genuinely stuck port as a crash rather than deferring to a dead server.
  */
-export function probeArgentToolServer(host: string, port: number, timeoutMs = 500): Promise<boolean> {
+export function probeArgentToolServer(
+  host: string,
+  port: number,
+  timeoutMs = 500
+): Promise<boolean> {
   return new Promise((resolve) => {
-    const req = http.request({ host, port, path: "/tools", method: "GET", timeout: timeoutMs }, (res) => {
-      const isArgentPeer = res.statusCode === 200 || res.statusCode === 401;
-      res.resume(); // drain the response so the socket can close
-      resolve(isArgentPeer);
-    });
+    const req = http.request(
+      { host, port, path: "/tools", method: "GET", timeout: timeoutMs },
+      (res) => {
+        const isArgentPeer = res.statusCode === 200 || res.statusCode === 401;
+        res.resume(); // drain the response so the socket can close
+        resolve(isArgentPeer);
+      }
+    );
     req.on("error", () => resolve(false)); // connection refused / reset / non-HTTP
     req.on("timeout", () => {
       req.destroy();

--- a/packages/tool-server/src/utils/probe-argent-tool-server.ts
+++ b/packages/tool-server/src/utils/probe-argent-tool-server.ts
@@ -1,0 +1,36 @@
+import * as http from "node:http";
+
+/**
+ * Probe whether a healthy argent tool-server is already listening on
+ * `host:port`. Used to tell a redundant/overlapping instance (which lost the
+ * bind with EADDRINUSE) that the port is owned by a live peer, so it can defer
+ * cleanly instead of crash-looping.
+ *
+ * An argent tool-server answers `GET /tools` with 200 (the tools JSON) or, when
+ * an auth token is configured, 401 — either proves a live argent peer. No token
+ * is sent: reachability + argent-shaped response is all we need. A wedged peer
+ * that never answers within the timeout resolves `false`, so we still surface a
+ * genuinely stuck port as a crash rather than deferring to a dead server.
+ */
+export function probeArgentToolServer(
+  host: string,
+  port: number,
+  timeoutMs = 500
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host, port, path: "/tools", method: "GET", timeout: timeoutMs },
+      (res) => {
+        const isArgentPeer = res.statusCode === 200 || res.statusCode === 401;
+        res.resume(); // drain the response so the socket can close
+        resolve(isArgentPeer);
+      }
+    );
+    req.on("error", () => resolve(false)); // connection refused / reset / non-HTTP
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
+}

--- a/packages/tool-server/test/bind-failure-telemetry.test.ts
+++ b/packages/tool-server/test/bind-failure-telemetry.test.ts
@@ -17,6 +17,14 @@ const registryMock = vi.hoisted(() => ({
   dispose: vi.fn().mockResolvedValue(undefined),
 }));
 
+// The probe is mocked so no test ever issues a real network request — the
+// un-mocked probe would GET http://127.0.0.1:3001/tools, and the outcome (and
+// so the test verdict) would depend on whatever happens to be listening on the
+// developer's real default tool-server port when the suite runs.
+const probeMock = vi.hoisted(() => ({
+  probeArgentToolServer: vi.fn<(host: string, port: number) => Promise<boolean>>(),
+}));
+
 // A minimal stand-in for the http.Server returned by app.listen(): just enough
 // of the surface index.ts touches — `.on("error")` to register the handler, a
 // manual `.emit()` to fire it, and the `.address()`/`.close()` shutdown() calls.
@@ -38,6 +46,11 @@ const serverMock = vi.hoisted(() => {
     },
     emit(event: string, ...args: unknown[]) {
       for (const cb of listeners.get(event) ?? []) cb(...args);
+    },
+    // Each test re-imports index.ts and calls start() again; without this the
+    // previous test's bind-error handler (a stale closure) would fire too.
+    reset() {
+      listeners.clear();
     },
     address: () => ({ port: 3001 }),
     close: (cb: () => void) => cb(),
@@ -74,6 +87,7 @@ vi.mock("@argent/registry", async (importOriginal) => {
 vi.mock("../src/utils/setup-registry", () => ({
   createRegistry: vi.fn(() => registryMock),
 }));
+vi.mock("../src/utils/probe-argent-tool-server", () => probeMock);
 vi.mock("../src/http", () => ({
   createHttpApp: vi.fn(() => httpHandleMock),
 }));
@@ -89,11 +103,24 @@ vi.mock("../src/utils/simulator-watcher", () => ({
   })),
 }));
 
+// Boot a fresh start() (fresh module state + a newly registered bind-error
+// handler) and fire a bind error at it once the handler is attached.
+async function startAndEmitBindError(err: NodeJS.ErrnoException): Promise<void> {
+  const { start } = await import("../src/index");
+  start();
+  await vi.waitFor(() => {
+    expect(serverMock.listenerCount("error")).toBeGreaterThan(0);
+  });
+  serverMock.emit("error", err);
+}
+
 describe("tool-server bind-failure telemetry", () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.resetModules();
+    serverMock.reset();
     exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
   });
 
@@ -101,18 +128,12 @@ describe("tool-server bind-failure telemetry", () => {
     exitSpy.mockRestore();
   });
 
-  it("captures the syscall on a startup-phase crash when the listener fails to bind", async () => {
-    const { start } = await import("../src/index");
+  it("captures the syscall on a startup-phase crash when nothing healthy owns the port", async () => {
+    // EADDRINUSE, but the probe finds no healthy argent peer (foreign holder,
+    // wedged server, or race already resolved) → still a genuine crash.
+    probeMock.probeArgentToolServer.mockResolvedValue(false);
 
-    start();
-
-    // Wait until the `.then` branch has run and registered the bind-error
-    // handler on the server, then simulate an EADDRINUSE bind failure.
-    await vi.waitFor(() => {
-      expect(serverMock.listenerCount("error")).toBeGreaterThan(0);
-    });
-    serverMock.emit(
-      "error",
+    await startAndEmitBindError(
       Object.assign(new Error("listen EADDRINUSE: address already in use 127.0.0.1:3001"), {
         code: "EADDRINUSE",
         syscall: "listen",
@@ -122,6 +143,8 @@ describe("tool-server bind-failure telemetry", () => {
     await vi.waitFor(() => {
       expect(telemetryMock.shutdown).toHaveBeenCalledWith(1500);
     });
+
+    expect(probeMock.probeArgentToolServer).toHaveBeenCalledWith("127.0.0.1", 3001);
 
     // The bind failure routes through crashShutdown: reason:"crash", phased as
     // "startup" (the listen callback never ran), with the syscall captured as
@@ -140,6 +163,58 @@ describe("tool-server bind-failure telemetry", () => {
       crash_fingerprint: expect.stringMatching(/^[0-9a-f]{16}$/),
       crash_phase: "startup",
     });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("defers cleanly (exit 0, reason 'deferred', no crash fields) when a healthy argent peer owns the port", async () => {
+    probeMock.probeArgentToolServer.mockResolvedValue(true);
+
+    await startAndEmitBindError(
+      Object.assign(new Error("listen EADDRINUSE: address already in use 127.0.0.1:3001"), {
+        code: "EADDRINUSE",
+        syscall: "listen",
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(telemetryMock.shutdown).toHaveBeenCalledWith(1500);
+    });
+
+    expect(probeMock.probeArgentToolServer).toHaveBeenCalledWith("127.0.0.1", 3001);
+
+    // The redundant instance leaves the crash population entirely: a clean stop
+    // with its own distinct reason (not "signal", so a supervisor relaunch loop
+    // over deferrals stays identifiable), no failure signal, no crash
+    // diagnostics — asserted via exact object equality.
+    expect(telemetryMock.track).toHaveBeenCalledWith("toolserver:stop", {
+      reason: "deferred",
+      uptime_ms: expect.any(Number),
+      total_tool_calls: 0,
+    });
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(exitSpy).not.toHaveBeenCalledWith(1);
+  });
+
+  it("crashes without probing on a non-EADDRINUSE bind error", async () => {
+    await startAndEmitBindError(
+      Object.assign(new Error("listen EACCES: permission denied 127.0.0.1:3001"), {
+        code: "EACCES",
+        syscall: "listen",
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(telemetryMock.shutdown).toHaveBeenCalledWith(1500);
+    });
+
+    expect(probeMock.probeArgentToolServer).not.toHaveBeenCalled();
+    expect(telemetryMock.track).toHaveBeenCalledWith(
+      "toolserver:stop",
+      expect.objectContaining({
+        reason: "crash",
+        error_syscall: "EACCES",
+      })
+    );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/tool-server/test/probe-argent-tool-server.test.ts
+++ b/packages/tool-server/test/probe-argent-tool-server.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as http from "node:http";
+import { probeArgentToolServer } from "../src/index";
+
+// Bind an ephemeral loopback server with a given handler; returns its port.
+function listen(handler: http.RequestListener): Promise<{ port: number; server: http.Server }> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      resolve({ port: typeof addr === "object" && addr ? addr.port : 0, server });
+    });
+  });
+}
+
+const servers: http.Server[] = [];
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => s.close(() => r()))));
+});
+
+describe("probeArgentToolServer", () => {
+  it("returns true for an argent peer answering /tools with 200", async () => {
+    const { port, server } = await listen((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ tools: [] }));
+    });
+    servers.push(server);
+    await expect(probeArgentToolServer("127.0.0.1", port)).resolves.toBe(true);
+  });
+
+  it("returns true for a token-protected peer answering /tools with 401", async () => {
+    const { port, server } = await listen((_req, res) => {
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "Missing or invalid Authorization header." }));
+    });
+    servers.push(server);
+    await expect(probeArgentToolServer("127.0.0.1", port)).resolves.toBe(true);
+  });
+
+  it("returns false for a foreign server answering with a non-argent status (500)", async () => {
+    const { port, server } = await listen((_req, res) => {
+      res.writeHead(500);
+      res.end("nope");
+    });
+    servers.push(server);
+    await expect(probeArgentToolServer("127.0.0.1", port)).resolves.toBe(false);
+  });
+
+  it("returns false when nothing is listening (connection refused)", async () => {
+    // Grab a port then immediately release it so the connection is refused.
+    const { port, server } = await listen((_req, res) => res.end());
+    await new Promise<void>((r) => server.close(() => r()));
+    await expect(probeArgentToolServer("127.0.0.1", port)).resolves.toBe(false);
+  });
+
+  it("returns false when the peer accepts but never responds (wedged) before the timeout", async () => {
+    const { port, server } = await listen(() => {
+      /* accept the request but never write a response → probe must time out */
+    });
+    servers.push(server);
+    await expect(probeArgentToolServer("127.0.0.1", port, 150)).resolves.toBe(false);
+  });
+});

--- a/packages/tool-server/test/probe-argent-tool-server.test.ts
+++ b/packages/tool-server/test/probe-argent-tool-server.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as http from "node:http";
-import { probeArgentToolServer } from "../src/index";
+import { probeArgentToolServer } from "../src/utils/probe-argent-tool-server";
 
 // Bind an ephemeral loopback server with a given handler; returns its port.
 function listen(handler: http.RequestListener): Promise<{ port: number; server: http.Server }> {


### PR DESCRIPTION
## Summary

Fixes **bucket B** of the 0.16.0 crash telemetry — the `toolserver_bind` / `EADDRINUSE` restart loop. It's the largest crash **volume** (~817 events, one machine alone = 785) even though it's a narrow user set (10). Companion to #531 (which fixed the widespread multi-user bucket A).

## Root cause (reproduced live)

The main HTTP listener's `server.on("error")` handler routed **every** bind error through `crashShutdown` (exit 1). When a second tool-server starts on an already-owned port, that exit just feeds a supervisor respawn → re-bind → crash, forever.

The telemetry signature was puzzling: all these crashes are `crash_phase=serving` with ~1s uptime and **0 tool calls** — i.e. the listener *bound successfully* and then died. I reproduced it: on macOS, a **second tool-server process's** `listen()` momentarily **succeeds** (the `listening` callback runs → `listening=true` → phase `serving`), and **then** the server emits an asynchronous `EADDRINUSE`. So the redundant instance binds, immediately errors, crashes, and the supervisor loops it (~1s each, 785× on one machine).

Live A/B on the compiled `dist` (isolated port, telemetry disabled), server A up then a second server B on the same port:

```
buggy (current 0.16.0):  B: "Tools server listening ..."  → "Failed to bind ... EADDRINUSE"  → exit 1  (→ respawn loop)
fixed:                   B: "Tools server listening ..."  → "deferring to it (redundant instance)" → exit 0
```

A survives in both.

## Fix

Handle `EADDRINUSE` specifically instead of crash-looping:

- Probe the port for a healthy argent tool-server (`GET /tools` → 200, or 401 when a token is configured).
- **If a healthy peer answers**, this instance is redundant → shut down **cleanly** (`shutdown(0)`) and defer to it. This removes it from the `reason:"crash"` restart-loop population entirely.
- **If nothing healthy owns the port** (a foreign holder, or a wedged peer that doesn't answer within the probe timeout) → still crash, so a genuinely stuck port stays visible.
- `EACCES` and all other server errors crash exactly as before.

It also corrects the now-false comment claiming these crashes are phased `startup` ("the listen callback never ran"). Telemetry and the live repro prove the bind succeeds first, so `listening=true` and the phase is genuinely `serving`.

## Testing

- **New unit tests** for `probeArgentToolServer`: peer answering 200 or 401 → `true`; foreign 500, connection-refused, and wedged/timeout → `false`.
- Full tool-server suite **2731 green**; `tsc` + `eslint` clean.
- **Live A/B** above, on the built dist.

## Note on scope

This is a robustness fix that breaks the loop for the redundant-instance case (the dominant one). The precise reason macOS lets a second process's bind succeed-then-error asynchronously (vs. failing immediately, as same-process contention does) is a kernel/loopback timing detail; the fix does not depend on it — any `EADDRINUSE`, immediate or deferred, now defers-or-crashes deterministically rather than hot-looping.
