### PR TITLE
docs(skills): slim argent-create-flow and split its reference material

### DIFF
--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -1,200 +1,83 @@
 ---
 name: argent-create-flow
-description: Record a reusable flow (scripted sequence of MCP tool calls) that can be replayed later with a single command. Use when the user asks to create, record, or build a flow, or to script a sequence of device actions. Also used proactively, without an explicit request, when a multi-step interaction sequence is about to be repeated (re-profiling, re-testing, or a complex path worth saving).
+description: Record a reusable flow — a scripted sequence of device actions saved as YAML and replayed with one command. Use when the user asks to create, record, or build a flow, or to script a sequence of device actions. Also use proactively, without an explicit request, when a multi-step interaction is about to be repeated (re-profiling, re-testing, or a hard-won path worth saving).
 ---
 
 ## Overview
 
-A flow is a sequence of steps saved to a `.yaml` file in the `.argent/flows/` directory. Each recorded step is **executed live** as you add it, so you verify it works before it becomes part of the flow. Replay a finished flow with `flow-execute`, or — for an e2e flow — headlessly with `argent flow run <name>`.
+A flow is a list of steps in `.argent/flows/<name>.yaml`. You record it by running each step live, so every step is verified before it lands in the file. Replay it with `flow-execute`, or headlessly with `argent flow run <name>`.
 
-Flows store **no device id**: the runner binds a device (the single booted one, or pass `device`/`platform`). A recorded coordinate `gesture-tap` is captured as a portable `tap: { selector }` step whenever the tapped element has stable text/identifier.
+Flows carry **no device id** — the runner binds a device at run time.
 
-**Two flow types**
+Two types:
 
