### PR TITLE
fix(skills): bound sub-agent fan-out in the RN optimization skill

### DIFF
--- a/packages/skills/skills/argent-react-native-optimization/SKILL.md
+++ b/packages/skills/skills/argent-react-native-optimization/SKILL.md
@@ -15,7 +15,7 @@ description: Optimizes a React Native app by profiling first to find real bottle
 - **Profile for discovery, not only verification.** Use the profiler to find issues static analysis missed, not only to confirm fixes.
 - **One fix per cycle for architectural changes.** Mechanical batch fixes (inline styles, index keys) can be grouped — re-profile once after the batch. When the measurement involves device interaction, record it as a flow (`argent-create-flow` skill) before the first run so all subsequent cycles replay identical steps.
 - **React Compiler**: if `react-profiler-analyze` reports `reactCompilerEnabled: true`, do NOT propose `useCallback`/`useMemo`/`React.memo` unless you confirmed compiler bail-out via `react-profiler-fiber-tree` (absent `useMemoCache`).
-- **Sub-agents**: Phases 1–2 dispatch sub-agents — one per file for lint results, one per checklist item for semantic. Sub-agents CANNOT touch the device - all profiling and E2E verification must happen in the main agent.
+- **Sub-agents**: Phases 1–2 may dispatch sub-agents, but the fan-out MUST be bounded — **never one per file, one per finding, or one per lint result**. Batch the work and run **at most 4 sub-agents per phase**. An unbounded sweep spawns one agent per source file, which costs far more than the fixes are worth. Sub-agents CANNOT touch the device - all profiling and E2E verification must happen in the main agent.
 
 ## Pipeline
 
@@ -33,12 +33,12 @@ Optimization Progress:
 
 ### Phase 1: Lint sweep
 
-Run ESLint once at the project root with a comprehensive RN performance ruleset. Dispatch sub-agents to fix results — one per file.
+Run ESLint once at the project root with a comprehensive RN performance ruleset, then apply `eslint --fix` — most of these rules autofix, which usually leaves only a handful of findings needing judgment. Group whatever remains by directory into **at most 4 batches** and dispatch **one sub-agent per batch** — never one per file.
 See [references/lint-rules.md](references/lint-rules.md) for ruleset and procedure.
 
 ### Phase 2: Semantic sweep
 
-Review each area requiring judgment — memoization, list rendering, animations, async patterns, effect cleanup, state hygiene, context architecture. Dispatch one sub-agent per checklist item.
+Review each area requiring judgment — memoization, list rendering, animations, async patterns, effect cleanup, state hygiene, context architecture. Split those seven areas across **at most 4 sub-agents**, grouping related areas together — never one sub-agent per finding.
 See [references/semantic-checklist.md](references/semantic-checklist.md) for full checklist.
 
 ### Phase 3: Visual profiling
@@ -55,8 +55,8 @@ Navigate every screen and UI flow within scope, confirm each renders without err
 
 ## App-wide optimization
 
-1. **Phase 1**: run lint centrally (one command), dispatch sub-agents to fix per-file in parallel
-2. **Phase 2**: one sub-agent per checklist item for semantic sweep
+1. **Phase 1**: run lint centrally (one command), autofix, then dispatch at most 4 batched sub-agents for what remains
+2. **Phase 2**: split the checklist areas across at most 4 sub-agents for the semantic sweep
 3. **Phase 3**: main agent profiles top offending screens; fixes architectural issues top-down
 4. **Phase 4**: main agent navigates all screens to verify nothing crashes
 

--- a/packages/skills/skills/argent-react-native-optimization/SKILL.md
+++ b/packages/skills/skills/argent-react-native-optimization/SKILL.md
@@ -33,7 +33,7 @@ Optimization Progress:
 
 ### Phase 1: Lint sweep
 
-Run ESLint once at the project root with a comprehensive RN performance ruleset, then apply `eslint --fix` — most of these rules autofix, which usually leaves only a handful of findings needing judgment. Group whatever remains by directory into **at most 4 batches** and dispatch **one sub-agent per batch** — never one per file.
+Run ESLint once at the project root with a comprehensive RN performance ruleset. Only `no-single-element-style-arrays` has an autofixer, so `eslint --fix` will not thin the list meaningfully — expect to work through the findings. Group them by directory into **at most 4 batches** and dispatch **one sub-agent per batch** — never one per file, however many findings there are.
 See [references/lint-rules.md](references/lint-rules.md) for ruleset and procedure.
 
 ### Phase 2: Semantic sweep
