### PR TITLE
fix: get ax-service working on ios-remote (sim-remote --json spawn + TCP artifact diagnostics)

### DIFF
--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -100,10 +100,13 @@ const ESM_REQUIRE_BANNER = {
 // only lives under darwin/.
 const BIN_SRC_ROOT = path.resolve(WORKSPACE_ROOT, "packages/native-devtools-ios/bin");
 const AX_BIN_SRC = path.resolve(BIN_SRC_ROOT, "darwin/ax-service");
-const AX_TCP_BIN_SRC = path.resolve(BIN_SRC_ROOT, "darwin/tcp/ax-service");
+// The tcp ax-service lives in a platform-NEUTRAL bin/tcp/ (not bin/darwin/tcp/):
+// it is uploaded to the remote macOS orchestrator, so it must resolve from any
+// host platform. Matches tcpBinDir() in native-devtools-ios/src/index.ts.
+const AX_TCP_BIN_SRC = path.resolve(BIN_SRC_ROOT, "tcp/ax-service");
 const BIN_DIR = path.resolve(__dirname, "../bin");
 const AX_BIN_DEST = path.resolve(BIN_DIR, "darwin/ax-service");
-const AX_TCP_BIN_DEST = path.resolve(BIN_DIR, "darwin/tcp/ax-service");
+const AX_TCP_BIN_DEST = path.resolve(BIN_DIR, "tcp/ax-service");
 // tvOS control binaries. Both are macOS-only: tvos-ax-service runs inside an
 // appletvsimulator, tvos-hid-daemon runs on the host. Unix-socket only.
 const TVOS_AX_BIN_SRC = path.resolve(BIN_SRC_ROOT, "darwin/tvos-ax-service");

--- a/packages/native-devtools-ios/scripts/build.sh
+++ b/packages/native-devtools-ios/scripts/build.sh
@@ -54,7 +54,10 @@ SRC_DIR="${SUBMODULE_DIR}/Sources/NativeDevtoolsIos"
 
 if [[ "$TRANSPORT" == "tcp" ]]; then
   DEST_DIR="${ROOT_DIR}/dylibs/tcp"
-  BIN_DIR="${ROOT_DIR}/bin/darwin/tcp"
+  # Platform-neutral: the tcp ax-service is an iOS-sim binary uploaded to the
+  # remote macOS orchestrator, so it must be resolvable from any host platform
+  # (not nested under bin/darwin/). Matches tcpBinDir() in src/index.ts.
+  BIN_DIR="${ROOT_DIR}/bin/tcp"
 else
   DEST_DIR="${ROOT_DIR}/dylibs"
   BIN_DIR="${ROOT_DIR}/bin/darwin"

--- a/packages/native-devtools-ios/src/index.ts
+++ b/packages/native-devtools-ios/src/index.ts
@@ -36,6 +36,29 @@ function requireDylibIn(dir: string, name: string): string {
   return p;
 }
 
+// The TCP-transport artifacts (`*Tcp` accessors) are only needed for ios-remote
+// (sim-remote) devices, and are built/downloaded separately from the default
+// unix-socket set — so they can be legitimately absent in a local/dev build or
+// an older package. When one is missing the caller (spawnAxDaemonRemote /
+// native-devtools setup) throws deep inside the ax-service factory, where
+// `describe` swallows it into a "reboot the simulator" hint that has nothing to
+// do with the real cause. Give an actionable, self-explaining error instead:
+// name the exact path, the env override that relocates the lookup, and how to
+// produce the binary.
+function requireTcpArtifact(dir: string, name: string, kind: "binary" | "dylib", envVar: string): string {
+  const p = path.join(dir, name);
+  if (!fs.existsSync(p)) {
+    throw new Error(
+      `TCP-transport ${kind} not found: ${p}. This ${kind} is required to drive an ` +
+        `ios-remote (sim-remote) device over the QUIC tunnel. It ships in the argent ` +
+        `package under bin/<platform>/tcp/ and dylibs/tcp/; if you are running a local ` +
+        `build, produce it with \`npm run build:ios-binaries:tcp\`. To point the lookup ` +
+        `at a directory that already contains it, set ${envVar}=<dir>.`
+    );
+  }
+  return p;
+}
+
 export const bootstrapDylibPath = () => {
   requireDarwin("bootstrapDylibPath");
   return requireDylibIn(DYLIB_DIR, "libArgentInjectionBootstrap.dylib");
@@ -50,7 +73,12 @@ export const keyboardPatchDylibPath = () => {
 };
 
 export const bootstrapDylibPathTcp = () => {
-  return requireDylibIn(DYLIB_TCP_DIR, "libArgentInjectionBootstrap.dylib");
+  return requireTcpArtifact(
+    DYLIB_TCP_DIR,
+    "libArgentInjectionBootstrap.dylib",
+    "dylib",
+    "ARGENT_NATIVE_DEVTOOLS_TCP_DIR"
+  );
 };
 
 export const bootstrapDylibPathTvos = () => {
@@ -62,10 +90,20 @@ export const nativeDevtoolsDylibPathTvos = () => {
   return requireDylibIn(DYLIB_TVOS_DIR, "libNativeDevtoolsIos.dylib");
 };
 export const nativeDevtoolsDylibPathTcp = () => {
-  return requireDylibIn(DYLIB_TCP_DIR, "libNativeDevtoolsIos.dylib");
+  return requireTcpArtifact(
+    DYLIB_TCP_DIR,
+    "libNativeDevtoolsIos.dylib",
+    "dylib",
+    "ARGENT_NATIVE_DEVTOOLS_TCP_DIR"
+  );
 };
 export const keyboardPatchDylibPathTcp = () => {
-  return requireDylibIn(DYLIB_TCP_DIR, "libKeyboardPatch.dylib");
+  return requireTcpArtifact(
+    DYLIB_TCP_DIR,
+    "libKeyboardPatch.dylib",
+    "dylib",
+    "ARGENT_NATIVE_DEVTOOLS_TCP_DIR"
+  );
 };
 
 /**
@@ -143,7 +181,12 @@ export function axServiceBinaryPath(): string {
 }
 
 export function axServiceBinaryPathTcp(): string {
-  return requireBinIn(platformTcpBinDir(), "ax-service");
+  return requireTcpArtifact(
+    platformTcpBinDir(),
+    "ax-service",
+    "binary",
+    "ARGENT_SIMULATOR_SERVER_TCP_DIR"
+  );
 }
 
 // tvOS control binaries. tvos-ax-service is `simctl spawn`d into an

--- a/packages/native-devtools-ios/src/index.ts
+++ b/packages/native-devtools-ios/src/index.ts
@@ -45,15 +45,20 @@ function requireDylibIn(dir: string, name: string): string {
 // do with the real cause. Give an actionable, self-explaining error instead:
 // name the exact path, the env override that relocates the lookup, and how to
 // produce the binary.
-function requireTcpArtifact(dir: string, name: string, kind: "binary" | "dylib", envVar: string): string {
+function requireTcpArtifact(
+  dir: string,
+  name: string,
+  kind: "binary" | "dylib",
+  envVar: string
+): string {
   const p = path.join(dir, name);
   if (!fs.existsSync(p)) {
     throw new Error(
       `TCP-transport ${kind} not found: ${p}. This ${kind} is required to drive an ` +
         `ios-remote (sim-remote) device over the QUIC tunnel. It ships in the argent ` +
-        `package under bin/<platform>/tcp/ and dylibs/tcp/; if you are running a local ` +
-        `build, produce it with \`npm run build:ios-binaries:tcp\`. To point the lookup ` +
-        `at a directory that already contains it, set ${envVar}=<dir>.`
+        `package under bin/tcp/ and dylibs/tcp/ (platform-neutral); if you are running a ` +
+        `local build, produce it with \`npm run build:ios-binaries:tcp\`. To point the ` +
+        `lookup at a directory that already contains it, set ${envVar}=<dir>.`
     );
   }
   return p;
@@ -141,9 +146,16 @@ export function hostPlatformKey(): string {
 function platformBinDir(): string {
   return path.join(BIN_DIR, hostPlatformKey());
 }
-// TCP dir: <platform>/tcp by default; ARGENT_SIMULATOR_SERVER_TCP_DIR overrides the whole path.
-function platformTcpBinDir(): string {
-  return process.env.ARGENT_SIMULATOR_SERVER_TCP_DIR ?? path.join(platformBinDir(), "tcp");
+// TCP dir: platform-NEUTRAL bin/tcp by default; ARGENT_SIMULATOR_SERVER_TCP_DIR
+// overrides the whole path. Unlike simulator-server and the unix ax-service —
+// host binaries that live under bin/<hostPlatform>/ — the tcp ax-service is an
+// iOS-simulator (darwin) binary that gets uploaded to and `simctl spawn`d on the
+// *remote* macOS orchestrator. It is therefore needed regardless of the host
+// platform and must NOT sit under a host-platform subdir: a Linux host would
+// resolve bin/linux/tcp and never find the darwin-built binary. This mirrors the
+// already-neutral dylibs/tcp location.
+function tcpBinDir(): string {
+  return process.env.ARGENT_SIMULATOR_SERVER_TCP_DIR ?? path.join(BIN_DIR, "tcp");
 }
 
 export function simulatorServerBinaryPath(): string {
@@ -181,12 +193,7 @@ export function axServiceBinaryPath(): string {
 }
 
 export function axServiceBinaryPathTcp(): string {
-  return requireTcpArtifact(
-    platformTcpBinDir(),
-    "ax-service",
-    "binary",
-    "ARGENT_SIMULATOR_SERVER_TCP_DIR"
-  );
+  return requireTcpArtifact(tcpBinDir(), "ax-service", "binary", "ARGENT_SIMULATOR_SERVER_TCP_DIR");
 }
 
 // tvOS control binaries. tvos-ax-service is `simctl spawn`d into an

--- a/packages/native-devtools-ios/test/index.test.ts
+++ b/packages/native-devtools-ios/test/index.test.ts
@@ -106,6 +106,22 @@ describe("requireDarwin gating", () => {
     const r = await loadResolver();
     expect(() => r.bootstrapDylibPathTcp()).toThrow(/dylib not found/);
     expect(() => r.bootstrapDylibPathTcp()).not.toThrow(/requires a macOS host/);
+    // The error must be self-servicing: name the override env var so a user
+    // hitting a stale/dev build learns how to relocate the lookup.
+    expect(() => r.bootstrapDylibPathTcp()).toThrow(/ARGENT_NATIVE_DEVTOOLS_TCP_DIR/);
+  });
+
+  it("throws an actionable not-found (naming the override env) for a missing TCP ax-service", async () => {
+    // A missing TCP ax-service otherwise surfaces deep in describe as a
+    // misleading "reboot the simulator" hint; the resolver error must instead
+    // point at the override env so the real cause is diagnosable.
+    setPlatform("darwin");
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "ax-tcp-missing-"));
+    fs.mkdirSync(path.join(dir, "darwin", "tcp"), { recursive: true });
+    process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
+    const r = await loadResolver();
+    expect(() => r.axServiceBinaryPathTcp()).toThrow(/TCP-transport binary not found/);
+    expect(() => r.axServiceBinaryPathTcp()).toThrow(/ARGENT_SIMULATOR_SERVER_TCP_DIR/);
   });
 
   it("throws with a root-cause message on linux for ax-service", async () => {

--- a/packages/native-devtools-ios/test/index.test.ts
+++ b/packages/native-devtools-ios/test/index.test.ts
@@ -97,6 +97,32 @@ describe("requireDarwin gating", () => {
     expect(r.keyboardPatchDylibPathTcp()).toBe(path.join(dir, "libKeyboardPatch.dylib"));
   });
 
+  it("resolves TCP dylibs from the default dylibs/tcp on linux (neutral, no override)", async () => {
+    // Without the tcp override env, the tcp dylib dir defaults to DYLIB_DIR/tcp —
+    // platform-NEUTRAL, exactly like the tcp ax-service's bin/tcp. Resolving from
+    // the base dir on a Linux host must land under tcp/, never a host-platform
+    // subdir, since these are darwin artifacts uploaded to the remote orchestrator.
+    setPlatform("linux");
+    const base = fs.mkdtempSync(path.join(tmpRoot, "dylibs-base-"));
+    const tcpDir = path.join(base, "tcp");
+    fs.mkdirSync(tcpDir, { recursive: true });
+    fs.writeFileSync(path.join(tcpDir, "libArgentInjectionBootstrap.dylib"), "");
+    fs.writeFileSync(path.join(tcpDir, "libNativeDevtoolsIos.dylib"), "");
+    fs.writeFileSync(path.join(tcpDir, "libKeyboardPatch.dylib"), "");
+    process.env.ARGENT_NATIVE_DEVTOOLS_DIR = base;
+    try {
+      const r = await loadResolver();
+      expect(r.bootstrapDylibPathTcp()).toBe(
+        path.join(tcpDir, "libArgentInjectionBootstrap.dylib")
+      );
+      expect(r.nativeDevtoolsDylibPathTcp()).toBe(path.join(tcpDir, "libNativeDevtoolsIos.dylib"));
+      expect(r.keyboardPatchDylibPathTcp()).toBe(path.join(tcpDir, "libKeyboardPatch.dylib"));
+    } finally {
+      if (originalDevtoolsDir === undefined) delete process.env.ARGENT_NATIVE_DEVTOOLS_DIR;
+      else process.env.ARGENT_NATIVE_DEVTOOLS_DIR = originalDevtoolsDir;
+    }
+  });
+
   it("throws a plain not-found (not a macOS-host error) for missing TCP dylibs on linux", async () => {
     // When the TCP artifacts haven't been downloaded, the file-existence check
     // gives a "not found" error — never the "requires a macOS host" gate.

--- a/packages/native-devtools-ios/test/index.test.ts
+++ b/packages/native-devtools-ios/test/index.test.ts
@@ -117,7 +117,7 @@ describe("requireDarwin gating", () => {
     // point at the override env so the real cause is diagnosable.
     setPlatform("darwin");
     const dir = fs.mkdtempSync(path.join(tmpRoot, "ax-tcp-missing-"));
-    fs.mkdirSync(path.join(dir, "darwin", "tcp"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "tcp"), { recursive: true });
     process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
     const r = await loadResolver();
     expect(() => r.axServiceBinaryPathTcp()).toThrow(/TCP-transport binary not found/);
@@ -133,13 +133,14 @@ describe("requireDarwin gating", () => {
     expect(() => r.axServiceBinaryPath()).toThrow(/requires a macOS host/);
   });
 
-  it("resolves the ax-service TCP binary on linux (remote upload artifact)", async () => {
+  it("resolves the ax-service TCP binary from the platform-neutral bin/tcp on linux", async () => {
     // The TCP ax-service is uploaded to and `simctl spawn`d on the remote Mac
-    // orchestrator, so a Linux host must be able to resolve it — no darwin gate.
+    // orchestrator, so a Linux host must resolve it from the neutral bin/tcp —
+    // NOT bin/linux/tcp, which would never hold the darwin-built binary.
     setPlatform("linux");
     setArch("x64");
     const dir = fs.mkdtempSync(path.join(tmpRoot, "ax-tcp-linux-"));
-    const tcpDir = path.join(dir, "linux", "tcp");
+    const tcpDir = path.join(dir, "tcp");
     fs.mkdirSync(tcpDir, { recursive: true });
     const binPath = path.join(tcpDir, "ax-service");
     fs.writeFileSync(binPath, "", { mode: 0o755 });
@@ -269,10 +270,11 @@ describe("ax-service path resolution", () => {
     expect(r.axServiceBinaryPath()).toBe(binPath);
   });
 
-  it("joins process.platform/tcp into the ax-service TCP bin path", async () => {
-    if (originalPlatform !== "darwin") return;
+  it("resolves the ax-service TCP binary from the platform-neutral bin/tcp", async () => {
+    // The tcp ax-service is host-platform-independent (uploaded to the remote
+    // orchestrator), so it resolves at bin/tcp — not bin/<hostPlatform>/tcp.
     const dir = fs.mkdtempSync(path.join(tmpRoot, "ax-tcp-"));
-    const tcpDir = path.join(dir, "darwin", "tcp");
+    const tcpDir = path.join(dir, "tcp");
     fs.mkdirSync(tcpDir, { recursive: true });
     const binPath = path.join(tcpDir, "ax-service");
     fs.writeFileSync(binPath, "", { mode: 0o755 });

--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -16,6 +16,17 @@ import { adaptNativeDescribeToDescribeResult } from "./ios-native-adapter";
 const DEGRADED_HINT =
   "This simulator was not booted through argent — system dialogs and native modals may not appear. You MUST call boot-device with force=true now to restart the simulator and apply full accessibility settings before continuing.";
 
+// The ios-remote (sim-remote) path needs the TCP-transport ax-service binary and
+// dylibs, which are shipped/built separately and can be absent in a local or old
+// build. When they are, the ax-service factory throws a "TCP-transport ... not
+// found" error that has nothing to do with the simulator's boot state — so
+// steer clear of DEGRADED_HINT (which tells the agent to force-reboot, a dead
+// end here) and surface the resolver's actionable message verbatim instead.
+function tcpArtifactHint(err: unknown): string | undefined {
+  const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return /TCP-transport (?:binary|dylib) not found/.test(message) ? message : undefined;
+}
+
 // tvOS classifies as platform "ios" by UDID shape. The `describe` tool routes
 // TV targets to the focus-driven `describeTv` before this iOS branch runs, so
 // the short-circuit below is only reached by internal callers that invoke
@@ -93,11 +104,13 @@ export async function describeIos(
     const response = await axApi.describe();
     tree = adaptAXDescribeToDescribeResult(response);
     hint = axApi.degraded ? DEGRADED_HINT : undefined;
-  } catch {
+  } catch (err) {
     // ax-service failed to start or timed out — treat as degraded with an
-    // empty tree so we still attempt the native-devtools fallback below.
+    // empty tree so we still attempt the native-devtools fallback below. A
+    // missing TCP-transport artifact (ios-remote) is a config error, not a boot
+    // state one: surface its actionable message instead of the reboot hint.
     tree = emptyTree();
-    hint = DEGRADED_HINT;
+    hint = tcpArtifactHint(err) ?? DEGRADED_HINT;
   }
 
   if (tree.children.length > 0) {

--- a/packages/tool-server/src/utils/sim-remote.ts
+++ b/packages/tool-server/src/utils/sim-remote.ts
@@ -167,6 +167,12 @@ export async function simctlSpawn(
   const cmd = ["spawn", stripRemotePrefix(udid)];
   if (opts.binPath) cmd.push("--bin", opts.binPath);
   if (opts.detach) cmd.push("--detach");
+  // Force the one-shot `{exit_code,stdout,stderr}` (or `{pid}` when detached)
+  // JSON object. Without `--json`, a non-detached `sim-remote spawn` streams the
+  // child's raw output live, which we then fail to `JSON.parse` below. `--detach`
+  // happens to emit JSON regardless, but the non-detached callers (bootstrapAx's
+  // `defaults write`, listRunningBundleIds' `launchctl list`) need this flag.
+  cmd.push("--json");
   const args = opts.args ?? [];
   if (args.length > 0) cmd.push("--", ...args);
   // Uploading a binary can take a moment; allow more than the default.

--- a/packages/tool-server/test/sim-remote-spawn-json.test.ts
+++ b/packages/tool-server/test/sim-remote-spawn-json.test.ts
@@ -33,7 +33,9 @@ beforeEach(() => {
 
 describe("simctlSpawn --json", () => {
   it("passes --json for a non-detached in-simulator argv", async () => {
-    await simctlSpawn("remote:ABCD1234", { args: ["defaults", "write", "com.apple.Accessibility", "X"] });
+    await simctlSpawn("remote:ABCD1234", {
+      args: ["defaults", "write", "com.apple.Accessibility", "X"],
+    });
     expect(calls).toHaveLength(1);
     const { cmd, args } = calls[0];
     expect(cmd).toBe("sim-remote");

--- a/packages/tool-server/test/sim-remote-spawn-json.test.ts
+++ b/packages/tool-server/test/sim-remote-spawn-json.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// `simctlSpawn` parses the CLI's stdout as one `{exit_code,stdout,stderr}` (or
+// `{pid}`) JSON object. `sim-remote spawn` only emits that object when passed
+// `--json`; without it a non-detached spawn streams the child's raw output live,
+// which then fails `JSON.parse` ("Unexpected end of JSON input"). These tests
+// pin `--json` onto every spawn argv so the regression that broke every
+// ios-remote describe (via bootstrapAx's `defaults write`) can't come back.
+const calls: Array<{ cmd: string; args: readonly string[] }> = [];
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFile: (
+      cmd: string,
+      args: readonly string[],
+      _opts: unknown,
+      cb?: (err: Error | null, out: { stdout: string; stderr: string }) => void
+    ) => {
+      const callback = typeof _opts === "function" ? _opts : cb!;
+      calls.push({ cmd, args });
+      callback(null, { stdout: '{"exit_code":0,"pid":null,"stdout":"","stderr":""}', stderr: "" });
+    },
+  };
+});
+
+import { simctlSpawn } from "../src/utils/sim-remote";
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+describe("simctlSpawn --json", () => {
+  it("passes --json for a non-detached in-simulator argv", async () => {
+    await simctlSpawn("remote:ABCD1234", { args: ["defaults", "write", "com.apple.Accessibility", "X"] });
+    expect(calls).toHaveLength(1);
+    const { cmd, args } = calls[0];
+    expect(cmd).toBe("sim-remote");
+    expect(args).toContain("--json");
+    // `--json` must precede the `--` argv separator so it is parsed as an option.
+    expect(args.indexOf("--json")).toBeLessThan(args.indexOf("--"));
+    // Everything after `--` is the in-simulator argv, untouched.
+    expect(args.slice(args.indexOf("--") + 1)).toEqual([
+      "defaults",
+      "write",
+      "com.apple.Accessibility",
+      "X",
+    ]);
+  });
+
+  it("passes --json alongside --bin and --detach for the ax-service daemon spawn", async () => {
+    await simctlSpawn("remote:ABCD1234", {
+      binPath: "/path/to/tcp/ax-service",
+      args: ["--port", "5000", "--timeout", "3600"],
+      detach: true,
+    });
+    const { args } = calls[0];
+    expect(args).toContain("--json");
+    expect(args).toContain("--detach");
+    expect(args).toContain("--bin");
+  });
+});

--- a/scripts/download-native-binaries.sh
+++ b/scripts/download-native-binaries.sh
@@ -118,17 +118,20 @@ fi
 # dylibs over a TCP socket tunnelled by sim-remote, rather than the AF_UNIX
 # sockets the local path uses — so it needs -DARGENT_USE_TCP=1 builds kept in a
 # separate tcp/ slot (axServiceBinaryPathTcp()/bootstrapDylibPathTcp() read from
-# bin/darwin/tcp/ and dylibs/tcp/). Like the tvOS dylibs, the three TCP dylibs
-# share basenames with the flat iOS dylibs, so they ship as a tarball extracted
-# into dylibs/tcp/; tcp-ax-service has a unique release name and lands flat as
-# bin/darwin/tcp/ax-service.
+# bin/tcp/ and dylibs/tcp/). Both are platform-NEUTRAL: these are darwin/iOS-sim
+# artifacts uploaded to and run on the *remote* macOS orchestrator, so they must
+# resolve from any host platform (a Linux host must not look under bin/linux/).
+# Like the tvOS dylibs, the three TCP dylibs share basenames with the flat iOS
+# dylibs, so they ship as a tarball extracted into dylibs/tcp/; tcp-ax-service
+# has a unique release name and lands flat as bin/tcp/ax-service.
 #
 # These assets only exist on releases built with TCP support. A pre-sim-remote
 # tag simply has no TCP artifacts, so a missing asset is skipped with a warning
 # rather than aborting the whole download (`gh release download` exits non-zero
 # on no match, which under `set -e` would otherwise leave a half-populated tree).
 TCP_DYLIBS_DIR="${DYLIBS_DIR}/tcp"
-TCP_BIN_DIR="${IOS_BIN_DIR}/tcp"
+# Platform-neutral (bin/tcp, not bin/darwin/tcp): see the comment above.
+TCP_BIN_DIR="${BIN_DIR}/tcp"
 mkdir -p "${TCP_DYLIBS_DIR}" "${TCP_BIN_DIR}"
 
 echo "  Downloading TCP dylibs..."


### PR DESCRIPTION
## Summary

Three fixes that together get `describe` (and the other ax-service / native-devtools tools) working against **ios-remote** (`sim-remote`) devices — including from a **Linux** host. Reproduced end-to-end against a live remote iPhone 17 simulator over the QUIC relay.

Before: `argent run describe --udid remote:<UDID>` returned an empty `ROOT AXGroup` with a misleading "reboot the simulator" hint.

### 1. `sim-remote spawn` output was never valid JSON (`fix(tool-server)`)

`simctlSpawn` parses the CLI's stdout as one `{exit_code,stdout,stderr}` (or `{pid}`) JSON object, but `sim-remote spawn` only emits that when passed `--json`. Without it a **non-detached** spawn streams the child's raw output live, so `JSON.parse` throws `Unexpected end of JSON input`.

This broke ios-remote describe at the first step: `remoteIosHost.bootstrapAx` runs `defaults write com.apple.Accessibility …` through a non-detached `simctlSpawn`, which failed before the ax-service daemon ever started — surfacing only as an empty AX tree. Fix: pass `--json` unconditionally (no-op for the already-JSON `--detach` path).

### 2. The tcp ax-service was resolved/packaged under a host-platform dir (`fix(native-devtools-ios)`)

The tcp `ax-service` is a **darwin/iOS-simulator** binary that is uploaded to and `simctl spawn`d on the **remote** macOS orchestrator, so it's needed on any *host* platform. But it was resolved (and packaged) under `bin/<hostPlatform>/tcp` via `platformBinDir()`, so a **Linux host looked at `bin/linux/tcp` and never found the darwin-built binary** — the ios-remote path was effectively macOS-host-only. (The tcp dylibs were already neutral at `dylibs/tcp`.)

Moved it to a platform-neutral `bin/tcp`, mirroring `dylibs/tcp`, and rewired every producer/consumer:
- resolver: `platformTcpBinDir()` → `tcpBinDir()` = `BIN_DIR/tcp`
- `native-devtools-ios/scripts/build.sh`: `bin/darwin/tcp` → `bin/tcp`
- `scripts/download-native-binaries.sh`: `TCP_BIN_DIR` → `bin/tcp`
- `packages/argent/scripts/bundle-tools.cjs`: copy from/to `bin/tcp`
- tests assert the neutral location on both linux and darwin

### 3. Missing tcp artifacts were undiagnosable (`fix(native-devtools-ios)`)

When a tcp artifact is absent (local/dev build, older package), the bare `... not found` error was thrown deep in the ax-service factory, where `describeIos` swallowed it and returned an empty tree plus `DEGRADED_HINT` — telling the agent to `boot-device --force`, a dead end. The only escape was discovering `ARGENT_SIMULATOR_SERVER_TCP_DIR` by reading source. Fix: `requireTcpArtifact` throws an actionable error naming the exact path, the override env var, and how to build it; `describeIos` surfaces that instead of the reboot hint.

## Testing

- New `sim-remote-spawn-json.test.ts` — asserts `--json` on both plain and `--bin/--detach` argv, before the `--` separator.
- `native-devtools-ios/test/index.test.ts` — the tcp binary resolves from the neutral `bin/tcp` on **both** linux and darwin; the not-found errors name their override env var.
- `native-devtools-ios` (16) + ios/describe tool-server suites pass; typecheck, eslint, prettier clean.
- Manual end-to-end against `remote:<UDID>` (darwin host): binary at `bin/tcp` → full tree from `source: "ax-service"`, no hint; binary removed → actionable `ARGENT_SIMULATOR_SERVER_TCP_DIR` hint.