-- **e2e** — begins with a `launch:` step, which starts that app from scratch (terminate + relaunch), so the flow controls its own start state. No `executionPrerequisite`. May `run:` other flows, and (on iOS/Android) may itself be a `run:` target — when nested, its `launch` runs inline, restarting the app for that sub-scenario. **Chromium is the exception:** the runner boots one Electron app per run (the top-level flow's), so a nested chromium e2e flow's `launch` can't boot its own instance and fails the run — keep chromium e2e flows top-level. Record one by adding a `restart-app` of the app under test as the **first** step — it is captured as the `launch` step.
-- **fragment** — doesn't begin with a launch; runs against the device's current state. May declare an `executionPrerequisite` (a documented entry-state contract). Invoked from other flows via a `run:` step, or directly by you at any time.
+- **e2e** — starts with a `launch:` step (terminate + relaunch), so it controls its own start state, and takes no `executionPrerequisite`. Only e2e flows are meaningful CI entries, since only a clean start gives a deterministic verdict.
+- **fragment** — no launch; runs against whatever is on screen. May declare an `executionPrerequisite` describing that entry state. Invoked from another flow with `run:`, or replayed directly.
 
-Both run via `argent flow run <name>` — a fragment simply runs against whatever is on screen (its prerequisite is printed as a reminder). Only e2e flows are meaningful CI/suite entries, since only they give a deterministic verdict from a clean start.
-
-### Step directives
-
-Beyond raw `tool:` steps and `echo:`, flows support declarative directives interpreted by the runner (they are **not** agent-callable tools). **Every directive hard-stops the flow on failure**; later steps are reported `skip`.
-
-| Directive    | YAML                                                                                                                                                                 | Meaning                                                                                                                                                         |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `launch`     | `- launch: com.acme.app` or `- launch: { ios: …, android: … }`                                                                                                       | start the app from scratch (terminate + relaunch) and wait until ready                                                                                          |
-| `tap`        | `- tap: Login`, `- tap: { x: 0.5, y: 0.57 }`, `- tap: { on: Login, times: 2 }`, `- tap: { on: { x: 0.5, y: 0.57 }, times: 2 }`                                       | tap by selector (auto-waits) or raw point; `times` (2 = double-tap) needs the target nested under `on:` — a selector or a point (`{ x, y, times }` is rejected) |
-| `long-press` | `- long-press: Row 3`, `- long-press: { x: 0.5, y: 0.6 }`, `- long-press: { on: <sel>, duration: 1200 }`, `- long-press: { on: { x: 0.5, y: 0.6 }, duration: 1200 }` | press and hold an element or raw point (default 800ms; Chromium: mouse press-hold); `duration` needs the target nested under `on:` — a selector or a point      |
-| `type`       | `- type: { into: email, text: "a@b.com" }`                                                                                                                           | focus a field, type, then press Enter to submit + dismiss the keyboard                                                                                          |
-| `scroll-to`  | `- scroll-to: "Order #1234"` (scrolls down) or `- scroll-to: { target: …, direction: right, within: … }`                                                             | momentum-free scroll until the target is visible                                                                                                                |
-| `pinch`      | `- pinch: { on: "Map", scale: 3 }` or `- pinch: { scale: 0.5 }`                                                                                                      | two-finger zoom in (`scale` > 1) or out (`< 1`); big scales chain gestures; `on` optional — defaults to screen center; open-loop — assert the visible result    |
-| `rotate`     | `- rotate: { on: "Map", by: 90 }` or `- rotate: { by: -45 }`                                                                                                         | two-finger rotation by degrees (+ CW, − CCW, within ±3000°; options map only); `on` optional — screen center default; not `tool: rotate` (orientation)          |
-| `await`      | `- await: { visible: Home }`                                                                                                                                         | wait for a UI condition                                                                                                                                         |
-| `wait`       | `- wait: 500`                                                                                                                                                        | pause for a fixed number of milliseconds (last resort — prefer `await`)                                                                                         |
-| `assert`     | `- assert: { visible: Welcome }`                                                                                                                                     | check a condition, hard-fail if it never holds                                                                                                                  |
-| `snapshot`   | `- snapshot: home` or `- snapshot: { name: home, maxMismatch: 0.5, cropOn: { id: order-summary } }`                                                                  | diff a screenshot — or one element's region — against a stored baseline                                                                                         |
-| `run`        | `- run: login`                                                                                                                                                       | execute another flow's steps inline (fragment or e2e)                                                                                                           |
-| `when`       | `- when: { visible: "What's new" }` + `steps: [...]`                                                                                                                 | run a guarded step block only when the condition holds (no else)                                                                                                |
-
-### Selectors
-
-A **selector** is `{ text?, id?, role? }` plus the optional scopes below (all-must-match; `text`/`role` are case-insensitive substrings, `id` matches the element's testID / accessibilityIdentifier / resource-id exactly, case-insensitive, also accepting the unqualified Android resource-id name — `submit` matches `com.example.app:id/submit`) — the same semantics `await-ui-element` uses, though that tool spells the `id` field `identifier` (flow YAML also accepts `identifier` as an alias for `id`, but `id` is the canonical spelling and what the recorder writes). A bare string is a _loose_ selector: it resolves **identifier-first, then falls back to text** (label/value), so `tap: Login` matches a `testID="Login"` or, failing that, visible text "Login" — no need to know which. Loose fallback applies uniformly to every selector slot (`tap`, `type.into`, `await`, `assert`, `scroll-to`). Use the map form to be strict: `{ id: submit-btn }` (identifier only) or `{ text: Login }` (text only, no fallback).
-
-`text` also takes a **regex matcher map** — `{ text: { matches: '^Order #\d+$' } }`, in any selector slot — for dynamic text no literal can pin. It tests each node's native **own** label/value (not the adapter-hoisted `subtreeText`), though on iOS a container's own label may itself aggregate descendant text, so a wrapper and its leaf can both match. Same regex rules as `text.in`'s `matches` (see _`await` and `assert`_): unanchored, **case-sensitive**, single-quoted, invalid pattern fails at parse. So `assert: { visible: { text: { matches: '^Taps: \d+$' } } }` asserts a counter is on screen with no locator at all, and `tap: { text: { matches: '^Order #\d+$' } }` taps a dynamic row — though a stable `id` stays the more robust action target.
-
-#### Scopes — CSS combinators, read off frames
-
-A map selector may also carry a **scope**: a nested selector naming another element the match must sit in a given spatial relation to. These are the geometric readings of the CSS combinators that survive a flattened tree — the child combinator `>` has no analog, since parent/child structure does not reach replay. They combine, and nest up to six scopes per selector:
-
-| Scope           | CSS     | Reads as                                                        | Example                                                               |
-| --------------- | ------- | --------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `within: <sel>` | `A B`   | the match's frame sits **inside** the scope element's frame     | `tap: { text: Delete, within: { id: profile-card } }`                 |
-| `after: <sel>`  | `A ~ B` | the match **follows** the scope element in reading order        | `assert: { visible: { role: Button, after: { text: Danger zone } } }` |
-| `next: <sel>`   | `A + B` | as `after`, narrowed to the **nearest** follower of each anchor | `tap: { role: Switch, next: { text: Wi-Fi } }`                        |
-
-And `any: true` is the CSS `*` universal selector. It carries no locator of its own, so the parser enforces two rules: it needs **at least one scope** (a bare `any: true` would match the whole screen), and it may **not** sit beside `text`/`id`/`role` (which it would only make redundant — write `{ role: Switch, next: … }`, not `{ any: true, role: Switch, next: … }`). Only the literal `true` is accepted. `assert: { hidden: { any: true, within: { id: empty-state } } }` asserts an empty container. It works for actions too — `tap: { any: true, next: { text: Airplane Mode } }` taps whatever sits right after that label — but on a real tree "whatever" includes spacers and wrappers, so **name the target** (`role`, `id`) whenever you can and keep `any` for conditions and for `next`, which reduces to a single element per anchor.
-
-All of it is **visual (frame-based), not tree ancestry** — flow trees are flattened, and "inside the card" / "the switch after this label" mean what the screen shows — the same frame-based reading of "within" that `scroll-to`'s container anchor uses. Every scope needs a **distinct element** (nothing scopes itself, so `{ id: card, within: { id: card } }` needs two nested elements), the synthetic screen root never counts, and a scope only narrows _where_ to look — the selector still needs its own `text`/`id`/`role` naming _what_ to find there, or `any: true`. The nested slot takes every selector form: a bare string keeps the loose identifier-first fallback (`within: profile-card`), the map form stays strict, the regex matcher works (`within: { text: { matches: '^Card \d+$' } }`). Scopes are flow-YAML only; the raw `await-ui-element` tool's selector accepts none of them. Prefer a unique `id` on the target itself when one exists — reach for a scope when the target has no unique locator of its own (repeated row actions, per-card buttons, list cells).
-
-**`within`** — `tap: { text: Delete, within: { id: profile-card } }` taps the Delete button in the profile card even when other cards show identical ones; `tap: { text: "Pin feed", within: { text: "For You" } }` picks one card's button out of a whole list. Scope to a container with a **tight frame** (a row, card, dialog, toast): a full-screen wrapper contains everything and scopes nothing. It chains outward: `{ text: Save, within: { id: cards, within: Settings } }` reads "Save inside cards inside Settings", each container's frame inside the next.
-
-**`after` / `next`** — reading order is row-band aware: an element **follows** the anchor when it starts below the anchor's bottom edge, _or_ shares its row band and sits entirely to its right. That is what makes `{ role: Switch, next: { text: Wi-Fi } }` resolve the Wi-Fi row's own switch even though the taller switch's frame starts a couple of pixels _higher_ than the label's. `next` keeps only the nearest follower — a match in the anchor's own row beats anything on the rows below, leftmost first — while `after` keeps them all, so `assert: { hidden: { role: Button, after: { text: Danger zone } } }` holds when nothing button-like appears past that heading. Both union over anchors exactly as CSS does: with three rows on screen, `{ role: Switch, next: { role: AXStaticText } }` yields all three switches, one per label. Note that "follows" is **not transitive** — against a tall anchor, an element can follow something that itself follows the anchor without following the anchor directly — so nesting `after` scopes is not the same as chaining CSS `~`: `{ after: { …, after: … } }` can match elements a single `after` excludes. Nest them only when each link is a container-sized step. An element sitting _inside_ the anchor does not follow **that** anchor — containment is not reading order — so scope by `within` for that.
-
-**Prefer the map form for a scope's anchor.** A bare-string scope (`next: wifi-row`) keeps the loose identifier-first fallback, and the runner takes the first pass that finds a _visible_ match — so if some unrelated element carries `testID="wifi-row"`, the identifier pass wins and the text pass never runs. Reproduced: with a decoy `testID="Wi-Fi"` elsewhere on screen, `tap: { role: Switch, next: Wi-Fi }` taps the decoy's neighbour and reports a pass. This is the ordinary identifier-first doctrine, but a scope makes a decoy likelier to "succeed": a decoy _container_ only wins if it actually holds a match, while a decoy _anchor_ wins if anything at all sits after it — which on a real screen it usually does. Spell an anchor you care about as a map: `next: { text: Wi-Fi }` or `next: { id: wifi-row }`.
-
-One way `next` is deliberately **looser than CSS `+`**: where `A + B` matches nothing unless the very next sibling is a `B`, `next` keeps looking and returns the nearest match further on. That is what makes it survive the wrapper and spacer nodes a flattened tree is full of, but it also means a row that is _missing_ the control you asked for silently resolves to the next row's — `{ role: Switch, next: { text: Wi-Fi } }` on a Wi-Fi row rendered without a switch returns the _Bluetooth_ row's switch rather than failing. When a row may legitimately lack the control, assert it first (`assert: { visible: { role: Switch, within: { id: wifi-row } } }`) or scope by `within` instead.
-
-Scopes compose, and it matters which one carries them. `{ role: Button, next: { text: Name, within: { id: card-b } } }` scopes the **anchor** — one label, so one pick, but that pick may land outside card-b. `{ role: Button, next: { text: Name }, within: { id: card-b } }` scopes the **target** — every label is still an anchor, but only card-b's buttons can be picked. They agree on a well-formed screen and diverge when card-b has no button: the first reaches on to the next card's, the second returns nothing. Scope the target when the container is the thing you trust. Conditions honor scopes like any other selector: `assert: { hidden: { text: Saved, within: { id: toast-area } } }` holds when nothing matching "Saved" is inside the toast area — matches elsewhere on screen don't count, and a missing scope element satisfies `hidden` (and fails `visible`/`exists`).
-
-Selectors resolve against the **full native hierarchy** (iOS: the UIView tree; Android: the complete accessibility hierarchy including not-important views) — strictly more than `describe` or the raw `await-ui-element` tool see (both use the trimmed tree), with complete `testID`/`resource-id` coverage. So an `id` selector works even when `describe` collapses or omits the element — don't fall back to coordinate taps just because a testID isn't visible in `describe` output. And when several elements match — including wrappers whose native text aggregates descendant content — the action directives (`tap`, `type`, `scroll-to`) pick the **most specific** match: an exact text/identifier match beats a substring hit (for a regex matcher, a pattern consuming the element's whole text counts as exact), then the smallest frame wins. (A universal `any: true` selector has no field to be exact about, so its matches rank by reading order instead — the first element in the scope, which is the element a condition reads too. Where two matches share a top-left corner, an action breaks the tie toward the smaller, more specific one and a condition does not, so those two can name different elements.)
-
-**Quote strings YAML would mangle.** An unquoted `#` starts a YAML comment — `tap: Order #1234` silently parses as `tap: Order` — and bare `yes`/`no`/`on`/`off`/numbers coerce to non-strings. When a selector or typed text contains `#`, `:`, quotes, or could read as a boolean/number, wrap it: `tap: "Order #1234"`.
-
-### `await` and `assert`
-
-The **condition is the key**, and its value is the selector:
-
-- `{ visible: Home }`, `{ exists: { id: row } }`, `{ hidden: spinner }`
-- `{ text: { in: <selector>, contains: "Taps:" } }` or `{ text: { in: <selector>, equals: "Taps: 0" } }` — `text` locates an element (`in`) and checks its rendered content against exactly one of `contains` (case-insensitive substring) or `equals` (case-insensitive exact match — use it when boundaries matter: `contains: "Taps: 3"` is also satisfied by "Taps: 30"). Reach for `text` only when the locator is an identifier/role; to assert a string is simply on screen, prefer `{ visible: "Taps: 0" }`.
-- `{ text: { in: total, matches: 'Total: \$\d+\.\d{2}' } }` — the third comparator: a JS regex for dynamic content (counters, prices, dates) that neither literal mode can pin. Unanchored like `contains` (anchor with `^…$` for the `equals` analog) and — unlike the literal modes — **case-sensitive**: the pattern carries its own semantics. An invalid pattern fails at parse time. **Quote the pattern in single quotes**: single-quoted and plain YAML scalars keep backslashes; double quotes would need `\\d`. To assert a dynamic string is simply on screen with no locator, prefer a regex **selector** — `{ visible: { text: { matches: '^Taps: \d+$' } } }` (see Selectors); `text.in` + `matches` is for checking a specific element's aggregated text.
-- A container's text aggregates its descendants' text (space-joined), so `text` can assert what a testID wrapper visibly shows even when the string lives in a child node. That also means `equals` against a wrapper must match _everything_ it shows or exactly the wrapper's own label/value — targeting the leaf holding exactly the value (or using `contains`) stays the clearer spelling.
-
-This condition-as-key form is the only spelling. `await` also accepts an optional `timeout` sibling key in milliseconds — `- await: { visible: Home, timeout: 15000 }` — for a transition that legitimately needs longer than the default budget. **Omit `timeout` by default**: the default budget covers normal transitions, and a habitual generous override just delays failure reporting on every broken step. Add one only after a step demonstrably needs it — it timed out at the default and the wait is legitimately slow (a cold start, a network round-trip, a long animation). `assert` has no timeout override: a check that needs seconds to become true is a wait — spell it `await`.
-
-For a custom poll interval or bundleId, drop to an explicit `- tool: await-ui-element` step — but the raw tool polls the trimmed `describe` tree, so a testID it reports as not found can still resolve fine as an `await:` directive (see Selectors). Prefer the directive.
-
-### `type` and `scroll-to`
-
-`type` presses Enter after typing to commit the value and dismiss the keyboard, so it can't cover later targets. For a chained form whose fields feed one explicit submit — e.g. email then password then a `tap: "Log in"` — set `submit: false` on the intermediate fields so a premature Enter doesn't fire the form early: `type: { into: password, text: "hunter2", submit: false }`.
-
-Never record a real credential into a flow — the YAML is committed to the repo. Use a secret placeholder instead: `type: { into: password, text: "{{secret:APP_PASSWORD}}" }`. The placeholder is stored verbatim (the YAML stays secret-free) and is resolved at run time by the tool-server from the `ARGENT_SECRET_APP_PASSWORD` environment variable — including agent-less `argent flow run` in CI, where the variable comes from the job's secrets.
-
-`scroll-to` takes an optional `direction` (`up` | `down` | `left` | `right`, default `down` — so the common case is just `- scroll-to: <selector>`) and optionally a `within: <selector>` that anchors the scroll inside a specific container — required to drive a **nested** scroller (e.g. a horizontal carousel inside a vertical list), since the device can't be asked which container to scroll. This step-level `within` (a sibling of `target`) anchors the _gesture_, and it is the **only** scope key the step body takes — `after:`/`next:`/`any:` beside `target` are rejected. It is distinct from a selector's scopes (see Selectors), which `target` may itself carry — `scroll-to: { target: { text: Delete, within: { id: cards } }, within: { id: settings-list } }` scrolls the settings list until the Delete button _inside the cards container_ is visible. It scrolls in bounded momentum-free increments, re-checks after each, and stops if a scroll reveals nothing new (end of the container). `tap`/`type` do **not** scroll — add a `scroll-to` before any target that may be off-screen. It's a no-op when the target is already visible, so a defensive `scroll-to` costs nothing on replay and keeps the flow working on smaller screens.
-
-### `snapshot` cropping
-
-`cropOn: <selector>` narrows a snapshot's comparison to one element's region — `- snapshot: { name: cart-total, cropOn: { id: order-summary } }`. The selector resolves like a directive target (settled tree, auto-wait, the standard not-found failure; selector-only, no point form), and the **cropped** image is what gets compared, stored as the baseline, and reported as the `current` artifact; the baseline filename still keys on the full capture's resolution — plus a `-crop-<hash>` selector suffix — so device-class drift is still caught. A cropped comparison never masks any region — every pixel of the crop is compared — so prefer elements clear of the top status-bar band (a crop overlapping it leans on best-effort status-bar pinning, and the clock/battery may diff). Crop **fixed-size containers**, addressed by `id`: a text selector resolves to the smallest matching node — typically the label itself, whose frame tracks text metrics — and the crop tracks the element's frame, so an element that grew or shrank by a pixel fails on dimensions ("nothing was compared") rather than on content. Baseline storage and seeding are covered under _Standalone runner_.
-
-### TV targets (Vega)
-
-A Vega (Fire TV) device is remote-driven — there is no touch input, so the touch directives (`tap`, `long-press`, `type`, `scroll-to`, `pinch`, `rotate`) fail on it with guidance. Drive focus with `tool: tv-remote` steps and type with `tool: keyboard` instead; everything else (`launch`, `await`, `assert`, `wait`, `snapshot`, `echo`, `run`, selectors) works unchanged — the tree comes from the on-device automation toolkit, which attaches at app launch (the `launch` step waits for it, so a leading `launch` also guarantees selectors resolve).
-
-```yaml
-steps:
-  - launch: com.example.app.main # the interactive component id from manifest.toml
-  - await: { visible: Home }
-  - tool: tv-remote
-    args: { button: [down, select] } # move focus, then confirm — one step per navigation
-  - await: { visible: Explore Screen }
-  - snapshot: explore
-```
-
-Since a `tv-remote` path is positional (like a coordinate tap), gate each navigation with an `await` on the destination screen and echo where focus should be — that is what makes the flow diagnosable when the focus order changes.
-
-### Standalone runner
-
-`argent flow run <name> [--device <id>] [--platform ios|android|chromium|vega] [--update-baselines] [--output <dir>] [--json]` runs a flow with no LLM in the loop and exits non-zero on any failure — suitable for CI (e2e flows; a fragment runs against the current device state, useful while authoring). `snapshot` baselines live in `.argent/flows/__baselines__/<flow>/`, keyed by platform + resolution; a `snapshot` step **fails** when no baseline exists for the run's device class, so seed baselines with `--update-baselines` and have the user review and commit `__baselines__/` — and pin the device class in CI (`--device`/`--platform`, same simulator model) so runs compare against the committed key. The status bar is pinned (iOS `simctl status_bar`, Android demo mode) for the run so it doesn't drive visual diffs. `--output <dir>` writes each failed snapshot's baseline/current/diff images to `<dir>/<flow>/` — a stable path for CI artifact upload.
+An e2e flow may `run:` other flows and (iOS/Android) be a `run:` target itself — its `launch` then restarts the app inline for that sub-scenario. **Chromium is the exception:** one Electron app boots per run, so a nested chromium e2e flow's `launch` fails the run. Keep those top-level.
 
 ## Tools
 
-| Tool                     | Purpose                                                                                                   |
-| ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| `flow-start-recording`   | Start recording — takes a name and (fragments only) an optional `executionPrerequisite`; creates the file |
-| `flow-add-step`          | Execute a tool call live and record it if it succeeds                                                     |
-| `flow-add-echo`          | Add a label/comment that prints during replay                                                             |
-| `flow-finish-recording`  | Stop recording and get a summary                                                                          |
-| `flow-read-prerequisite` | Read a flow's execution prerequisite without running it                                                   |
-| `flow-execute`           | Replay a saved flow by name                                                                               |
+| Tool                     | Purpose                                                                    |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `flow-start-recording`   | Start recording — takes a name and, for fragments, `executionPrerequisite` |
+| `flow-add-step`          | Execute a tool call live and record it if it succeeds                      |
+| `flow-add-echo`          | Add a label that prints during replay                                      |
+| `flow-finish-recording`  | Stop recording and return a summary                                        |
+| `flow-read-prerequisite` | Read a flow's execution prerequisite without running it                    |
+| `flow-execute`           | Replay a saved flow by name                                                |
 
-Every tool during recording returns the current flow file contents, so you can track what has been recorded. Rules:
+- **Every step runs live and only successes are recorded.** A failed call writes nothing — fix it and retry.
+- **Pass `project_root` once**: absolute, to `flow-start-recording`. The other tools track the active flow themselves.
+- **One flow at a time.** Starting a second recording abandons the first; its file stays on disk.
+- Each tool returns the current file contents, so you always see what has been captured. Edit the `.yaml` directly to remove or reorder steps.
 
-- **Every step runs live.** You see the real tool result (including screenshots) — verify the step worked before continuing. **Only successful steps are recorded**: a failed call writes nothing to the flow file; fix the issue and try again.
-- **Pass `project_root` once.** Give the absolute `project_root` (an error is returned if the path is not absolute) to `flow-start-recording` — it is stored for the session and used by all subsequent flow tools. You do **not** pass a flow name to `flow-add-step`, `flow-add-echo`, or `flow-finish-recording` — the active flow is tracked automatically.
-- **Start before adding.** Calling those tools without an active recording returns _"No active flow. Call flow-start-recording first."_
-- **One flow at a time.** `flow-start-recording` while already recording switches to the new flow — the response tells you which flow was abandoned and which is now active; the old flow's file remains on disk.
-- **Mistakes can be edited out.** Edit the `.yaml` file directly to remove or reorder steps.
-
-### flow-add-step arguments
-
-The `command` parameter is the MCP tool name; `args` is a **JSON string** (not an object), omitted entirely for tools with no arguments:
+`flow-add-step` takes `command` (the MCP tool name) and `args` as a **JSON string**, omitted entirely for tools with no arguments:
 
 ```
 command: "gesture-tap"
 args: "{\"udid\": \"<UDID>\", \"x\": 0.5, \"y\": 0.35}"
-
-command: "await-ui-element"
-args: "{\"udid\": \"<UDID>\", \"condition\": \"visible\", \"selector\": {\"text\": \"Continue\"}}"
 ```
-
-Record an `await-ui-element` step to **gate** the next step on a screen transition — it blocks until the element is `visible`/`hidden` (or contains `text`), so the following step runs only once the screen has actually settled; prefer this over a fixed `delayMs`. If its condition is not met before the timeout, replay **stops at that step** (the steps after it assume the transition happened). See the `await-ui-element` section of `argent-device-interact` for the full condition/selector reference. The live call sees only the trimmed `describe` tree — if it can't find an identifier you know exists, gate on visible text to get the step recorded, then retarget the identifier in the `await:` form during polish (the directive resolves the full hierarchy — see Selectors); don't conclude the testID is unusable in the flow.
 
 ## Recording
 
-1. **Start, then launch as the first step (e2e) or set the stage yourself (fragment).** Call `flow-start-recording` with a descriptive name and the absolute `project_root`. For an **e2e** flow, record a `restart-app` of the app under test as the **first** step — it runs live (resetting the device for the rest of the recording) and is captured as the flow's `launch` step. For a **fragment**, bring the device to the entry state _before_ recording and pass an `executionPrerequisite` describing it (e.g. "App on the login screen") to `flow-start-recording` instead.
-2. **Build step-by-step**: for each action, call `flow-add-step` with the tool name and args. The tool runs immediately — check the result before moving on, and gate each navigation with an `await-ui-element` step.
-3. **Add labels**: use `flow-add-echo` between steps — echo the expected state, not just the action (see _Making flows resilient_).
-4. **Finish**: call `flow-finish-recording`. It returns the file path where the flow was saved and a summary of all steps.
-5. **Polish**: **read the saved `.yaml` file** and convert the raw `tool:` steps that have a cleaner directive form (the recorder leaves these as tools):
-   - `tool: keyboard` typing into a field → `type: { into: "<field>", text: "…" }`, folding in the `tap` that focused the field.
-   - `tool: await-ui-element` gating a transition → `await: { visible: "…" }` / `{ hidden: … }` / `{ text: { in: …, equals: … } }`, carrying a custom `timeoutMs` over as a `timeout` sibling key. Converting also upgrades the wait from the trimmed `describe` tree to the flow's full-hierarchy tree (see Selectors). Keep the raw `tool: await-ui-element` step only when it sets a custom `pollIntervalMs`/`bundleId` the directive can't express.
-   - A scroll-to-reach-an-element — a `tool: gesture-swipe` (or its chromium analog, `gesture-scroll`) used to bring a specific element on screen before interacting with it (a `tap`, `type`, `assert`, …) → `scroll-to: { target: "<that element>", direction: … }`, dropping the swipe. This is far more robust than a fixed-distance swipe: it scrolls momentum-free and stops exactly when the target appears, so it survives layout and content changes. (`tap`/`type` do not scroll, so a raw swipe whose fling lands differently on another device leaves the following tap unresolved — always prefer the `scroll-to` rewrite.) Keep a `gesture-swipe` as a raw `tool:` step when it isn't scrolling toward a specific element — especially a velocity-dependent gesture like swipe-to-dismiss, edge-swipe-back, or swipe-to-reveal a row action, which a momentum-free `scroll-to` would not reproduce.
-   - `tool: gesture-pinch` → `pinch: { on: "<target>", scale: … }`, deriving `scale` as `endDistance / startDistance`. Set `on:` to the element under the pinch center when the pinch was aimed at one (the map or image being zoomed); omit it for a screen-center pinch. Don't carry the recorded distances/angle over — the directive re-derives the geometry (finger placement, system-edge avoidance, chaining of large scales) at run time, so the conversion swaps device-specific coordinates for a portable selector with auto-wait. Keep the raw `tool: gesture-pinch` step when the pinch is anchored at a specific point _inside_ a large element (zooming toward a particular map location, not the map's center) or deliberately pans via `endCenterX`/`endCenterY` — `on:` takes only a selector and re-centers the pinch on the element's frame center, so converting would silently move the zoom anchor.
-   - `tool: gesture-rotate` → `rotate: { on: "<target>", by: … }`, deriving `by` as `endAngle − startAngle` (the tool's `endAngle` > `startAngle` turns clockwise, matching the directive's positive `by`). Set `on:` to the element under the rotation center when the rotation was aimed at one (the map or image being rotated); omit it for a screen-center rotation. Don't carry the recorded `centerX`/`centerY`, radii (`radius` or `radiusX`/`radiusY`), `startAngle`, or `durationMs` over — the directive re-derives the geometry (finger placement, physical-circle radius, system-edge avoidance) and runs at a fixed pace (~90° per 300 ms), so the conversion swaps device-specific coordinates for a portable selector with auto-wait. Keep the raw `tool: gesture-rotate` step when the rotation is anchored at a specific point _inside_ a large element rather than its center (the directive re-centers on the element's frame center, so converting would silently move the pivot), when the gesture's speed itself matters (the directive's pace is fixed), or when the sweep exceeds the directive's ±3000° bound.
+1. **Start.** Call `flow-start-recording` with a descriptive name and the absolute `project_root`. For a fragment, bring the device to the entry state first and pass an `executionPrerequisite` (e.g. "App on the login screen, user logged out").
+2. **For an e2e flow, record a `restart-app` of the app under test as the first step** — it resets the device for the rest of the recording and is captured as the flow's `launch`.
+3. **Add each action** with `flow-add-step`, checking the live result before moving on. Gate every navigation with an `await-ui-element` step instead of a delay: replay then stops at the unmet wait rather than running blind.
+4. **Label with `flow-add-echo`** — echo the expected state, not the action: "On Settings > General, about to tap About". These labels are your reference when the flow later breaks.
+5. **Finish** with `flow-finish-recording`, polish the saved file (below), then re-run `flow-execute` to confirm the cleaned flow still passes.
 
