### PR TITLE
ci: unified publish-npm workflow (provenance-ready, trusted-publishing prerequisite)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,291 @@
+name: Publish npm package
+
+# Unified npm publishing workflow — successor to publish.yml ("Publish to npm")
+# and publish-next.yml ("Publish prerelease to npm (next)"). Merging them into
+# one file is a prerequisite for npm trusted publishing, which registers a
+# single workflow filename as the package's trusted publisher.
+#
+# Modes (derived from the trigger + the ref's version, never spelled twice):
+#
+#   push to main       → canary: version derived + stamped (<base>-next.<k>),
+#                        published under the `next` dist-tag. Gated behind the
+#                        PUBLISH_NPM_UNIFIED repository variable (see Cutover).
+#   workflow_dispatch  → publishes the ref's package.json version verbatim.
+#                        The dist-tag is derived from the version itself:
+#                          prerelease (has a "-IDENTIFIER" suffix) → `next`
+#                          stable                                  → `latest`
+#                        The optional `channel` input is an assertion, not a
+#                        selector: the run fails if the ref's version doesn't
+#                        land on the channel you expected. `dry_run` exercises
+#                        the full build + bundle verification without publishing.
+#
+# Provenance / trusted publishing:
+#   The job has `id-token: write` and publishes with --provenance, so every
+#   release from this workflow carries a provenance attestation immediately —
+#   the repo is public and package.json's `repository.url` matches, which is
+#   what the registry verifies. Once @swmansion/argent registers THIS file
+#   (publish-npm.yml) as its npm Trusted Publisher, npm's OIDC exchange takes
+#   over authentication; at that point remove the NODE_AUTH_TOKEN lines from
+#   the publish steps below (the token remains needed by sync-next-tag.yml,
+#   which mutates dist-tags — OIDC only covers publishing).
+#
+# Cutover plan (old workflows stay until all steps are done):
+#   1. Merge this workflow. Test it with a workflow_dispatch dry_run, then a
+#      real prerelease dispatch (a -next.N ref).
+#   2. On npmjs.com, register publish-npm.yml as the trusted publisher for
+#      @swmansion/argent (org software-mansion, repo argent).
+#   3. Set the repository variable PUBLISH_NPM_UNIFIED=1 and, in the same PR,
+#      delete publish.yml and publish-next.yml — the gate exists precisely so
+#      canaries are never double-published while both workflows coexist.
+#   4. Remove NODE_AUTH_TOKEN from the publish steps; optionally restrict the
+#      package's publishing access on npmjs.com to the trusted publisher only.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to publish (e.g. v0.17.0 or v0.17.0-next.0)"
+        required: true
+        type: string
+      channel:
+        description: "Expected dist-tag; 'auto' derives it from the version (prerelease → next, stable → latest), an explicit value makes the run fail on a mismatch"
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - latest
+          - next
+      dry_run:
+        description: "Build and verify the bundle, but skip npm publish"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # Serialize canary publishes: the per-base counter is derived from the
+  # registry (next index after the highest published `<base>-next.<k>`), so two
+  # overlapping runs could otherwise read the same index and collide on npm.
+  # Manual dispatches get their own lane. Never cancel an in-flight publish.
+  group: publish-npm-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Canary-on-push stays dormant until cutover (step 3 in the header plan) so
+    # this workflow can coexist with publish-next.yml without publishing every
+    # main commit twice. Manual dispatches always run.
+    if: github.event_name == 'workflow_dispatch' || vars.PUBLISH_NPM_UNIFIED == '1'
+    permissions:
+      contents: read
+      id-token: write # npm provenance attestation + trusted-publishing OIDC exchange
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # push → the pushed commit; dispatch → the requested ref.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@swmansion"
+
+      # Trusted publishing needs npm >= 11.5.1; pin the major instead of
+      # trusting whatever Node 24 happens to bundle on the runner image.
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
+      # One derivation point for everything mode-dependent: the publish mode,
+      # the dist-tag, and which signed-binaries release tag to download from.
+      - name: Resolve publish mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Canary builds source the floating main build of the signed
+            # binaries; the version is derived + stamped later, at publish time.
+            echo "mode=canary" >> "$GITHUB_OUTPUT"
+            echo "dist_tag=next" >> "$GITHUB_OUTPUT"
+            echo "binaries_tag=argent-main" >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(node -p "require('./packages/argent/package.json').version")
+            case "$VERSION" in
+              *-*) DERIVED=next ;;
+              *)   DERIVED=latest ;;
+            esac
+            CHANNEL="${{ inputs.channel }}"
+            if [ "$CHANNEL" != "auto" ] && [ "$CHANNEL" != "$DERIVED" ]; then
+              echo "::error::Version '$VERSION' at ref '${{ inputs.ref }}' belongs on the '$DERIVED' dist-tag, but channel '$CHANNEL' was requested. Pick the ref matching the channel you meant (or leave channel on 'auto')." >&2
+              exit 1
+            fi
+            echo "Resolved version: $VERSION → dist-tag '$DERIVED'"
+            REF="${{ inputs.ref }}"
+            echo "mode=dispatch" >> "$GITHUB_OUTPUT"
+            echo "dist_tag=$DERIVED" >> "$GITHUB_OUTPUT"
+            echo "binaries_tag=argent-${REF//\//-}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download signed simulator-server binary
+        run: bash scripts/download-simulator-server.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download signed native binaries (dylibs, ax-service, Android helper APK)
+        run: bash scripts/download-native-binaries.sh "${{ steps.mode.outputs.binaries_tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Perfetto trace-processor WASM artifacts
+        run: bash scripts/download-trace-processor.sh "${{ steps.mode.outputs.binaries_tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: npm ci
+
+      - run: npx tsc --build
+
+      - run: npm run build -w @swmansion/argent
+
+      # Per-platform bundle layout (commit 80e724a). darwin is always required;
+      # both Linux keys (x86_64 "linux" and arm64 "linux-arm64") are gated by
+      # ARGENT_REQUIRE_LINUX_BINARY so the existing release pipeline keeps
+      # working until radon's Linux artifacts are reliably present — flip the
+      # env var to "1" once that lands. The inventory always logs what shipped
+      # so a silently-missing Linux binary shows up in the run.
+      - name: Verify per-platform simulator-server binaries
+        env:
+          ARGENT_REQUIRE_LINUX_BINARY: "0"
+        run: |
+          set -e
+          missing=0
+          echo "simulator-server inventory:"
+          for plat in darwin linux linux-arm64; do
+            p="packages/argent/bin/${plat}/simulator-server"
+            if [[ -x "$p" ]]; then
+              size=$(wc -c <"$p")
+              echo "  ✓ ${plat}: ${p} (${size} bytes; $(file -b "$p"))"
+            else
+              echo "  ✗ ${plat}: ${p} — missing"
+              if [[ "$plat" == "darwin" ]]; then missing=1; fi
+              if [[ "$plat" == linux* && "${ARGENT_REQUIRE_LINUX_BINARY}" == "1" ]]; then missing=1; fi
+            fi
+          done
+          [[ "$missing" == "0" ]] || { echo "::error::required simulator-server binary missing"; exit 1; }
+      - run: test -x packages/argent/bin/darwin/ax-service
+      - run: test -f packages/argent/dylibs/libNativeDevtoolsIos.dylib
+      - run: test -f packages/argent/dylibs/libKeyboardPatch.dylib
+      - run: test -f packages/argent/dylibs/libArgentInjectionBootstrap.dylib
+      # tvOS (Apple TV) binaries — fail the publish if any is missing rather
+      # than silently shipping a package where tv-* tools crash at runtime.
+      - run: test -x packages/argent/bin/darwin/tvos-ax-service
+      - run: test -x packages/argent/bin/darwin/tvos-hid-daemon
+      - run: test -f packages/argent/dylibs/tvos/libNativeDevtoolsIos.dylib
+      - run: test -f packages/argent/dylibs/tvos/libKeyboardPatch.dylib
+      - run: test -f packages/argent/dylibs/tvos/libArgentInjectionBootstrap.dylib
+      # TCP-transport (sim-remote / ios-remote) binaries — the ax-service and
+      # native-devtools variants the remote code path spawns/injects over a
+      # sim-remote-tunnelled TCP socket. Absent from 0.15.0 because the release
+      # never built them; gate the publish so they can't silently regress again.
+      # (bin/tcp is platform-NEUTRAL — axServiceBinaryPathTcp() resolves
+      # bin/tcp on every host, never a bin/<platform>/tcp subdir.)
+      - run: test -x packages/argent/bin/tcp/ax-service
+      - run: test -f packages/argent/dylibs/tcp/libNativeDevtoolsIos.dylib
+      - run: test -f packages/argent/dylibs/tcp/libKeyboardPatch.dylib
+      - run: test -f packages/argent/dylibs/tcp/libArgentInjectionBootstrap.dylib
+      - run: test -f packages/argent/assets/argent.tracecfg.pbtxt
+      - run: test -d packages/argent/assets/queries
+      - run: test -f packages/argent/assets/manifest.json
+      - run: test -f packages/argent/assets/trace-processor/trace_processor.wasm
+      - run: test -f packages/argent/assets/trace-processor/engine_bundle.node.js
+      - run: test -f packages/argent/assets/trace-processor/engine.mjs
+      - run: test -f packages/argent/assets/trace-processor/LICENSE
+      - run: head -c4 packages/argent/assets/trace-processor/trace_processor.wasm | grep -q $'\x00asm'
+      - run: ls packages/argent/bin/argent-android-devtools-*.apk
+
+      # Canary version: <patch-bump of highest published>-next.<counter>, where
+      # the counter resets to 0 per base and increments per publish (derived
+      # from the registry). Stamped into package.json so the published build
+      # reports it. Done after `npm ci` (the checked-out lockfile still matches
+      # the original version at install time) and after the build (the CLI reads
+      # its version from package.json at runtime — nothing bakes it in), but
+      # before pack/publish.
+      - name: Compute and stamp canary version
+        if: steps.mode.outputs.mode == 'canary'
+        id: canary
+        run: |
+          VERSION="$(node scripts/next-canary-version.mjs --write)"
+          echo "Canary version: ${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # The shipped CLI reads its version from package.json at runtime, so this
+      # is exactly what `argent --version` prints after install. Fail loudly if
+      # they ever diverge.
+      - name: Verify argent --version reports the canary version
+        if: steps.mode.outputs.mode == 'canary'
+        run: |
+          REPORTED="$(node packages/argent/dist/cli.js --version)"
+          EXPECTED="${{ steps.canary.outputs.version }}"
+          echo "argent --version → ${REPORTED} (expected ${EXPECTED})"
+          [ "${REPORTED}" = "${EXPECTED}" ] || { echo "::error::argent --version (${REPORTED}) != published version (${EXPECTED})"; exit 1; }
+
+      - run: npm pack --dry-run -w @swmansion/argent
+
+      - name: Dry run — skipping publish
+        if: steps.mode.outputs.mode == 'dispatch' && inputs.dry_run
+        run: |
+          VERSION=$(node -p "require('./packages/argent/package.json').version")
+          echo "dry_run: would have published ${VERSION} under dist-tag '${{ steps.mode.outputs.dist_tag }}'"
+          echo "Dry run — **not** published: \`@swmansion/argent@${VERSION}\` (dist-tag \`${{ steps.mode.outputs.dist_tag }}\`)" >> "$GITHUB_STEP_SUMMARY"
+
+      # Dispatch publishes the ref's verbatim version on its derived dist-tag.
+      - name: Publish
+        if: steps.mode.outputs.mode == 'dispatch' && !inputs.dry_run
+        run: npm publish -w @swmansion/argent --tag "${{ steps.mode.outputs.dist_tag }}" --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Canary publish. Serialization makes concurrent index collisions
+      # impossible, but npm's read-after-write lag could still hand a back-to-back
+      # run a stale version list, so retry a version-exists collision by
+      # recomputing + restamping. Any other publish failure is real and fails fast.
+      - name: Publish canary
+        if: steps.mode.outputs.mode == 'canary'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for attempt in 1 2 3; do
+            VERSION="$(node -p "require('./packages/argent/package.json').version")"
+            echo "Publishing ${VERSION} (attempt ${attempt})"
+            if npm publish -w @swmansion/argent --tag next --provenance; then
+              echo "Published ${VERSION}"
+              exit 0
+            fi
+            if npm view "@swmansion/argent@${VERSION}" version >/dev/null 2>&1; then
+              echo "::warning::${VERSION} already on npm (lost a race / stale read) — recomputing"
+              node scripts/next-canary-version.mjs --write
+              sleep 10
+            else
+              echo "::error::npm publish failed for ${VERSION} (not a version collision)"
+              exit 1
+            fi
+          done
+          echo "::error::canary publish still colliding after 3 attempts"
+          exit 1
+
+      - name: Publish summary
+        if: success() && !(steps.mode.outputs.mode == 'dispatch' && inputs.dry_run)
+        run: |
+          VERSION=$(node -p "require('./packages/argent/package.json').version")
+          echo "Published \`@swmansion/argent@${VERSION}\` under dist-tag \`${{ steps.mode.outputs.dist_tag }}\` (with provenance)" >> "$GITHUB_STEP_SUMMARY"
+
+      # `npm publish --tag` already tags this release. Re-pointing `next` at
+      # the highest published version (and self-healing it if it was left
+      # stale) is handled by the "Sync 'next' dist-tag" workflow, which runs
+      # automatically once this workflow succeeds.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,6 +18,10 @@ name: Publish npm package
 #                        selector: the run fails if the ref's version doesn't
 #                        land on the channel you expected. `dry_run` exercises
 #                        the full build + bundle verification without publishing.
