### PR TITLE
fix(flow): elect the topmost element under a recorded tap

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -17,9 +17,10 @@ import { invokeSubTool } from "../../utils/sub-invoke";
 import { resolveDevice } from "../../utils/device-info";
 import { stripDeviceKeys } from "./flow-device";
 import { fetchFlowTree } from "./flow-tree";
-import type { DescribeSource } from "../describe/contract";
+import type { DescribeNode, DescribeSource } from "../describe/contract";
 import {
   nodeAtPoint,
+  nodesStackedAtPoint,
   deriveSelector,
   selectorToFrame,
   frameContains,
@@ -55,6 +56,42 @@ function fallbackSourceWarning(source: DescribeSource, platform: string): string
   const expected = REPLAY_TREE_SOURCES[platform];
   if (!expected || source === expected) return undefined;
   return `selector captured from the fallback ${source} tree (${expected} unavailable) — replay resolves against the full hierarchy, which may not match it`;
+}
+
+// How many overlapping elements a caveat names before it counts the rest: past a
+// few the list stops being readable, and the count still conveys how crowded the
+// point is.
+const MAX_NAMED_OVERLAPS = 3;
+
+// Name an element for a caveat, in the same vocabulary as the selector the
+// caveat is attached to. A node `deriveSelector` rejects (an icon-only pressable
+// under a generic role) is still named by that role — the caveat reports what
+// covers the point, and an element no stable selector could address is exactly
+// one worth naming.
+function describeOverlap(node: DescribeNode): string {
+  return describeSelector(deriveSelector(node) ?? { role: node.role });
+}
+
+/**
+ * Caveat for a tap whose point is covered by elements that only paint order
+ * separates from the one recorded — see `nodesStackedAtPoint`. The element
+ * elected is the best reading of the tree, but "best reading" is not "the
+ * element you touched", and a step recorded against the wrong one replays and
+ * PASSES silently: the runner requires only that the selector resolve.
+ */
+function overlapWarning(stacked: DescribeNode[], recorded: Selector): string | undefined {
+  if (stacked.length === 0) return undefined;
+  const named = stacked.slice(0, MAX_NAMED_OVERLAPS).map(describeOverlap);
+  const rest = stacked.length - named.length;
+  const others = [...named, ...(rest > 0 ? [`${rest} more`] : [])].join(", ");
+  return `recorded the topmost element under the tap, ${describeSelector(recorded)}, but ${others} also cover${stacked.length === 1 ? "s" : ""} that point; confirm the step targets the element you tapped`;
+}
+
+// Warnings compose: a capture can be both from a fallback tree source and over a
+// contested point, and dropping either would understate the caveat.
+function joinWarnings(...parts: (string | undefined)[]): string | undefined {
+  const kept = parts.filter((p): p is string => p !== undefined);
+  return kept.length > 0 ? kept.join("; ") : undefined;
 }
 
 /**
@@ -105,7 +142,13 @@ async function captureTapSelector(
         warning: `selector ${describeSelector(selector)} resolves to a different element on this screen; kept coordinates (brittle)`,
       };
     }
-    return { selector, warning: fallbackSourceWarning(source, device.platform) };
+    return {
+      selector,
+      warning: joinWarnings(
+        fallbackSourceWarning(source, device.platform),
+        overlapWarning(nodesStackedAtPoint(tree, point), selector)
+      ),
+    };
   } catch (err) {
     return {
       warning: `selector capture failed (${err instanceof Error ? err.message : String(err)}); kept coordinates`,

--- a/packages/tool-server/src/utils/ui-tree-match.ts
+++ b/packages/tool-server/src/utils/ui-tree-match.ts
@@ -435,11 +435,11 @@ function afterTester(anchors: DescribeNode[]): (node: DescribeNode) => boolean {
 // top-left corners — a container and the label leaf flush inside it, an
 // everyday shape in a flattened tree — resolve to the smaller, more specific
 // element rather than to whichever the tree happened to list first (matching
-// the "smallest frame wins" doctrine `selectorToFrame` and `nodeAtPoint`
-// already rank by), then into the individual extents, which separate the shapes
-// area alone cannot: two zero-area rules of different lengths, and a wide-short
-// frame against a narrow-tall one. Only frames identical on all four fields are
-// left to tree order, and those are indistinguishable to act on anyway.
+// the "smallest frame wins" tiebreak `selectorToFrame` ranks matches by), then
+// into the individual extents, which separate the shapes area alone cannot: two
+// zero-area rules of different lengths, and a wide-short frame against a
+// narrow-tall one. Only frames identical on all four fields are left to tree
+// order, and those are indistinguishable to act on anyway.
 function comparePick(a: DescribeFrame, b: DescribeFrame): number {
   return frameArea(a) - frameArea(b) || a.width - b.width || a.height - b.height;
 }
@@ -688,25 +688,120 @@ function frameArea(frame: DescribeFrame): number {
   return frame.width * frame.height;
 }
 
+// Every visible node whose frame contains the point, in tree order. The
+// synthetic full-screen root is skipped: it contains every point and names no
+// element.
+function candidatesAtPoint(root: DescribeNode, point: { x: number; y: number }): DescribeNode[] {
+  const found: DescribeNode[] = [];
+  const walk = (node: DescribeNode): void => {
+    if (isVisible(node) && frameContains(node.frame, point.x, point.y)) found.push(node);
+    for (const child of node.children) walk(child);
+  };
+  for (const child of root.children) walk(child);
+  return found;
+}
+
 /**
- * Reverse lookup for recording: the smallest visible node whose frame contains
- * the tapped point. "Smallest" picks the most specific element (a button over
- * its container). Skips the synthetic root. Returns undefined if nothing
+ * Do two frames overlapping a point STACK — cover it while nesting neither way?
+ * The geometric reading of "two separate things are drawn here": neither is the
+ * container the other is laid out inside, so which one the finger reaches is
+ * decided by paint order alone. Frames equal within {@link WITHIN_EPS} are
+ * within each other both ways and so do not stack — they are one rectangle, and
+ * a touch cannot tell them apart.
+ */
+function framesStacked(a: DescribeFrame, b: DescribeFrame): boolean {
+  return !frameWithin(a, b) && !frameWithin(b, a);
+}
+
+/**
+ * Given that both frames contain the tapped point and `candidate` comes LATER in
+ * tree order, is `candidate` the one drawn on top?
+ *
+ * Two rules, and geometry alone decides which applies:
+ *   - NESTING. An element is drawn over the container that lays it out,
+ *     whichever order the tree lists the two in — so a frame contained in the
+ *     other's wins. This is what makes a button beat its container, and (on the
+ *     flattened flow trees, where that container is a sibling leaf rather than
+ *     an ancestor) a label leaf beat the testID container flush around it.
+ *   - STACKING. Frames that nest neither way belong to separate branches drawn
+ *     over one another, so the later one is on top and takes the touch.
+ * Frames equal within the tolerance put the same point under the finger; the
+ * incumbent is kept rather than churning the pick between them.
+ */
+function paintsOver(candidate: DescribeFrame, incumbent: DescribeFrame): boolean {
+  const candidateInside = frameWithin(candidate, incumbent);
+  const incumbentInside = frameWithin(incumbent, candidate);
+  // Exactly one containment: the contained frame is the nested one, and nesting
+  // beats tree order.
+  if (candidateInside !== incumbentInside) return candidateInside;
+  // Both (one rectangle) keeps the incumbent; neither (stacked) hands it to the
+  // later-listed candidate.
+  return !candidateInside;
+}
+
+function electTopmost(candidates: DescribeNode[]): DescribeNode | undefined {
+  let best: DescribeNode | undefined;
+  for (const node of candidates) {
+    if (best === undefined || paintsOver(node.frame, best.frame)) best = node;
+  }
+  return best;
+}
+
+/**
+ * Reverse lookup for recording: the visible element a tap at `point` reaches —
+ * the topmost of those whose frames contain it. Returns undefined when nothing
  * sensible is under the point.
+ *
+ * A hit test, not a smallest-frame search, because frames on these trees are not
+ * clipped by what is drawn over them. Android reports a scroll container's rows
+ * at their laid-out bounds even where a bottom bar covers them, so feed content
+ * genuinely extends under a tab bar and a small text node inside it genuinely
+ * shares a point with the tab button the finger hits — with the smallest frame
+ * winning, recording captures the buried node and the step replays against a
+ * different element.
+ *
+ * "Topmost" is read off geometry and tree order together (see
+ * {@link paintsOver}), and both inputs survive every tree source, which is why
+ * this needs no per-source case:
+ *   - nesting is geometric, so it holds for the flattened flow trees — where a
+ *     container is a sibling leaf, not an ancestor — as well as for a nested
+ *     describe tree;
+ *   - sibling order is back-to-front on the platforms the recorder runs on: iOS
+ *     reads `subviews` and Android the view-child order uiautomator walks, and
+ *     both paint earlier siblings first. It is CSS paint order on Chromium too
+ *     for everything the cascade does not reorder.
+ * What that leaves is a genuine ambiguity no tie-break would settle — a
+ * `z-index`-reordered pair on Chromium, or Vega's undocumented ordering. Those
+ * are reported to the recorder instead of passing for certain; see
+ * {@link nodesStackedAtPoint}.
  */
 export function nodeAtPoint(
   root: DescribeNode,
   point: { x: number; y: number }
 ): DescribeNode | undefined {
-  let best: DescribeNode | undefined;
-  const walk = (node: DescribeNode): void => {
-    if (isVisible(node) && frameContains(node.frame, point.x, point.y)) {
-      if (best === undefined || frameArea(node.frame) < frameArea(best.frame)) best = node;
-    }
-    for (const child of node.children) walk(child);
-  };
-  for (const child of root.children) walk(child);
-  return best;
+  return electTopmost(candidatesAtPoint(root, point));
+}
+
+/**
+ * The visible elements that STACK against the one {@link nodeAtPoint} elects
+ * (see {@link framesStacked}): they cover the tapped point without nesting
+ * either way, so something genuinely overlaps the touch and only paint order
+ * separates them. Empty for the ordinary tap, where everything else under the
+ * point is a container the target is drawn inside.
+ *
+ * Read by the recorder to caveat the step it writes. The elected element is the
+ * best reading of the tree, but on a source whose sibling order is not paint
+ * order the finger may have reached one of these instead, and a step recorded
+ * against the wrong element still replays — and passes — silently.
+ */
+export function nodesStackedAtPoint(
+  root: DescribeNode,
+  point: { x: number; y: number }
+): DescribeNode[] {
+  const candidates = candidatesAtPoint(root, point);
+  const hit = electTopmost(candidates);
+  if (hit === undefined) return [];
+  return candidates.filter((n) => n !== hit && framesStacked(n.frame, hit.frame));
 }
 
 // Does the regex consume the WHOLE non-empty string? The regex analog of an exact