-Every other recorded tool (a velocity-dependent `gesture-swipe`, a fixed-distance `gesture-scroll` not aimed at an element, `button`, `screenshot`, …) has no directive form — leave it as a `tool:` step. The recorder already handles the rest: coordinate `gesture-tap`s are captured as portable `tap:` selector steps, a `restart-app` is captured as a `launch:` step, a `flow-execute` of a sibling fragment is captured as a `run: <name>` composition directive, and device ids are stripped. Captured selectors are emitted in the strict map form (`tap: { text: General }`), never as a loose bare string — the recorder verified the exact element the tap hit, and a bare string would re-parse as loose and route through the identifier-first fallback it was never checked against. After editing, re-run with `flow-execute` to confirm the cleaned flow still passes.
+The recorder handles portability: a coordinate tap is captured as a `tap:` selector step whenever the tapped element has stable text or an identifier (otherwise the coordinates are kept, with a warning), `restart-app` becomes `launch:`, a `flow-execute` of a sibling flow becomes `run:`, and device ids are stripped. Captured selectors use the strict map form — `tap: { text: General }` — because the recorder verified the exact element the tap hit.
 
-### Example session
+A live `await-ui-element` call sees only the trimmed `describe` tree. If it can't find an identifier you know exists, gate on visible text to get the step recorded, then retarget the identifier once you convert it to an `await:` directive, which resolves the full hierarchy.
+
+### Polish
+
+Read the saved YAML and rewrite raw `tool:` steps that have a directive form. These directives wait for their target, resolve the full element hierarchy, and carry no device coordinates, so they survive layout changes that break a recorded gesture.
+
+| Recorded tool                                          | Rewrite as                                                        | Keep raw when                                                                                                   |
+| ------------------------------------------------------ | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `keyboard` typing into a field                         | `type: { into: <field>, text: … }`, folding in the focusing `tap` | —                                                                                                               |
+| `await-ui-element`                                     | `await: { visible: … }` (`timeoutMs` → `timeout`)                 | it sets a `pollIntervalMs`/`bundleId` the directive can't express                                               |
+| `gesture-swipe` / `gesture-scroll` to reach an element | `scroll-to: { target: <that element> }`                           | it is velocity-dependent (swipe-to-dismiss, edge-swipe-back, swipe-to-reveal) or aimed at no particular element |
+| `gesture-pinch`                                        | `pinch: { on: <target>, scale: end ÷ start distance }`            | the pinch is anchored off the element's center or pans via `endCenterX`/`endCenterY`                            |
+| `gesture-rotate`                                       | `rotate: { on: <target>, by: end − start angle }`                 | the pivot is off-center, the gesture's speed matters, or the sweep exceeds ±3000°                               |
+
+Drop the recorded geometry when converting — the directive re-derives finger placement, edge avoidance and pacing at run time, and `on:` re-centers on the element's frame. Every other tool (`button`, `screenshot`, …) has no directive form and stays a `tool:` step.
+
+### Example
 
 ```
 flow-start-recording  { name: "open-about", project_root: "/Users/dev/MyApp" }
-flow-add-echo  { message: "Start Settings from scratch" }
-flow-add-step  { command: "restart-app", args: "{\"udid\": \"ABC\", \"bundleId\": \"com.apple.Preferences\"}" }   # ⇒ captured as `- launch: com.apple.Preferences` — this is now an e2e flow
-flow-add-echo  { message: "On the Settings root list, tapping the 'General' row" }
-flow-add-step  { command: "gesture-tap", args: "{\"udid\": \"ABC\", \"x\": 0.5, \"y\": 0.35}" }   # ⇒ captured as `- tap: { text: General }` (portable selector, no udid)
-flow-add-step  { command: "await-ui-element", args: "{\"udid\": \"ABC\", \"condition\": \"visible\", \"selector\": {\"text\": \"About\"}}" }   # gate the transition
-flow-add-echo  { message: "On Settings > General, tapping 'About'" }
-flow-add-step  { command: "gesture-tap", args: "{\"udid\": \"ABC\", \"x\": 0.5, \"y\": 0.17}" }
-flow-add-step  { command: "await-ui-element", args: "{\"udid\": \"ABC\", \"condition\": \"visible\", \"selector\": {\"text\": \"Model Name\"}}" }
+flow-add-echo   { message: "Start Settings from scratch" }
+flow-add-step   { command: "restart-app", args: "{\"udid\": \"ABC\", \"bundleId\": \"com.apple.Preferences\"}" }
+flow-add-echo   { message: "On the Settings root list, tapping the 'General' row" }
+flow-add-step   { command: "gesture-tap", args: "{\"udid\": \"ABC\", \"x\": 0.5, \"y\": 0.35}" }
+flow-add-step   { command: "await-ui-element", args: "{\"udid\": \"ABC\", \"condition\": \"visible\", \"selector\": {\"text\": \"About\"}}" }
 flow-finish-recording  {}
 ```
 