+#                        Note dry_run only rehearses the dispatch path — the
+#                        canary machinery (version stamping, --version check,
+#                        collision retry) is copied verbatim from
+#                        publish-next.yml and first runs here after cutover.
 #
 # Provenance / trusted publishing:
 #   The job has `id-token: write` and publishes with --provenance, so every
@@ -36,7 +40,9 @@ name: Publish npm package
 #      @swmansion/argent (org software-mansion, repo argent).
 #   3. Set the repository variable PUBLISH_NPM_UNIFIED=1 and, in the same PR,
 #      delete publish.yml and publish-next.yml — the gate exists precisely so
-#      canaries are never double-published while both workflows coexist.
+#      canaries are never double-published while both workflows coexist. Drop
+#      the two old workflow names from sync-next-tag.yml's workflow_run
+#      trigger in that PR too.
 #   4. Remove NODE_AUTH_TOKEN from the publish steps; optionally restrict the
 #      package's publishing access on npmjs.com to the trusted publisher only.
 
@@ -105,8 +111,13 @@ jobs:
 
       # One derivation point for everything mode-dependent: the publish mode,
       # the dist-tag, and which signed-binaries release tag to download from.
+      # inputs.ref reaches the script through env, never template interpolation —
+      # this file is the trusted publisher, so a crafted ref name must stay data.
       - name: Resolve publish mode
         id: mode
