### PR TITLE
feat(ios): keyboard, rotate, open-url, restart-app and screenshot-diff on physical iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ CoreDevice "remote control" services (the same path Xcode's device window uses).
 interaction runs natively inside the bundled **simulator-server** (radon's `ios_device`
 controller). The CoreDevice tunnel is a userspace TCP stack over the USB connection, so every
 command runs unprivileged, with no admin prompt and nothing installed on the host. Supported interactions: `screenshot`, `gesture-tap`, `gesture-swipe`,
-`keyboard`, `button`, `rotate`, `launch-app`, `restart-app`, `open-url`, `screenshot-diff`, and
+`gesture-custom` (single touch), `keyboard`, `button`, `rotate`, `launch-app`, `restart-app`,
+`open-url`, `screenshot-diff`, and
 `describe` (the live on-screen accessibility tree — see the note below). The device shows up in `list-devices` with `kind: "device"`.
 
 **Requirements**
@@ -94,15 +95,21 @@ no manual step, no `sudo`.
   to tell whether the screen changed. (For pixel-exact in-app frames + taps you'd need an on-device
   XCUITest runner, which requires code-signing.)
 
-- **Multi-touch is not available.** `gesture-pinch`, `gesture-rotate` and `gesture-custom` return a
-  clear "not supported" error. The device registers a single touch surface, `mainTouchscreen`
-  (HID usage page `0x0D` "Digitizer" / usage `0x04` "Touch Screen"), and its report carries one
-  contact. The surface that sounds like a second candidate, `touchscreenGesture`, enumerates as
-  usage page `0x01` "Generic Desktop" / usage `0x02` "Mouse" — the pointer for the mirroring
-  window, not a second finger.
+- **Multi-touch is not available.** `gesture-pinch` and `gesture-rotate` return a clear "not
+  supported" error, and `gesture-custom` rejects any event carrying a second touch point
+  (`x2`/`y2`) — its single-touch sequences (long press, drag-and-drop, custom scroll) work. The
+  device registers a single touch surface, `mainTouchscreen` (HID usage page `0x0D` "Digitizer" /
+  usage `0x04` "Touch Screen"), and its report carries one contact. The surface that sounds like a
+  second candidate, `touchscreenGesture`, enumerates as usage page `0x01` "Generic Desktop" /
+  usage `0x02` "Mouse" — the pointer for the mirroring window, not a second finger.
 
-- Also not supported (all return a clear "not supported" error): `paste`, `reinstall-app`, and the
-  native inspection / profiling tools (`native-*`, `native-profiler-*`). `launch-app`,
+- **`await-screen-idle` is not available.** It decides "idle" from two consecutive identical
+  accessibility trees, and the read below rotates the element order on every call, so the
+  comparison never matches. Poll `screenshot` instead.
+
+- Also not supported (all return a clear "not supported" error): `paste`, `reinstall-app`,
+  `settings-permissions`, screen recording, and the native inspection / profiling tools
+  (`native-*`, `native-profiler-*`). `launch-app`,
   `restart-app` and `open-url` go through `devicectl` rather than the CoreDevice session, so they
   work even before the first interaction has warmed it.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ CoreDevice "remote control" services (the same path Xcode's device window uses).
 interaction runs natively inside the bundled **simulator-server** (radon's `ios_device`
 controller). The CoreDevice tunnel is a userspace TCP stack over the USB connection, so every
 command runs unprivileged, with no admin prompt and nothing installed on the host. Supported interactions: `screenshot`, `gesture-tap`, `gesture-swipe`,
-`button`, `launch-app`, and `describe` (the live on-screen accessibility tree — see the note
-below). The device shows up in `list-devices` with `kind: "device"`.
+`keyboard`, `button`, `rotate`, `launch-app`, `restart-app`, `open-url`, `screenshot-diff`, and
+`describe` (the live on-screen accessibility tree — see the note below). The device shows up in `list-devices` with `kind: "device"`.
 
 **Requirements**
 
@@ -94,12 +94,17 @@ no manual step, no `sudo`.
   to tell whether the screen changed. (For pixel-exact in-app frames + taps you'd need an on-device
   XCUITest runner, which requires code-signing.)
 
-- Not supported yet (return a clear "not supported" error): keyboard/typing, `paste`, multi-touch
-  gestures (`gesture-pinch`, `gesture-rotate`, `gesture-custom`), device orientation (`rotate`),
-  `open-url`, `reinstall-app`, `restart-app`, and the native inspection / profiling tools
-  (`native-*`, `native-profiler-*`, `screenshot-diff`). `launch-app` (via `devicectl`) works
-  independently of the CoreDevice session — it can succeed even before the first interaction has
-  warmed it.
+- **Multi-touch is not available.** `gesture-pinch`, `gesture-rotate` and `gesture-custom` return a
+  clear "not supported" error. The device registers a single touch surface, `mainTouchscreen`
+  (HID usage page `0x0D` "Digitizer" / usage `0x04` "Touch Screen"), and its report carries one
+  contact. The surface that sounds like a second candidate, `touchscreenGesture`, enumerates as
+  usage page `0x01` "Generic Desktop" / usage `0x02` "Mouse" — the pointer for the mirroring
+  window, not a second finger.
+
+- Also not supported (all return a clear "not supported" error): `paste`, `reinstall-app`, and the
+  native inspection / profiling tools (`native-*`, `native-profiler-*`). `launch-app`,
+  `restart-app` and `open-url` go through `devicectl` rather than the CoreDevice session, so they
+  work even before the first interaction has warmed it.
 
 ---
 

--- a/packages/tool-server/src/tools/await-screen-idle/index.ts
+++ b/packages/tool-server/src/tools/await-screen-idle/index.ts
@@ -68,8 +68,13 @@ interface IdleResult {
   polls: number;
 }
 
+// Physical iPhones are excluded: their accessibility read starts from the
+// device's VoiceOver cursor and advances it, so consecutive `describe` calls
+// return the same elements rotated by one, with resynthesised frames. The
+// signature below therefore changes on every poll even on a frozen screen, and
+// the tool could only ever burn the full timeout and report `settled: false`.
 const capability: ToolCapability = {
-  apple: { simulator: true, device: true },
+  apple: { simulator: true, device: false },
   android: { emulator: true, device: true, unknown: true },
   chromium: { app: true },
 };

--- a/packages/tool-server/src/tools/gesture-custom/index.ts
+++ b/packages/tool-server/src/tools/gesture-custom/index.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { ToolCapability, ToolDefinition } from "@argent/registry";
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
+import { UnsupportedOperationError } from "../../utils/capability";
 import { sendCommand } from "../../utils/simulator-client";
 import { interpolateEvents } from "../../utils/gesture-utils";
 
@@ -48,8 +49,12 @@ interface Result {
   events: number;
 }
 
+// Physical iPhones are in: the single-contact half of this tool (long press,
+// drag-and-drop, custom scroll) is exactly the Down/Move/Up stream the CoreDevice
+// digitizer takes. Only the `x2`/`y2` half is out of reach there, and that is
+// rejected per-request below rather than by shutting the whole tool out.
 const capability: ToolCapability = {
-  apple: { simulator: true, device: false },
+  apple: { simulator: true, device: true },
   appleRemote: { simulator: true },
   android: { emulator: true, device: true, unknown: true },
 };
@@ -63,6 +68,7 @@ For pinch gestures use gesture-pinch. For rotation gestures use gesture-rotate.
 All x/y values are normalized 0.0–1.0 (screen fractions, not pixels). delayMs controls the delay before each event (default 16ms ≈ 60fps).
 Set interpolate to auto-generate smooth intermediate Move events between your keyframes.
 Returns { events: number } with the total count of events dispatched. Fails if the target device is not booted or an event type is invalid.
+On a physical iPhone the touchscreen takes one contact, so x2/y2 are rejected there; single-touch sequences work.
 
 Example long-press at center:
   [{"type":"Down","x":0.5,"y":0.5},{"type":"Up","x":0.5,"y":0.5,"delayMs":800}]
@@ -83,6 +89,26 @@ Example pinch-to-zoom (with interpolate:10 for smoothness):
   }),
   async execute(services, params) {
     const api = services.simulatorServer as SimulatorServerApi;
+
+    const device = resolveDevice(params.udid);
+    if (device.platform === "ios" && device.kind === "device") {
+      // Checked across the whole sequence before the first event goes out: a
+      // rejection partway through would leave the contact down on the device
+      // with no Up to follow. Indexed against the caller's own `events`, not the
+      // interpolated expansion, so the reported position is one they can find.
+      const secondTouchAt = params.events.findIndex(
+        (e) => e.x2 !== undefined || e.y2 !== undefined
+      );
+      if (secondTouchAt !== -1) {
+        throw new UnsupportedOperationError(
+          "gesture-custom",
+          device,
+          `a second touch point (x2/y2, first at events[${secondTouchAt}]) needs two contacts, and CoreDevice exposes a single-contact touchscreen; ` +
+            `single-touch sequences - long press, drag-and-drop, custom scroll - work`
+        );
+      }
+    }
+
     const events =
       params.interpolate && params.interpolate > 0
         ? interpolateEvents(params.events, params.interpolate)

--- a/packages/tool-server/src/tools/keyboard/index.ts
+++ b/packages/tool-server/src/tools/keyboard/index.ts
@@ -42,7 +42,7 @@ const zodSchema = z.object({
 type Params = z.infer<typeof zodSchema>;
 
 const capability: ToolCapability = {
-  apple: { simulator: true, device: false },
+  apple: { simulator: true, device: true },
   appleRemote: { simulator: true },
   android: { emulator: true, device: true, unknown: true },
   chromium: { app: true },

--- a/packages/tool-server/src/tools/open-url/platforms/ios.ts
+++ b/packages/tool-server/src/tools/open-url/platforms/ios.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { FAILURE_CODES, FailureError, subprocessFailureMetadata } from "@argent/registry";
+import { assertPhysicalIosEnabled } from "../../../blueprints/simulator-server";
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
-import { UnsupportedOperationError } from "../../../utils/capability";
 import type { OpenUrlParams, OpenUrlResult, OpenUrlServices } from "../types";
 import { httpDeepLinkNote } from "../deep-link-note";
 
@@ -12,18 +12,35 @@ export const iosImpl: PlatformImpl<OpenUrlServices, OpenUrlParams, OpenUrlResult
   requires: ["xcrun"],
   handler: async (_services, params, device) => {
     if (device.kind === "device") {
-      // Not wired up for physical iOS yet: the supported surface there is
-      // screenshot, describe, gesture-tap, gesture-swipe, button and launch-app.
-      // `xcrun devicectl device process openURL` is the mechanism this would use
-      // — the same binary the launch-app branch already shells — so this is a
-      // scope boundary, not a platform limit. UnsupportedOperationError maps to
-      // a clean 400 (a plain Error would surface as a generic 500).
-      throw new UnsupportedOperationError(
-        "open-url",
-        device,
-        "opening URLs on a physical iPhone is not implemented yet — launch the app with launch-app, " +
-          "or open the link by driving the UI (gesture-tap / keyboard on a simulator)"
-      );
+      // Physical iPhones open URLs through devicectl rather than simctl. Like
+      // launch-app — the other tool that shells devicectl instead of going
+      // through a CoreDevice service — this has to enforce the opt-in itself,
+      // since no simulator-server ref is built on this path to run the gate.
+      assertPhysicalIosEnabled();
+      try {
+        await execFileAsync("xcrun", [
+          "devicectl",
+          "device",
+          "process",
+          "openURL",
+          "--device",
+          params.udid,
+          params.url,
+        ]);
+      } catch (err) {
+        throw new FailureError(
+          `Failed to open URL on physical iOS device ${params.udid}.`,
+          {
+            error_code: FAILURE_CODES.IOS_OPEN_URL_FAILED,
+            failure_stage: "ios_open_url_devicectl_openurl",
+            failure_area: "tool_server",
+            error_kind: "subprocess",
+            ...subprocessFailureMetadata(err, "xcrun_devicectl"),
+          },
+          { cause: err instanceof Error ? err : new Error(String(err)) }
+        );
+      }
+      return { opened: true, url: params.url, note: httpDeepLinkNote(params.url) };
     }
     try {
       await execFileAsync("xcrun", ["simctl", "openurl", params.udid, params.url]);

--- a/packages/tool-server/src/tools/restart-app/platforms/ios.ts
+++ b/packages/tool-server/src/tools/restart-app/platforms/ios.ts
@@ -11,8 +11,8 @@ import {
   precheckNativeDevtools,
   type NativeDevtoolsApi,
 } from "../../../blueprints/native-devtools";
+import { assertPhysicalIosEnabled } from "../../../blueprints/simulator-server";
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
-import { UnsupportedOperationError } from "../../../utils/capability";
 import type { RestartAppParams, RestartAppResult } from "../types";
 
 const execFileAsync = promisify(execFile);
@@ -29,19 +29,40 @@ export function makeIosImpl(
     handler: async (_services, params, device) => {
       const { udid, bundleId } = params;
       if (device.kind === "device") {
-        // The simulator path restarts *through* native-devtools so the relaunched
-        // process comes back injected; that injection is simulator-only, so there
-        // is nothing for this tool to preserve on hardware and it is not wired up
-        // for physical iOS. (`devicectl device process launch --terminate-existing`
-        // would relaunch a plain, uninjected app — see launch-app.)
-        // UnsupportedOperationError maps to a clean 400 (a plain Error would
-        // surface as a generic 500).
-        throw new UnsupportedOperationError(
-          "restart-app",
-          device,
-          "restarting an app on a physical iPhone is not implemented yet — use launch-app to bring " +
-            "it back to the foreground"
-        );
+        // A physical iPhone restarts through devicectl, which relaunches the app
+        // as it is installed. The simulator path restarts *through*
+        // native-devtools so the process comes back injected; that injection is
+        // simulator-only, so there is nothing to preserve here and a plain
+        // relaunch is the whole operation. Like launch-app — the other tool that
+        // shells devicectl rather than going through a CoreDevice service — this
+        // enforces the opt-in itself, since no simulator-server ref is built on
+        // this path to run the gate.
+        assertPhysicalIosEnabled();
+        try {
+          await execFileAsync("xcrun", [
+            "devicectl",
+            "device",
+            "process",
+            "launch",
+            "--terminate-existing",
+            "--device",
+            udid,
+            bundleId,
+          ]);
+        } catch (err) {
+          throw new FailureError(
+            `Failed to restart ${bundleId} on physical iOS device ${udid} via devicectl — the app must already be installed and signed on the device.`,
+            {
+              error_code: FAILURE_CODES.IOS_RESTART_LAUNCH_FAILED,
+              failure_stage: "ios_restart_app_devicectl_launch",
+              failure_area: "tool_server",
+              error_kind: "subprocess",
+              ...subprocessFailureMetadata(err, "xcrun_devicectl"),
+            },
+            { cause: err instanceof Error ? err : new Error(String(err)) }
+          );
+        }
+        return { restarted: true, bundleId };
       }
       const ndRef = nativeDevtoolsRef(device);
       const nativeDevtools = await registry.resolveService<NativeDevtoolsApi>(

--- a/packages/tool-server/src/tools/rotate/index.ts
+++ b/packages/tool-server/src/tools/rotate/index.ts
@@ -18,7 +18,7 @@ interface Result {
 }
 
 const capability: ToolCapability = {
-  apple: { simulator: true, device: false },
+  apple: { simulator: true, device: true },
   appleRemote: { simulator: true },
   android: { emulator: true, device: true, unknown: true },
 };

--- a/packages/tool-server/src/tools/screenshot-diff/index.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/index.ts
@@ -75,7 +75,7 @@ export interface ScreenshotDiffResult {
 type CaptureScreenshot = typeof httpScreenshot;
 
 const capability: ToolCapability = {
-  apple: { simulator: true, device: false },
+  apple: { simulator: true, device: true },
   android: { emulator: true, device: true, unknown: true },
 };
 

--- a/packages/tool-server/test/physical-ios-devicectl.test.ts
+++ b/packages/tool-server/test/physical-ios-devicectl.test.ts
@@ -21,9 +21,12 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("@argent/configuration-core", () => ({ isFlagEnabled: vi.fn() }));
 
-const { iosImpl: openUrlIos } = await import("../src/tools/open-url/platforms/ios");
-const { makeIosImpl: makeRestartAppIosImpl } =
-  await import("../src/tools/restart-app/platforms/ios");
+// Static imports are safe despite the mocks above: vitest hoists `vi.mock` calls
+// above every import in the file, so both modules see the mocked
+// `node:child_process`. (A top-level `await import` would also work at runtime
+// but does not typecheck under the test tsconfig's module setting.)
+import { iosImpl as openUrlIos } from "../src/tools/open-url/platforms/ios";
+import { makeIosImpl as makeRestartAppIosImpl } from "../src/tools/restart-app/platforms/ios";
 
 const PHYSICAL_UDID = "00008120-000E6D0C0ABBA01E";
 const device = resolveDevice(PHYSICAL_UDID);
@@ -100,8 +103,9 @@ describe("restart-app on a physical iPhone", () => {
         "com.example.app",
       ],
     ]);
-    expect(result.restarted).toBe(true);
-    expect(result.bundleId).toBe("com.example.app");
+    // toMatchObject, not property access: the declared result type is a union
+    // with the native-devtools init-failure shape, which has neither field.
+    expect(result).toMatchObject({ restarted: true, bundleId: "com.example.app" });
   });
 
   it("reports a devicectl failure rather than claiming a restart", async () => {

--- a/packages/tool-server/test/physical-ios-devicectl.test.ts
+++ b/packages/tool-server/test/physical-ios-devicectl.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { isFlagEnabled } from "@argent/configuration-core";
+import { InvalidToolInputError } from "../src/utils/capability";
+import { resolveDevice } from "../src/utils/device-info";
+
+// The two physical-iOS operations that shell `devicectl` instead of going
+// through a CoreDevice service. Isolated in their own file so the
+// `node:child_process` mock can't reach the suites that run the real binary.
+const execCalls: string[][] = [];
+let execResult: () => Promise<{ stdout: string; stderr: string }> = () =>
+  Promise.resolve({ stdout: "", stderr: "" });
+
+vi.mock("node:child_process", () => ({
+  execFile: Object.assign(() => undefined, {
+    [Symbol.for("nodejs.util.promisify.custom")]: (file: string, args: string[]) => {
+      execCalls.push([file, ...args]);
+      return execResult();
+    },
+  }),
+}));
+
+vi.mock("@argent/configuration-core", () => ({ isFlagEnabled: vi.fn() }));
+
+const { iosImpl: openUrlIos } = await import("../src/tools/open-url/platforms/ios");
+const { makeIosImpl: makeRestartAppIosImpl } =
+  await import("../src/tools/restart-app/platforms/ios");
+
+const PHYSICAL_UDID = "00008120-000E6D0C0ABBA01E";
+const device = resolveDevice(PHYSICAL_UDID);
+const restartIos = makeRestartAppIosImpl({} as never);
+const mockFlag = vi.mocked(isFlagEnabled);
+
+beforeEach(() => {
+  execCalls.length = 0;
+  execResult = () => Promise.resolve({ stdout: "", stderr: "" });
+  mockFlag.mockReturnValue(true);
+});
+
+describe("open-url on a physical iPhone", () => {
+  it("opens the URL through devicectl", async () => {
+    const result = await openUrlIos.handler(
+      {} as never,
+      { udid: PHYSICAL_UDID, url: "https://example.com" } as never,
+      device
+    );
+
+    expect(execCalls).toEqual([
+      [
+        "xcrun",
+        "devicectl",
+        "device",
+        "process",
+        "openURL",
+        "--device",
+        PHYSICAL_UDID,
+        "https://example.com",
+      ],
+    ]);
+    expect(result.opened).toBe(true);
+    expect(result.url).toBe("https://example.com");
+  });
+
+  it("never reaches simctl, which cannot address hardware", async () => {
+    await openUrlIos.handler(
+      {} as never,
+      { udid: PHYSICAL_UDID, url: "myapp://x" } as never,
+      device
+    );
+    expect(execCalls.flat()).not.toContain("simctl");
+  });
+
+  it("is refused while the physical-iOS flag is off", async () => {
+    mockFlag.mockReturnValue(false);
+    await expect(
+      openUrlIos.handler({} as never, { udid: PHYSICAL_UDID, url: "https://x" } as never, device)
+    ).rejects.toBeInstanceOf(InvalidToolInputError);
+    // The gate has to run before the subprocess, not after it.
+    expect(execCalls).toEqual([]);
+  });
+});
+
+describe("restart-app on a physical iPhone", () => {
+  it("relaunches through devicectl, terminating the running instance first", async () => {
+    const result = await restartIos.handler(
+      {} as never,
+      { udid: PHYSICAL_UDID, bundleId: "com.example.app" } as never,
+      device
+    );
+
+    expect(execCalls).toEqual([
+      [
+        "xcrun",
+        "devicectl",
+        "device",
+        "process",
+        "launch",
+        "--terminate-existing",
+        "--device",
+        PHYSICAL_UDID,
+        "com.example.app",
+      ],
+    ]);
+    expect(result.restarted).toBe(true);
+    expect(result.bundleId).toBe("com.example.app");
+  });
+
+  it("reports a devicectl failure rather than claiming a restart", async () => {
+    execResult = () => Promise.reject(new Error("app not installed"));
+    await expect(
+      restartIos.handler(
+        {} as never,
+        { udid: PHYSICAL_UDID, bundleId: "com.example.app" } as never,
+        device
+      )
+    ).rejects.toThrow(/Failed to restart com\.example\.app/);
+  });
+
+  it("is refused while the physical-iOS flag is off", async () => {
+    mockFlag.mockReturnValue(false);
+    await expect(
+      restartIos.handler({} as never, { udid: PHYSICAL_UDID, bundleId: "com.x" } as never, device)
+    ).rejects.toBeInstanceOf(InvalidToolInputError);
+    expect(execCalls).toEqual([]);
+  });
+});

--- a/packages/tool-server/test/physical-ios-followups.test.ts
+++ b/packages/tool-server/test/physical-ios-followups.test.ts
@@ -10,9 +10,10 @@
  *  - launch-app enforces the opt-in flag itself (it shells `devicectl`, not the
  *    sim-server, so it can't ride the factory's gate);
  *  - tools that are unsupported on physical iOS reject with a 400-mapped
- *    UnsupportedOperationError, not a generic 500 (open-url/reinstall/restart,
- *    native-profiler), while `describe` returns the CoreDevice ax tree and stays
- *    supported on simulators/Android;
+ *    UnsupportedOperationError, not a generic 500 (reinstall-app, the
+ *    native-devtools and native-profiler families, the multi-touch gestures,
+ *    await-screen-idle), while `describe` returns the CoreDevice ax tree and
+ *    stays supported on simulators/Android;
  *  - run-sequence must not eagerly hold simulator-server for a physical iPhone;
  *  - gesture-swipe routes a physical iPhone to the sim-server and honors `settle`.
  */
@@ -33,9 +34,7 @@ import { buttonTool } from "../src/tools/button";
 import { createBootDeviceTool } from "../src/tools/devices/boot-device";
 import { createRunSequenceTool } from "../src/tools/run-sequence";
 import { describeIos } from "../src/tools/describe/platforms/ios";
-import { iosImpl as openUrlIos } from "../src/tools/open-url/platforms/ios";
 import { iosImpl as reinstallIos } from "../src/tools/reinstall-app/platforms/ios";
-import { makeIosImpl as makeRestartAppIosImpl } from "../src/tools/restart-app/platforms/ios";
 import { makeIosImpl as makeLaunchAppIosImpl } from "../src/tools/launch-app/platforms/ios";
 import { gestureSwipeTool } from "../src/tools/gesture-swipe";
 import { gestureTapTool } from "../src/tools/gesture-tap";
@@ -46,6 +45,7 @@ import { gestureCustomTool } from "../src/tools/gesture-custom";
 import { pasteTool } from "../src/tools/paste";
 import { rotateTool } from "../src/tools/rotate";
 import { createTvRemoteTool } from "../src/tools/tv-remote";
+import { createAwaitScreenIdleTool } from "../src/tools/await-screen-idle";
 import { screenshotDiffTool } from "../src/tools/screenshot-diff";
 import { nativeDescribeScreenTool } from "../src/tools/native-devtools/native-describe-screen";
 import { nativeDevtoolsStatusTool } from "../src/tools/native-devtools/native-devtools-status";
@@ -71,9 +71,8 @@ beforeEach(() => {
   mockFlag.mockReturnValue(true);
 });
 
-// Physical-iOS branches of both handlers throw/reject before ever touching
-// `registry` (see the assertions below), so a stub registry is safe here.
-const restartIos = makeRestartAppIosImpl({} as never);
+// The physical-iOS branch throws/rejects before ever touching `registry` (see
+// the assertions below), so a stub registry is safe here.
 const launchAppIos = makeLaunchAppIosImpl({} as never);
 const keyboardTool = createKeyboardTool({} as never);
 
@@ -396,6 +395,11 @@ describe("capability matrix is honest about physical-iOS support (clean 400 at t
       ["gesture-rotate", gestureRotateTool.capability],
       ["gesture-custom", gestureCustomTool.capability],
       ["tv-remote", createTvRemoteTool({} as never).capability],
+      // Not simulator-only in its backend, but unusable on a physical iPhone for
+      // the same practical reason: idle is decided by two consecutive identical
+      // accessibility trees, and the device's read rotates the element order (and
+      // resynthesises frames) on every call, so the signature never repeats.
+      ["await-screen-idle", createAwaitScreenIdleTool({} as never).capability],
       ["native-describe-screen", nativeDescribeScreenTool.capability],
       ["native-devtools-status", nativeDevtoolsStatusTool.capability],
       ["native-find-views", nativeFindViewsTool.capability],

--- a/packages/tool-server/test/physical-ios-followups.test.ts
+++ b/packages/tool-server/test/physical-ios-followups.test.ts
@@ -268,6 +268,83 @@ describe("gesture-swipe on physical iOS routes to the sim-server ios_device cont
   });
 });
 
+describe("gesture-custom on physical iOS: single contact only, rejected as a whole", () => {
+  const touch = vi.fn();
+  const services = () => ({ simulatorServer: { transport: { touch } } });
+
+  beforeEach(() => touch.mockClear());
+
+  it("dispatches a single-touch sequence", async () => {
+    const result = await gestureCustomTool.execute(
+      services() as never,
+      {
+        udid: PHYSICAL_UDID,
+        events: [
+          { type: "Down", x: 0.5, y: 0.7 },
+          { type: "Move", x: 0.5, y: 0.5 },
+          { type: "Up", x: 0.5, y: 0.3 },
+        ],
+      } as never
+    );
+
+    expect(result.events).toBe(3);
+    expect(touch).toHaveBeenCalledTimes(3);
+    expect(touch.mock.calls.map(([c]) => c.type)).toEqual(["Down", "Move", "Up"]);
+    expect(touch.mock.calls.every(([c]) => c.secondX === undefined)).toBe(true);
+  });
+
+  it("rejects a second touch point before dispatching anything, so no contact is left down", async () => {
+    await expect(
+      gestureCustomTool.execute(
+        services() as never,
+        {
+          udid: PHYSICAL_UDID,
+          events: [
+            { type: "Down", x: 0.5, y: 0.5 },
+            { type: "Move", x: 0.4, y: 0.5, x2: 0.6, y2: 0.5 },
+            { type: "Up", x: 0.3, y: 0.5, x2: 0.7, y2: 0.5 },
+          ],
+        } as never
+      )
+    ).rejects.toBeInstanceOf(UnsupportedOperationError);
+    // The `Down` before the offending event must NOT have gone out: a partial
+    // dispatch would strand a finger on the screen with no `Up` to follow.
+    expect(touch).not.toHaveBeenCalled();
+  });
+
+  it("indexes the rejection against the caller's events, not the interpolated expansion", async () => {
+    await expect(
+      gestureCustomTool.execute(
+        services() as never,
+        {
+          udid: PHYSICAL_UDID,
+          events: [
+            { type: "Down", x: 0.5, y: 0.5 },
+            { type: "Up", x: 0.4, y: 0.5, x2: 0.6, y2: 0.5 },
+          ],
+          interpolate: 10,
+        } as never
+      )
+    ).rejects.toThrow(/events\[1\]/);
+  });
+
+  it("still sends a two-finger sequence to a simulator (no regression)", async () => {
+    const result = await gestureCustomTool.execute(
+      services() as never,
+      {
+        udid: SIM_UDID,
+        events: [
+          { type: "Down", x: 0.4, y: 0.5, x2: 0.6, y2: 0.5 },
+          { type: "Up", x: 0.2, y: 0.5, x2: 0.8, y2: 0.5 },
+        ],
+      } as never
+    );
+
+    expect(result.events).toBe(2);
+    expect(touch.mock.calls.map(([c]) => c.secondX)).toEqual([0.6, 0.8]);
+  });
+});
+
 describe("tools unsupported on physical iOS reject with UnsupportedOperationError (400)", () => {
   const device = resolveDevice(PHYSICAL_UDID);
 
@@ -393,7 +470,6 @@ describe("capability matrix is honest about physical-iOS support (clean 400 at t
       ["paste", pasteTool.capability],
       ["gesture-pinch", gesturePinchTool.capability],
       ["gesture-rotate", gestureRotateTool.capability],
-      ["gesture-custom", gestureCustomTool.capability],
       ["tv-remote", createTvRemoteTool({} as never).capability],
       // Not simulator-only in its backend, but unusable on a physical iPhone for
       // the same practical reason: idle is decided by two consecutive identical

--- a/packages/tool-server/test/physical-ios-followups.test.ts
+++ b/packages/tool-server/test/physical-ios-followups.test.ts
@@ -272,12 +272,6 @@ describe("gesture-swipe on physical iOS routes to the sim-server ios_device cont
 describe("tools unsupported on physical iOS reject with UnsupportedOperationError (400)", () => {
   const device = resolveDevice(PHYSICAL_UDID);
 
-  it("open-url", async () => {
-    await expect(
-      openUrlIos.handler({} as never, { udid: PHYSICAL_UDID, url: "https://x" } as never, device)
-    ).rejects.toBeInstanceOf(UnsupportedOperationError);
-  });
-
   it("reinstall-app", async () => {
     await expect(
       reinstallIos.handler(
@@ -285,12 +279,6 @@ describe("tools unsupported on physical iOS reject with UnsupportedOperationErro
         { udid: PHYSICAL_UDID, bundleId: "com.x", appPath: "/tmp/x.app" } as never,
         device
       )
-    ).rejects.toBeInstanceOf(UnsupportedOperationError);
-  });
-
-  it("restart-app", async () => {
-    await expect(
-      restartIos.handler({} as never, { udid: PHYSICAL_UDID, bundleId: "com.x" } as never, device)
     ).rejects.toBeInstanceOf(UnsupportedOperationError);
   });
 
@@ -358,13 +346,20 @@ describe("capability matrix is honest about physical-iOS support (clean 400 at t
   it("supported tools accept a physical iPhone", () => {
     expect(() => assertSupported("gesture-tap", gestureTapTool.capability, physical)).not.toThrow();
     expect(() => assertSupported("button", buttonTool.capability, physical)).not.toThrow();
+    // Driven on hardware over CoreDevice: keyboard through the HID keyboard
+    // surface, rotate through the devicecontrol service. screenshot-diff is
+    // host-side pixel work over a screenshot, so it needs nothing device-side
+    // beyond the screenshot a physical iPhone already serves.
+    expect(() => assertSupported("keyboard", keyboardTool.capability, physical)).not.toThrow();
+    expect(() => assertSupported("rotate", rotateTool.capability, physical)).not.toThrow();
+    expect(() =>
+      assertSupported("screenshot-diff", screenshotDiffTool.capability, physical)
+    ).not.toThrow();
   });
 
   it("simulator-only tools reject a physical iPhone via the capability gate", () => {
     for (const [id, cap] of [
-      ["keyboard", keyboardTool.capability],
       ["gesture-pinch", gesturePinchTool.capability],
-      ["screenshot-diff", screenshotDiffTool.capability],
       ["native-describe-screen", nativeDescribeScreenTool.capability],
       // native-profiler-start does LIVE capture via simulator-only simctl (the
       // process enumeration mislabels a real iPhone as a "simulator"), so it
@@ -396,13 +391,10 @@ describe("capability matrix is honest about physical-iOS support (clean 400 at t
   // path and fails deep with a 500 instead of at the gate with a 400.
   it("every simulator-only tool rejects a physical iPhone, and none of them lost simulator support", () => {
     const simulatorOnly: ReadonlyArray<readonly [string, ToolCapability | undefined]> = [
-      ["keyboard", keyboardTool.capability],
       ["paste", pasteTool.capability],
-      ["rotate", rotateTool.capability],
       ["gesture-pinch", gesturePinchTool.capability],
       ["gesture-rotate", gestureRotateTool.capability],
       ["gesture-custom", gestureCustomTool.capability],
-      ["screenshot-diff", screenshotDiffTool.capability],
       ["tv-remote", createTvRemoteTool({} as never).capability],
       ["native-describe-screen", nativeDescribeScreenTool.capability],
       ["native-devtools-status", nativeDevtoolsStatusTool.capability],


### PR DESCRIPTION
Stacked on #538. Needs radon software-mansion/radon#156 for `rotate`.

Five tools were declared `apple.device: false` for reasons that turn out not to hold. Each is verified on a tethered iPhone 15 (iOS 27).

## Driven over CoreDevice

- **`keyboard`** — the controller already implemented `send_key` against the HID keyboard surface, and nothing in the tool rejected hardware. Only the capability flag was off. Typing `hello` into Spotlight put "hello" in the search field and returned live results.
- **`rotate`** — now backed by the `devicecontrol` orientation service (radon#156). `portrait → landscapeLeft → landscapeRight → portrait`, each confirmed with `devicectl device orientation get`.

## Shelled through `devicectl`

The same binary `launch-app` already uses, so like `launch-app` both enforce the physical-iOS opt-in themselves — no simulator-server ref is built on these paths to run the gate.

- **`open-url`** via `devicectl device process openURL`. Confirmed opening example.com in Safari on the device.
- **`restart-app`** via `devicectl device process launch --terminate-existing`. The simulator path restarts *through* native-devtools so the app comes back injected; that injection is simulator-only, so a plain relaunch is the whole operation on hardware.

## Gate was simply wrong

- **`screenshot-diff`** is host-side pixel work over a screenshot. It needs nothing device-side beyond the screenshot a physical iPhone already serves.

## Multi-touch stays unsupported — and the README now says why

Previously it sat in a "not supported yet" list that read as unfinished work. It is a platform limit: the device registers one touch surface, `mainTouchscreen` (usage page `0x0D` "Digitizer" / usage `0x04` "Touch Screen"), carrying a single contact. `touchscreenGesture` — the other candidate — enumerates as usage page `0x01` "Generic Desktop" / usage `0x02` "Mouse", the pointer for the mirroring window. Detail and the on-device experiments are in radon#156.

## Tests

`packages/tool-server/test/physical-ios-devicectl.test.ts` is new: it mocks `node:child_process` and pins the exact devicectl argv for both tools, that neither reaches `simctl`, and that the opt-in gate runs *before* the subprocess. Mutation-checked — dropping `--terminate-existing` or lower-casing `openURL` fails it.

The two tests in `physical-ios-followups.test.ts` that asserted `open-url`/`restart-app` reject with `UnsupportedOperationError` are gone (they pinned the old boundary); the capability matrix there moves `keyboard`, `rotate` and `screenshot-diff` from the simulator-only enumeration into the supported set.

Full `tool-server` suite: 298 files, 3122 passed, 1 skipped. `tsc --noEmit` clean for both `src` and `tsconfig.test.json`; prettier and eslint clean.