-Then polish the saved file: the two `await-ui-element` steps become `await:` directives (see the file below).
-
-## Replaying
-
-Call `flow-execute` with the flow name (and `project_root`, unless a recording this session already stored it). If the flow has an execution prerequisite, the tool returns a **notice** with the prerequisite text instead of running — verify the prerequisite is met (you can also inspect it beforehand with `flow-read-prerequisite`) and call `flow-execute` again with `prerequisiteAcknowledged: true`. A flow without a prerequisite runs immediately. The run executes all steps in order and returns a structured report: `{ ok, passed, failed, skipped, errored, steps }`.
-
-**What each step reports.** Raw `tool:` steps include the underlying tool's full `result` (screenshots and other outputs render as usual). The directive steps are summarized: `tap`/`type`/`await`/`assert` report only `status` + `reason`, and `snapshot` adds `artifacts` only when there is something to look at — a failed comparison (baseline/current/diff paths), a missing-baseline failure (`current` only), or a baseline write; a clean pass reports just `status` + `reason`. So converting a `tool: gesture-tap` into a `tap:` directive during cleanup drops only that tap's (uninteresting) raw result — output-bearing tools like `screenshot` have no directive form and stay `tool:` steps, so their results keep flowing through.
-
-## Flow file format
-
-The top-level is an object with `steps` (array) and — fragments only — `executionPrerequisite` (an e2e flow, one beginning with `launch:`, has none). Besides the directives above:
-
-- `- echo: <message>` — a label printed during replay
-- `- tool: <name>` with optional `args:` — a raw tool call. A tool step may also carry `delayMs: <ms>` to sleep that long before it runs. (`await-ui-element` is an ordinary tool step; see _flow-add-step arguments_ and _Making flows resilient_ for when to gate a transition with one.)
-- **`when:` blocks** handle one-sided divergences (interstitials, coach marks): `- when: { visible: "What's new" }` with a sibling `steps: [...]` list runs the block only if the condition holds — checked once with the short assert grace (~1s), so a skipped block barely costs a clean run. Guards are one condition key (`exists`/`visible`/`hidden`/`text`, the await/assert shapes) or `platform: ios|android|chromium|vega`. **No else** (parse-rejected): a block exists to dismiss the divergence and reconverge, never to test two paths — two paths are two flows. Failures inside an entered block are real failures; a skipped block reports `skip` lines. Tap-if-present is a one-step block (`when: { visible: "Got it" }` + `steps: [tap: "Got it"]`); there is NO per-step `optional:` key — it is rejected at parse with a pointer to `when:`.
-
-The polished result of the example session above:
+After polish — no device ids, the `await-ui-element` step now an `await:` directive:
 
 ```yaml
 steps:
@@ -203,97 +86,39 @@ steps:
   - echo: On the Settings root list, tapping the 'General' row
   - tap: { text: General }
   - await: { visible: About }
-  - echo: On Settings > General, tapping 'About'
-  - tap: { text: About }
-  - await: { visible: Model Name }
 ```
 
-Note there is **no device id** anywhere in the file — the recorder strips them and the runner injects the bound device.
+## Replaying
 
-## When to proactively record a flow
+Call `flow-execute` with the flow name (and `project_root`, unless a recording this session already stored it). A flow with an execution prerequisite returns a **notice** with the prerequisite text instead of running: confirm the state is met — `flow-read-prerequisite` inspects it beforehand — then call again with `prerequisiteAcknowledged: true`.
 
-Proactive recording is part of this skill's scope (see the description). Record a flow without waiting to be asked — telling the user you are doing so — when you recognize any of these patterns:
+The run executes every step in order and returns `{ ok, passed, failed, skipped, errored, steps }`. Raw `tool:` steps carry the tool's full result (screenshots render as usual); directive steps report `status` + `reason`, plus `artifacts` for a `snapshot` that wrote or failed a comparison.
 