+        env:
+          REF: ${{ inputs.ref }}
+          CHANNEL: ${{ inputs.channel }}
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             # Canary builds source the floating main build of the signed
@@ -120,13 +131,11 @@ jobs:
               *-*) DERIVED=next ;;
               *)   DERIVED=latest ;;
             esac
-            CHANNEL="${{ inputs.channel }}"
             if [ "$CHANNEL" != "auto" ] && [ "$CHANNEL" != "$DERIVED" ]; then
-              echo "::error::Version '$VERSION' at ref '${{ inputs.ref }}' belongs on the '$DERIVED' dist-tag, but channel '$CHANNEL' was requested. Pick the ref matching the channel you meant (or leave channel on 'auto')." >&2
+              echo "::error::Version '$VERSION' at ref '$REF' belongs on the '$DERIVED' dist-tag, but channel '$CHANNEL' was requested. Pick the ref matching the channel you meant (or leave channel on 'auto')." >&2
               exit 1
             fi
             echo "Resolved version: $VERSION → dist-tag '$DERIVED'"
-            REF="${{ inputs.ref }}"
             echo "mode=dispatch" >> "$GITHUB_OUTPUT"
             echo "dist_tag=$DERIVED" >> "$GITHUB_OUTPUT"
             echo "binaries_tag=argent-${REF//\//-}" >> "$GITHUB_OUTPUT"