@@ -754,9 +849,17 @@ function exactFieldCount(
  * selector matches the container as well as the leaf that actually carries the
  * text — and the container's centre can sit over a different nested child
  * entirely. Matches are therefore ranked: exact field matches beat substring
- * hits, then the smallest frame wins (the most specific element, mirroring
- * nodeAtPoint's reverse lookup), with reading order as the final tiebreak.
- * Returns undefined when no visible element matches.
+ * hits, then the smallest frame wins (the most specific element), with reading
+ * order as the final tiebreak. Returns undefined when no visible element
+ * matches.
+ *
+ * Specificity, deliberately — not the stacking order {@link nodeAtPoint} elects
+ * by. The two answer different questions. A hit test knows a point and asks
+ * which of the elements covering it the finger reaches, so paint order decides.
+ * This ranks the elements a SELECTOR matches, most of which do not overlap at
+ * all, and asks which one the flow author meant — a question about how tightly
+ * each match fits the selector, which the topmost of two unrelated matches says
+ * nothing about.
  *
  * The universal selector (flow YAML's `any: true`) is the one case that ranking
  * cannot serve: with no field to be exact about, "smallest" degenerates to

--- a/packages/tool-server/test/flows/flow-record-tap.test.ts
+++ b/packages/tool-server/test/flows/flow-record-tap.test.ts
@@ -151,6 +151,77 @@ describe("flow-add-step tap selector capture", () => {
     expect(await recordedSteps()).toEqual([{ kind: "tap", x: 0.2, y: 0.52 }]);
   });
 
+  it("records the tab button over unclipped feed content, with an overlap caveat", async () => {
+    // The reported shape: a bottom tab bar drawn over a feed whose rows Android
+    // reports at their laid-out bounds, so a row's wide-but-short text leaf
+    // shares the tapped point with the tab button. Bounds are the normalized
+    // form of the Pixel 3a pixels measured in ui-tree-match.test.ts. The button
+    // is recorded, and the step says the point was contested.
+    setTree([
+      n({
+        label: "Reply from @alice",
+        frame: { x: 154 / 1080, y: 2021 / 2220, width: 636 / 1080, height: 50 / 2220 },
+      }),
+      n({
+        identifier: "app:id/feed_row",
+        frame: { x: 22 / 1080, y: 1969 / 2220, width: 1058 / 1080, height: 154 / 2220 },
+      }),
+      n({
+        identifier: "app:id/feed",
+        frame: { x: 0, y: 245 / 2220, width: 1, height: 1975 / 2220 },
+      }),
+      n({
+        identifier: "app:id/tab_feeds",
+        label: "Feeds",
+        frame: { x: 216 / 1080, y: 1934 / 2220, width: 216 / 1080, height: 220 / 2220 },
+      }),
+      n({
+        identifier: "app:id/tab_bar",
+        frame: { x: 0, y: 1934 / 2220, width: 1, height: 220 / 2220 },
+      }),
+    ]);
+
+    const result = await recordTap({ x: 324 / 1080, y: 2044 / 2220 });
+
+    expect(await recordedSteps()).toEqual([
+      { kind: "tap", selector: { identifier: "app:id/tab_feeds" } },
+    ]);
+    expect(result.message).toContain(
+      'recorded the topmost element under the tap, id="app:id/tab_feeds"'
+    );
+    expect(result.message).toContain('text="Reply from @alice"');
+    expect(result.message).toContain('id="app:id/feed_row"');
+    expect(result.message).toContain("confirm the step targets the element you tapped");
+    // The feed and the bar contain the button, so they are its containers rather
+    // than contenders for the touch, and must not be listed.
+    expect(result.message).not.toContain('id="app:id/feed"');
+    expect(result.message).not.toContain('id="app:id/tab_bar"');
+  });
+
+  it("compounds the fallback-source caveat with the overlap caveat", async () => {
+    // Both hold at once — the tree came from the fallback source AND the point
+    // was contested — and dropping either would understate the caveat.
+    setTree(
+      [
+        n({ label: "Reply from @alice", frame: { x: 0.2, y: 0.91, width: 0.6, height: 0.02 } }),
+        n({
+          identifier: "app:id/tab_feeds",
+          label: "Feeds",
+          frame: { x: 0.2, y: 0.87, width: 0.2, height: 0.1 },
+        }),
+      ],
+      "ax-service"
+    );
+
+    const result = await recordTap({ x: 0.3, y: 0.92 });
+
+    expect(result.message).toContain("fallback ax-service tree");
+    expect(result.message).toContain("recorded the topmost element under the tap");
+    expect(await recordedSteps()).toEqual([
+      { kind: "tap", selector: { identifier: "app:id/tab_feeds" } },
+    ]);
+  });
+
   it("records the selector with a caveat when captured from the fallback tree source", async () => {
     setTree(
       [n({ label: "Settings", frame: { x: 0.3, y: 0.5, width: 0.4, height: 0.06 } })],

--- a/packages/tool-server/test/flows/flow-record-tap.test.ts
+++ b/packages/tool-server/test/flows/flow-record-tap.test.ts
@@ -152,11 +152,11 @@ describe("flow-add-step tap selector capture", () => {
   });
 
   it("records the tab button over unclipped feed content, with an overlap caveat", async () => {
-    // The reported shape: a bottom tab bar drawn over a feed whose rows Android
-    // reports at their laid-out bounds, so a row's wide-but-short text leaf
-    // shares the tapped point with the tab button. Bounds are the normalized
-    // form of the Pixel 3a pixels measured in ui-tree-match.test.ts. The button
-    // is recorded, and the step says the point was contested.
+    // A bottom tab bar drawn over a feed whose rows Android reports at their
+    // laid-out bounds, so a row's wide-but-short text leaf shares the tapped
+    // point with the tab button. Bounds are the normalized form of the Pixel 3a
+    // pixels ui-tree-match.test.ts measures and documents. The button is
+    // recorded, and the step says the point was contested.
     setTree([
       n({
         label: "Reply from @alice",

--- a/packages/tool-server/test/utils/ui-tree-match.test.ts
+++ b/packages/tool-server/test/utils/ui-tree-match.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import type { DescribeNode } from "../../src/tools/describe/contract";
 import {
   nodeAtPoint,
+  nodesStackedAtPoint,
   selectorToFrame,
   deriveSelector,
   evaluateCondition,
@@ -43,15 +44,132 @@ const root = node({
 });
 
 describe("ui-tree-match", () => {
-  it("nodeAtPoint returns the smallest element under a point", () => {
-    // (0.2, 0.15) sits inside both the button and the surrounding group; the
-    // button has the smaller area and wins.
+  it("nodeAtPoint returns the element nested inside a container under a point", () => {
+    // (0.2, 0.15) sits inside both the button and the group whose frame
+    // surrounds it; the button is drawn inside that container, so it is what
+    // the touch reaches.
     const hit = nodeAtPoint(root, { x: 0.2, y: 0.15 });
     expect(hit?.label).toBe("Login");
   });
 
   it("nodeAtPoint returns undefined when nothing is under the point", () => {
     expect(nodeAtPoint(root, { x: 0.95, y: 0.95 })).toBeUndefined();
+  });
+
+  // ── Bottom bar over unclipped scroll content ───────────────────────────────
+  //
+  // Pixel bounds measured with `uiautomator dump --compressed` on a Pixel 3a
+  // API 34 emulator (1080×2220), from a bottom-tab-bar app over a scrolling
+  // list: the bar is a ViewGroup at [0,1934][1080,2154] with 216×220 px tab
+  // buttons ([216,1934][432,2154] for the second), the list is a RecyclerView
+  // reaching the screen bottom at [0,245][1080,2220], its rows are 154 px tall
+  // spanning [22,…][1080,…], and a row's text leaf is 636×50 px starting at
+  // x=154. Android does NOT clip a view's bounds to what is drawn over it, so
+  // the rows under the bar are reported at their laid-out bounds — the shape
+  // the bug report describes as "feed content stretching under the bottom
+  // navigation bar", with "another, WIDER element" beating the tab button.
+  const SCREEN = { width: 1080, height: 2220 };
+
+  function px(x1: number, y1: number, x2: number, y2: number): DescribeNode["frame"] {
+    return {
+      x: x1 / SCREEN.width,
+      y: y1 / SCREEN.height,
+      width: (x2 - x1) / SCREEN.width,
+      height: (y2 - y1) / SCREEN.height,
+    };
+  }
+
+  // The row text leaf: 636 px wide against the tab button's 216, yet 31 800 px²
+  // against its 47 520 — wider, but smaller in area, which is what let it win.
+  const rowText = node({
+    role: "android.widget.TextView",
+    label: "Reply from @alice",
+    frame: px(154, 2021, 790, 2071),
+  });
+  const feedRow = node({
+    role: "android.view.ViewGroup",
+    identifier: "com.example.social:id/feed_row",
+    frame: px(22, 1969, 1080, 2123),
+  });
+  const feed = node({
+    role: "androidx.recyclerview.widget.RecyclerView",
+    identifier: "com.example.social:id/feed",
+    scrollable: true,
+    frame: px(0, 245, 1080, 2220),
+  });
+  const tabButton = node({
+    role: "android.widget.FrameLayout",
+    identifier: "com.example.social:id/tab_feeds",
+    label: "Feeds",
+    clickable: true,
+    frame: px(216, 1934, 432, 2154),
+  });
+  const tabBar = node({
+    role: "android.view.ViewGroup",
+    identifier: "com.example.social:id/tab_bar",
+    frame: px(0, 1934, 1080, 2154),
+  });
+
+  // The flat, post-order shape every flow adapter emits (see
+  // flow-tree-flatten): descendants precede their container, and the tab bar's
+  // branch follows the feed's because it is drawn over it.
+  function flowTree(children: DescribeNode[]): DescribeNode {
+    return node({ role: "Screen", frame: { x: 0, y: 0, width: 1, height: 1 }, children });
+  }
+
+  const feedUnderTabBar = flowTree([rowText, feedRow, feed, tabButton, tabBar]);
+  // The centre of the second tab button, 972 px down the screen — inside the
+  // button, the row, the row's text leaf, the feed, and the bar.
+  const tabPoint = { x: 324 / SCREEN.width, y: 2044 / SCREEN.height };
+
+  it("nodeAtPoint elects the tab button drawn over feed content it overlaps", () => {
+    expect(nodeAtPoint(feedUnderTabBar, tabPoint)?.identifier).toBe(
+      "com.example.social:id/tab_feeds"
+    );
+  });
+
+  it("nodeAtPoint elects the overlapping element the tree draws last", () => {
+    // The same five frames with the bar's branch listed FIRST: the feed is then
+    // the one painted over the bar, and its text leaf is what the touch reaches.
+    // Nothing but tree order differs, so this pins paint order specifically —
+    // not a preference for the wider, the clickable, or the later-measured node.
+    const barUnderFeed = flowTree([tabButton, tabBar, rowText, feedRow, feed]);
+    expect(nodeAtPoint(barUnderFeed, tabPoint)?.label).toBe("Reply from @alice");
+  });
+
+  it("nodesStackedAtPoint names the elements only paint order separates", () => {
+    // The feed row and its text leaf cover the tapped point while nesting
+    // neither way with the tab button — a genuine overlap the recorder must
+    // caveat. The feed and the bar are excluded: the button sits inside both, so
+    // they are containers, not contenders.
+    expect(
+      nodesStackedAtPoint(feedUnderTabBar, tabPoint).map((n) => n.label ?? n.identifier)
+    ).toEqual(["Reply from @alice", "com.example.social:id/feed_row"]);
+  });
+
+  it("nodesStackedAtPoint reports nothing for a plain nested pick", () => {
+    // Everything else under the point is a container the elected button is drawn
+    // inside, so an ordinary tap carries no caveat.
+    expect(nodesStackedAtPoint(root, { x: 0.2, y: 0.15 })).toEqual([]);
+  });
+
+  it("nodeAtPoint keeps the first of two elements sharing one frame", () => {
+    // A testID container and the label leaf flush inside it — the everyday
+    // flattened-tree shape — report the same rectangle, so nothing about the
+    // touch distinguishes them and both give the same tap point. The first
+    // stands, and no caveat is raised over a difference the finger cannot make.
+    const coincident = flowTree([
+      node({ role: "android.widget.TextView", label: "Submit", frame: px(66, 900, 400, 1000) }),
+      node({
+        role: "android.view.ViewGroup",
+        identifier: "com.example.social:id/submit",
+        clickable: true,
+        frame: px(66, 900, 400, 1000),
+      }),
+    ]);
+    const point = { x: 233 / SCREEN.width, y: 950 / SCREEN.height };
+    expect(nodeAtPoint(coincident, point)?.label).toBe("Submit");
+    expect(nodesStackedAtPoint(coincident, point)).toEqual([]);
   });
 
   it("selectorToFrame resolves the first visible match", () => {
@@ -106,7 +224,9 @@ describe("ui-tree-match", () => {
 
   it("selectorToFrame prefers the smallest of several exact matches", () => {
     // Both the inner AXGroup and its leaf text are exactly "Inner Touchable";
-    // the leaf (smaller, more specific) wins — same philosophy as nodeAtPoint.
+    // the leaf (smaller, more specific) wins. Ranking selector matches asks
+    // which element the author meant, so it turns on specificity — unlike
+    // nodeAtPoint, which knows a point and asks what the finger reaches.
     const frame = selectorToFrame(aggregated, { text: "Inner Touchable" });
     expect(frame).toMatchObject({ x: 0.37, y: 0.57 });
   });

--- a/packages/tool-server/test/utils/ui-tree-match.test.ts
+++ b/packages/tool-server/test/utils/ui-tree-match.test.ts
@@ -58,16 +58,16 @@ describe("ui-tree-match", () => {
 
   // ── Bottom bar over unclipped scroll content ───────────────────────────────
   //
-  // Pixel bounds measured with `uiautomator dump --compressed` on a Pixel 3a
-  // API 34 emulator (1080×2220), from a bottom-tab-bar app over a scrolling
-  // list: the bar is a ViewGroup at [0,1934][1080,2154] with 216×220 px tab
-  // buttons ([216,1934][432,2154] for the second), the list is a RecyclerView
-  // reaching the screen bottom at [0,245][1080,2220], its rows are 154 px tall
-  // spanning [22,…][1080,…], and a row's text leaf is 636×50 px starting at
-  // x=154. Android does NOT clip a view's bounds to what is drawn over it, so
-  // the rows under the bar are reported at their laid-out bounds — the shape
-  // the bug report describes as "feed content stretching under the bottom
-  // navigation bar", with "another, WIDER element" beating the tab button.
+  // A translucent tab bar over a feed, the layout an RN social app draws:
+  // Android does NOT clip a view's bounds to what is painted over it, so the
+  // feed rows beneath the bar are reported at their full laid-out bounds and
+  // share their points with the tab buttons. Every pixel rectangle below was
+  // measured with `uiautomator dump --compressed` on a Pixel 3a API 34 emulator
+  // (1080×2220) — the bar and its 216×220 px tab buttons from a bottom-tab-bar
+  // screen, the screen-bottom-reaching list and its 154 px rows with a 636×50 px
+  // text leaf from a scrolling list screen of the same app — and composed into
+  // the overlapping layout, which no stock Android app produces (native layouts
+  // put the bar beside the content, so nothing overlaps to measure).
   const SCREEN = { width: 1080, height: 2220 };
 
   function px(x1: number, y1: number, x2: number, y2: number): DescribeNode["frame"] {
@@ -132,7 +132,7 @@ describe("ui-tree-match", () => {
     // The same five frames with the bar's branch listed FIRST: the feed is then
     // the one painted over the bar, and its text leaf is what the touch reaches.
     // Nothing but tree order differs, so this pins paint order specifically —
-    // not a preference for the wider, the clickable, or the later-measured node.
+    // not a preference for the wider, the clickable, or the larger node.
     const barUnderFeed = flowTree([tabButton, tabBar, rowText, feedRow, feed]);
     expect(nodeAtPoint(barUnderFeed, tabPoint)?.label).toBe("Reply from @alice");
   });


### PR DESCRIPTION
## Symptom

QA on Bluesky, physical Android phone:

> `flow-add-step` sometimes records the wrong element and does not warn about it. When another, WIDER element lies underneath a visible clickable element in the view tree (e.g. feed content stretching under the bottom navigation bar), `flow-add-step` grabs that element underneath instead of the actual touch target. It does so with no warning whatsoever. At `flow-execute` the step then hits a completely different element - and still gets a PASS.

## Root cause

Two facts that are each fine alone and wrong together.

**Frames are not clipped by what is drawn over them.** A uiautomator dump reports a view at its laid-out bounds regardless of occlusion, and the flow tree keeps that. Measured on a Pixel 3a API 34 emulator (1080x2220): a bottom tab bar is `[0,1934][1080,2220]` while the scroll container behind it runs to `[0,242][1080,1934]` and, on a list that reaches the screen bottom, to `[0,245][1080,2220]`. Feed rows under the bar are really there, at their real bounds.

**`nodeAtPoint` ranked by area.** It walked the whole tree and kept the smallest visible frame containing the point:

```ts
if (best === undefined || frameArea(node.frame) < frameArea(best.frame)) best = node;
```

A tab button is 216x220 px = 47 520 px². A feed row's text leaf measured on the same device is 636x50 px = 31 800 px² - **wider than the button, yet smaller in area**, which is exactly the shape the report describes. So the buried text leaf won, `deriveSelector` turned it into `tap: { text: … }`, and replay resolved a feed row on the other side of the screen.

Paint order was ignored entirely.

## What changed

`nodeAtPoint` is now a hit test. Among the visible candidates containing the point, `paintsOver` decides pairwise, on geometry alone:

- **Nesting** - a frame contained in the other's wins, whichever order the tree lists them in. This preserves the old intent ("a button over its container"), and on the flattened flow trees it is also what keeps a label leaf beating the testID container flush around it.
- **Stacking** - frames that nest neither way are separate branches drawn over one another, so the later-listed one is on top and takes the touch.
- Frames equal within `WITHIN_EPS` put the same point under the finger, so the incumbent stands (unchanged from the old strict `<`).

The election is a single left-to-right reduction over the candidates in tree order, so "later" means "later in the tree" without reconstructing ancestry - which matters, because `nodeAtPoint`'s only production caller feeds it a **flat** tree. Every flow adapter (`flow-android-tree`, `flow-ios-tree`, `flow-chromium-tree`, `flow-vega-tree`) runs `flattenHoisting`, which emits `children: []` leaves under one synthetic root in **post-order** - descendants precede their container. Verified against a real dump: `adaptFullAndroidHierarchyToDescribeResult` on the emulator's Clock screen yields `flat leaves: 51 | nested? false`. A recursive "descend children in reverse" walk would have been a no-op there, and a plain "last containing node wins" would have elected the outermost container every time.

### Cross-platform: deliberately not source-aware

Both inputs the rule uses survive every source, which is why there is no per-platform branch:

- Nesting is geometric, so it holds identically for a flattened flow tree and a nested describe tree.
- Sibling order is back-to-front where the recorder actually runs: iOS reads `subviews`, Android the view-child order uiautomator walks, and both paint earlier siblings first. On Chromium it is CSS paint order for everything the cascade does not reorder.

What is left is genuine ambiguity, not a tie-break away from being solved: a `z-index`-reordered pair on Chromium, or Vega's undocumented page-source ordering. Those are **reported**, not guessed - see below. The rationale lives in `nodeAtPoint`'s doc comment.

### The missing warning

`nodesStackedAtPoint` returns the visible candidates that cover the point while nesting neither way with the elected element - i.e. something genuinely overlaps the touch. Containers of the pick are excluded (they are not contenders), and so are equal-framed nodes (same tap point either way). `captureTapSelector` folds that into the existing `warning` channel:

```
Step added to "x" flow — recorded the topmost element under the tap, id="app:id/tab_feeds",
but text="Reply from @alice", id="app:id/feed_row" also cover that point;
confirm the step targets the element you tapped
```

Warnings now compose (`joinWarnings`): a capture can be both from a fallback tree source and over a contested point, and dropping either would understate the caveat. Empty for the ordinary tap, so quiet recordings stay quiet.

### `selectorToFrame` - the divergence, resolved in prose

Its ranking is unchanged: exact fields, then smallest frame, then reading order. Changing it would touch every `tap`/`type`/`assert` and is not what the report is about; more importantly the two functions answer different questions. A hit test knows a point and asks which of the elements covering it the finger reaches, so paint order decides. `selectorToFrame` ranks the elements a *selector* matches - most of which do not overlap at all - and asks which one the flow author meant, which is a question about fit, not stacking. That is now said explicitly in its docstring, and the three sites that claimed a single shared "smallest frame wins" doctrine no longer cross-reference `nodeAtPoint`: its own docstring, the `comparePick` comment, and the test comment on `selectorToFrame prefers the smallest of several exact matches`.

## Existing test expectations I changed

- **`nodeAtPoint returns the smallest element under a point` -> `... returns the element nested inside a container under a point`.** The assertion is unchanged and still passes: the fixture's overlapping `AXGroup` geometrically *contains* the `AXButton`, so the nesting rule elects the button just as the area rule did. Only the name and comment changed - they asserted a doctrine the code no longer follows, and the name would have misled the next reader about why the button wins.
- **`selectorToFrame prefers the smallest of several exact matches`** - comment only. It said "same philosophy as `nodeAtPoint`", which is now false; it explains the specificity-vs-stacking split instead.

No existing expectation was weakened or deleted.

## Verification

**Reproduced first, on the reporter's geometry.** The new fixture is built from pixels measured with `uiautomator dump --compressed` on an allocated Pixel 3a API 34 (bar `[0,1934][1080,2154]`, 216x220 px tabs, an edge-to-edge list at `[0,245][1080,2220]`, 154 px rows, a 636x50 px row text leaf), arranged in the flat post-order shape `flattenHoisting` emits. With `src/` stashed to `origin/main` and the tests kept:

```
× nodeAtPoint elects the tab button drawn over feed content it overlaps
    AssertionError: expected undefined to be 'com.example.social:id/tab_feeds'
× nodesStackedAtPoint names the elements only paint order separates
× nodesStackedAtPoint reports nothing for a plain nested pick
× records the tab button over unclipped feed content, with an overlap caveat
    AssertionError: expected [ { kind: 'tap', …(1) } ] to deeply equal [ { kind: 'tap', selector: {…} } ]
  Tests  4 failed | 80 passed
```

`expected undefined` is the bug: on `origin/main` the elected node is the feed text leaf, which carries no identifier.

**Mutation checks** - each rule pinned independently, restoring in between:

| mutation | result |
|---|---|
| stacking rule killed (`return candidateInside`) | 4 failed |
| nesting rule inverted (`return incumbentInside`) | 5 failed |
| tie-break churns (`return true`) | 1 failed (`keeps the first of two elements sharing one frame`) |
| `fallbackSourceWarning` dropped from the join | 2 failed |
| `overlapWarning` dropped from the join | 2 failed |

The third came back **green** on the first attempt - the equal-frames tie-break was unpinned, so I added `nodeAtPoint keeps the first of two elements sharing one frame` before re-running.

**Gates**, all from the worktree root: `npx tsc --build`, `npx prettier --check .`, `npx eslint . --max-warnings 0`, `npm run typecheck:tests -w @argent/tool-server`, `npm test -w @argent/tool-server` -> **295 files, 3077 passed, 1 skipped**. No flakes hit this run.

**On a real device** (allocated `emulator-5554`, freed after; worktree tool-server driven over `POST /tools/:name`), against the real Android full-hierarchy flow tree rather than a fixture:

- `flow-start-recording` + `flow-add-step` a `gesture-tap` on the Clock app's bottom nav at (0.5, 0.9207), run twice - once with this branch's build, once with `src/` stashed to `origin/main` and rebuilt:
  - `origin/main` -> `id="…:id/navigation_bar_item_icon_view"` (smallest frame, 4 356 px²)
  - branch -> `id="…:id/navigation_bar_item_active_indicator_view"` (topmost, 6 160 px²)
  - Both are nested inside the tab item, their centres are the same pixel, and both hit the pre-existing re-resolve guard (the id repeats across all five tabs), so the recorded step is coordinates either way. No regression; it shows the descent landing on the topmost drawn view.
- Fetched the untrimmed hierarchy straight from the `com.argent.androiddevtools` helper over its forwarded socket and replayed **both** rules offline through the built `adaptFullAndroidHierarchyToDescribeResult` - the offline run reproduces the two live picks exactly, which is what validates the harness. It also confirms the flat/post-order shape (`51 leaves, nested? false`).
- `flow-add-step` on the Add-city FAB recorded `tap: { id: …:id/fab_container }` with **no** caveat (correctly - everything else under the point contains the pick), then `flow-finish-recording` and `flow-execute` -> `ok: true, passed: 1`.

**What I could not reproduce end to end:** the unclipped-overlap shape itself, on a device. I swept the emulator's stock apps (Clock, Contacts, Photos, Maps, Gmail, Play Store, launcher) and the installed RN/Expo test builds with a script looking for exactly this pattern and found none - native Android layouts put the bar *beside* the content, not over it, so nothing overlaps. The report's app is React Native with a translucent tab bar over the feed. I patched a local Expo fixture app to `tabBarStyle: { position: "absolute" }` to produce it for real, but its installed dev build no longer matches its JS (`ExpoLinearGradient` view manager missing, Reanimated 4.1.6 vs 4.1.7) and redboxed; the file was restored byte-identical. So the fixture geometry is measured on the device and composed into the reported layout rather than captured from one screen - stated as such in the test comment.

## Deliberately out of scope

**The "still gets a PASS" half is not closed.** With the right element recorded the replay resolves the right selector, so the primary defect is gone - but the pass criterion itself is untouched. `runTap` (`flow-actions.ts:707-718`) dispatches `gesture-tap` and returns `{ ok: true }`; `execLeafStep` (`flow-run.ts:1074`) maps that straight to `status: "pass"`. **Selector resolution alone is the pass criterion**: no post-tap tree read, no landed-on-target assertion, no before/after fingerprint diff (`treeFingerprint`'s two call sites are both *pre*-action), and no occlusion notion anywhere on the replay path - `isVisible` is area-only. A tap onto an occluding overlay, a disabled control, or a container whose centre sits over a different child still reports PASS; the only guard is an author-written `assert`/`await`/`snapshot` step. Closing it means adding a verification step to the replay path plus a `warning` field to `StepReport` (the CLI already renders one - `argent-cli/src/flow.ts:26`, glyph at `:200`, counted at `:215` - but no server code emits it any more). That is a separate change with its own blast radius.

**A candidate whose frame fits entirely inside the tab button** is indistinguishable, from frames plus a flattened tree, from the tab's own icon or label leaf: in post-order a real descendant also precedes its container, so both "nested and earlier" cases look identical. The nesting rule therefore elects it, and no caveat fires - warning there would fire on every ordinary tab tap. The reported shape is the *wider* overlapping element, which the stacking rule does fix. Separating the two needs a non-geometric signal (Android's `clickable` is the obvious candidate, but it is platform-skewed and rows are often clickable too).

**No platform was scoped out**, but the residual ambiguity is unevenly distributed: iOS and Android give a real back-to-front sibling order, Chromium gives one only absent `z-index`, and Vega's is undocumented. The caveat is what covers the last two.

## Interaction with open PRs

Checked #589, #581, #574 and merged #569:

- **#569** (merged, in this branch's base) is the doctrine this had to reconcile with - it is the source of the three "smallest frame wins" cross-references, all updated here.
- **#574** `feat/concurrent-flow-recordings` edits `flow-add-step.ts` heavily but not one line inside `captureTapSelector`. It does rewrite the `message` template and the `warning` assignment in `execute`, which this PR leaves untouched - so the two are same-file, non-overlapping. Whoever rebases second should keep `joinWarnings`' output flowing into its new `Step added to "${params.name}"` template.
- **#589** `codex/flow-screen-selectors` touches `ui-tree-match.ts` only at `fetchTree`, ~155 lines below `nodeAtPoint`. Worth flagging semantically: it adds a *screen* tree source to `fetchFlowTree`, while `captureTapSelector` still captures against the app tree - a hit test and a caveat computed on one tree say nothing about the other. The caveat's wording is about the tapped point, not a guarantee about replay, so it stays true; but the pairing deserves a look when #589 lands.
- **#581** `feat/flow-type-clear` touches none of these files (and targets `feat/keyboard-clear`, not `main`). Its `waitForFocus` reads `selectorToFrame`, whose ranking this PR deliberately leaves alone.