-- **About to re-profile**: You completed a profiling session and are about to apply a fix and re-profile. Record the interaction steps now so the re-profile replays them identically (see `argent-react-native-profiler` and `argent-native-profiler` skills).
-- **Repeating steps**: You have already performed a multi-step interaction sequence once and the task requires doing it again (comparison, retry, re-test).
-- **Complex path discovered**: You worked through a non-trivial sequence of taps/swipes/navigation to reach a desired app state. Capture it before it is lost.
-- **User says "again" / "one more time"**: Any request to redo what you just did is a signal to record first, then replay.
+For headless runs, CI, and screenshot baselines, see `references/runner.md`.
 
-## Flow self-improvement
+## When a flow breaks
 
-Flows break. UI layouts change, coordinates drift, screens get added or removed. When `flow-execute` returns a failure, follow this procedure to diagnose and fix the flow instead of silently re-recording or giving up.
+A failure is a hard `ERROR` on a step, or a clean run that ends on the wrong screen. Either way:
 
-### Classify the result
+1. `screenshot` to see where the app actually is, and `describe` for the current tree.
+2. State the root cause in one sentence — drifted coordinates, missing element, wrong screen, timing, or an unmet prerequisite.
+3. Apply the smallest fix that addresses it: edit the step's args, or re-record from the divergence point.
+4. Re-run `flow-execute`. **Hard cap: 2 correction cycles** — then report the diagnosis and recommend a full re-record.
 
-After every `flow-execute`, classify the outcome before proceeding:
+`references/repair.md` has the full procedure and the habits that keep flows from breaking.
 
-| Outcome                | Signal                                                                | Action             |
-| ---------------------- | --------------------------------------------------------------------- | ------------------ |
-| **Success**            | All steps completed, final screenshot shows expected state            | Continue with task |
-| **Hard error**         | A step has `ERROR` in the result — engine stopped there               | Enter **Diagnose** |
-| **Silent misfire**     | All steps completed but final screenshot shows wrong screen           | Enter **Diagnose** |
-| **Partial divergence** | Intermediate screenshot shows wrong state even though later steps ran | Enter **Diagnose** |
+## Record proactively
 
-For silent misfires and partial divergence, echo annotations (see _Making flows resilient_) are your reference for what each screen _should_ look like.
+Record without being asked — telling the user you are doing so — when:
 
-### Diagnose
+- **You are about to re-profile.** Capture the interaction now so the post-fix profile replays it identically (see `argent-react-native-profiler`, `argent-native-profiler`).
+- **You have run a multi-step sequence once and need it again** for a comparison, retry, or re-test.
+- **You worked out a non-trivial path** to a desired app state — capture it before it is lost.
+- **The user says "again" or "one more time."**
 
-1. Note the failure step index and error message (if hard error).
-2. Call `screenshot` to see where the app actually is now.
-3. Call `describe` or `debugger-component-tree` to get the current element tree. Remember `describe` shows less than the flow tree — a testID missing from its output can still resolve as a selector (see Selectors).
-4. Compare current state to what the failed step expected. Classify the root cause:
+## Reference
 
-| Root cause       | Symptoms                                                        |
-| ---------------- | --------------------------------------------------------------- |
-| Coordinate drift | Tap succeeded but hit wrong element; elements shifted positions |
-| Missing element  | Target element not present in element tree                      |
-| Wrong screen     | Screenshot shows entirely different page than expected          |
-| Timing           | Element exists in tree but tap missed; loading spinner visible  |
-| State mismatch   | First step fails — executionPrerequisite was not actually met   |
-
-5. State the diagnosis in one sentence before attempting any correction.
-
-### Correct
-
-Choose the lightest strategy that fits:
-
-**Strategy 1 — Edit the YAML** (coordinate drift, parameter changes).
-Read `.argent/flows/<flow-name>.yaml`, update the broken step's `x`/`y`, `bundleId`, `text`, or other args. Re-run `flow-execute` to verify.
-
-**Strategy 2 — Manual recovery + continue** (timing/transient issues, one-off replay).
-Manually execute the failed step with corrected coordinates from the Diagnose step, then manually execute remaining steps. Does not fix the YAML — use only when re-recording is not worth it.
-
-**Strategy 3 — Re-record from failure point** (structural changes, new intermediate screens).
-Navigate the app to the state just before the failure point. Call `flow-start-recording` with the same flow name (overwrites). Re-add the working prefix steps via `flow-add-step`, then continue recording new steps from the divergence point. Call `flow-finish-recording`.
-
-**Strategy 4 — Full re-record** (major changes, unclear diagnosis, or 3+ broken steps).
-Reset the app to prerequisite state (`restart-app` + `launch-app`). Record from scratch with the same flow name.
-
-**Decision heuristic:**
-
-- 1 step broken, parameter-only change → Strategy 1
-- 1 step broken, transient issue, not worth persisting → Strategy 2
-- 2–3 steps broken or flow structure partially changed → Strategy 3
-- 3+ steps broken, or unclear root cause → Strategy 4
-- Flow used for profiling comparison (must be identical) → Strategy 4
-
-### Verify and bound retries
-
-After applying a correction, re-run `flow-execute` to verify.
-
-- If it succeeds → done. Report what changed (e.g. "Fixed step 4: updated tap coordinates from 0.5,0.35 to 0.5,0.42").
-- If it fails at a **different** step → return to Diagnose for a second attempt.
-- If this is already the second correction attempt → **stop**. Report the diagnosis to the user and recommend a full re-record or manual investigation.
-
-**Hard cap: 2 correction cycles.** Do not enter an unbounded fix loop.
-
-### Making flows resilient
-
-Apply these when recording new flows to reduce future breakage:
-
-- **Echo expected state, not just actions.** Write `"On Settings > General screen, about to tap About"` not `"Tap About"`. During diagnosis these tell you what the screen _should_ look like.
-- **Gate transitions with `await-ui-element`, not fixed delays.** After a tap that triggers a navigation, record an `await-ui-element` step that waits for the next screen's element to be `visible` (or a spinner to be `hidden`) before the following step — converted to an `await:` directive during polish. This removes the **Timing** failure mode in Diagnose (the element is in the tree but the tap fired before the screen settled) and is more reliable than `delayMs` or an extra `screenshot`. An unmet wait stops replay at that step, so a mistimed step can never run blind.
-- **Add screenshot steps after critical navigation.** Insert `screenshot` steps after screen transitions. These produce images in the flow result you can inspect during diagnosis.
-- **Write specific executionPrerequisites.** `"App on home tab, user logged in, simulator UDID is <X>"` — not `"App running"`. Verify with `screenshot` + `describe` before acknowledging.
-- **Prefer launch-app / open-url over navigation chains.** Deep links are more resilient to layout changes than tap sequences.
-- **Echo accessibility labels for coordinate taps.** When recording a tap, add an echo with the target's label or testID: `"Tapping 'Submit' button (testID: submit-btn) at 0.5, 0.82"`. During repair, use `describe` to find the element by label and update coordinates. Only use `screenshot` for permission or system overlays when `describe` cannot expose the target reliably.
+- `references/directives.md` — the flow file format and every directive (`launch`, `tap`, `type`, `scroll-to`, `await`, `assert`, `when`, `snapshot`, …), plus TV/Vega targets.
+- `references/selectors.md` — selector grammar, regex matchers, and the `within`/`after`/`next` scopes.
+- `references/runner.md` — `argent flow run`, snapshot baselines, CI.
+- `references/repair.md` — diagnosing and repairing a broken flow.