@@ -138,14 +147,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download signed native binaries (dylibs, ax-service, Android helper APK)
-        run: bash scripts/download-native-binaries.sh "${{ steps.mode.outputs.binaries_tag }}"
+        run: bash scripts/download-native-binaries.sh "$BINARIES_TAG"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BINARIES_TAG: ${{ steps.mode.outputs.binaries_tag }}
 
       - name: Download Perfetto trace-processor WASM artifacts
-        run: bash scripts/download-trace-processor.sh "${{ steps.mode.outputs.binaries_tag }}"
+        run: bash scripts/download-trace-processor.sh "$BINARIES_TAG"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BINARIES_TAG: ${{ steps.mode.outputs.binaries_tag }}
 
       - run: npm ci
 
@@ -157,17 +168,22 @@ jobs:
       # both Linux keys (x86_64 "linux" and arm64 "linux-arm64") are gated by
       # ARGENT_REQUIRE_LINUX_BINARY so the existing release pipeline keeps
       # working until radon's Linux artifacts are reliably present — flip the
-      # env var to "1" once that lands. The inventory always logs what shipped
-      # so a silently-missing Linux binary shows up in the run.
+      # env var to "1" once that lands. win32 is gated the same way: it needs
+      # radon's Windows argent build (radon PR #134) merged plus one
+      # build-sim-server dispatch to publish the asset. The inventory always
+      # logs every platform so a silently-missing binary shows up in the run.
       - name: Verify per-platform simulator-server binaries
         env:
           ARGENT_REQUIRE_LINUX_BINARY: "0"
