### PR TITLE
fix(ci): check tcp ax-service at its platform-neutral bin/tcp path

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -128,8 +128,9 @@ jobs:
       # native-devtools variants the remote code path spawns/injects over a
       # sim-remote-tunnelled TCP socket. Absent from 0.15.0 because the release
       # never built them; gate the publish so they can't silently regress again.
-      # (Host=darwin here, so axServiceBinaryPathTcp() resolves bin/darwin/tcp.)
-      - run: test -x packages/argent/bin/darwin/tcp/ax-service
+      # (bin/tcp is platform-NEUTRAL — axServiceBinaryPathTcp() resolves
+      # bin/tcp on every host, never a bin/<platform>/tcp subdir.)
+      - run: test -x packages/argent/bin/tcp/ax-service
       - run: test -f packages/argent/dylibs/tcp/libNativeDevtoolsIos.dylib
       - run: test -f packages/argent/dylibs/tcp/libKeyboardPatch.dylib
       - run: test -f packages/argent/dylibs/tcp/libArgentInjectionBootstrap.dylib

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,8 +92,9 @@ jobs:
       # native-devtools variants the remote code path spawns/injects over a
       # sim-remote-tunnelled TCP socket. Absent from 0.15.0 because the release
       # never built them; gate the publish so they can't silently regress again.
-      # (Host=darwin here, so axServiceBinaryPathTcp() resolves bin/darwin/tcp.)
-      - run: test -x packages/argent/bin/darwin/tcp/ax-service
+      # (bin/tcp is platform-NEUTRAL — axServiceBinaryPathTcp() resolves
+      # bin/tcp on every host, never a bin/<platform>/tcp subdir.)
+      - run: test -x packages/argent/bin/tcp/ax-service
       - run: test -f packages/argent/dylibs/tcp/libNativeDevtoolsIos.dylib
       - run: test -f packages/argent/dylibs/tcp/libKeyboardPatch.dylib
       - run: test -f packages/argent/dylibs/tcp/libArgentInjectionBootstrap.dylib


### PR DESCRIPTION
## Problem

Every **Publish prerelease to npm (next)** run on main has failed since #536 landed (e.g. [run 29897926322](https://github.com/software-mansion/argent/actions/runs/29897926322/job/88851967242)), blocking canaries — including the canary that would ship the ios-remote ax-service fix itself.

The failing step is the sanity check:

```
test -x packages/argent/bin/darwin/tcp/ax-service
```

But the binary is fine — the job log right above the failure shows `✓ Copied ax-service (tcp) binary → bin/tcp/ax-service`. The whole pipeline deliberately uses the **platform-neutral** `bin/tcp/` slot, not `bin/darwin/tcp/`:

- `scripts/download-native-binaries.sh` writes to `bin/tcp/ax-service`
- `bundle-tools.cjs` copies from/to `bin/tcp/ax-service`
- `axServiceBinaryPathTcp()` / `tcpBinDir()` in `native-devtools-ios` resolve `bin/tcp` on every host

The neutrality is intentional: the tcp ax-service is a darwin/iOS-sim binary uploaded to and `simctl spawn`'d on the *remote* macOS orchestrator, so a Linux host must still resolve it — `bin/linux/tcp` would never match. Only the sanity checks (and their comments) got the path wrong.

## Fix

- Point the check in `publish-next.yml` and `publish.yml` at `packages/argent/bin/tcp/ax-service` (the stable-release workflow had the identical wrong path and would have failed the same way on the next release).
- Correct the comment claiming `axServiceBinaryPathTcp()` resolves `bin/darwin/tcp`.

Note: `packages/argent-private/.github/workflows/build-native-binaries.yml:549` has the same stale comment ("download-native-binaries.sh writes it to bin/darwin/tcp/ax-service") — that lives in the private submodule repo, so it isn't part of this PR.

## Testing

Verified against the failing run's log (binary lands at `bin/tcp/ax-service`, check looks in `bin/darwin/tcp/`) and cross-checked all three path producers/consumers listed above. `grep -rn 'darwin/tcp'` now only matches comments explaining why the path is *not* used.