--- a/packages/skills/skills/argent-create-flow/references/directives.md
+++ b/packages/skills/skills/argent-create-flow/references/directives.md
@@ -1,0 +1,113 @@
+# Flow file format and directives
+
+A flow file is an object with `steps:` and — fragments only — `executionPrerequisite:`, a sentence describing the entry state the flow assumes.
+
+```yaml
+executionPrerequisite: App on the login screen, user logged out
+steps:
+  - echo: Signing in
+  - type: { into: email, text: "a@b.com", submit: false }
+  - type: { into: password, text: "{{secret:APP_PASSWORD}}", submit: false }
+  - tap: "Log in"
+  - await: { visible: Home }
+```
+
+Three kinds of step:
+
+- `- echo: <message>` — a label printed during replay.
+- `- tool: <name>` — a raw tool call. It takes only the sibling keys `args:` and `delayMs:` (milliseconds to sleep before it runs). Raw steps report the tool's full result; directive steps report only `status` + `reason`.
+- **Directives** — declarative steps interpreted by the runner. They are not agent-callable tools. **Every directive hard-stops the flow on failure**; later steps report `skip`.
+
+## Directives
+
+| Directive    | YAML                                                                                                | Meaning                                                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `launch`     | `- launch: com.acme.app` or `- launch: { ios: …, android: … }`                                      | start the app from scratch (terminate + relaunch) and wait until ready                                                  |
+| `tap`        | `- tap: Login`, `- tap: { x: 0.5, y: 0.57 }`, `- tap: { on: Login, times: 2 }`                      | tap by selector (auto-waits) or raw point                                                                               |
+| `long-press` | `- long-press: Row 3`, `- long-press: { on: <sel>, duration: 1200 }`                                | press and hold an element or point (default 800 ms; Chromium: mouse press-hold)                                         |
+| `type`       | `- type: { into: email, text: "a@b.com" }`                                                          | focus a field, type, then press Enter to submit and dismiss the keyboard                                                |
+| `scroll-to`  | `- scroll-to: "Order #1234"` or `- scroll-to: { target: …, direction: right, within: … }`           | momentum-free scroll until the target is visible                                                                        |
+| `pinch`      | `- pinch: { on: "Map", scale: 3 }` or `- pinch: { scale: 0.5 }`                                     | two-finger zoom in (`scale` > 1) or out (< 1); large scales chain gestures; open-loop — assert the visible result       |
+| `rotate`     | `- rotate: { on: "Map", by: 90 }` or `- rotate: { by: -45 }`                                        | two-finger rotation in degrees (+ CW, − CCW, within ±3000°; options map only). Not `tool: rotate`, which is orientation |
+| `await`      | `- await: { visible: Home }`                                                                        | wait for a UI condition                                                                                                 |
+| `wait`       | `- wait: 500`                                                                                       | pause a fixed number of milliseconds — last resort, prefer `await`                                                      |
+| `assert`     | `- assert: { visible: Welcome }`                                                                    | check a condition, hard-fail if it never holds                                                                          |
+| `snapshot`   | `- snapshot: home` or `- snapshot: { name: home, maxMismatch: 0.5, cropOn: { id: order-summary } }` | diff a screenshot — or one element's region — against a stored baseline                                                 |
+| `run`        | `- run: login`                                                                                      | execute another flow's steps inline (fragment or e2e)                                                                   |
+| `when`       | `- when: { visible: "What's new" }` + sibling `steps: [...]`                                        | run a guarded block only when the condition holds (no else)                                                             |
+
+`tap`'s `times` (2 = double-tap) and `long-press`'s `duration` require the target nested under `on:` — a selector or a point. `{ x, y, times }` is rejected.
+
+`pinch`/`rotate` take `on:` as a selector only; omitted, they act on the screen center.
+
+## `type`
+
+Enter is pressed after typing, so the keyboard can't cover later targets. In a chained form whose fields feed one explicit submit, set `submit: false` on the intermediate fields so a premature Enter doesn't fire the form early.
+
+**Never record a real credential** — the YAML is committed. Use `text: "{{secret:APP_PASSWORD}}"`: the placeholder is stored verbatim and resolved at run time from the `ARGENT_SECRET_APP_PASSWORD` environment variable, including agent-less `argent flow run` in CI. The `ARGENT_SECRET_` prefix is mandatory. Placeholders resolve only in text-entry steps, never in `when`/`await`/`assert` conditions.
+
+## `scroll-to`
+
+`direction` is `up` | `down` | `left` | `right`, default `down`, so the common case is just `- scroll-to: <selector>`. It scrolls in bounded momentum-free increments, re-checks after each, and stops when a scroll reveals nothing new.
+
+A step-level `within: <selector>` (sibling of `target`) anchors the _gesture_ inside a container — required to drive a nested scroller, e.g. a horizontal carousel inside a vertical list. It is the only scope key the step body accepts; `after:`/`next:`/`any:` beside `target` are rejected. It is distinct from the scopes `target` may itself carry (see `selectors.md`):
+
+```yaml
+- scroll-to: { target: { text: Delete, within: { id: cards } }, within: { id: settings-list } }
+```
+
+`tap` and `type` never scroll — put a `scroll-to` before any target that may be off-screen. It is a no-op when the target is already visible, so a defensive one costs nothing and keeps the flow working on smaller screens.
+
+## `await` and `assert`
+
+The **condition is the key** and its value is the selector. This is the only spelling.
+
+- `{ visible: Home }`, `{ exists: { id: row } }`, `{ hidden: spinner }`
+- `{ text: { in: <selector>, contains: "Taps:" } }` — locate an element with `in`, then check its rendered text against exactly one comparator:
+  - `contains` — case-insensitive substring.
+  - `equals` — case-insensitive exact match; use it when boundaries matter, since `contains: "Taps: 3"` is also satisfied by "Taps: 30".
+  - `matches` — a JS regex for dynamic content (counters, prices, dates). Unanchored like `contains`, but **case-sensitive**; an invalid pattern fails at parse. **Single-quote the pattern** so YAML keeps the backslashes: `{ text: { in: total, matches: 'Total: \$\d+\.\d{2}' } }`.
+
+Reach for `text` only when the locator is an identifier or role. To assert a string is simply on screen, prefer `{ visible: "Taps: 0" }`, or a regex selector for dynamic text — `{ visible: { text: { matches: '^Taps: \d+$' } } }`.
+
+A container's text aggregates its descendants' text, space-joined, so `text` can assert what a testID wrapper visibly shows even when the string lives in a child node. `equals` against a wrapper must then match everything it shows; targeting the leaf, or using `contains`, is clearer.
+
+`await` accepts an optional `timeout` sibling key in milliseconds. **Omit it by default** — the default budget covers normal transitions, and a habitual override just delays failure reporting. Add one only after a step demonstrably needs it (cold start, network round-trip, long animation). `assert` has no timeout: a check that needs seconds to become true is a wait, so spell it `await`.
+
+For a custom poll interval or bundleId, drop to a raw `- tool: await-ui-element` step. That tool polls the trimmed `describe` tree, so a testID it reports as missing can still resolve as an `await:` directive — prefer the directive.
+
+## `when` blocks
+
+`when:` handles one-sided divergences (interstitials, coach marks): the sibling `steps:` list runs only if the guard holds, checked once with the short assert grace (~1 s), so a skipped block barely costs a clean run.
+
+```yaml
+- when: { visible: "Got it" }
+  steps:
+    - tap: "Got it"
+```
+
+Guards are one condition key (`exists`/`visible`/`hidden`/`text`, the await/assert shapes) or `platform: ios|android|chromium|vega`. **There is no else** — it is parse-rejected. A block exists to dismiss a divergence and reconverge; two real paths are two flows. Failures inside an entered block are real failures; a skipped block reports `skip` lines. There is also no per-step `optional:` key — it is rejected at parse with a pointer to `when:`.
+
+## `snapshot`
+
+`cropOn: <selector>` narrows the comparison to one element's region. The selector resolves like any directive target (settled tree, auto-wait, selector only — no point form), and the cropped image is what gets compared, stored as the baseline, and reported as the `current` artifact. The baseline filename still keys on the full capture's resolution plus a `-crop-<hash>` suffix, so device-class drift is still caught.
+
+A cropped comparison masks nothing — every pixel of the crop is compared — so prefer elements clear of the status-bar band. Crop **fixed-size containers addressed by `id`**: a text selector resolves to the smallest matching node, whose frame tracks text metrics, and a frame that grew by a pixel fails on dimensions ("nothing was compared") rather than on content.
+
+Baseline storage and seeding are covered in `runner.md`.
+
+## TV targets (Vega)
+
+A Vega (Fire TV) device is remote-driven, so the touch directives (`tap`, `long-press`, `type`, `scroll-to`, `pinch`, `rotate`) fail on it with guidance. Drive focus with `tool: tv-remote` and type with `tool: keyboard`; everything else (`launch`, `await`, `assert`, `wait`, `snapshot`, `echo`, `run`, selectors) works unchanged. The element tree comes from the on-device automation toolkit, which attaches at app launch — so a leading `launch`, which waits for it, also guarantees selectors resolve.
+
+```yaml
+steps:
+  - launch: com.example.app.main # the interactive component id from manifest.toml
+  - await: { visible: Home }
+  - tool: tv-remote
+    args: { button: [down, select] } # move focus, then confirm — one step per navigation
+  - await: { visible: Explore Screen }
+  - snapshot: explore
+```
+
+A `tv-remote` path is positional, like a coordinate tap, so gate each navigation with an `await` on the destination and echo where focus should be. That is what makes the flow diagnosable when the focus order changes.

--- a/packages/skills/skills/argent-create-flow/references/repair.md
+++ b/packages/skills/skills/argent-create-flow/references/repair.md
@@ -1,0 +1,59 @@
+# Repairing a broken flow
+
+Flows break: layouts change, coordinates drift, screens come and go. Diagnose before re-recording.
+
+## 1. Classify the outcome
+
+| Outcome            | Signal                                                                  |
+| ------------------ | ----------------------------------------------------------------------- |
+| Success            | All steps passed and the final screenshot shows the expected state      |
+| Hard error         | A step reports `ERROR` — the run stopped there                          |
+| Silent misfire     | All steps completed but the final screenshot shows the wrong screen     |
+| Partial divergence | An intermediate screenshot shows the wrong state though later steps ran |
+
+Anything but success goes to diagnosis. For the silent cases, the flow's `echo` labels are the reference for what each screen should have looked like.
+
+## 2. Diagnose
+
+1. Note the failing step index and its error message.
+2. `screenshot` to see where the app actually is.
+3. `describe` or `debugger-component-tree` for the current element tree. `describe` shows less than the flow's tree — a testID missing from its output can still resolve as a selector.
+4. Name the root cause in one sentence before changing anything:
+
+| Root cause       | Symptoms                                                        |
+| ---------------- | --------------------------------------------------------------- |
+| Coordinate drift | The tap landed, but on the wrong element; elements have shifted |
+| Missing element  | The target is not in the element tree at all                    |
+| Wrong screen     | The screenshot shows an entirely different page                 |
+| Timing           | The element exists but the tap fired before the screen settled  |
+| State mismatch   | The first step fails — the `executionPrerequisite` was not met  |
+
+## 3. Correct
+
+Pick the lightest fix that addresses the diagnosis:
+
+| Situation                                                                               | Fix                                                                                                                                                            |
+| --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| One step, parameter-only change                                                         | Edit `.argent/flows/<name>.yaml` — the selector, coordinates, `bundleId`, text                                                                                 |
+| One step, transient issue not worth persisting                                          | Run the corrected step and the remaining ones by hand; the YAML stays as it is                                                                                 |
+| 2–3 steps broken, or a new intermediate screen                                          | Navigate to the state just before the divergence, `flow-start-recording` with the same name (overwrites), re-add the working prefix, then record the new steps |
+| 3+ steps broken, unclear cause, or a profiling-comparison flow that must stay identical | Reset with `restart-app` and record from scratch under the same name                                                                                           |
+
+## 4. Verify, and bound the retries
+
+Re-run `flow-execute`.
+
+- It passes → report what changed, e.g. "Fixed step 4: retargeted the tap from coordinates to `{ id: about-row }`".
+- It fails at a **different** step → diagnose once more.
+- This was already the second correction → **stop.** Report the diagnosis and recommend a full re-record or manual investigation.
+
+**Hard cap: 2 correction cycles.** Never enter an unbounded fix loop.
+
+## Recording habits that prevent breakage
+
+- **Echo the expected state, not the action.** "On Settings > General, about to tap About" beats "Tap About" — during diagnosis it tells you what the screen should have shown.
+- **Gate transitions with `await`, never a fixed delay.** An unmet wait stops replay at that step, so a mistimed step can never run blind. This removes the Timing failure mode outright.
+- **Screenshot after critical navigation.** Raw `screenshot` steps put images in the run report, which is what you inspect during diagnosis.
+- **Write a specific `executionPrerequisite`.** "App on the home tab, user logged in" — not "App running". Verify it with `screenshot` + `describe` before acknowledging.
+- **Prefer `launch-app` / `open-url` over long navigation chains.** A deep link survives layout changes that a tap sequence does not.
+- **Prefer selectors to coordinates.** When a coordinate tap is unavoidable, echo the target's label or testID alongside it so repair can find the element by name.