+          ARGENT_REQUIRE_WINDOWS_BINARY: "0"
         run: |
           set -e
           missing=0
           echo "simulator-server inventory:"
-          for plat in darwin linux linux-arm64; do
-            p="packages/argent/bin/${plat}/simulator-server"
+          for plat in darwin linux linux-arm64 win32; do
+            bin="simulator-server"
+            if [[ "$plat" == "win32" ]]; then bin="simulator-server.exe"; fi
+            p="packages/argent/bin/${plat}/${bin}"
             if [[ -x "$p" ]]; then
               size=$(wc -c <"$p")
               echo "  ✓ ${plat}: ${p} (${size} bytes; $(file -b "$p"))"
@@ -175,6 +191,7 @@ jobs:
               echo "  ✗ ${plat}: ${p} — missing"
               if [[ "$plat" == "darwin" ]]; then missing=1; fi
               if [[ "$plat" == linux* && "${ARGENT_REQUIRE_LINUX_BINARY}" == "1" ]]; then missing=1; fi
+              if [[ "$plat" == "win32" && "${ARGENT_REQUIRE_WINDOWS_BINARY}" == "1" ]]; then missing=1; fi
             fi
           done
           [[ "$missing" == "0" ]] || { echo "::error::required simulator-server binary missing"; exit 1; }
@@ -247,9 +264,10 @@ jobs:
       # Dispatch publishes the ref's verbatim version on its derived dist-tag.
       - name: Publish
         if: steps.mode.outputs.mode == 'dispatch' && !inputs.dry_run
-        run: npm publish -w @swmansion/argent --tag "${{ steps.mode.outputs.dist_tag }}" --provenance
+        run: npm publish -w @swmansion/argent --tag "$DIST_TAG" --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DIST_TAG: ${{ steps.mode.outputs.dist_tag }}
 
       # Canary publish. Serialization makes concurrent index collisions
       # impossible, but npm's read-after-write lag could still hand a back-to-back
