### PR TITLE
Project-scope configuration with schema-driven merge + `argent config`

### DIFF
--- a/packages/argent-cli/src/config.ts
+++ b/packages/argent-cli/src/config.ts
@@ -7,9 +7,12 @@
 // new top-level `argent` command. Values with a dedicated lifecycle command
 // (e.g. telemetry) are surfaced read-only and point the user at that command.
 
+import * as path from "node:path";
 import pc from "picocolors";
 import {
   CONFIG_SCHEMA,
+  configDir,
+  findProjectRoot,
   getConfigValueByKey,
   getConfigValueAtScope,
   setConfigValue,
@@ -147,11 +150,13 @@ parsed (e.g. \`true\`, \`42\`, \`["a","b"]\`); anything else is stored as a stri
   }
 
   const targetScope: FlagScope = scope ?? "global";
+  const warning = degenerateProjectScopeWarning(targetScope);
   try {
     // Echo the normalized value that was actually stored (asString trims,
     // asStringArray drops blanks, …), not the raw CLI input.
     const stored = setConfigValue(key, coerceCliValue(rawValue), targetScope);
-    console.log(`Set ${pc.bold(key)} = ${formatValuePlain(stored)} (${targetScope}).`);
+    if (warning) console.error(pc.yellow(warning));
+    console.log(`Set ${pc.bold(key)} = ${formatValuePlain(stored)} (${scopeLabel(targetScope)}).`);
   } catch (err) {
     reportError(err);
   }
@@ -179,11 +184,13 @@ other scope / the default on the next read.`);
   }
 
   const targetScope: FlagScope = scope ?? "global";