--- a/packages/skills/skills/argent-create-flow/references/runner.md
+++ b/packages/skills/skills/argent-create-flow/references/runner.md
@@ -1,0 +1,22 @@
+# Standalone runner
+
+```
+argent flow run <name> [--device <id>] [--platform ios|android|chromium|vega]
+                       [--update-baselines] [--output <dir>] [--json]
+```
+
+Runs a flow with no LLM in the loop and exits non-zero on any failure, which is what makes it usable in CI. Both flow types run: an e2e flow starts from its own `launch`, a fragment runs against the current device state (its prerequisite is printed as a reminder) — useful while authoring, but only e2e flows give a deterministic verdict from a clean start.
+
+`--device` / `--platform` narrow device auto-detection; omitted, the runner binds the single booted device.
+
+## Snapshot baselines
+
+Baselines live in `.argent/flows/__baselines__/<flow>/`, keyed by platform and resolution. A `snapshot` step **fails when no baseline exists** for the run's device class, so:
+
+1. Seed with `--update-baselines`.
+2. Have the user review and commit `__baselines__/`.
+3. Pin the device class in CI (`--device`/`--platform`, same simulator model) so runs compare against the committed key.
+
+The status bar is pinned for the run (iOS `simctl status_bar`, Android demo mode) so a clock or battery change never drives a visual diff.
+
+`--output <dir>` writes each failed snapshot's baseline/current/diff images to `<dir>/<flow>/` — a stable path for CI artifact upload. `--json` prints the raw report.

--- a/packages/skills/skills/argent-create-flow/references/selectors.md
+++ b/packages/skills/skills/argent-create-flow/references/selectors.md
@@ -1,0 +1,74 @@
+# Selectors
+
+A selector is `{ text?, id?, role? }` plus optional scopes. All present fields must match.
+
+- `text` and `role` are case-insensitive substrings.
+- `id` matches the element's testID / accessibilityIdentifier / resource-id exactly, case-insensitively, and also accepts the unqualified Android resource-id name: `submit` matches `com.example.app:id/submit`. (`identifier` is accepted as an alias, but `id` is canonical and what the recorder writes.)
+
+A **bare string is a loose selector**: it resolves identifier-first, then falls back to text (label/value). `tap: Login` matches `testID="Login"` or, failing that, visible text "Login" — no need to know which. Loose fallback applies in every selector slot (`tap`, `type.into`, `await`, `assert`, `scroll-to`). Use the map form to be strict: `{ id: submit-btn }` or `{ text: Login }`.
+
+**Quote strings YAML would mangle.** An unquoted `#` starts a comment, so `tap: Order #1234` silently parses as `tap: Order`; bare `yes`/`no`/`on`/`off`/numbers coerce to non-strings. Wrap anything containing `#`, `:`, quotes, or that reads as a boolean or number: `tap: "Order #1234"`.
+
+## Regex matchers
+
+`text` also takes `{ matches: '…' }`, in any selector slot, for dynamic text no literal can pin:
+
+```yaml
+- assert: { visible: { text: { matches: '^Taps: \d+$' } } }
+- tap: { text: { matches: '^Order #\d+$' } }
+```
+
+The pattern is unanchored, **case-sensitive**, and must be single-quoted so YAML keeps the backslashes; an invalid pattern fails at parse. It tests each node's own label/value, not the adapter-hoisted `subtreeText` — though on iOS a container's own label may itself aggregate descendant text, so a wrapper and its leaf can both match. A stable `id` is still the more robust action target.
+
+## Resolution and ranking
+
+Selectors resolve against the **full native hierarchy** (iOS: the UIView tree; Android: the complete accessibility hierarchy including not-important views) — strictly more than `describe` or the raw `await-ui-element` tool see, both of which use the trimmed tree. An `id` selector therefore works even when `describe` collapses or omits the element; don't fall back to a coordinate tap just because a testID is missing from `describe` output.
+
+When several elements match, the action directives (`tap`, `type`, `scroll-to`) pick the **most specific**: an exact text/identifier match beats a substring hit — a regex consuming the element's whole text counts as exact — and then the smallest frame wins. An `any: true` selector has no field to be exact about, so its matches rank by reading order instead: the first element in the scope, which is the one a condition reads too. Where two matches share a top-left corner, an action breaks the tie toward the smaller element and a condition does not, so the two can name different elements.
+
+## Scopes
+
+A map selector may carry a **scope**: a nested selector naming another element the match must sit in a given spatial relation to. These are the geometric readings of the CSS combinators that survive a flattened tree; the child combinator `>` has no analog, since parent/child structure does not reach replay.
+
+| Scope           | CSS     | Reads as                                                         | Example                                                               |
+| --------------- | ------- | ---------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `within: <sel>` | `A B`   | the match's frame sits **inside** the scope element's frame      | `tap: { text: Delete, within: { id: profile-card } }`                 |
+| `after: <sel>`  | `A ~ B` | the match **follows** the scope element in reading order         | `assert: { visible: { role: Button, after: { text: Danger zone } } }` |
+| `next: <sel>`   | `A + B` | as `after`, narrowed to the **nearest** follower of each anchor  | `tap: { role: Switch, next: { text: Wi-Fi } }`                        |
+| `any: true`     | `*`     | universal — matches anything in the scope, no locator of its own | `assert: { hidden: { any: true, within: { id: empty-state } } }`      |
+
+Rules that hold for all of them:
+
+- Scopes are **visual (frame-based), not tree ancestry** — "inside the card" and "the switch after this label" mean what the screen shows.
+- A scope only narrows _where_ to look; the selector still needs its own `text`/`id`/`role` naming _what_ to find, or `any: true`.
+- Every scope needs a **distinct element** — nothing scopes itself, and the synthetic screen root never counts.
+- Scopes combine and nest, up to six per selector. The nested slot takes every selector form: a bare string stays loose, the map form stays strict, regex matchers work.
+- `any: true` needs at least one scope (bare, it would match the whole screen), may not sit beside `text`/`id`/`role`, and accepts only the literal `true`.
+- Scopes are flow-YAML only — the raw `await-ui-element` tool's selector accepts none of them.
+
+Prefer a unique `id` on the target itself when one exists. Reach for a scope when the target has no unique locator: repeated row actions, per-card buttons, list cells.
+
+### `within`
+
+`tap: { text: Delete, within: { id: profile-card } }` taps the Delete button in the profile card even when other cards show identical ones. Scope to a container with a **tight frame** — a row, card, dialog, toast; a full-screen wrapper contains everything and scopes nothing. It chains outward, each container's frame inside the next: `{ text: Save, within: { id: cards, within: Settings } }`.
+
+### `after` and `next`
+
+Reading order is row-band aware: an element **follows** the anchor when it starts below the anchor's bottom edge, _or_ shares its row band and sits entirely to its right. That is what makes `{ role: Switch, next: { text: Wi-Fi } }` resolve the Wi-Fi row's own switch even though the taller switch's frame starts a few pixels higher than the label's.
+
+`next` keeps only the nearest follower — a match in the anchor's own row beats anything below, leftmost first — while `after` keeps them all, so `assert: { hidden: { role: Button, after: { text: Danger zone } } }` holds when nothing button-like appears past that heading. Both union over anchors exactly as CSS does: with three rows on screen, `{ role: Switch, next: { role: AXStaticText } }` yields all three switches, one per label.
+
+An element sitting _inside_ the anchor does not follow it — containment is not reading order — so use `within` for that.
+
+### Pitfalls
+
+- **Spell an anchor as a map.** A bare-string anchor (`next: wifi-row`) keeps the identifier-first fallback, and the runner takes the first pass that finds a visible match. A decoy `testID="Wi-Fi"` elsewhere on screen makes `tap: { role: Switch, next: Wi-Fi }` tap the decoy's neighbour and report a pass. A decoy _container_ only wins if it actually holds a match; a decoy _anchor_ wins if anything at all sits after it. Write `next: { text: Wi-Fi }`.
+- **`next` is looser than CSS `+`.** Where `A + B` matches nothing unless the very next sibling is a `B`, `next` keeps looking and returns the nearest match further on — which is what lets it survive wrapper and spacer nodes, but also means a row missing the control resolves to the next row's. On a Wi-Fi row rendered without a switch, `{ role: Switch, next: { text: Wi-Fi } }` returns the Bluetooth row's switch instead of failing. When a row may legitimately lack the control, assert it first or scope by `within`.
+- **"Follows" is not transitive**, so nesting `after` is not the same as chaining CSS `~`: against a tall anchor, an element can follow something that itself follows the anchor without following the anchor directly. `{ after: { …, after: … } }` can match elements a single `after` excludes. Nest only when each link is a container-sized step.
+- **It matters which side carries the scope.** `{ role: Button, next: { text: Name, within: { id: card-b } } }` scopes the _anchor_ — one label, so one pick, but that pick may land outside card-b. `{ role: Button, next: { text: Name }, within: { id: card-b } }` scopes the _target_ — every label is still an anchor, but only card-b's buttons can be picked. They agree on a well-formed screen and diverge when card-b has no button: the first reaches on to the next card's, the second returns nothing. Scope the target when the container is the thing you trust.
+
+### Scopes in conditions
+
+Conditions honor scopes like any other selector. `assert: { hidden: { text: Saved, within: { id: toast-area } } }` holds when nothing matching "Saved" is inside the toast area — matches elsewhere on screen don't count. A missing scope element satisfies `hidden` and fails `visible`/`exists`.
+
+`any: true` works for actions too — `tap: { any: true, next: { text: Airplane Mode } }` taps whatever sits right after that label — but on a real tree "whatever" includes spacers and wrappers. Name the target (`role`, `id`) whenever you can, and keep `any` for conditions and for `next`, which reduces to one element per anchor.

