### PR TITLE
fix(tool-server): remove self-referential node_modules symlink committed in #476

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 .yarn
 
 # Build outputs
@@ -6,7 +6,7 @@ dist/
 build/
 packages/*/dist/
 packages/*/build/
-packages/*/node_modules/
+packages/*/node_modules
 
 # TypeScript build info
 *.tsbuildinfo

--- a/packages/tool-server/node_modules
+++ b/packages/tool-server/node_modules
@@ -1,1 +1,0 @@
-/Users/ignacylatka/dev/argent/packages/tool-server/node_modules


### PR DESCRIPTION
## What

`packages/tool-server/node_modules` is tracked in git as a **self-referential symlink** — mode `120000`, target `/Users/.../packages/tool-server/node_modules` (it points at itself). It was introduced in `300bc30e` (#476) and is the only tracked `node_modules` in the repo; sibling packages have plain empty dirs.

Every clone/pull of `main` now materializes a circular **ELOOP** link that breaks any recursive directory walker (`find`, globbers, bundlers, backup tools). Runtime is unaffected — deps hoist to the root `node_modules`, so the loop is silently bypassed.

## Why it slipped past `.gitignore`

The `node_modules/` and `packages/*/node_modules/` rules have a **trailing slash → directories only**. Git treats a symlink as a file (blob), so neither rule matched and the path was addable → it rode into #476. `git check-ignore` confirmed it was NOT ignored.

## Fix

- Remove the tracked self-symlink.
- Drop the trailing slash on both ignore rules so a `node_modules` of **any** type (dir, file, or symlink) is ignored — verified with `git check-ignore` that a symlink at `packages/*/node_modules` is now refused.

No runtime code touched.