+  const warning = degenerateProjectScopeWarning(targetScope);
   try {
     const removed = unsetConfigValue(key, targetScope);
+    if (removed && warning) console.error(pc.yellow(warning));
     console.log(
       removed
-        ? `Unset ${pc.bold(key)} (${targetScope}).`
+        ? `Unset ${pc.bold(key)} (${scopeLabel(targetScope)}).`
         : pc.dim(`${key} was not set at ${targetScope} scope.`)
     );
   } catch (err) {
@@ -235,6 +242,43 @@ function parseScope(raw: string | undefined): FlagScope {
 
 function wantsHelp(argv: string[]): boolean {
   return argv.includes("--help") || argv.includes("-h");
+}
+
+/**
+ * `(global)` for the global scope; `(project: /resolved/root)` for the project
+ * scope, so a write always shows which directory "project" resolved to.
+ */
+function scopeLabel(scope: FlagScope): string {
+  if (scope === "global") return "global";
+  return `project: ${path.dirname(configDir("project"))}`;
+}
+
+/**
+ * A stderr warning when "project" scope resolves somewhere surprising: to the
+ * home directory (where the project config file IS the global one — `~/.argent`
+ * itself is a project marker, so any non-project cwd under $HOME lands here),
+ * or to the bare cwd because no marker was found up to the fs root. Must be
+ * called BEFORE the write — a project-scope `set` creates `.argent` in the
+ * resolved root, which would make the no-marker case undetectable afterwards.
+ */
+function degenerateProjectScopeWarning(scope: FlagScope): string | null {
+  if (scope !== "project") return null;
+  const projDir = configDir("project");
+  if (path.resolve(projDir) === path.resolve(configDir("global"))) {
+    return (
+      `WARNING: no project found between ${process.cwd()} and your home directory — ` +
+      `"project" scope resolved to the home directory, so this writes the GLOBAL ` +
+      `config file (${path.join(projDir, "config.json")}).`
+    );
+  }
+  if (findProjectRoot(process.cwd()) === null) {
+    return (
+      `WARNING: no project markers (.argent, .git, package.json) found above ` +
+      `${process.cwd()} — treating it as the project root and creating ` +
+      `${path.join(projDir, "config.json")}.`
+    );
+  }
+  return null;
 }
 
 /** JSON for arrays/objects, the bare string for strings, `String()` otherwise. */

--- a/packages/argent-cli/src/config.ts
+++ b/packages/argent-cli/src/config.ts
@@ -148,10 +148,10 @@ parsed (e.g. \`true\`, \`42\`, \`["a","b"]\`); anything else is stored as a stri
 
   const targetScope: FlagScope = scope ?? "global";
   try {
-    setConfigValue(key, coerceCliValue(rawValue), targetScope);
-    console.log(
-      `Set ${pc.bold(key)} = ${formatValuePlain(coerceCliValue(rawValue))} (${targetScope}).`
-    );
+    // Echo the normalized value that was actually stored (asString trims,
+    // asStringArray drops blanks, …), not the raw CLI input.
+    const stored = setConfigValue(key, coerceCliValue(rawValue), targetScope);
+    console.log(`Set ${pc.bold(key)} = ${formatValuePlain(stored)} (${targetScope}).`);
   } catch (err) {
     reportError(err);
   }

--- a/packages/argent-cli/src/config.ts
+++ b/packages/argent-cli/src/config.ts
@@ -1,0 +1,298 @@
+// Universal configuration CLI for argent: the `argent config` command with
+// `list` / `get` / `set` / `unset` subcommands.
+//
+// This is the single front door for the schema-driven config system in
+// `@argent/configuration-core`. New configurations are added by registering
+// them in the schema (CONFIG_SCHEMA) — they show up here automatically, with no
+// new top-level `argent` command. Values with a dedicated lifecycle command
+// (e.g. telemetry) are surfaced read-only and point the user at that command.
+
+import pc from "picocolors";
+import {
+  CONFIG_SCHEMA,
+  getConfigValueByKey,
+  getConfigValueAtScope,
+  setConfigValue,
+  unsetConfigValue,
+  listConfig,
+  coerceCliValue,
+  UnknownConfigKeyError,
+  ConfigScopeError,
+  ConfigValidationError,
+  ConfigManagedElsewhereError,
+  type FlagScope,
+  type ConfigEntryView,
+} from "@argent/configuration-core";
+
+export function config(argv: string[]): void {
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+    printUsage();
+    return;
+  }
+
+  const [sub, ...rest] = argv;
+  switch (sub) {
+    case "list":
+      return cmdList(rest);
+    case "get":
+      return cmdGet(rest);
+    case "set":
+      return cmdSet(rest);
+    case "unset":
+      return cmdUnset(rest);
+    default:
+      console.error(`Error: unknown subcommand "config ${sub}". Try \`argent config --help\`.`);
+      process.exit(2);
+  }
+}
+
+// ── list ───────────────────────────────────────────────────────────────────
+
+function cmdList(argv: string[]): void {
+  if (wantsHelp(argv)) {
+    console.log(`Usage: argent config list [--json]
+
+Show every recognized configuration value, its effective (merged) value, and
+the raw value stored at each scope.`);
+    return;
+  }
+  const json = argv.includes("--json");
+  const entries = listConfig();
+
+  if (json) {
+    console.log(JSON.stringify({ config: entries }, null, 2));
+    return;
+  }
+
+  if (entries.length === 0) {
+    console.log("No configurations are defined.");
+    return;
+  }
+
+  console.log("Configuration (project overrides global unless noted):\n");
+  const maxKey = entries.reduce((m, e) => Math.max(m, e.key.length), 0);
+  for (const e of entries) {
+    const managed = e.manageCommand ? pc.dim(`  [managed by \`${e.manageCommand}\`]`) : "";
+    console.log(`  ${e.key.padEnd(maxKey)}  ${formatValue(e.effective)}${managed}`);
+    console.log(`  ${" ".repeat(maxKey)}  ${pc.dim(e.description)}`);
+    console.log(`  ${" ".repeat(maxKey)}  ${pc.dim(scopeDetail(e))}`);
+  }
+}
+
+function scopeDetail(e: ConfigEntryView): string {
+  const parts: string[] = [`scopes: ${e.scopes.join(", ")}`];
+  if (e.project !== undefined) parts.push(`project=${formatValuePlain(e.project)}`);
+  if (e.global !== undefined) parts.push(`global=${formatValuePlain(e.global)}`);
+  return parts.join("  ·  ");
+}
+
+// ── get ────────────────────────────────────────────────────────────────────
+
+function cmdGet(argv: string[]): void {
+  if (wantsHelp(argv)) {
+    console.log(`Usage: argent config get <key> [--scope global|project] [--json]
+
+Print a configuration value. Without --scope, prints the effective value after
+merging project and global. With --scope, prints only that scope's stored value.`);
+    return;
+  }
+  const { positionals, scope, json } = parseArgs(argv);
+  const key = positionals[0];
+  if (!key) {
+    console.error("Error: `argent config get` requires a <key>.");
+    process.exit(2);
+  }
+  if (positionals.length > 1) {
+    console.error(`Error: unexpected extra argument "${positionals[1]}".`);
+    process.exit(2);
+  }
+
+  try {
+    const value = scope ? getConfigValueAtScope(key, scope) : getConfigValueByKey(key);
+    if (json) {
+      console.log(
+        JSON.stringify({ key, scope: scope ?? "effective", value: value ?? null }, null, 2)
+      );
+    } else if (value === undefined) {
+      console.log("(unset)");
+    } else {
+      console.log(formatValuePlain(value));
+    }
+  } catch (err) {
+    reportError(err);
+  }
+}
+
+// ── set ────────────────────────────────────────────────────────────────────
+
+function cmdSet(argv: string[]): void {
+  if (wantsHelp(argv)) {
+    console.log(`Usage: argent config set <key> <value> [--scope global|project]
+
+Set a configuration value. Default scope is global; pass --scope project to
+write <project-root>/.argent/config.json. Booleans, numbers, and JSON arrays are
+parsed (e.g. \`true\`, \`42\`, \`["a","b"]\`); anything else is stored as a string.`);
+    return;
+  }
+  const { positionals, scope } = parseArgs(argv);
+  const key = positionals[0];
+  const rawValue = positionals[1];
+  if (!key || rawValue === undefined) {
+    console.error("Error: `argent config set` requires a <key> and a <value>.");
+    process.exit(2);
+  }
+  if (positionals.length > 2) {
+    console.error(`Error: unexpected extra argument "${positionals[2]}".`);
+    process.exit(2);
+  }
+
+  const targetScope: FlagScope = scope ?? "global";
+  try {
+    setConfigValue(key, coerceCliValue(rawValue), targetScope);
+    console.log(
+      `Set ${pc.bold(key)} = ${formatValuePlain(coerceCliValue(rawValue))} (${targetScope}).`
+    );
+  } catch (err) {
+    reportError(err);
+  }
+}
+
+// ── unset ──────────────────────────────────────────────────────────────────
+
+function cmdUnset(argv: string[]): void {
+  if (wantsHelp(argv)) {
+    console.log(`Usage: argent config unset <key> [--scope global|project]
+
+Remove a configuration value at a scope (default global). Falls back to the
+other scope / the default on the next read.`);
+    return;
+  }
+  const { positionals, scope } = parseArgs(argv);
+  const key = positionals[0];
+  if (!key) {
+    console.error("Error: `argent config unset` requires a <key>.");
+    process.exit(2);
+  }
+  if (positionals.length > 1) {
+    console.error(`Error: unexpected extra argument "${positionals[1]}".`);
+    process.exit(2);
+  }
+
+  const targetScope: FlagScope = scope ?? "global";
+  try {
+    const removed = unsetConfigValue(key, targetScope);
+    console.log(
+      removed
+        ? `Unset ${pc.bold(key)} (${targetScope}).`
+        : pc.dim(`${key} was not set at ${targetScope} scope.`)
+    );
+  } catch (err) {
+    reportError(err);
+  }
+}
+
+// ── shared helpers ───────────────────────────────────────────────────────────
+
+interface ParsedArgs {
+  positionals: string[];
+  scope: FlagScope | null;
+  json: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  let scope: FlagScope | null = null;
+  let json = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i]!;
+    if (tok === "--json") {
+      json = true;
+      continue;
+    }
+    if (tok === "--scope") {
+      scope = parseScope(argv[++i]);
+      continue;
+    }
+    if (tok.startsWith("--scope=")) {
+      scope = parseScope(tok.slice("--scope=".length));
+      continue;
+    }
+    if (tok.startsWith("--")) {
+      console.error(`Error: unknown flag "${tok}".`);
+      process.exit(2);
+    }
+    positionals.push(tok);
+  }
+  return { positionals, scope, json };
+}
+
+function parseScope(raw: string | undefined): FlagScope {
+  if (raw === "global" || raw === "project") return raw;
+  console.error(`Error: --scope must be "global" or "project"${raw ? `, got "${raw}"` : ""}.`);
+  process.exit(2);
+}
+
+function wantsHelp(argv: string[]): boolean {
+  return argv.includes("--help") || argv.includes("-h");
+}
+
+/** JSON for arrays/objects, the bare string for strings, `String()` otherwise. */
+function formatValuePlain(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+/** Colorized variant for the human list view (booleans green/red). */
+function formatValue(value: unknown): string {
+  if (value === undefined) return pc.dim("(unset)");
+  if (typeof value === "boolean" && process.stdout.isTTY) {
+    return value ? pc.green("true") : pc.red("false");
+  }
+  return formatValuePlain(value);
+}
+
+function reportError(err: unknown): never {
+  if (err instanceof ConfigManagedElsewhereError) {
+    console.error(`Error: ${err.message} Use \`${err.command}\` instead.`);
+  } else if (
+    err instanceof UnknownConfigKeyError ||
+    err instanceof ConfigScopeError ||
+    err instanceof ConfigValidationError
+  ) {
+    console.error(`Error: ${err.message}`);
+    if (err instanceof UnknownConfigKeyError) {
+      console.error(`Run \`argent config list\` to see available keys.`);
+    }
+  } else {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  process.exit(2);
+}
+
+function printUsage(): void {
+  const keys = CONFIG_SCHEMA.map((d) => d.key);
+  const maxKey = keys.reduce((m, k) => Math.max(m, k.length), 0);
+  const keyLines = CONFIG_SCHEMA.map((d) => {
+    const managed = d.manageCommand ? pc.dim(` [managed by \`${d.manageCommand}\`]`) : "";
+    return `  ${d.key.padEnd(maxKey)}  ${d.description}${managed}`;
+  });
+
+  console.log(`Usage: argent config <command> [options]
+
+Manage argent configuration. Values are stored at two scopes and merged per the
+configuration's policy:
+  ~/.argent/config.json                 (global, default)
+  <project-root>/.argent/config.json    (project, with --scope project)
+
+Commands:
+  list                 Show all configurations and their values
+  get <key>            Print a value (effective, or --scope <scope>)
+  set <key> <value>    Set a value (--scope global|project, default global)
+  unset <key>          Remove a value at a scope (default global)
+
+Recognized keys:
+${keyLines.join("\n")}
+
+Run \`argent config <command> --help\` for command-specific help.`);
+}

--- a/packages/argent-cli/src/index.ts
+++ b/packages/argent-cli/src/index.ts
@@ -4,6 +4,7 @@ export { tools, type ToolsCommandOptions } from "./tools.js";
 export { server } from "./server.js";
 export { lens, type LensCommandOptions } from "./lens.js";
 export { enable, disable, flags } from "./flags.js";
+export { config } from "./config.js";
 export { link, unlink } from "./link.js";
 // Backward-compat re-export: the flag primitives now live in
 // @argent/configuration-core, but @argent/cli's public surface keeps exposing

--- a/packages/argent-cli/test/config-command.test.ts
+++ b/packages/argent-cli/test/config-command.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { config } from "../src/config.js";
+
+// Real-filesystem integration test: drives the actual `config()` entry point
+// against a sandboxed global home (HOME) and project cwd (a tmp dir with a
+// `.git` marker so the project root resolves there). No fs mocks — this
+// exercises the command → configuration-core → disk path end to end.
+
+let homeDir: string;
+let projectDir: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+let originalCwd: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+beforeEach(() => {
+  homeDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-cli-home-")));
+  projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-cli-proj-")));
+  fs.mkdirSync(path.join(projectDir, ".git"), { recursive: true });
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  originalCwd = process.cwd();
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+  process.chdir(projectDir);
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0);
+  }) as never);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  vi.restoreAllMocks();
+  fs.rmSync(homeDir, { recursive: true, force: true });
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+function output(): string {
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+}
+function errors(): string {
+  return errSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+}
+
+describe("argent config — set/get across scopes", () => {
+  it("sets global and reads it back as the effective value", () => {
+    config(["set", "lens.agent", "claude"]);
+    logSpy.mockClear();
+    config(["get", "lens.agent"]);
+    expect(output()).toBe("claude");
+    // Landed in the global config file.
+    const globalCfg = JSON.parse(
+      fs.readFileSync(path.join(homeDir, ".argent", "config.json"), "utf8")
+    );
+    expect(globalCfg).toEqual({ lens: { agent: "claude" } });
+  });
+
+  it("project scope overrides global under prioritize-local", () => {
+    config(["set", "lens.agent", "claude", "--scope", "global"]);
+    config(["set", "lens.agent", "codex", "--scope", "project"]);
+    logSpy.mockClear();
+    config(["get", "lens.agent"]);
+    expect(output()).toBe("codex");
+    // The project file lives under the project root, not HOME.
+    const projCfg = JSON.parse(
+      fs.readFileSync(path.join(projectDir, ".argent", "config.json"), "utf8")
+    );
+    expect(projCfg).toEqual({ lens: { agent: "codex" } });
+  });
+
+  it("get --scope shows only that scope's stored value", () => {
+    config(["set", "lens.agent", "claude", "--scope", "global"]);
+    config(["set", "lens.agent", "codex", "--scope", "project"]);
+    logSpy.mockClear();
+    config(["get", "lens.agent", "--scope", "global"]);
+    expect(output()).toBe("claude");
+    logSpy.mockClear();
+    config(["get", "lens.agent", "--scope", "project"]);
+    expect(output()).toBe("codex");
+  });
+
+  it("get prints (unset) for an absent value", () => {
+    config(["get", "lens.agent"]);
+    expect(output()).toBe("(unset)");
+  });
+
+  it("unset removes the value at a scope", () => {
+    config(["set", "lens.agent", "claude"]);
+    config(["unset", "lens.agent"]);
+    logSpy.mockClear();
+    config(["get", "lens.agent"]);
+    expect(output()).toBe("(unset)");
+  });
+});
+
+describe("argent config — validation & errors", () => {
+  it("rejects an unknown key with exit 2 and a hint", () => {
+    expect(() => config(["set", "does.not.exist", "1"])).toThrow(ExitError);
+    expect(errors()).toMatch(/Unknown configuration key/);
+    expect(errors()).toMatch(/argent config list/);
+  });
+
+  it("refuses to set a telemetry key, pointing at the dedicated command", () => {
+    expect(() => config(["set", "telemetry.enabled", "false"])).toThrow(ExitError);
+    expect(errors()).toMatch(/argent telemetry/);
+  });
+
+  it("rejects an invalid --scope", () => {
+    expect(() => config(["get", "lens.agent", "--scope", "bogus"])).toThrow(ExitError);
+    expect(errors()).toMatch(/--scope must be/);
+  });
+
+  it("rejects a value that fails the schema validator", () => {
+    // lens.agent must be a non-blank string; a JSON number is invalid.
+    expect(() => config(["set", "lens.agent", "42"])).toThrow(ExitError);
+    expect(errors()).toMatch(/Invalid value/);
+  });
+});
+
+describe("argent config — list & json", () => {
+  it("list --json reports every schema entry with per-scope values", () => {
+    config(["set", "lens.agent", "codex", "--scope", "project"]);
+    logSpy.mockClear();
+    config(["list", "--json"]);
+    const parsed = JSON.parse(output());
+    const lens = parsed.config.find((e: { key: string }) => e.key === "lens.agent");
+    expect(lens.project).toBe("codex");
+    expect(lens.effective).toBe("codex");
+    const telemetry = parsed.config.find((e: { key: string }) => e.key === "telemetry.enabled");
+    expect(telemetry.manageCommand).toBe("argent telemetry");
+  });
+
+  it("get --json emits a structured record", () => {
+    config(["set", "lens.agent", "claude"]);
+    logSpy.mockClear();
+    config(["get", "lens.agent", "--json"]);
+    expect(JSON.parse(output())).toEqual({
+      key: "lens.agent",
+      scope: "effective",
+      value: "claude",
+    });
+  });
+});