--- a/packages/skills/skills/argent-create-flow/references/selectors.md
+++ b/packages/skills/skills/argent-create-flow/references/selectors.md
@@ -67,8 +67,10 @@ An element sitting _inside_ the anchor does not follow it — containment is not
 - **"Follows" is not transitive**, so nesting `after` is not the same as chaining CSS `~`: against a tall anchor, an element can follow something that itself follows the anchor without following the anchor directly. `{ after: { …, after: … } }` can match elements a single `after` excludes. Nest only when each link is a container-sized step.
 - **It matters which side carries the scope.** `{ role: Button, next: { text: Name, within: { id: card-b } } }` scopes the _anchor_ — one label, so one pick, but that pick may land outside card-b. `{ role: Button, next: { text: Name }, within: { id: card-b } }` scopes the _target_ — every label is still an anchor, but only card-b's buttons can be picked. They agree on a well-formed screen and diverge when card-b has no button: the first reaches on to the next card's, the second returns nothing. Scope the target when the container is the thing you trust.
 
+### `any: true`
+
+It works for actions — `tap: { any: true, next: { text: Airplane Mode } }` taps whatever sits right after that label — but on a real tree "whatever" includes spacers and wrappers. Name the target (`role`, `id`) whenever you can, and keep `any` for conditions and for `next`, which reduces to one element per anchor.
+
 ### Scopes in conditions
 
 Conditions honor scopes like any other selector. `assert: { hidden: { text: Saved, within: { id: toast-area } } }` holds when nothing matching "Saved" is inside the toast area — matches elsewhere on screen don't count. A missing scope element satisfies `hidden` and fails `visible`/`exists`.
-
-`any: true` works for actions too — `tap: { any: true, next: { text: Airplane Mode } }` taps whatever sits right after that label — but on a real tree "whatever" includes spacers and wrappers. Name the target (`role`, `id`) whenever you can, and keep `any` for conditions and for `next`, which reduces to one element per anchor.

--- a/packages/skills/skills/argent-react-native-profiler/SKILL.md
+++ b/packages/skills/skills/argent-react-native-profiler/SKILL.md
@@ -141,7 +141,7 @@ This is useful for before/after comparisons: profile, fix, re-profile, then relo
 
 If fix is present, read the source code of the identified bottleneck using `react-profiler-component-source` or the Read tool. Apply the fix, then re-profile (Step 1 -> user interaction -> Step 2 -> Step 3 -> Step 4). Report whether the target metric improved, stayed flat, or regressed. Also check whether the fix introduced regressions in other metrics (e.g., render count dropped but CPU time increased, or a different component now re-renders more). If the fix showed no net benefit or unacceptable tradeoffs, revert and reconsider.
 
-**Tip:** If the interaction sequence was recorded as a flow (see "Use flows for reproducible profiling" above), replay it with `flow-execute` instead of manually repeating the steps. This guarantees identical interaction conditions for the comparison. If the flow fails during replay (e.g., a UI fix changed the layout), follow `argent-create-flow` skill §10 (Flow Self-Improvement) to diagnose and repair the flow before retrying the profiling cycle.
+**Tip:** If the interaction sequence was recorded as a flow (see "Use flows for reproducible profiling" above), replay it with `flow-execute` instead of manually repeating the steps. This guarantees identical interaction conditions for the comparison. If the flow fails during replay (e.g., a UI fix changed the layout), follow the `argent-create-flow` skill ("When a flow breaks", detailed in its `references/repair.md`) to diagnose and repair the flow before retrying the profiling cycle.
 
 If the user stated that they do not wish for changes, present the profiling report and skip the fix but suggest it to the user.
 

--- a/packages/skills/skills/argent-test-ui-flow/SKILL.md
+++ b/packages/skills/skills/argent-test-ui-flow/SKILL.md
@@ -108,7 +108,7 @@ Steps:
 - If tap misses target: re-run discovery tool (`describe` / `debugger-component-tree`), retry once with new coordinates.
 - If a permission dialog or modal is visible: re-run `describe` first. Stay in screenshot-driven navigation only when the overlay is not exposed reliably, then switch back to `describe` / `debugger-component-tree` as soon as it is dismissed.
 - If tap fails twice at same coordinates: stop, re-discover, report if element not found.
-- If a **saved flow** fails during `flow-execute` replay (as opposed to live test steps above): follow `argent-create-flow` skill §10 for structured diagnosis and correction.
+- If a **saved flow** fails during `flow-execute` replay (as opposed to live test steps above): follow the `argent-create-flow` skill ("When a flow breaks", detailed in its `references/repair.md`) for structured diagnosis and correction.
 
 ## Tips
 

--- a/packages/tool-server/test/flows/flow-skill-docs.test.ts
+++ b/packages/tool-server/test/flows/flow-skill-docs.test.ts
@@ -8,13 +8,19 @@ import { parseFlow } from "../../src/tools/flows/flow-utils";
  * a snippet that no longer parses is a live defect: an agent copies it and the
  * flow fails at parse. Guards the examples against parser drift.
  */
-const SKILL = path.resolve(__dirname, "../../../skills/skills/argent-create-flow/SKILL.md");
+const SELECTORS_DOC = path.resolve(
+  __dirname,
+  "../../../skills/skills/argent-create-flow/references/selectors.md"
+);
 
 function scopesSection(): string {
-  const md = readFileSync(SKILL, "utf8");
-  const after = md.split("#### Scopes")[1];
-  expect(after, "the scopes section is missing from SKILL.md").toBeDefined();
-  return after!.split("\nSelectors resolve against")[0]!;
+  const md = readFileSync(SELECTORS_DOC, "utf8");
+  // Everything from the `## Scopes` heading to the end of the document. The
+  // `\n## ` prefix keeps the `### Scopes in conditions` subsection inside the
+  // slice instead of ending it.
+  const after = md.split(/\n## Scopes\n/)[1];
+  expect(after, "the scopes section is missing from selectors.md").toBeDefined();
+  return after!;
 }
 
 // `…` marks an illustrative fragment (`within: <sel>`, and the deliberately
@@ -46,7 +52,7 @@ describe("create-flow SKILL.md scope snippets", () => {
     // The docs tell agents to write `{ role: Switch, next: … }` and NOT
     // `{ any: true, role: Switch, next: … }`. If the parser ever started
     // accepting the second, the advice would be noise.
-    expect(scopesSection()).toContain("may **not** sit beside");
+    expect(scopesSection()).toContain("may not sit beside");
     expect(() =>
       parseFlow("steps:\n  - tap: { any: true, role: Switch, next: { text: Wi-Fi } }\n")
     ).toThrow(/already matches every element/);


### PR DESCRIPTION
## Why

`argent-create-flow/SKILL.md` had grown to **6,854 words in one file** — past the point where it reads as usable instructions, and past the 5,000-word ceiling Anthropic's [skill-building guide](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) gives for a SKILL.md body ("Large context issues → move detailed docs to `references/`, link instead of inline"). The guide's other failure modes applied too: instructions too verbose, the operative workflow buried under reference material, and the same points restated in several places.

## What changed

Restructured around progressive disclosure. `SKILL.md` now carries only what an agent runs — record, polish, replay, repair, when to record proactively — and links out to four single-topic references:

| File | Holds |
| ---- | ----- |
| `references/directives.md` | flow file format and every directive, plus Vega |
| `references/selectors.md` | selector grammar, regex matchers, `within`/`after`/`next` scopes |
| `references/runner.md` | `argent flow run`, snapshot baselines, CI |
| `references/repair.md` | diagnosing and repairing a broken flow |

Content is condensed, not dropped:

- Repeated explanations stated once instead of 3-5 times — the trimmed `describe` tree vs the flow's full hierarchy, "gate with `await`, not a delay", "`tap`/`type` never scroll".
- The four repair "strategies" plus their decision heuristic collapse into one situation → fix table.
- The five polish conversions (keyboard, await-ui-element, swipe, pinch, rotate) become one table with a "keep raw when" column, replacing ~700 words of prose.
- Opinionated asides trimmed (e.g. the paragraph justifying why `timeout` should be omitted is now one sentence).

**SKILL.md: 6,854 → 1,403 words (-80%).** All five files together: 5,259 words (-23%), with the always-loaded part being the part that shrank.

## Verification

- Every factual claim re-checked against `packages/tool-server/src/tools/flows/` and `packages/argent-cli/src/flow.ts` — directive shapes, `ARGENT_SECRET_` resolution, `long-press` 800 ms default, `when` guard keys, `delayMs` as a tool-step sibling, runner flags.
- Term-level audit over ~40 load-bearing identifiers from the old file (`cropOn`, `pollIntervalMs`, `__baselines__`, `optional:`, `endCenterX`, …): all still present.
- `node scripts/grade-skills.mjs` — 10.0/10, all 15 skills (this is the Skill Description Quality CI gate).
- `prettier --check` clean.
- Install path exercised end to end: `skills add <skill dir>` into a scratch repo ships `SKILL.md` + all four `references/*.md`. The npm bundler copies skill dirs recursively and already documents `<skill>/references/*.md` as an expected shape.

## Ripple

`argent-react-native-profiler` and `argent-test-ui-flow` both pointed callers at "`argent-create-flow` skill §10 (Flow Self-Improvement)" — a section number that never existed and a heading that does not any more. Both now name the current location.


`packages/tool-server/test/flows/flow-skill-docs.test.ts` parses every YAML snippet in the scopes section to guard the docs against parser drift; it located that section by splitting `SKILL.md` on `#### Scopes`. It now reads `references/selectors.md` and slices from `\n## Scopes\n` — the `\n## ` prefix matters, since a plain `"## Scopes"` split would also match `### Scopes in conditions` and silently truncate the slice.
