### PR TITLE
feat(config): `ios.additionalDeviceSets` — additive array of extra CoreSimulator device sets

### DIFF
--- a/packages/argent-cli/test/config-command.test.ts
+++ b/packages/argent-cli/test/config-command.test.ts
@@ -84,6 +84,31 @@ describe("argent config — set/get across scopes", () => {
     expect(projCfg).toEqual({ lens: { agent: "codex" } });
   });
 
+  it("an additive array key (ios.additionalDeviceSets) unions the scopes instead of shadowing", () => {
+    config([
+      "set",
+      "ios.additionalDeviceSets",
+      '["/tmp/sets/a","/tmp/sets/b"]',
+      "--scope",
+      "global",
+    ]);
+    config([
+      "set",
+      "ios.additionalDeviceSets",
+      '["/tmp/sets/b","/tmp/sets/c"]',
+      "--scope",
+      "project",
+    ]);
+    logSpy.mockClear();
+    // Effective value = global baseline + project extras, deduplicated.
+    config(["get", "ios.additionalDeviceSets"]);
+    expect(output()).toBe('["/tmp/sets/a","/tmp/sets/b","/tmp/sets/c"]');
+    logSpy.mockClear();
+    // Each scope still stores (and reports) only its own entries.
+    config(["get", "ios.additionalDeviceSets", "--scope", "project"]);
+    expect(output()).toBe('["/tmp/sets/b","/tmp/sets/c"]');
+  });
+
   it("get --scope shows only that scope's stored value", () => {
     config(["set", "lens.agent", "claude", "--scope", "global"]);
     config(["set", "lens.agent", "codex", "--scope", "project"]);

--- a/packages/configuration-core/src/config-access.ts
+++ b/packages/configuration-core/src/config-access.ts
@@ -7,8 +7,9 @@
 // `unsetConfigValue` validate against the schema before writing. `argent config`
 // and the migrated lens getters are both thin wrappers over these.
 
-import type { FlagScope } from "./flags.js";
-import type { ConfigPathOptions } from "./paths.js";
+import * as path from "node:path";
+import { resolveProjectRoot, type FlagScope } from "./flags.js";
+import { resolveHomeDir, type ConfigPathOptions } from "./paths.js";
 import { readConfigObject, updateConfig, getAtPath, setAtPath, deleteAtPath } from "./config.js";
 import { applyMergePolicy } from "./merge.js";
 import { CONFIG_SCHEMA, getConfigDefinition, type ConfigDefinition } from "./config-schema.js";
@@ -232,4 +233,48 @@ export function setRememberedAgent(agentId: string, options: ConfigPathOptions =
 /** Forget the remembered `argent lens` agent (so the picker shows again). */
 export function clearRememberedAgent(options: ConfigPathOptions = {}): void {
   unsetConfigValue(LENS_AGENT_KEY, "global", options);
+}
+
+// ── iOS additional device sets ────────────────────────────────────────────
+// `ios.additionalDeviceSets` is the first *additive* entry: instead of one
+// scope shadowing the other, the union of both applies — a repo can commit the
+// device sets its tooling needs and they extend (never replace) the user's
+// global ones. This reader is the runtime surface iOS tooling should call.
+
+const IOS_ADDITIONAL_DEVICE_SETS_KEY = "ios.additionalDeviceSets";
+
+/**
+ * The extra CoreSimulator device-set directories argent should consider, as
+ * normalized absolute paths. Entries are read per scope so relative paths keep
+ * their intuitive base — the project root for the project scope, the home
+ * directory for global — and `~`/`~/…` expands to home in either. Order
+ * matches the `union` merge preset (global baseline first, project extras
+ * after) with post-normalization duplicates dropped. Empty when unset.
+ */
+export function getAdditionalIosDeviceSets(options: ConfigPathOptions = {}): string[] {
+  const def = requireDefinition(IOS_ADDITIONAL_DEVICE_SETS_KEY) as ConfigDefinition<string[]>;
+  const home = resolveHomeDir(options);
+  const global = resolveDeviceSetEntries(readScopeValue(def, "global", options), home, home);
+  const project = resolveDeviceSetEntries(
+    readScopeValue(def, "project", options),
+    () => resolveProjectRoot(options.cwd ?? process.cwd()),
+    home
+  );
+  return Array.from(new Set([...global, ...project]));
+}
+
+/** Resolve one scope's entries against its base; `base` is lazy so the
+ * project-root walk only runs when the project scope actually has entries. */
+function resolveDeviceSetEntries(
+  entries: string[] | undefined,
+  base: string | (() => string),
+  home: string
+): string[] {
+  if (!entries || entries.length === 0) return [];
+  const baseDir = typeof base === "function" ? base() : base;
+  return entries.map((entry) => {
+    if (entry === "~") return path.normalize(home);
+    if (entry.startsWith("~/")) return path.join(home, entry.slice(2));
+    return path.resolve(baseDir, entry);
+  });
 }

--- a/packages/configuration-core/src/config-access.ts
+++ b/packages/configuration-core/src/config-access.ts
@@ -253,28 +253,37 @@ const IOS_ADDITIONAL_DEVICE_SETS_KEY = "ios.additionalDeviceSets";
  */
 export function getAdditionalIosDeviceSets(options: ConfigPathOptions = {}): string[] {
   const def = requireDefinition(IOS_ADDITIONAL_DEVICE_SETS_KEY) as ConfigDefinition<string[]>;
+  // Path resolution must happen per scope *before* deduplication, so the union
+  // is re-implemented here instead of going through `applyMergePolicy` — keep
+  // the order in sync with the schema entry's `union` preset.
+  if (def.merge !== "union") {
+    throw new Error(
+      `Expected "${IOS_ADDITIONAL_DEVICE_SETS_KEY}" to use the "union" merge preset; ` +
+        "update getAdditionalIosDeviceSets to match the new policy."
+    );
+  }
   const home = resolveHomeDir(options);
   const global = resolveDeviceSetEntries(readScopeValue(def, "global", options), home, home);
   const project = resolveDeviceSetEntries(
     readScopeValue(def, "project", options),
-    () => resolveProjectRoot(options.cwd ?? process.cwd()),
+    resolveProjectRoot(options.cwd ?? process.cwd()),
     home
   );
   return Array.from(new Set([...global, ...project]));
 }
 
-/** Resolve one scope's entries against its base; `base` is lazy so the
- * project-root walk only runs when the project scope actually has entries. */
+/** Resolve one scope's entries against its base. `path.resolve` (rather than
+ * join/normalize) in every branch so trailing separators are stripped and the
+ * post-resolution dedup actually collapses equivalent spellings. */
 function resolveDeviceSetEntries(
   entries: string[] | undefined,
-  base: string | (() => string),
+  baseDir: string,
   home: string
 ): string[] {
   if (!entries || entries.length === 0) return [];
-  const baseDir = typeof base === "function" ? base() : base;
   return entries.map((entry) => {
-    if (entry === "~") return path.normalize(home);
-    if (entry.startsWith("~/")) return path.join(home, entry.slice(2));
+    if (entry === "~") return path.resolve(home);
+    if (entry.startsWith("~/")) return path.resolve(home, entry.slice(2));
     return path.resolve(baseDir, entry);
   });
 }

--- a/packages/configuration-core/src/config-schema.ts
+++ b/packages/configuration-core/src/config-schema.ts
@@ -105,6 +105,20 @@ export const CONFIG_SCHEMA: readonly ConfigDefinition[] = [
     merge: "prioritize-local",
     example: "claude",
   },
+  {
+    key: "ios.additionalDeviceSets",
+    description:
+      "Additional CoreSimulator device-set directories whose simulators argent should see " +
+      "alongside the default set. Absolute paths (or ~/…); relative entries resolve against " +
+      "the project root (project scope) or home (global scope).",
+    scopes: ["project", "global"],
+    parse: asStringArray,
+    // Additive: the scopes extend each other rather than shadow — a repo's
+    // committed device sets are appended to the user's global ones (global
+    // baseline first, project extras after, deduplicated).
+    merge: "union",
+    example: '["~/DeviceSets/ci"]',
+  },
 ] as const;
 
 /** Look up a schema entry by key, or `undefined` when the key is unknown. */

--- a/packages/configuration-core/src/config-schema.ts
+++ b/packages/configuration-core/src/config-schema.ts
@@ -115,7 +115,9 @@ export const CONFIG_SCHEMA: readonly ConfigDefinition[] = [
     parse: asStringArray,
     // Additive: the scopes extend each other rather than shadow — a repo's
     // committed device sets are appended to the user's global ones (global
-    // baseline first, project extras after, deduplicated).
+    // baseline first, project extras after, deduplicated). Note that
+    // `getAdditionalIosDeviceSets` re-implements this union (path resolution
+    // must precede dedup) and guards on the preset staying "union".
     merge: "union",
     example: '["~/DeviceSets/ci"]',
   },

--- a/packages/configuration-core/src/index.ts
+++ b/packages/configuration-core/src/index.ts
@@ -14,7 +14,13 @@ export {
   type FlagsPathOptions,
 } from "./flags.js";
 
-export { argentHomeDir, configDir, configFilePath, type ConfigPathOptions } from "./paths.js";
+export {
+  argentHomeDir,
+  resolveHomeDir,
+  configDir,
+  configFilePath,
+  type ConfigPathOptions,
+} from "./paths.js";
 
 export { readConfigObject, updateConfig, getAtPath, setAtPath, deleteAtPath } from "./config.js";
 
@@ -51,6 +57,7 @@ export {
   getRememberedAgent,
   setRememberedAgent,
   clearRememberedAgent,
+  getAdditionalIosDeviceSets,
   UnknownConfigKeyError,
   ConfigScopeError,
   ConfigValidationError,

--- a/packages/configuration-core/src/paths.ts
+++ b/packages/configuration-core/src/paths.ts
@@ -23,13 +23,20 @@ function nonEmpty(value: string | undefined): string | null {
   return trimmed === "" ? null : value;
 }
 
+/**
+ * The user's home directory, honoring HOME (POSIX) / USERPROFILE (Windows) and
+ * the test-sandbox `homeDir` override — the base the global scope hangs off.
+ */
+export function resolveHomeDir(options: ConfigPathOptions = {}): string {
+  if (options.homeDir) return options.homeDir;
+  return process.platform === "win32"
+    ? (nonEmpty(process.env.USERPROFILE) ?? os.homedir())
+    : (nonEmpty(process.env.HOME) ?? os.homedir());
+}
+
 /** The `~/.argent` directory, honoring HOME (POSIX) / USERPROFILE (Windows). */
 export function argentHomeDir(): string {
-  const home =
-    process.platform === "win32"
-      ? (nonEmpty(process.env.USERPROFILE) ?? os.homedir())
-      : (nonEmpty(process.env.HOME) ?? os.homedir());
-  return path.join(home, ".argent");
+  return path.join(resolveHomeDir(), ".argent");
 }
 
 /**
@@ -39,7 +46,7 @@ export function argentHomeDir(): string {
  */
 export function configDir(scope: FlagScope = "global", options: ConfigPathOptions = {}): string {
   if (scope === "global") {
-    return options.homeDir ? path.join(options.homeDir, ".argent") : argentHomeDir();
+    return path.join(resolveHomeDir(options), ".argent");
   }
   const cwd = options.cwd ?? process.cwd();
   return path.join(resolveProjectRoot(cwd), ".argent");

--- a/packages/configuration-core/tests/config-access.test.ts
+++ b/packages/configuration-core/tests/config-access.test.ts
@@ -11,6 +11,7 @@ import {
   unsetConfigValue,
   listConfig,
   coerceCliValue,
+  getAdditionalIosDeviceSets,
   UnknownConfigKeyError,
   ConfigScopeError,
   ConfigValidationError,
@@ -191,6 +192,63 @@ describe("coerceCliValue", () => {
     expect(coerceCliValue('["a","b"]')).toEqual(["a", "b"]);
     expect(coerceCliValue("/tmp/device-set")).toBe("/tmp/device-set");
     expect(coerceCliValue("claude")).toBe("claude");
+  });
+});
+
+describe("ios.additionalDeviceSets — additive union across scopes", () => {
+  it("reads as an empty list when neither scope is set", () => {
+    expect(getAdditionalIosDeviceSets(opts())).toEqual([]);
+    expect(getConfigValueByKey("ios.additionalDeviceSets", opts())).toBeUndefined();
+  });
+
+  it("unions the scopes additively: global baseline first, project extras after, deduped", () => {
+    setConfigValue("ios.additionalDeviceSets", ["/tmp/sets/a", "/tmp/sets/b"], "global", opts());
+    setConfigValue("ios.additionalDeviceSets", ["/tmp/sets/b", "/tmp/sets/c"], "project", opts());
+    expect(getConfigValueByKey("ios.additionalDeviceSets", opts())).toEqual([
+      "/tmp/sets/a",
+      "/tmp/sets/b",
+      "/tmp/sets/c",
+    ]);
+    // Each scope's file holds only its own entries — the union is read-time.
+    expect(readConfigObject("global", opts())).toEqual({
+      ios: { additionalDeviceSets: ["/tmp/sets/a", "/tmp/sets/b"] },
+    });
+    expect(readConfigObject("project", opts())).toEqual({
+      ios: { additionalDeviceSets: ["/tmp/sets/b", "/tmp/sets/c"] },
+    });
+  });
+
+  it("rejects a non-array value; normalizes entries (trims, drops blanks/non-strings)", () => {
+    expect(() =>
+      setConfigValue("ios.additionalDeviceSets", "/tmp/sets/a", "global", opts())
+    ).toThrow(ConfigValidationError);
+    expect(
+      setConfigValue("ios.additionalDeviceSets", ["  /tmp/sets/a ", "", 42], "global", opts())
+    ).toEqual(["/tmp/sets/a"]);
+  });
+
+  it("getAdditionalIosDeviceSets expands ~ and resolves relative entries per scope", () => {
+    setConfigValue("ios.additionalDeviceSets", ["~/DeviceSets/ci", "shared"], "global", opts());
+    setConfigValue("ios.additionalDeviceSets", ["device-sets/e2e", "/abs/set"], "project", opts());
+    expect(getAdditionalIosDeviceSets(opts())).toEqual([
+      path.join(homeDir, "DeviceSets/ci"),
+      // Relative global entries resolve against home…
+      path.join(homeDir, "shared"),
+      // …while relative project entries resolve against the project root.
+      path.join(projectDir, "device-sets/e2e"),
+      path.resolve("/abs/set"),
+    ]);
+  });
+
+  it("drops duplicates that only converge after normalization", () => {
+    setConfigValue("ios.additionalDeviceSets", ["~/DeviceSets/ci"], "global", opts());
+    setConfigValue(
+      "ios.additionalDeviceSets",
+      [path.join(homeDir, "DeviceSets", "ci")],
+      "project",
+      opts()
+    );
+    expect(getAdditionalIosDeviceSets(opts())).toEqual([path.join(homeDir, "DeviceSets/ci")]);
   });
 });
 

--- a/packages/configuration-core/tests/config-access.test.ts
+++ b/packages/configuration-core/tests/config-access.test.ts
@@ -250,6 +250,21 @@ describe("ios.additionalDeviceSets — additive union across scopes", () => {
     );
     expect(getAdditionalIosDeviceSets(opts())).toEqual([path.join(homeDir, "DeviceSets/ci")]);
   });
+
+  it("strips trailing separators so slash-suffixed spellings dedup too", () => {
+    setConfigValue("ios.additionalDeviceSets", ["~/DeviceSets/ci/"], "global", opts());
+    setConfigValue(
+      "ios.additionalDeviceSets",
+      [path.join(homeDir, "DeviceSets", "ci"), "~"],
+      "project",
+      opts()
+    );
+    expect(getAdditionalIosDeviceSets(opts())).toEqual([
+      path.join(homeDir, "DeviceSets/ci"),
+      // Bare `~` resolves to home without a trailing separator either.
+      homeDir,
+    ]);
+  });
 });
 
 describe("getConfigValue — direct definition + custom-typed default", () => {


### PR DESCRIPTION
## Summary

**Stacked on #534.** Adds the first *additive* configuration entry on the new schema — `ios.additionalDeviceSets`, a list of extra CoreSimulator device-set directories — delivering the config side of the #401 discussion on the #534 machinery.

### The schema entry

One registry entry in `config-schema.ts`:

- key `ios.additionalDeviceSets`, scopes `project` + `global`, `parse: asStringArray`, **`merge: "union"`**

Unlike `lens.agent` (project *shadows* global), this is additive: the effective value is the **union of both scopes** — the global baseline first, the project's extras appended, deduplicated. A repo can commit the device sets its tooling needs to `.argent/config.json` and they *extend* (never replace) the user's global list. `argent config list/get/set/unset` handle the array key with zero command changes — arrays already round-trip through the JSON value coercion.

### The runtime reader

`getAdditionalIosDeviceSets(options): string[]` in `config-access.ts` — the surface iOS tooling should call. It reads each scope separately so paths normalize against the base the author meant:

- `~` / `~/…` expands to the home directory (honoring the sandbox `homeDir` override)
- relative **project** entries resolve against the **project root**, relative **global** entries against **home**
- output order matches the `union` preset (global first), with **post-normalization** duplicates dropped — `~/DeviceSets/ci` in global and its absolute spelling in the project file collapse to one entry
- empty array when unset

Support refactor: `resolveHomeDir()` extracted in `paths.ts` (the HOME/USERPROFILE + override logic previously inlined in `argentHomeDir`/`configDir`).

### Out of scope (follow-up)

Actually pointing simctl at the extra sets. There is no central simctl wrapper today (~25 call sites build `xcrun simctl …` argv inline, and `ax-prefs.ts` hardcodes the default set's `CoreSimulator/Devices` path), so consuming this reader in `list-devices`/boot/etc. is its own change — the runtime-read-off-disk design here means that consumer needs no CLI/env threading, matching how #534's description framed the split.

## Testing

- `configuration-core`: 5 new tests (82 total, green) — additive union across scopes + per-scope file isolation, non-array rejection + entry normalization, reader `~`/relative resolution per scope, post-normalization dedup, empty-when-unset
- `argent-cli`: new real-filesystem CLI round-trip (274 total, green) — `config set` an array at each scope, effective `get` shows the union while `get --scope` shows only that scope's entries
- `tsc` build + `typecheck:tests` + eslint clean on touched packages