--- a/packages/argent-cli/test/config-command.test.ts
+++ b/packages/argent-cli/test/config-command.test.ts
@@ -126,6 +126,35 @@ describe("argent config — set/get across scopes", () => {
     expect(output()).toContain("was not set at project scope");
     expect(fs.existsSync(projectCfg)).toBe(false);
   });
+
+  it("a project-scope write echoes the resolved project root", () => {
+    config(["set", "lens.agent", "codex", "--scope", "project"]);
+    // (Assert on the un-colorized segment after the bold key.)
+    expect(output()).toContain(`(project: ${projectDir}).`);
+    // A real project (a `.git` marker at projectDir) is not degenerate — no warning.
+    expect(errors()).toBe("");
+    logSpy.mockClear();
+    config(["unset", "lens.agent", "--scope", "project"]);
+    expect(output()).toContain(`(project: ${projectDir}).`);
+  });
+
+  it("warns when project scope resolves to the home directory", () => {
+    // Materialize ~/.argent via a global write, then run from a non-project dir
+    // under HOME: the marker walk stops at ~/.argent, so "project" IS global.
+    config(["set", "lens.agent", "claude"]);
+    const nested = path.join(homeDir, "not-a-project");
+    fs.mkdirSync(nested);
+    process.chdir(nested);
+    logSpy.mockClear();
+    config(["set", "lens.agent", "codex", "--scope", "project"]);
+    expect(errors()).toContain("resolved to the home directory");
+    expect(output()).toContain(`(project: ${homeDir}).`);
+    // The write landed in the global config file.
+    const globalCfg = JSON.parse(
+      fs.readFileSync(path.join(homeDir, ".argent", "config.json"), "utf8")
+    );
+    expect(globalCfg).toEqual({ lens: { agent: "codex" } });
+  });
 });
 
 describe("argent config — validation & errors", () => {
@@ -163,6 +192,16 @@ describe("argent config — list & json", () => {
     expect(lens.effective).toBe("codex");
     const telemetry = parsed.config.find((e: { key: string }) => e.key === "telemetry.enabled");
     expect(telemetry.manageCommand).toBe("argent telemetry");
+  });
+
+  it("telemetry.enabled reads as true (opt-out default) on a fresh install", () => {
+    config(["get", "telemetry.enabled"]);
+    expect(output()).toBe("true");
+    logSpy.mockClear();
+    config(["list", "--json"]);
+    const parsed = JSON.parse(output());
+    const telemetry = parsed.config.find((e: { key: string }) => e.key === "telemetry.enabled");
+    expect(telemetry.effective).toBe(true);
   });
 
   it("get --json emits a structured record", () => {

--- a/packages/argent-cli/test/config-command.test.ts
+++ b/packages/argent-cli/test/config-command.test.ts
@@ -110,8 +110,11 @@ describe("argent config — set/get across scopes", () => {
 
   it("set reports the normalized value that was stored", () => {
     config(["set", "lens.agent", "  codex  "]);
-    // The message echoes the trimmed value that actually landed on disk.
-    expect(output()).toContain("Set lens.agent = codex (global).");
+    // The message echoes the trimmed value that actually landed on disk, not the
+    // raw CLI input. (Assert on the un-colorized value segment — the key is
+    // wrapped in bold ANSI codes when color is enabled, e.g. in CI.)
+    expect(output()).toContain("= codex (global).");
+    expect(output()).not.toContain("  codex  ");
     logSpy.mockClear();
     config(["get", "lens.agent"]);
     expect(output()).toBe("codex");

--- a/packages/argent-cli/test/config-command.test.ts
+++ b/packages/argent-cli/test/config-command.test.ts
@@ -16,7 +16,6 @@ let originalUserProfile: string | undefined;
 let originalCwd: string;
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errSpy: ReturnType<typeof vi.spyOn>;
-let exitSpy: ReturnType<typeof vi.spyOn>;
 
 class ExitError extends Error {
   constructor(public code: number) {
@@ -36,7 +35,7 @@ beforeEach(() => {
   process.chdir(projectDir);
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
     throw new ExitError(code ?? 0);
   }) as never);
 });

--- a/packages/argent-cli/test/config-command.test.ts
+++ b/packages/argent-cli/test/config-command.test.ts
@@ -107,6 +107,22 @@ describe("argent config — set/get across scopes", () => {
     config(["get", "lens.agent"]);
     expect(output()).toBe("(unset)");
   });
+
+  it("set reports the normalized value that was stored", () => {
+    config(["set", "lens.agent", "  codex  "]);
+    // The message echoes the trimmed value that actually landed on disk.
+    expect(output()).toContain("Set lens.agent = codex (global).");
+    logSpy.mockClear();
+    config(["get", "lens.agent"]);
+    expect(output()).toBe("codex");
+  });
+
+  it("a no-op unset does not create the project config file", () => {
+    const projectCfg = path.join(projectDir, ".argent", "config.json");
+    config(["unset", "lens.agent", "--scope", "project"]);
+    expect(output()).toContain("was not set at project scope");
+    expect(fs.existsSync(projectCfg)).toBe(false);
+  });
 });
 
 describe("argent config — validation & errors", () => {

--- a/packages/argent/src/cli.ts
+++ b/packages/argent/src/cli.ts
@@ -95,6 +95,7 @@ Commands:
   enable      Enable a feature flag (global by default, --scope project for project)
   disable     Disable a feature flag (global by default, --scope project for project)
   flags       Show current feature-flag state
+  config      Manage configuration (list / get / set / unset, project & global)
   telemetry   Manage opt-out telemetry (status / enable / disable)
 
 Options:
@@ -163,6 +164,8 @@ async function main(): Promise<void> {
       return (await loadCli()).disable(rest);
     case "flags":
       return (await loadCli()).flags(rest);
+    case "config":
+      return (await loadCli()).config(rest);
     case "telemetry":
       return (await loadCli()).telemetry(rest);
     case "--version":

--- a/packages/configuration-core/src/config-access.ts
+++ b/packages/configuration-core/src/config-access.ts
@@ -117,7 +117,9 @@ export class ConfigManagedElsewhereError extends Error {
 /**
  * Validate and persist a configuration value at a scope. `rawValue` is a
  * pre-parsed JSON value (the CLI coerces its string argument first); it is run
- * through the schema's validator, and the normalized result is stored.
+ * through the schema's validator, and the normalized result is stored. Returns
+ * the normalized value that was written, so callers can report exactly what
+ * landed on disk rather than the raw input.
  */
 export function setConfigValue(
   key: string,
@@ -125,13 +127,14 @@ export function setConfigValue(
   scope: FlagScope = "global",
   options: ConfigPathOptions = {},
   registry: readonly ConfigDefinition[] = CONFIG_SCHEMA
-): void {
+): unknown {
   const def = requireDefinition(key, registry);
   if (def.manageCommand) throw new ConfigManagedElsewhereError(key, def.manageCommand);
   if (!def.scopes.includes(scope)) throw new ConfigScopeError(key, scope, def.scopes);
   const parsed = def.parse(rawValue);
   if (parsed === undefined) throw new ConfigValidationError(key);
   updateConfig((config) => setAtPath(config, key, parsed), scope, options);
+  return parsed;
 }
 
 /**
@@ -147,6 +150,12 @@ export function unsetConfigValue(
   const def = requireDefinition(key, registry);
   if (def.manageCommand) throw new ConfigManagedElsewhereError(key, def.manageCommand);
   if (!def.scopes.includes(scope)) throw new ConfigScopeError(key, scope, def.scopes);
+  // Fast path for a no-op: if the key is absent at this scope there is nothing
+  // to remove, so skip the write path entirely. Otherwise `updateConfig` would
+  // mkdir the scope's `.argent` dir and rewrite an unchanged config.json —
+  // materializing a project file (and dirtying git status) for an unset that
+  // removed nothing.
+  if (getAtPath(readConfigObject(scope, options), key) === undefined) return false;
   let removed = false;
   updateConfig(
     (config) => {

--- a/packages/configuration-core/src/config-access.ts
+++ b/packages/configuration-core/src/config-access.ts
@@ -1,0 +1,226 @@
+// Schema-driven read/write for scoped configuration values.
+//
+// This is the layer the rest of argent should use to read a configuration:
+// instead of poking at a single global config.json, `getConfigValue` reads
+// every scope the value's schema entry allows, merges them under the entry's
+// policy, and falls back to the entry's default. `setConfigValue` /
+// `unsetConfigValue` validate against the schema before writing. `argent config`
+// and the migrated lens getters are both thin wrappers over these.
+
+import type { FlagScope } from "./flags.js";
+import type { ConfigPathOptions } from "./paths.js";
+import { readConfigObject, updateConfig, getAtPath, setAtPath, deleteAtPath } from "./config.js";
+import { applyMergePolicy } from "./merge.js";
+import { CONFIG_SCHEMA, getConfigDefinition, type ConfigDefinition } from "./config-schema.js";
+
+/** Read + parse one scope's value for a definition (no merge, no default). */
+function readScopeValue<T>(
+  def: ConfigDefinition<T>,
+  scope: FlagScope,
+  options: ConfigPathOptions
+): T | undefined {
+  if (!def.scopes.includes(scope)) return undefined;
+  const raw = getAtPath(readConfigObject(scope, options), def.key);
+  return raw === undefined ? undefined : def.parse(raw);
+}
+
+/**
+ * The effective value of a configuration: the project and global scopes read,
+ * validated, merged under the entry's policy, then defaulted. This is what a
+ * runtime consumer (e.g. the simctl device-set reader) should call.
+ */
+export function getConfigValue<T>(
+  def: ConfigDefinition<T>,
+  options: ConfigPathOptions = {}
+): T | undefined {
+  const local = readScopeValue(def, "project", options);
+  const global = readScopeValue(def, "global", options);
+  const merged = applyMergePolicy(def.merge, local, global);
+  return merged ?? def.default;
+}
+
+/** The raw parsed value stored at a single scope (no merge/default). Throws on
+ * an unknown key. Backs `argent config get --scope`. */
+export function getConfigValueAtScope(
+  key: string,
+  scope: FlagScope,
+  options: ConfigPathOptions = {},
+  registry: readonly ConfigDefinition[] = CONFIG_SCHEMA
+): unknown {
+  const def = requireDefinition(key, registry);
+  return readScopeValue(def, scope, options);
+}
+
+/** Same as `getConfigValue` but looked up by key; throws on an unknown key. */
+export function getConfigValueByKey(
+  key: string,
+  options: ConfigPathOptions = {},
+  registry: readonly ConfigDefinition[] = CONFIG_SCHEMA
+): unknown {
+  const def = requireDefinition(key, registry);
+  return getConfigValue(def, options);
+}
+
+function requireDefinition(
+  key: string,
+  registry: readonly ConfigDefinition[] = CONFIG_SCHEMA
+): ConfigDefinition {
+  const def = getConfigDefinition(key, registry);
+  if (!def) {
+    throw new UnknownConfigKeyError(key);
+  }
+  return def;
+}
+
+/** Thrown when a key is not present in the schema. */
+export class UnknownConfigKeyError extends Error {
+  constructor(public readonly key: string) {
+    super(`Unknown configuration key "${key}".`);
+    this.name = "UnknownConfigKeyError";
+  }
+}
+
+/** Thrown when a write targets a scope the value's schema does not allow. */
+export class ConfigScopeError extends Error {
+  constructor(
+    public readonly key: string,
+    public readonly scope: FlagScope,
+    public readonly allowed: readonly FlagScope[]
+  ) {
+    super(`Config key "${key}" cannot be set at ${scope} scope (allowed: ${allowed.join(", ")}).`);
+    this.name = "ConfigScopeError";
+  }
+}
+
+/** Thrown when a value fails the schema's `parse` validator. */
+export class ConfigValidationError extends Error {
+  constructor(public readonly key: string) {
+    super(`Invalid value for config key "${key}".`);
+    this.name = "ConfigValidationError";
+  }
+}
+
+/**
+ * Thrown when a key is delegated to a dedicated command (`manageCommand`) and
+ * must not be written through the generic `argent config` path.
+ */
+export class ConfigManagedElsewhereError extends Error {
+  constructor(
+    public readonly key: string,
+    public readonly command: string
+  ) {
+    super(`Config key "${key}" is managed by \`${command}\`.`);
+    this.name = "ConfigManagedElsewhereError";
+  }
+}
+
+/**
+ * Validate and persist a configuration value at a scope. `rawValue` is a
+ * pre-parsed JSON value (the CLI coerces its string argument first); it is run
+ * through the schema's validator, and the normalized result is stored.
+ */
+export function setConfigValue(
+  key: string,
+  rawValue: unknown,
+  scope: FlagScope = "global",
+  options: ConfigPathOptions = {},
+  registry: readonly ConfigDefinition[] = CONFIG_SCHEMA
+): void {
+  const def = requireDefinition(key, registry);
+  if (def.manageCommand) throw new ConfigManagedElsewhereError(key, def.manageCommand);
+  if (!def.scopes.includes(scope)) throw new ConfigScopeError(key, scope, def.scopes);
+  const parsed = def.parse(rawValue);
+  if (parsed === undefined) throw new ConfigValidationError(key);
+  updateConfig((config) => setAtPath(config, key, parsed), scope, options);
+}
+
+/**
+ * Remove a configuration value at a scope. Returns true when an entry was
+ * removed. Refuses keys delegated to a dedicated command.
+ */
+export function unsetConfigValue(
+  key: string,
+  scope: FlagScope = "global",
+  options: ConfigPathOptions = {},
+  registry: readonly ConfigDefinition[] = CONFIG_SCHEMA
+): boolean {
+  const def = requireDefinition(key, registry);
+  if (def.manageCommand) throw new ConfigManagedElsewhereError(key, def.manageCommand);
+  if (!def.scopes.includes(scope)) throw new ConfigScopeError(key, scope, def.scopes);
+  let removed = false;
+  updateConfig(
+    (config) => {
+      removed = deleteAtPath(config, key);
+    },
+    scope,
+    options
+  );
+  return removed;
+}
+
+/** A schema entry plus its current per-scope and effective values, for display. */
+export interface ConfigEntryView {
+  key: string;
+  description: string;
+  scopes: readonly FlagScope[];
+  manageCommand?: string;
+  /** Effective (merged + defaulted) value. */
+  effective: unknown;
+  /** Raw parsed value stored at the project scope, or undefined. */
+  project: unknown;
+  /** Raw parsed value stored at the global scope, or undefined. */
+  global: unknown;
+}
+
+/** Every schema entry with its current values — backs `argent config list`. */
+export function listConfig(
+  options: ConfigPathOptions = {},
+  registry: readonly ConfigDefinition[] = CONFIG_SCHEMA
+): ConfigEntryView[] {
+  return registry.map((def) => ({
+    key: def.key,
+    description: def.description,
+    scopes: def.scopes,
+    ...(def.manageCommand ? { manageCommand: def.manageCommand } : {}),
+    effective: getConfigValue(def, options),
+    project: readScopeValue(def, "project", options),
+    global: readScopeValue(def, "global", options),
+  }));
+}
+
+/**
+ * Coerce a raw CLI string into a JSON value for `setConfigValue`. Tries JSON
+ * first (so `true`, `42`, `["a","b"]` parse to their types) and falls back to
+ * the literal string (so bare paths like `/tmp/set` don't need quoting).
+ */
+export function coerceCliValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+// ── Argent Lens preferences (migrated onto the schema) ────────────────────
+// `lens.agent` is a real schema entry now, so these wrappers demonstrate the
+// merged reader on a live consumer: a project can pin the agent, falling back
+// to the user's global remembered choice. The public surface is unchanged so
+// `argent lens` keeps working without edits.
+
+const LENS_AGENT_KEY = "lens.agent";
+
+/** The remembered `argent lens` agent id, or null when none is stored. */
+export function getRememberedAgent(options: ConfigPathOptions = {}): string | null {
+  const value = getConfigValueByKey(LENS_AGENT_KEY, options);
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+/** Persist the chosen `argent lens` agent id so later runs skip the picker. */
+export function setRememberedAgent(agentId: string, options: ConfigPathOptions = {}): void {
+  setConfigValue(LENS_AGENT_KEY, agentId, "global", options);
+}
+
+/** Forget the remembered `argent lens` agent (so the picker shows again). */
+export function clearRememberedAgent(options: ConfigPathOptions = {}): void {
+  unsetConfigValue(LENS_AGENT_KEY, "global", options);
+}

--- a/packages/configuration-core/src/config-schema.ts
+++ b/packages/configuration-core/src/config-schema.ts
@@ -80,12 +80,17 @@ export function asStringArray(raw: unknown): string[] | undefined {
 export const CONFIG_SCHEMA: readonly ConfigDefinition[] = [
   {
     key: "telemetry.enabled",
-    description: "Whether anonymous opt-out telemetry is enabled.",
+    description:
+      "Whether anonymous opt-out telemetry is enabled (on by default; environment opt-outs " +
+      "like DO_NOT_TRACK are not reflected here — `argent telemetry status` shows effective consent).",
     scopes: ["global"],
     parse: asBoolean,
     // A committed project file must never re-enable telemetry a user disabled
     // globally, so the more-restrictive (opt-out) value always wins.
     merge: "prioritize-restrictive",
+    // Telemetry is opt-out: with nothing stored, consent.ts treats it as
+    // enabled, and the config surface must report the same instead of "(unset)".
+    default: true,
     // Read-only under `argent config`: opt-in/out goes through the dedicated
     // command so the live client is drained/reset, not just the file rewritten.
     manageCommand: "argent telemetry",

--- a/packages/configuration-core/src/config-schema.ts
+++ b/packages/configuration-core/src/config-schema.ts
@@ -1,0 +1,111 @@
+// The configuration schema: the single source of truth for every recognized
+// config value, its shape, where it may be set, and how the two scopes merge.
+//
+// Adding a new configuration is meant to be a one-liner here: give it a dotted
+// `key`, a `description`, the `scopes` it accepts, a `parse` validator, and a
+// `merge` policy (a preset name, or your own function). Nothing else in the
+// system needs to change — `argent config`, the merged reader, and validation
+// are all schema-driven.
+
+import type { FlagScope } from "./flags.js";
+import type { MergePolicy } from "./merge.js";
+
+/**
+ * One recognized configuration value.
+ *
+ * `key` is a dotted path into the shared config document (`ios.deviceSet` →
+ * `{ "ios": { "deviceSet": ... } }`). `parse` both validates and normalizes a
+ * raw JSON value, returning `undefined` for anything malformed so a broken
+ * config never crashes a reader. `merge` decides the effective value when both
+ * scopes are set.
+ */
+export interface ConfigDefinition<T = unknown> {
+  /** Dotted path into config.json, e.g. `"ios.deviceSet"`. */
+  readonly key: string;
+  /** One-line summary shown by `argent config` / `argent config list`. */
+  readonly description: string;
+  /** Scopes this value may be written to. Reads only merge the listed scopes. */
+  readonly scopes: readonly FlagScope[];
+  /** Validate + normalize a raw JSON value; `undefined` means absent/invalid. */
+  readonly parse: (raw: unknown) => T | undefined;
+  /** How the project and global values combine into the effective value. */
+  readonly merge: MergePolicy<T>;
+  /** Effective value when no scope contributes one. */
+  readonly default?: T;
+  /**
+   * When set, `argent config set/unset` refuses this key and points the user at
+   * the given command instead. Used for values that have a dedicated,
+   * lifecycle-aware command (e.g. telemetry, which must also drain the running
+   * client on opt-out) while still surfacing them read-only under `argent config`.
+   */
+  readonly manageCommand?: string;
+  /** Optional example value shown in help/usage. */
+  readonly example?: string;
+}
+
+// ── parse/normalize helpers ──────────────────────────────────────────────
+// Reusable validators so schema entries stay one-liners. Each returns the
+// normalized value or `undefined` for an absent/wrong-typed input.
+
+/** Accept a JSON boolean. */
+export function asBoolean(raw: unknown): boolean | undefined {
+  return typeof raw === "boolean" ? raw : undefined;
+}
+
+/** Accept a non-blank string, trimmed. Blank/whitespace reads as unset. */
+export function asString(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+/** Accept a finite JSON number. */
+export function asNumber(raw: unknown): number | undefined {
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
+}
+
+/** Accept an array of non-blank strings (blank entries dropped). */
+export function asStringArray(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item === "string" && item.trim() !== "") out.push(item.trim());
+  }
+  return out;
+}
+
+// ── The registry ─────────────────────────────────────────────────────────
+// The only place you edit to add a configuration.
+
+export const CONFIG_SCHEMA: readonly ConfigDefinition[] = [
+  {
+    key: "telemetry.enabled",
+    description: "Whether anonymous opt-out telemetry is enabled.",
+    scopes: ["global"],
+    parse: asBoolean,
+    // A committed project file must never re-enable telemetry a user disabled
+    // globally, so the more-restrictive (opt-out) value always wins.
+    merge: "prioritize-restrictive",
+    // Read-only under `argent config`: opt-in/out goes through the dedicated
+    // command so the live client is drained/reset, not just the file rewritten.
+    manageCommand: "argent telemetry",
+  },
+  {
+    key: "lens.agent",
+    description: "Coding-agent id remembered by `argent lens` to skip the picker.",
+    scopes: ["project", "global"],
+    parse: asString,
+    // A repo can pin the agent its screenshots should use; falls back to the
+    // user's global remembered choice.
+    merge: "prioritize-local",
+    example: "claude",
+  },
+] as const;
+
+/** Look up a schema entry by key, or `undefined` when the key is unknown. */
+export function getConfigDefinition(
+  key: string,
+  registry: readonly ConfigDefinition[] = CONFIG_SCHEMA
+): ConfigDefinition | undefined {
+  return registry.find((def) => def.key === key);
+}

--- a/packages/configuration-core/src/config.ts
+++ b/packages/configuration-core/src/config.ts
@@ -1,25 +1,103 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { argentHomeDir, configFilePath } from "./paths.js";
+import { configDir, configFilePath, type ConfigPathOptions } from "./paths.js";
+import type { FlagScope } from "./flags.js";
 
-// Shared read/write for ~/.argent/config.json. The config holds several
-// independent keys (telemetry consent, first-run notices, Lens preferences,
-// ...), so every writer must merge rather than overwrite, and publish
-// atomically so an interrupted write can never truncate keys it does not own.
+// Shared read/write for the `.argent/config.json` documents. The config holds
+// several independent keys (telemetry consent, first-run notices, Lens
+// preferences, ...) at two scopes — `global` (`~/.argent`) and `project`
+// (`<project-root>/.argent`) — so every writer must merge rather than
+// overwrite, and publish atomically so an interrupted write can never truncate
+// keys it does not own.
 
-/** Parse the config document, returning an empty object when missing/malformed. */
-export function readConfigObject(): Record<string, unknown> {
+/**
+ * Parse a scope's config document, returning an empty object when
+ * missing/malformed. Defaults to the global scope for backward compatibility.
+ */
+export function readConfigObject(
+  scope: FlagScope = "global",
+  options: ConfigPathOptions = {}
+): Record<string, unknown> {
   try {
-    const raw = fs.readFileSync(configFilePath(), "utf8");
+    const raw = fs.readFileSync(configFilePath(scope, options), "utf8");
     const json = JSON.parse(raw) as unknown;
-    if (json && typeof json === "object") {
+    if (json && typeof json === "object" && !Array.isArray(json)) {
       return json as Record<string, unknown>;
     }
   } catch {
     /* missing or malformed — treat as a fresh document */
   }
   return {};
+}
+
+// ── dotted-path access ────────────────────────────────────────────────────
+// Config keys are dotted paths (`ios.deviceSet`) into the nested document.
+// These helpers read/write/remove a leaf while refusing prototype-polluting
+// segments so a crafted key can never reach `Object.prototype`.
+
+const FORBIDDEN_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
+
+function splitKey(dottedKey: string): string[] {
+  const parts = dottedKey.split(".");
+  if (parts.length === 0 || parts.some((p) => p === "")) {
+    throw new Error(`Invalid config key "${dottedKey}": empty path segment`);
+  }
+  for (const p of parts) {
+    if (FORBIDDEN_SEGMENTS.has(p)) {
+      throw new Error(`Invalid config key "${dottedKey}": forbidden segment "${p}"`);
+    }
+  }
+  return parts;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Read the value at a dotted key, or `undefined` when any segment is missing. */
+export function getAtPath(obj: Record<string, unknown>, dottedKey: string): unknown {
+  const parts = splitKey(dottedKey);
+  let cur: unknown = obj;
+  for (const part of parts) {
+    if (!isPlainObject(cur)) return undefined;
+    cur = cur[part];
+  }
+  return cur;
+}
+
+/** Set the value at a dotted key, creating intermediate objects as needed. */
+export function setAtPath(obj: Record<string, unknown>, dottedKey: string, value: unknown): void {
+  const parts = splitKey(dottedKey);
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i]!;
+    const next = cur[part];
+    if (!isPlainObject(next)) {
+      cur[part] = {};
+    }
+    cur = cur[part] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]!] = value;
+}
+
+/**
+ * Delete the leaf at a dotted key. Returns true when something was removed.
+ * Intermediate objects are left in place (an emptied parent stays as `{}`),
+ * matching how the previous per-key clearers behaved.
+ */
+export function deleteAtPath(obj: Record<string, unknown>, dottedKey: string): boolean {
+  const parts = splitKey(dottedKey);
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const next = cur[parts[i]!];
+    if (!isPlainObject(next)) return false;
+    cur = next;
+  }
+  const leaf = parts[parts.length - 1]!;
+  if (!Object.hasOwn(cur, leaf)) return false;
+  delete cur[leaf];
+  return true;
 }
 
 // A read → mutate → publish cycle completes in well under a second; a lock held
@@ -48,8 +126,8 @@ interface ConfigLock {
 // non-null result must be released. Stale-lock recovery is best-effort: in the
 // pathological case of two writers observing the same orphaned lock at once the
 // steal can race, but that is vastly rarer than the lost-update it replaces.
-function acquireConfigLock(): ConfigLock | null {
-  const lockPath = configFilePath() + ".lock";
+function acquireConfigLock(finalPath: string): ConfigLock | null {
+  const lockPath = finalPath + ".lock";
   const deadline = Date.now() + LOCK_MAX_WAIT_MS;
   for (;;) {
     try {
@@ -107,16 +185,21 @@ function releaseConfigLock(lock: ConfigLock): void {
  * the last `rename` wins — silently dropping the other's change (e.g. a
  * telemetry opt-out lost behind a first-run-notice write).
  */
-export function updateConfig(mutate: (config: Record<string, unknown>) => void): void {
-  fs.mkdirSync(argentHomeDir(), { recursive: true });
+export function updateConfig(
+  mutate: (config: Record<string, unknown>) => void,
+  scope: FlagScope = "global",
+  options: ConfigPathOptions = {}
+): void {
+  const dir = configDir(scope, options);
+  fs.mkdirSync(dir, { recursive: true });
 
-  const lock = acquireConfigLock();
+  const finalPath = configFilePath(scope, options);
+  const lock = acquireConfigLock(finalPath);
   try {
-    const next = readConfigObject();
+    const next = readConfigObject(scope, options);
     mutate(next);
 
-    const finalPath = configFilePath();
-    const tmpPath = path.join(argentHomeDir(), `.config.tmp.${process.pid}.${crypto.randomUUID()}`);
+    const tmpPath = path.join(dir, `.config.tmp.${process.pid}.${crypto.randomUUID()}`);
     const fd = fs.openSync(tmpPath, "wx", 0o600);
     try {
       fs.writeSync(fd, JSON.stringify(next, null, 2) + "\n");
@@ -137,48 +220,4 @@ export function updateConfig(mutate: (config: Record<string, unknown>) => void):
   } finally {
     if (lock) releaseConfigLock(lock);
   }
-}
-
-// ── Argent Lens preferences ──────────────────────────────────────────────
-// Stored under the `lens` key of the shared config document, e.g.
-// `{ "lens": { "agent": "claude" } }`. `argent lens` reads `agent` to skip the
-// window's agent picker on subsequent runs, and writes it when the human ticks
-// "Remember this choice".
-
-/** Shape of the `lens` config section. Only the keys we read are typed. */
-interface LensConfig {
-  /** The coding-agent id last remembered for `argent lens` (e.g. "claude"). */
-  agent?: string;
-}
-
-function readLensConfig(): LensConfig {
-  const lens = readConfigObject().lens;
-  return lens && typeof lens === "object" ? (lens as LensConfig) : {};
-}
-
-/** The remembered `argent lens` agent id, or null when none is stored. */
-export function getRememberedAgent(): string | null {
-  const agent = readLensConfig().agent;
-  return typeof agent === "string" && agent.trim() ? agent : null;
-}
-
-/** Persist the chosen `argent lens` agent id so later runs skip the picker. */
-export function setRememberedAgent(agentId: string): void {
-  updateConfig((config) => {
-    const lens =
-      config.lens && typeof config.lens === "object"
-        ? (config.lens as Record<string, unknown>)
-        : {};
-    lens.agent = agentId;
-    config.lens = lens;
-  });
-}
-
-/** Forget the remembered `argent lens` agent (so the picker shows again). */
-export function clearRememberedAgent(): void {
-  updateConfig((config) => {
-    if (config.lens && typeof config.lens === "object") {
-      delete (config.lens as Record<string, unknown>).agent;
-    }
-  });
 }

--- a/packages/configuration-core/src/flags.ts
+++ b/packages/configuration-core/src/flags.ts
@@ -82,17 +82,27 @@ export interface FlagsPathOptions {
   homeDir?: string;
 }
 
-export function resolveProjectRoot(startDir: string): string {
-  const initial = path.resolve(startDir);
-  let current = initial;
+/**
+ * Walk up from `startDir` looking for a project marker. Returns the marker
+ * directory, or `null` when no marker exists anywhere up to the fs root —
+ * callers that need to distinguish "found a project" from the cwd fallback
+ * (e.g. to warn before materializing `.argent` in an arbitrary directory)
+ * use this; everything else goes through `resolveProjectRoot`.
+ */
+export function findProjectRoot(startDir: string): string | null {
+  let current = path.resolve(startDir);
   while (true) {
     for (const marker of PROJECT_MARKERS) {
       if (fs.existsSync(path.join(current, marker))) return current;
     }
     const parent = path.dirname(current);
-    if (parent === current) return initial;
+    if (parent === current) return null;
     current = parent;
   }
+}
+
+export function resolveProjectRoot(startDir: string): string {
+  return findProjectRoot(startDir) ?? path.resolve(startDir);
 }
 
 export function getFlagsPath(scope: FlagScope, options: FlagsPathOptions = {}): string {

--- a/packages/configuration-core/src/index.ts
+++ b/packages/configuration-core/src/index.ts
@@ -12,12 +12,46 @@ export {
   type FlagsPathOptions,
 } from "./flags.js";
 
-export { argentHomeDir, configFilePath } from "./paths.js";
+export { argentHomeDir, configDir, configFilePath, type ConfigPathOptions } from "./paths.js";
 
+export { readConfigObject, updateConfig, getAtPath, setAtPath, deleteAtPath } from "./config.js";
+
+// Merge policies for scoped values.
 export {
-  readConfigObject,
-  updateConfig,
+  applyMergePolicy,
+  MERGE_PRESETS,
+  type MergePreset,
+  type MergeFn,
+  type MergePolicy,
+  type MergeInputs,
+} from "./merge.js";
+
+// The configuration schema: the registry of recognized values + parse helpers.
+export {
+  CONFIG_SCHEMA,
+  getConfigDefinition,
+  asBoolean,
+  asString,
+  asNumber,
+  asStringArray,
+  type ConfigDefinition,
+} from "./config-schema.js";
+
+// Schema-driven read/write, plus the migrated lens getters.
+export {
+  getConfigValue,
+  getConfigValueByKey,
+  getConfigValueAtScope,
+  setConfigValue,
+  unsetConfigValue,
+  listConfig,
+  coerceCliValue,
   getRememberedAgent,
   setRememberedAgent,
   clearRememberedAgent,
-} from "./config.js";
+  UnknownConfigKeyError,
+  ConfigScopeError,
+  ConfigValidationError,
+  ConfigManagedElsewhereError,
+  type ConfigEntryView,
+} from "./config-access.js";

--- a/packages/configuration-core/src/index.ts
+++ b/packages/configuration-core/src/index.ts
@@ -1,6 +1,7 @@
 export {
   FLAG_REGISTRY,
   getFlagDefinition,
+  findProjectRoot,
   resolveProjectRoot,
   getFlagsPath,
   readFlags,

--- a/packages/configuration-core/src/merge.ts
+++ b/packages/configuration-core/src/merge.ts
@@ -1,0 +1,135 @@
+// Merge policies for scoped configuration values.
+//
+// A configuration value can be set at two scopes — `project`
+// (`<project-root>/.argent/config.json`) and `global` (`~/.argent/config.json`).
+// When both scopes hold a value, a *merge policy* decides the effective value.
+// Feature flags get away with a single hardcoded rule (project overrides
+// global) because every flag is a homogeneous opt-in boolean. Config values are
+// heterogeneous — a device-set path wants project-wins, a telemetry opt-out
+// wants the more-restrictive value to win so a committed project file can never
+// re-enable something the user disabled globally — so each value declares its
+// own policy in the schema (see `config-schema.ts`).
+//
+// The presets below cover the common cases; a schema entry can also supply an
+// arbitrary function for a bespoke rule.
+
+/** Built-in merge behaviors, chosen per config value in the schema. */
+export type MergePreset =
+  /** Project value wins; fall back to global when the project scope is unset. */
+  | "prioritize-local"
+  /** Global value wins; fall back to project when the global scope is unset. */
+  | "prioritize-global"
+  /**
+   * The more restrictive of the two wins — for booleans, `false` (opt-out) beats
+   * `true`; for numbers, the smaller value. Use for privacy/permission toggles
+   * where a committed project file must never loosen a stricter global choice.
+   */
+  | "prioritize-restrictive"
+  /** Arrays only: the de-duplicated union of both scopes (global first). */
+  | "union"
+  /** Arrays only: the elements present in BOTH scopes (order follows project). */
+  | "intersection";
+
+/** The two scope values handed to a merge function. `undefined` = unset. */
+export interface MergeInputs<T> {
+  /** Value from `<project-root>/.argent/config.json`, if set. */
+  local: T | undefined;
+  /** Value from `~/.argent/config.json`, if set. */
+  global: T | undefined;
+}
+
+/**
+ * A bespoke merge rule. Receives both scope values (either may be `undefined`)
+ * and returns the effective value, or `undefined` to fall through to the
+ * schema default. Provided as an escape hatch on a schema entry when none of
+ * the presets fit.
+ */
+export type MergeFn<T> = (inputs: MergeInputs<T>) => T | undefined;
+
+/** A preset name or a custom function. */
+export type MergePolicy<T> = MergePreset | MergeFn<T>;
+
+/** The set of recognized preset names, for validation and docs. */
+export const MERGE_PRESETS: readonly MergePreset[] = [
+  "prioritize-local",
+  "prioritize-global",
+  "prioritize-restrictive",
+  "union",
+  "intersection",
+];
+
+function mergeRestrictive<T>(local: T | undefined, global: T | undefined): T | undefined {
+  if (local === undefined) return global;
+  if (global === undefined) return local;
+  // Booleans: any `false` (opt-out) wins over `true`.
+  if (typeof local === "boolean" && typeof global === "boolean") {
+    return (local && global) as unknown as T;
+  }
+  // Numbers: the smaller (stricter) bound wins.
+  if (typeof local === "number" && typeof global === "number") {
+    return Math.min(local, global) as unknown as T;
+  }
+  // No ordering defined for other types — keep the project value, matching the
+  // fall-through of the other presets. (The schema restricts this preset to
+  // boolean/number values, so this branch is a safety net, not a real path.)
+  return local;
+}
+
+function toArray(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? value : null;
+}
+
+function mergeUnion<T>(local: T | undefined, global: T | undefined): T | undefined {
+  const l = toArray(local);
+  const g = toArray(global);
+  // If neither scope holds an array there is nothing to union — behave like
+  // prioritize-local so a mis-typed value still resolves predictably.
+  if (l === null && g === null) return local ?? global;
+  // Global first so project entries append after the shared baseline; dedup by
+  // value (works for primitive arrays — the documented array element type).
+  const merged = [...(g ?? []), ...(l ?? [])];
+  return Array.from(new Set(merged)) as unknown as T;
+}
+
+function mergeIntersection<T>(local: T | undefined, global: T | undefined): T | undefined {
+  const l = toArray(local);
+  const g = toArray(global);
+  // Intersection needs both sides. When a scope is unset there is no constraint
+  // to intersect against, so the present scope passes through unchanged.
+  if (l === null && g === null) return local ?? global;
+  if (l === null) return global;
+  if (g === null) return local;
+  const globalSet = new Set(g);
+  return l.filter((item) => globalSet.has(item)) as unknown as T;
+}
+
+/**
+ * Combine a project (`local`) and `global` value under `policy`, returning the
+ * effective value or `undefined` when neither scope contributes one. A function
+ * policy is called directly; a preset name dispatches to the built-in rules.
+ */
+export function applyMergePolicy<T>(
+  policy: MergePolicy<T>,
+  local: T | undefined,
+  global: T | undefined
+): T | undefined {
+  if (typeof policy === "function") return policy({ local, global });
+  switch (policy) {
+    case "prioritize-local":
+      return local ?? global;
+    case "prioritize-global":
+      return global ?? local;
+    case "prioritize-restrictive":
+      return mergeRestrictive(local, global);
+    case "union":
+      return mergeUnion(local, global);
+    case "intersection":
+      return mergeIntersection(local, global);
+    default: {
+      // Exhaustiveness guard: a new preset added to the union without a case
+      // here becomes a compile error.
+      const _exhaustive: never = policy;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/configuration-core/src/merge.ts
+++ b/packages/configuration-core/src/merge.ts
@@ -23,6 +23,11 @@ export type MergePreset =
    * The more restrictive of the two wins — for booleans, `false` (opt-out) beats
    * `true`; for numbers, the smaller value. Use for privacy/permission toggles
    * where a committed project file must never loosen a stricter global choice.
+   *
+   * Caveat: the numeric rule hardcodes "smaller = stricter". Only apply this
+   * preset to a numeric config where a lower value is genuinely the safer bound.
+   * If larger is stricter (e.g. a retry cap, a minimum log level, a rate limit),
+   * do not use this preset — supply a custom `MergeFn` on the schema entry instead.
    */
   | "prioritize-restrictive"
   /** Arrays only: the de-duplicated union of both scopes (global first). */

--- a/packages/configuration-core/src/paths.ts
+++ b/packages/configuration-core/src/paths.ts
@@ -1,11 +1,20 @@
 import * as os from "node:os";
 import * as path from "node:path";
+import { resolveProjectRoot, type FlagScope } from "./flags.js";
 
 // Filesystem locations under the shared `~/.argent` home. These are general
 // (config.json holds telemetry consent, first-run notices, Lens preferences,
 // ...), so they live in configuration-core rather than any one consumer.
 // Telemetry-specific paths (the identity file, the debug log) stay in
 // `@argent/telemetry` and are built on top of `argentHomeDir`.
+
+/** Overrides for resolving config paths — used by tests to sandbox locations. */
+export interface ConfigPathOptions {
+  /** Directory to resolve the project root from (defaults to `process.cwd()`). */
+  cwd?: string;
+  /** Home directory for the global scope (defaults to HOME/USERPROFILE). */
+  homeDir?: string;
+}
 
 // Resolve at call time so tests can override HOME/USERPROFILE per case.
 function nonEmpty(value: string | undefined): string | null {
@@ -23,8 +32,29 @@ export function argentHomeDir(): string {
   return path.join(home, ".argent");
 }
 
-/** Shared config document (`~/.argent/config.json`). Holds several independent
- * keys — every writer must merge rather than overwrite (see `updateConfig`). */
-export function configFilePath(): string {
-  return path.join(argentHomeDir(), "config.json");
+/**
+ * The `.argent` directory for a config scope. `global` is `~/.argent`; `project`
+ * is `<project-root>/.argent`, where the root is resolved by walking up from
+ * `cwd` for a `.argent` / `.git` / `package.json` marker (same rule as flags).
+ */
+export function configDir(scope: FlagScope = "global", options: ConfigPathOptions = {}): string {
+  if (scope === "global") {
+    return options.homeDir ? path.join(options.homeDir, ".argent") : argentHomeDir();
+  }
+  const cwd = options.cwd ?? process.cwd();
+  return path.join(resolveProjectRoot(cwd), ".argent");
+}
+
+/**
+ * Shared config document for a scope. Defaults to the global
+ * `~/.argent/config.json` (backward-compatible with the no-arg callers); pass
+ * `"project"` for `<project-root>/.argent/config.json`. Holds several
+ * independent keys — every writer must merge rather than overwrite (see
+ * `updateConfig`).
+ */
+export function configFilePath(
+  scope: FlagScope = "global",
+  options: ConfigPathOptions = {}
+): string {
+  return path.join(configDir(scope, options), "config.json");
 }

--- a/packages/configuration-core/tests/config-access.test.ts
+++ b/packages/configuration-core/tests/config-access.test.ts
@@ -164,6 +164,26 @@ describe("listConfig", () => {
   });
 });
 
+describe("telemetry.enabled — opt-out default", () => {
+  it("reads as true (the opt-out default) when nothing is stored", () => {
+    expect(getConfigValueByKey("telemetry.enabled", opts())).toBe(true);
+    const entry = listConfig(opts()).find((e) => e.key === "telemetry.enabled")!;
+    expect(entry.effective).toBe(true);
+    expect(entry.global).toBeUndefined();
+  });
+
+  it("reflects a persisted opt-out from the global config file", () => {
+    // Written by hand — `setConfigValue` refuses manageCommand-delegated keys,
+    // matching how `argent telemetry disable` owns this write in production.
+    fs.mkdirSync(path.join(homeDir, ".argent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(homeDir, ".argent", "config.json"),
+      JSON.stringify({ telemetry: { enabled: false } })
+    );
+    expect(getConfigValueByKey("telemetry.enabled", opts())).toBe(false);
+  });
+});
+
 describe("coerceCliValue", () => {
   it("parses JSON scalars and arrays, falling back to a bare string", () => {
     expect(coerceCliValue("true")).toBe(true);

--- a/packages/configuration-core/tests/config-access.test.ts
+++ b/packages/configuration-core/tests/config-access.test.ts
@@ -130,6 +130,23 @@ describe("unsetConfigValue", () => {
     expect(getConfigValueByKey("lens.agent", opts())).toBeUndefined();
     expect(unsetConfigValue("lens.agent", "global", opts())).toBe(false);
   });
+
+  it("a no-op unset never materializes the scope's config file", () => {
+    const projectConfig = configFilePath("project", opts());
+    expect(fs.existsSync(projectConfig)).toBe(false);
+    // Nothing is stored at the project scope, so this removes nothing…
+    expect(unsetConfigValue("lens.agent", "project", opts())).toBe(false);
+    // …and must not create <project-root>/.argent/config.json to prove it.
+    expect(fs.existsSync(projectConfig)).toBe(false);
+  });
+});
+
+describe("setConfigValue — return value", () => {
+  it("returns the normalized (stored) value, not the raw input", () => {
+    // asString trims, so the stored/returned value is the trimmed form.
+    expect(setConfigValue("lens.agent", "  codex  ", "global", opts())).toBe("codex");
+    expect(getConfigValueByKey("lens.agent", opts())).toBe("codex");
+  });
 });
 
 describe("listConfig", () => {

--- a/packages/configuration-core/tests/config-access.test.ts
+++ b/packages/configuration-core/tests/config-access.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { configFilePath } from "../src/paths.js";
+import { readConfigObject, getAtPath, setAtPath, deleteAtPath } from "../src/config.js";
+import {
+  getConfigValue,
+  getConfigValueByKey,
+  setConfigValue,
+  unsetConfigValue,
+  listConfig,
+  coerceCliValue,
+  UnknownConfigKeyError,
+  ConfigScopeError,
+  ConfigValidationError,
+  ConfigManagedElsewhereError,
+} from "../src/config-access.js";
+import type { ConfigDefinition } from "../src/config-schema.js";
+
+// Sandbox both scopes: `homeDir` for global (~/.argent), `cwd` for the project
+// root (a tmp dir seeded with a `.git` marker so resolveProjectRoot stops there).
+let homeDir: string;
+let projectDir: string;
+
+beforeEach(() => {
+  homeDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-home-")));
+  projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-project-")));
+  fs.mkdirSync(path.join(projectDir, ".git"), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(homeDir, { recursive: true, force: true });
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+const opts = () => ({ homeDir, cwd: projectDir });
+
+describe("dotted-path helpers", () => {
+  it("gets, sets, and deletes nested leaves", () => {
+    const obj: Record<string, unknown> = {};
+    setAtPath(obj, "ios.deviceSet", "/tmp/set");
+    expect(obj).toEqual({ ios: { deviceSet: "/tmp/set" } });
+    expect(getAtPath(obj, "ios.deviceSet")).toBe("/tmp/set");
+    expect(deleteAtPath(obj, "ios.deviceSet")).toBe(true);
+    expect(obj).toEqual({ ios: {} });
+    expect(deleteAtPath(obj, "ios.deviceSet")).toBe(false);
+  });
+
+  it("refuses prototype-polluting segments", () => {
+    const obj: Record<string, unknown> = {};
+    expect(() => setAtPath(obj, "__proto__.polluted", true)).toThrow(/forbidden/);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+describe("getConfigValue — scope merge (lens.agent = prioritize-local)", () => {
+  it("returns null-equivalent (undefined) when neither scope is set", () => {
+    expect(getConfigValueByKey("lens.agent", opts())).toBeUndefined();
+  });
+
+  it("reads the global value when only global is set", () => {
+    setConfigValue("lens.agent", "claude", "global", opts());
+    expect(getConfigValueByKey("lens.agent", opts())).toBe("claude");
+  });
+
+  it("project overrides global under prioritize-local", () => {
+    setConfigValue("lens.agent", "claude", "global", opts());
+    setConfigValue("lens.agent", "codex", "project", opts());
+    expect(getConfigValueByKey("lens.agent", opts())).toBe("codex");
+    // Each scope's file holds only its own value.
+    expect(readConfigObject("global", opts())).toEqual({ lens: { agent: "claude" } });
+    expect(readConfigObject("project", opts())).toEqual({ lens: { agent: "codex" } });
+  });
+
+  it("writes project config under <project-root>/.argent/config.json", () => {
+    setConfigValue("lens.agent", "codex", "project", opts());
+    expect(fs.existsSync(configFilePath("project", opts()))).toBe(true);
+    expect(configFilePath("project", opts())).toBe(path.join(projectDir, ".argent", "config.json"));
+  });
+});
+
+describe("setConfigValue — validation", () => {
+  it("rejects an unknown key", () => {
+    expect(() => setConfigValue("nope.nope", "x", "global", opts())).toThrow(UnknownConfigKeyError);
+  });
+
+  it("rejects a project write for a global-only value via ConfigScopeError", () => {
+    // A settable, global-only definition supplied through the registry param
+    // (telemetry.enabled is global-only too, but it's manageCommand-delegated so
+    // it throws ConfigManagedElsewhereError first — this isolates the scope check).
+    const registry: ConfigDefinition[] = [
+      {
+        key: "test.onlyGlobal",
+        description: "test",
+        scopes: ["global"],
+        parse: (r) => (typeof r === "boolean" ? r : undefined),
+        merge: "prioritize-restrictive",
+      },
+    ];
+    expect(() => setConfigValue("test.onlyGlobal", true, "project", opts(), registry)).toThrow(
+      ConfigScopeError
+    );
+    // Global scope is accepted.
+    expect(() => setConfigValue("test.onlyGlobal", true, "global", opts(), registry)).not.toThrow();
+  });
+
+  it("refuses to set a manageCommand-delegated key (telemetry)", () => {
+    expect(() => setConfigValue("telemetry.enabled", false, "global", opts())).toThrow(
+      ConfigManagedElsewhereError
+    );
+    expect(() => unsetConfigValue("telemetry.enabled", "global", opts())).toThrow(
+      ConfigManagedElsewhereError
+    );
+  });
+
+  it("rejects an invalid value shape", () => {
+    // lens.agent expects a non-blank string.
+    expect(() => setConfigValue("lens.agent", 42, "global", opts())).toThrow(ConfigValidationError);
+    expect(() => setConfigValue("lens.agent", "   ", "global", opts())).toThrow(
+      ConfigValidationError
+    );
+  });
+});
+
+describe("unsetConfigValue", () => {
+  it("removes a stored value and reports whether anything was removed", () => {
+    setConfigValue("lens.agent", "claude", "global", opts());
+    expect(unsetConfigValue("lens.agent", "global", opts())).toBe(true);
+    expect(getConfigValueByKey("lens.agent", opts())).toBeUndefined();
+    expect(unsetConfigValue("lens.agent", "global", opts())).toBe(false);
+  });
+});
+
+describe("listConfig", () => {
+  it("reports every schema entry with per-scope and effective values", () => {
+    setConfigValue("lens.agent", "claude", "global", opts());
+    setConfigValue("lens.agent", "codex", "project", opts());
+    const entries = listConfig(opts());
+    const lens = entries.find((e) => e.key === "lens.agent")!;
+    expect(lens.global).toBe("claude");
+    expect(lens.project).toBe("codex");
+    expect(lens.effective).toBe("codex");
+    const telemetry = entries.find((e) => e.key === "telemetry.enabled")!;
+    expect(telemetry.manageCommand).toBe("argent telemetry");
+    expect(telemetry.scopes).toEqual(["global"]);
+  });
+});
+
+describe("coerceCliValue", () => {
+  it("parses JSON scalars and arrays, falling back to a bare string", () => {
+    expect(coerceCliValue("true")).toBe(true);
+    expect(coerceCliValue("42")).toBe(42);
+    expect(coerceCliValue('["a","b"]')).toEqual(["a", "b"]);
+    expect(coerceCliValue("/tmp/device-set")).toBe("/tmp/device-set");
+    expect(coerceCliValue("claude")).toBe("claude");
+  });
+});
+
+describe("getConfigValue — direct definition + custom-typed default", () => {
+  it("applies the schema default when no scope contributes a value", () => {
+    const def: ConfigDefinition<string> = {
+      key: "demo.value",
+      description: "demo",
+      scopes: ["project", "global"],
+      parse: (r) => (typeof r === "string" && r.trim() ? r.trim() : undefined),
+      merge: "prioritize-local",
+      default: "fallback",
+    };
+    expect(getConfigValue(def, opts())).toBe("fallback");
+  });
+});

--- a/packages/configuration-core/tests/config.test.ts
+++ b/packages/configuration-core/tests/config.test.ts
@@ -3,13 +3,12 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { argentHomeDir, configFilePath } from "../src/paths.js";
+import { readConfigObject, updateConfig } from "../src/config.js";
 import {
-  readConfigObject,
-  updateConfig,
   getRememberedAgent,
   setRememberedAgent,
   clearRememberedAgent,
-} from "../src/config.js";
+} from "../src/config-access.js";
 
 // Redirect the `~/.argent` home into a tmp dir by mutating process.env.HOME
 // (consumed by os.homedir() via argentHomeDir).

--- a/packages/configuration-core/tests/flags.test.ts
+++ b/packages/configuration-core/tests/flags.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import {
   FLAG_REGISTRY,
+  findProjectRoot,
   getFlagDefinition,
   getFlagsPath,
   isFlagEnabled,
@@ -124,6 +125,24 @@ describe("resolveProjectRoot", () => {
     const nested = path.join(tmpProject, "sub");
     fs.mkdirSync(nested);
     expect(resolveProjectRoot(nested)).toBe(tmpProject);
+  });
+});
+
+describe("findProjectRoot", () => {
+  it("returns the marker directory when one exists", () => {
+    const nested = path.join(tmpProject, "a", "b");
+    fs.mkdirSync(nested, { recursive: true });
+    expect(findProjectRoot(nested)).toBe(tmpProject);
+  });
+
+  it("returns null when no marker exists in ancestry (unlike resolveProjectRoot)", () => {
+    const bare = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-flags-noroot-")));
+    try {
+      expect(findProjectRoot(bare)).toBeNull();
+      expect(resolveProjectRoot(bare)).toBe(bare);
+    } finally {
+      fs.rmSync(bare, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/configuration-core/tests/merge.test.ts
+++ b/packages/configuration-core/tests/merge.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { applyMergePolicy, MERGE_PRESETS, type MergeFn } from "../src/merge.js";
+
+describe("applyMergePolicy — presets", () => {
+  it("prioritize-local prefers the project value, falling back to global", () => {
+    expect(applyMergePolicy("prioritize-local", "p", "g")).toBe("p");
+    expect(applyMergePolicy("prioritize-local", undefined, "g")).toBe("g");
+    expect(applyMergePolicy("prioritize-local", "p", undefined)).toBe("p");
+    expect(applyMergePolicy("prioritize-local", undefined, undefined)).toBeUndefined();
+  });
+
+  it("prioritize-global prefers the global value, falling back to project", () => {
+    expect(applyMergePolicy("prioritize-global", "p", "g")).toBe("g");
+    expect(applyMergePolicy("prioritize-global", "p", undefined)).toBe("p");
+    expect(applyMergePolicy("prioritize-global", undefined, "g")).toBe("g");
+  });
+
+  it("prioritize-restrictive: any boolean false (opt-out) wins", () => {
+    expect(applyMergePolicy("prioritize-restrictive", true, false)).toBe(false);
+    expect(applyMergePolicy("prioritize-restrictive", false, true)).toBe(false);
+    expect(applyMergePolicy("prioritize-restrictive", true, true)).toBe(true);
+    // A single defined scope passes through.
+    expect(applyMergePolicy("prioritize-restrictive", undefined, false)).toBe(false);
+    expect(applyMergePolicy("prioritize-restrictive", true, undefined)).toBe(true);
+  });
+
+  it("prioritize-restrictive: numbers take the smaller (stricter) bound", () => {
+    expect(applyMergePolicy("prioritize-restrictive", 5, 3)).toBe(3);
+    expect(applyMergePolicy("prioritize-restrictive", 2, 9)).toBe(2);
+  });
+
+  it("union: de-duplicated concat of both arrays, global first", () => {
+    expect(applyMergePolicy("union", ["b", "c"], ["a", "b"])).toEqual(["a", "b", "c"]);
+    expect(applyMergePolicy("union", undefined, ["a"])).toEqual(["a"]);
+    expect(applyMergePolicy("union", ["a"], undefined)).toEqual(["a"]);
+  });
+
+  it("intersection: elements present in both arrays, order follows project", () => {
+    expect(applyMergePolicy("intersection", ["a", "b", "c"], ["b", "c", "d"])).toEqual(["b", "c"]);
+    // A missing scope imposes no constraint — the present scope passes through.
+    expect(applyMergePolicy("intersection", ["a", "b"], undefined)).toEqual(["a", "b"]);
+    expect(applyMergePolicy("intersection", undefined, ["x"])).toEqual(["x"]);
+    expect(applyMergePolicy("intersection", ["a"], ["b"])).toEqual([]);
+  });
+});
+
+describe("applyMergePolicy — custom function", () => {
+  it("delegates to a supplied merge function", () => {
+    const sum: MergeFn<number> = ({ local, global }) => (local ?? 0) + (global ?? 0);
+    expect(applyMergePolicy(sum, 2, 3)).toBe(5);
+    expect(applyMergePolicy(sum, undefined, 3)).toBe(3);
+  });
+});
+
+describe("MERGE_PRESETS", () => {
+  it("lists every preset name", () => {
+    expect(MERGE_PRESETS).toEqual([
+      "prioritize-local",
+      "prioritize-global",
+      "prioritize-restrictive",
+      "union",
+      "intersection",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a general, **scoped** configuration system on top of the shared `config.json`, plus a universal `argent config` command to manage it. Motivated by the discussion on #401 (iOS device set): config that needs to work naturally with the MCP server should be read off disk at runtime like telemetry consent is — not threaded through CLI flags/env and a kill-and-respawn dance. This lands the reusable machinery; the device-set becomes a one-line schema entry + a runtime reader on top of it.

Four pieces, matching the requirements:

### 1. Project-scope config files
`config.json` now resolves at two scopes:
- `~/.argent/config.json` (**global**, default)
- `<project-root>/.argent/config.json` (**project**, resolved by the same `.argent`/`.git`/`package.json` marker walk as feature flags)

`configFilePath` / `readConfigObject` / `updateConfig` take an optional `scope` (default `global`), so **every existing caller is unchanged** (telemetry, notices, lens). Per-scope lock + atomic write are preserved.

### 2. Schema-driven merged reads
`getConfigValue(def)` reads each scope the value's schema entry allows, merges them under the entry's policy, and falls back to the entry's default. This is the reader consumers should call instead of poking at a single global file. The existing **lens** getters (`getRememberedAgent` etc.) are migrated onto it as the first live consumer — a repo can now pin its lens agent, falling back to the user's global choice.

### 3. A registration file for configurations (`config-schema.ts`)
Adding a configuration is a one-liner: `key`, `description`, allowed `scopes`, a `parse` validator, and a `merge` policy. Merge presets:
- `prioritize-local` (project wins) · `prioritize-global` (global wins)
- `prioritize-restrictive` (booleans/numbers — opt-out/stricter wins)
- `union` / `intersection` (arrays)
- …plus an escape hatch: pass your **own** `(inputs) => value` function for a bespoke rule.

### 4. `argent config` — one universal command
`argent config <list | get | set | unset>` with `--scope global|project` and `--json`. New configs are added as **schema entries**, not new top-level `argent` commands, to avoid bloat.

**Telemetry stays backward-compatible** on its dedicated `argent telemetry` command (which also drains/resets the live client). It's surfaced *read-only* under `argent config` via a `manageCommand` guard — so `argent config set telemetry.enabled` refuses and points at `argent telemetry`, and a committed project file can never re-enable a global opt-out (`prioritize-restrictive`, global-only).

## Testing

- **Unit / integration**: 71 configuration-core tests (merge presets + custom fn, dotted-path + prototype-pollution guards, scope merge, scope/validation/manage-command errors, `listConfig`, `coerceCliValue`) and 11 real-filesystem CLI tests driving the actual `config()` entry point across sandboxed HOME + project cwd. Full suites green: configuration-core 71, argent-cli 268, telemetry 281, argent 60.
- **Live, on the built binary** (`node packages/argent/dist/cli.js …`): set global + project (from a deep subdir) → effective get returns the project value; per-scope gets return each file; both files land in the right place; `argent telemetry disable/enable` writes `config.json` and `argent config get telemetry.enabled` reflects it read-only; unknown-key / invalid-value / bad-scope errors exit non-zero with hints.
- `tsc --build` across the workspace, prettier, and eslint (`--max-warnings 0`) all clean.

## Notes / follow-ups
- Config-file reads are not yet fingerprint-cached the way telemetry's consent read is; a long-lived tool-server re-reads on each `getConfigValue`. Fine for CLI/low-frequency use; a hot runtime consumer (e.g. a future device-set reader) may want the same mtime/inode cache.