@@ -55,7 +55,7 @@ Navigate every screen and UI flow within scope, confirm each renders without err
 
 ## App-wide optimization
 
-1. **Phase 1**: run lint centrally (one command), autofix, then dispatch at most 4 batched sub-agents for what remains
+1. **Phase 1**: run lint centrally (one command), then dispatch at most 4 batched sub-agents for the findings
 2. **Phase 2**: split the checklist areas across at most 4 sub-agents for the semantic sweep
 3. **Phase 3**: main agent profiles top offending screens; fixes architectural issues top-down
 4. **Phase 4**: main agent navigates all screens to verify nothing crashes

--- a/packages/skills/skills/argent-react-native-optimization/references/lint-rules.md
+++ b/packages/skills/skills/argent-react-native-optimization/references/lint-rules.md
@@ -53,3 +53,6 @@ Install missing plugins before running: `npm install --save-dev eslint-plugin-re
    2b. If no config, create a temporary `.eslintrc.json` with all rules above.
 2. Run: `npx eslint --format json <src_dir>` — replace `<src_dir>` with the project's JS/TS source root (check `package.json` scripts or look for `src/`, `app/`, `lib/`)
 3. Parse output into: `file:line -> rule -> message`.
+4. Group the findings by directory into at most 4 batches and fix them with at most 4 sub-agents — never one per file or one per finding.
+
+Note: of the rules above only `react-native/no-single-element-style-arrays` is autofixable, and `react-hooks/exhaustive-deps` offers editor suggestions rather than a fix `--fix` will apply. Running `eslint --fix` first is harmless but leaves essentially the whole list in place.


### PR DESCRIPTION
> Draft - please hold off reviewing for now.

## Why

A user reported that on their setup, Claude Code + Argent pushed Opus 4.8 into dispatching 45+ parallel sub-agents when writing mobile app features.

## What was wrong

`argent-react-native-optimization/SKILL.md` told the agent to dispatch one sub-agent per file (Phase 1, lint) and one per checklist item (Phase 2, semantic), with no cap anywhere in any shipped skill.

Phase 1 runs ESLint across the whole source root with a ruleset that fires on nearly every RN component file: `react-native/no-inline-styles`, `react-perf/jsx-no-new-function-as-prop` (every `onPress={() => ...}`), `no-color-literals`, `exhaustive-deps`. So "one per file" expands to roughly one sub-agent per source file in the project - dozens to hundreds in parallel.

This skill is the documented entry point for all performance work, and `rules/argent.md` (`alwaysApply: true`) forces skill loading before any argent tool use, so an ordinary "the app feels slow" prompt reaches it.

Each spawned agent carries its own system prompt plus argent's tool schemas (~9-32K tokens, depending on whether progressive tool loading applies), so a single prompt could burn a large share of a subscription's usage limit in minutes.

## Why only Claude Code hit it

Claude Code has a sub-agent primitive and executes "dispatch one per file" literally. Codex has no equivalent, so the same instruction degraded to inline sequential work and never blew up - exactly the asymmetry that was reported.

## Change

- Batch the findings into at most 4 sub-agents per phase.
- Say explicitly that one-per-file, one-per-finding and one-per-lint-result dispatch is not allowed.

Worst case goes from unbounded (roughly 50-150+ agents) to 8 total.

## Verification

- Measured what `eslint --fix` actually clears for this ruleset, since an earlier revision of this PR claimed autofix would do most of the work. It does not: only `react-native/no-single-element-style-arrays` has a fixer `--fix` applies (`react-hooks/exhaustive-deps` declares one but exposes it as editor suggestions). A real run over a component with inline styles, a colour literal, an index key, arrow/object/array props and an empty dep array went 13 problems -> 11, the single edit being `style={[styles.one]}` -> `style={styles.one}`. The skill and the ruleset reference now say so; the 4-agent cap, not autofix, is what bounds the work.
- `node scripts/grade-skills.mjs`: 10.0/10, all 14 skills pass.
- `prettier --check`: clean.
- Grepped all canonical shipped content under `packages/skills/`: no imperative per-unit dispatch remains, and every surviving mention is a prohibition.
- Confirmed `packages/skills/` is the single git-tracked source (`packages/argent/skills` and `packages/mcp/skills` are gitignored build copies), so this covers the whole class rather than one instance.