@@ -259,11 +277,12 @@ jobs:
         if: steps.mode.outputs.mode == 'canary'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DIST_TAG: ${{ steps.mode.outputs.dist_tag }}
         run: |
           for attempt in 1 2 3; do
             VERSION="$(node -p "require('./packages/argent/package.json').version")"
             echo "Publishing ${VERSION} (attempt ${attempt})"
-            if npm publish -w @swmansion/argent --tag next --provenance; then
+            if npm publish -w @swmansion/argent --tag "$DIST_TAG" --provenance; then
               echo "Published ${VERSION}"
               exit 0
             fi

--- a/.github/workflows/sync-next-tag.yml
+++ b/.github/workflows/sync-next-tag.yml
@@ -10,6 +10,9 @@ on:
     workflows:
       - "Publish to npm"
       - "Publish prerelease to npm (next)"
+      # Unified successor to the two workflows above; they coexist during the
+      # trusted-publishing cutover (see publish-npm.yml's header).
+      - "Publish npm package"
     types:
       - completed
   workflow_dispatch:


### PR DESCRIPTION
## Why

npm provenance / trusted publishing for `@swmansion/argent` requires registering **one** workflow file as the package's trusted publisher on npmjs.com — but we currently publish from two (`publish.yml` for stable, `publish-next.yml` for canaries/prereleases). This PR adds their unified successor, **`publish-npm.yml`**, without touching the old workflows: they keep running unchanged until cutover.

## Design

One file, mode derived from the trigger and the version — nothing is spelled twice:

| Trigger | Behavior |
|---|---|
| `push` to `main` | Canary: version derived + stamped (`<base>-next.<k>`), published under `next` with the same registry-race retry loop as before. **Dormant until the `PUBLISH_NPM_UNIFIED` repo variable is set to `1`** — otherwise every main push would publish two canaries while `publish-next.yml` still exists. |
| `workflow_dispatch` | Publishes the ref's `package.json` version verbatim. Dist-tag derived from the version itself: prerelease → `next`, stable → `latest`. The optional `channel` input is an assertion (fails on mismatch), not a selector — you can't accidentally ship a prerelease to `latest` or vice versa. `dry_run` runs the full build + bundle verification + pack without publishing. |

Provenance is on from day one: the job has `id-token: write` and every publish path uses `--provenance` (repo is public, `repository.url` matches — the two things the registry verifies). Token auth (`NPM_TOKEN`) is kept for now; npm ≥ 11.5.1 is ensured in the job so the OIDC exchange takes over transparently once the trusted publisher is registered.

`sync-next-tag.yml` now also triggers on the new workflow, so `next` keeps getting re-pointed after publishes from either generation. (Until cutover a main push may trigger the sync twice — once per publish workflow — which is harmless: the script is idempotent.)

## Cutover checklist (follow-up, also documented in the workflow header)

1. Test: `workflow_dispatch` with `dry_run`, then a real prerelease dispatch (`v*-next.N` ref).
2. On npmjs.com, register `publish-npm.yml` as the trusted publisher for `@swmansion/argent` (org `software-mansion`, repo `argent`).
3. Set repo variable `PUBLISH_NPM_UNIFIED=1` and delete `publish.yml` + `publish-next.yml` in the same PR (also dropping their names from `sync-next-tag.yml`'s `workflow_run` trigger).
4. Remove `NODE_AUTH_TOKEN` from the publish steps (`NPM_TOKEN` stays for `sync-next-tag.yml` — dist-tag mutation isn't covered by OIDC); optionally restrict the package's publishing access to the trusted publisher only.

## Behavior differences vs the old pair

- Stable dispatch now publishes with an explicit `--tag latest` (same effect as the old default) and `--provenance`.
- The old `publish-next.yml` dispatch guard ("refuse non-prerelease versions") is generalized: a stable-version ref dispatched here goes to `latest` instead of erroring. Set `channel: next` if you want the old refusal behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
