### PR TITLE
feat(link): sync preferences with remote server

### DIFF
--- a/packages/argent-cli/src/link.ts
+++ b/packages/argent-cli/src/link.ts
@@ -9,6 +9,7 @@ import {
   type LinkConfig,
 } from "@argent/tools-client";
 import { parsePort, StartFlagError } from "./server.js";
+import { syncLinkedServerPreferences } from "./remote-preferences.js";
 
 interface LinkFlags {
   host: string | null;
@@ -18,6 +19,7 @@ interface LinkFlags {
   url: string | null;
   yes: boolean;
   noVerify: boolean;
+  syncPreferences: boolean;
   help: boolean;
 }
 
@@ -60,6 +62,7 @@ export function parseLinkFlags(argv: string[]): LinkFlags {
     url: null,
     yes: false,
     noVerify: false,
+    syncPreferences: true,
     help: false,
   };
 
@@ -81,6 +84,10 @@ export function parseLinkFlags(argv: string[]): LinkFlags {
     }
     if (tok === "--no-verify") {
       flags.noVerify = true;
+      continue;
+    }
+    if (tok === "--no-sync-preferences") {
+      flags.syncPreferences = false;
       continue;
     }
     if (tok === "--host") {
@@ -179,6 +186,9 @@ Flags:
   --token <t>       Bearer token for a server that enforces auth. Usually
                     supplied inside the argent:// string instead.
   --no-verify       Skip the pre-flight GET /tools health check.
+  --no-sync-preferences
+                    Do not overlay portable local preferences on the linked
+                    server process. Sync is enabled by default.
   --yes, -y         Non-interactive. Requires --host (port defaults to 3001).
                     Fails if --host is missing.
   --help, -h        Show this help.
@@ -201,6 +211,9 @@ Security:
 
 Notes:
   - If ARGENT_TOOLS_URL is also set in your environment, it overrides the link.
+  - Portable, live server preferences are overlaid for the remote process
+    lifetime by default. Remote config files are not changed. Server-owned,
+    startup-only, and client-only settings are never copied.
   - To stop using the remote target, run \`argent unlink\`.
   - \`argent server start/stop/status\` manage the local tool-server lifecycle
     and are unaffected by linking.
@@ -230,6 +243,8 @@ Notes:
     precedence after unlinking — unset it manually for fully local behaviour.
   - This does not stop or start any tool-server process. Use
     \`argent server stop\` if you also want to terminate a running local server.
+  - Preferences already synced to the remote process remain active until that
+    process restarts or another \`argent link\` sync replaces them.
   - Restart your editor afterwards — a running \`argent mcp\` process won't
     revert to local auto-spawn until it's relaunched.
 `);
@@ -402,21 +417,18 @@ export async function link(argv: string[]): Promise<void> {
   // Resolve token: an explicit --token / argent:// URL wins; otherwise reuse
   // the existing link's token when re-pointing at the same target, so a bare
   // `argent link` re-run doesn't silently drop authentication.
-  const token: string | undefined =
+  const resolveToken = (): string | undefined =>
     flags.token ??
     (existing && existing.host === host && existing.port === port ? existing.token : undefined);
+  let token = resolveToken();
 
   // A full http(s):// / argent:// target carries its own canonical URL (scheme,
   // optional path); the --host/--port path builds a plain http://host:port.
   let url = flags.url ?? formatToolsServerUrl(host, port);
 
   // Overwrite confirmation (interactive only)
-  if (!flags.yes && existing) {
-    if (existing.url === url) {
-      p.log.info(`Already linked to ${pc.cyan(url)}.`);
-      p.outro("No changes.");
-      return;
-    }
+  const initiallySameTarget = existing?.url === url;
+  if (!flags.yes && existing && !initiallySameTarget) {
     const overwrite = await p.confirm({
       message: `Replace existing link ${pc.dim(existing.url)} with ${pc.cyan(url)}?`,
       initialValue: true,
@@ -476,11 +488,18 @@ export async function link(argv: string[]): Promise<void> {
         host = await promptHost(existing, host);
         port = await promptPort(existing, port);
         url = formatToolsServerUrl(host, port);
+        // A token inherited from the old same-target link must not follow the
+        // user to a different host. An explicitly supplied --token still wins.
+        token = resolveToken();
       }
       // "retry" (or after "modify") loops and re-runs preflightHealth.
     }
   }
 
+  // Verification may have changed the target through the interactive
+  // "Modify host and port" path, so compare the final URL when reporting what
+  // was saved rather than reusing the pre-verification result.
+  const sameTarget = existing?.url === url;
   const cfg: LinkConfig = {
     url,
     host,
@@ -490,12 +509,25 @@ export async function link(argv: string[]): Promise<void> {
   };
   await writeLinkConfig(cfg);
 
-  if (existing && existing.url !== url) {
+  if (sameTarget) {
+    console.log(`${pc.green("✓")} Link refreshed: ${pc.cyan(url)}`);
+  } else if (existing) {
     console.log(`${pc.green("✓")} Link updated: ${pc.dim(existing.url)} → ${pc.cyan(url)}`);
   } else {
     console.log(`${pc.green("✓")} Linked: ${pc.cyan(url)}`);
   }
   if (token) console.log(pc.dim("  auth: token stored in ~/.argent/link.json (0600)"));
+  if (flags.syncPreferences) {
+    const syncResult = await syncLinkedServerPreferences(url, token);
+    if (syncResult.status === "synced") {
+      const detail = syncResult.telemetryDisabled ? " (including telemetry opt-out)" : "";
+      console.log(pc.dim(`  preferences: synced${detail}`));
+    } else if (syncResult.status === "unsupported") {
+      console.log(pc.dim("  preferences: remote server does not support sync; link saved anyway"));
+    } else {
+      console.log(pc.yellow(`  preferences: sync failed (${syncResult.error}); link saved anyway`));
+    }
+  }
   printSecurityCaveat(host, token, url);
   if (process.env.ARGENT_TOOLS_URL) {
     console.log(

--- a/packages/argent-cli/src/remote-preferences.ts
+++ b/packages/argent-cli/src/remote-preferences.ts
@@ -1,0 +1,81 @@
+import {
+  buildRemotePreferencesSnapshot,
+  type RemotePreferencesSnapshot,
+} from "@argent/configuration-core";
+import { getConsentState } from "@argent/telemetry";
+
+const SYNC_TIMEOUT_MS = 3_000;
+
+export type RemotePreferencesSyncResult =
+  | {
+      status: "synced";
+      telemetryDisabled: boolean;
+    }
+  | { status: "unsupported" }
+  | { status: "failed"; error: string };
+
+export async function syncLinkedServerPreferences(
+  url: string,
+  token?: string
+): Promise<RemotePreferencesSyncResult> {
+  const snapshot = buildRemotePreferencesSnapshot({
+    telemetryEnabled: getConsentState().enabled,
+  });
+  return pushRemotePreferences(url, token, snapshot);
+}
+
+/** Exported separately so the HTTP compatibility behavior stays unit-testable. */
+export async function pushRemotePreferences(
+  url: string,
+  token: string | undefined,
+  snapshot: RemotePreferencesSnapshot
+): Promise<RemotePreferencesSyncResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SYNC_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${url.replace(/\/+$/, "")}/preferences/sync`, {
+      method: "PUT",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(snapshot),
+    });
+
+    if (response.status === 404) {
+      await response.body?.cancel().catch(() => {});
+      return { status: "unsupported" };
+    }
+    if (!response.ok) {
+      const detail = (await response.text().catch(() => "")).slice(0, 1_000);
+      return {
+        status: "failed",
+        error: `${response.status} ${response.statusText}${detail ? `: ${detail}` : ""}`,
+      };
+    }
+
+    const body: unknown = await response.json();
+    if (!isRecord(body) || body.version !== snapshot.version) {
+      return { status: "failed", error: "Invalid preference sync response version." };
+    }
+    if (typeof body.telemetryDisabled !== "boolean") {
+      return { status: "failed", error: "Invalid preference sync response body." };
+    }
+    if (snapshot.telemetryDisabled && !body.telemetryDisabled) {
+      return { status: "failed", error: "Remote telemetry opt-out was not confirmed." };
+    }
+    return {
+      status: "synced",
+      telemetryDisabled: body.telemetryDisabled,
+    };
+  } catch (error) {
+    return { status: "failed", error: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/argent-cli/test/link-preferences.test.ts
+++ b/packages/argent-cli/test/link-preferences.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const toolsClient = vi.hoisted(() => ({
+  readLinkConfig: vi.fn(),
+  writeLinkConfig: vi.fn(),
+}));
+const syncLinkedServerPreferences = vi.hoisted(() => vi.fn());
+const prompts = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+  select: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  text: vi.fn(),
+}));
+
+vi.mock("@argent/tools-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@argent/tools-client")>()),
+  readLinkConfig: toolsClient.readLinkConfig,
+  writeLinkConfig: toolsClient.writeLinkConfig,
+}));
+
+vi.mock("../src/remote-preferences.js", () => ({ syncLinkedServerPreferences }));
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
+  ...prompts,
+  log: { error: vi.fn(), info: vi.fn() },
+}));
+
+import { link } from "../src/link.js";
+
+const TARGET = "http://127.0.0.1:3001";
+const SYNCED = {
+  status: "synced" as const,
+  telemetryDisabled: false,
+};
+
+describe("link preference sync orchestration", () => {
+  const originalToolsUrl = process.env.ARGENT_TOOLS_URL;
+
+  beforeEach(() => {
+    delete process.env.ARGENT_TOOLS_URL;
+    toolsClient.readLinkConfig.mockReset().mockResolvedValue(null);
+    toolsClient.writeLinkConfig.mockReset().mockResolvedValue(undefined);
+    syncLinkedServerPreferences.mockReset().mockResolvedValue(SYNCED);
+    prompts.confirm.mockReset();
+    prompts.isCancel.mockClear();
+    prompts.select.mockReset();
+    prompts.spinner.mockClear();
+    prompts.text.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalToolsUrl === undefined) delete process.env.ARGENT_TOOLS_URL;
+    else process.env.ARGENT_TOOLS_URL = originalToolsUrl;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("syncs by default after persisting a new link", async () => {
+    await link([TARGET, "--no-verify"]);
+
+    expect(toolsClient.writeLinkConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ url: TARGET, host: "127.0.0.1", port: 3001 })
+    );
+    expect(syncLinkedServerPreferences).toHaveBeenCalledWith(TARGET, undefined);
+    expect(toolsClient.writeLinkConfig.mock.invocationCallOrder[0]).toBeLessThan(
+      syncLinkedServerPreferences.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("honors --no-sync-preferences", async () => {
+    await link([TARGET, "--no-verify", "--no-sync-preferences"]);
+
+    expect(toolsClient.writeLinkConfig).toHaveBeenCalledOnce();
+    expect(syncLinkedServerPreferences).not.toHaveBeenCalled();
+  });
+
+  it("refreshes preferences when linking the same target again", async () => {
+    toolsClient.readLinkConfig.mockResolvedValue({
+      url: TARGET,
+      host: "127.0.0.1",
+      port: 3001,
+      token: "existing-token",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    await link([TARGET, "--no-verify"]);
+
+    expect(toolsClient.writeLinkConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ url: TARGET, token: "existing-token" })
+    );
+    expect(syncLinkedServerPreferences).toHaveBeenCalledWith(TARGET, "existing-token");
+  });
+
+  it("reports the final target after verification modifies a same-target link", async () => {
+    toolsClient.readLinkConfig.mockResolvedValue({
+      url: TARGET,
+      host: "127.0.0.1",
+      port: 3001,
+      token: "existing-token",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    prompts.select.mockResolvedValueOnce("modify");
+    prompts.text.mockResolvedValueOnce("localhost").mockResolvedValueOnce("3002");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await link([TARGET]);
+
+    expect(toolsClient.writeLinkConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://localhost:3002",
+        host: "localhost",
+        port: 3002,
+      })
+    );
+    expect(toolsClient.writeLinkConfig.mock.calls[0]![0]).not.toHaveProperty("token");
+    expect(syncLinkedServerPreferences).toHaveBeenCalledWith("http://localhost:3002", undefined);
+    expect(fetchMock.mock.calls[1]![1]).toEqual(expect.objectContaining({ headers: {} }));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Link updated:"));
+    expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining("Link refreshed:"));
+  });
+
+  it("keeps the saved link when preference sync fails", async () => {
+    syncLinkedServerPreferences.mockResolvedValue({ status: "failed", error: "offline" });
+
+    await expect(link([TARGET, "--no-verify"])).resolves.toBeUndefined();
+
+    expect(toolsClient.writeLinkConfig).toHaveBeenCalledOnce();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("link saved anyway"));
+  });
+});

--- a/packages/argent-cli/test/parse-link-flags.test.ts
+++ b/packages/argent-cli/test/parse-link-flags.test.ts
@@ -11,6 +11,7 @@ describe("parseLinkFlags — defaults", () => {
       url: null,
       yes: false,
       noVerify: false,
+      syncPreferences: true,
       help: false,
     });
   });
@@ -28,10 +29,11 @@ describe("parseLinkFlags — flag forms", () => {
     expect(parseLinkFlags(["--port=4000"]).port).toBe(4000);
   });
 
-  it("parses boolean flags --yes/-y, --no-verify, --help/-h", () => {
+  it("parses boolean flags --yes/-y, --no-verify, --no-sync-preferences, --help/-h", () => {
     expect(parseLinkFlags(["--yes"]).yes).toBe(true);
     expect(parseLinkFlags(["-y"]).yes).toBe(true);
     expect(parseLinkFlags(["--no-verify"]).noVerify).toBe(true);
+    expect(parseLinkFlags(["--no-sync-preferences"]).syncPreferences).toBe(false);
     expect(parseLinkFlags(["--help"]).help).toBe(true);
     expect(parseLinkFlags(["-h"]).help).toBe(true);
   });
@@ -45,6 +47,7 @@ describe("parseLinkFlags — flag forms", () => {
       url: null,
       yes: true,
       noVerify: true,
+      syncPreferences: true,
       help: false,
     });
   });

--- a/packages/argent-cli/test/remote-preferences.test.ts
+++ b/packages/argent-cli/test/remote-preferences.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pushRemotePreferences } from "../src/remote-preferences.js";
+
+const SNAPSHOT = {
+  version: 1 as const,
+  flags: { "video-watermark": false },
+  telemetryDisabled: true,
+};
+
+describe("pushRemotePreferences", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("sends the snapshot with bearer authentication", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            version: 1,
+            telemetryDisabled: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      pushRemotePreferences("https://example.test/argent///", "secret", SNAPSHOT)
+    ).resolves.toEqual({
+      status: "synced",
+      telemetryDisabled: true,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test/argent/preferences/sync",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({ Authorization: "Bearer secret" }),
+        body: JSON.stringify(SNAPSHOT),
+      })
+    );
+  });
+
+  it("treats an older server's 404 as unsupported", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      pushRemotePreferences("http://127.0.0.1:3001", undefined, SNAPSHOT)
+    ).resolves.toEqual({ status: "unsupported" });
+  });
+
+  it("returns failures without throwing so linking can continue", async () => {
+    const fetchMock = vi.fn(async () => new Response("nope", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const result = await pushRemotePreferences("http://127.0.0.1:3001", undefined, SNAPSHOT);
+    expect(result).toMatchObject({ status: "failed", error: expect.stringContaining("500") });
+  });
+
+  it("rejects malformed success bodies and unconfirmed telemetry opt-outs", async () => {
+    const malformed = vi.fn(async () => Response.json({ version: 1 }));
+    vi.stubGlobal("fetch", malformed);
+    await expect(
+      pushRemotePreferences("http://127.0.0.1:3001", undefined, SNAPSHOT)
+    ).resolves.toMatchObject({ status: "failed", error: expect.stringContaining("body") });
+
+    const unconfirmed = vi.fn(async () =>
+      Response.json({
+        version: 1,
+        telemetryDisabled: false,
+      })
+    );
+    vi.stubGlobal("fetch", unconfirmed);
+    await expect(
+      pushRemotePreferences("http://127.0.0.1:3001", undefined, SNAPSHOT)
+    ).resolves.toMatchObject({ status: "failed", error: expect.stringContaining("not confirmed") });
+  });
+});

--- a/packages/configuration-core/src/flags.ts
+++ b/packages/configuration-core/src/flags.ts
@@ -9,15 +9,15 @@
 // commands live in `@argent/cli` and import the primitives below.
 //
 // `setFlag` writes a boolean, `unsetFlag` removes the entry at the chosen scope.
-// `isFlagEnabled` walks project → global, so an entry at the project scope
-// shadows the same key at the global scope. To opt a single project out of
-// a globally-enabled flag, hand-edit `<project>/.argent/flags.json` to
-// `{"flags":{"name":false}}` — there is no CLI for an explicit override.
+// `isFlagEnabled` walks process overlay → project → global. To opt a single
+// project out of a globally-enabled flag, hand-edit
+// `<project>/.argent/flags.json` to `{"flags":{"name":false}}` — there is no
+// CLI for an explicit persisted override.
 //
 // FLAG_REGISTRY below is the single source of truth for which flags exist:
 // `argent enable` only accepts a name listed there, and `argent flags`
-// documents every entry. `isFlagEnabled` only reads storage — it never
-// consults the registry, keeping runtime callers decoupled from CLI validation.
+// documents every entry. `isFlagEnabled` never consults the registry, keeping
+// runtime callers decoupled from CLI validation.
 //
 // Deprecating a flag is safe: only the *write* path (`argent enable`) consults
 // the registry. Every read path (readFlags / isFlagEnabled / `argent flags`)
@@ -34,11 +34,33 @@ interface FlagsFile {
   flags?: Record<string, boolean>;
 }
 
+// A linked client can temporarily override the receiving process without
+// rewriting the remote operator's project/global files. The whole map is
+// replaced in one synchronous step after a snapshot has been validated.
+let runtimeFlagOverrides: ReadonlyMap<string, boolean> = new Map();
+
+export function replaceRuntimeFlagOverrides(overrides: Readonly<Record<string, boolean>>): void {
+  const next = new Map<string, boolean>();
+  for (const [name, value] of Object.entries(overrides)) {
+    if (typeof value !== "boolean") {
+      throw new TypeError(`Runtime flag override "${name}" must be boolean.`);
+    }
+    next.set(name, value);
+  }
+  runtimeFlagOverrides = next;
+}
+
+export function clearRuntimeFlagOverrides(): void {
+  runtimeFlagOverrides = new Map();
+}
+
 // A recognized feature flag. `name` is what users pass to enable/disable and
 // what `isFlagEnabled` reads; `description` is shown by `argent flags`.
 export interface FlagDefinition {
   readonly name: string;
   readonly description: string;
+  /** Whether `argent link` should copy this live flag to the remote process. */
+  readonly syncToRemote?: true;
   // Opt-OUT flag: the feature is ON when the flag has never been set. `argent
   // disable <name>` then persists an explicit `false` (rather than unsetting,
   // which would revert to this ON default), and `argent enable <name>` / no
@@ -58,6 +80,7 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     name: "argent-lens",
     description:
       "Argent Lens — the propose_variant / await_user_selection tools and the Electron preview window for staging UI design variants and letting a human pick among them. Off by default while the feature is in development.",
+    syncToRemote: true,
   },
   {
     name: "artifacts-list-endpoint",
@@ -76,6 +99,7 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     name: "video-watermark",
     description:
       "Overlay the argent corner watermark on recorded screen videos. On by default; turn it off with `argent disable video-watermark`.",
+    syncToRemote: true,
     defaultEnabled: true,
   },
 ];
@@ -213,14 +237,15 @@ export function unsetFlag(name: string, scope: FlagScope, options: FlagsPathOpti
   return true;
 }
 
-// Effective value: project overrides global. Returns the caller-supplied
-// `default` (false when omitted) if the flag is not set in either scope. Stays
-// storage-only and registry-decoupled — for a flag's *declared* default use
-// `isFeatureEnabled`.
+// Effective value: the process-only linked-client overlay overrides project,
+// which overrides global. Returns the caller-supplied `default` (false when
+// omitted) if the flag is not set in any layer. Stays registry-decoupled — for
+// a flag's *declared* default use `isFeatureEnabled`.
 export function isFlagEnabled(
   name: string,
   options: FlagsPathOptions & { default?: boolean } = {}
 ): boolean {
+  if (runtimeFlagOverrides.has(name)) return runtimeFlagOverrides.get(name)!;
   // hasOwn, not `in`: otherwise prototype keys ("toString", "constructor", …)
   // resolve to a truthy Object.prototype member for a flag that was never set.
   const projectFlags = readFlags("project", options);
@@ -232,7 +257,8 @@ export function isFlagEnabled(
 
 // Registry-aware read: resolves an unset flag to its declared `defaultEnabled`
 // (so an opt-out feature reads as on until disabled). This is the check runtime
-// features should use; `isFlagEnabled` stays the low-level storage primitive.
+// features should use; `isFlagEnabled` stays the low-level registry-agnostic
+// primitive.
 export function isFeatureEnabled(
   name: string,
   options: FlagsPathOptions = {},

--- a/packages/configuration-core/src/index.ts
+++ b/packages/configuration-core/src/index.ts
@@ -9,10 +9,20 @@ export {
   unsetFlag,
   isFlagEnabled,
   isFeatureEnabled,
+  clearRuntimeFlagOverrides,
   type FlagScope,
   type FlagDefinition,
   type FlagsPathOptions,
 } from "./flags.js";
+
+export {
+  REMOTE_PREFERENCES_VERSION,
+  RemotePreferencesValidationError,
+  buildRemotePreferencesSnapshot,
+  parseRemotePreferencesSnapshot,
+  applyRemotePreferenceFlags,
+  type RemotePreferencesSnapshot,
+} from "./remote-preferences.js";
 
 export {
   argentHomeDir,

--- a/packages/configuration-core/src/remote-preferences.ts
+++ b/packages/configuration-core/src/remote-preferences.ts
@@ -1,0 +1,101 @@
+import {
+  FLAG_REGISTRY,
+  isFeatureEnabled,
+  replaceRuntimeFlagOverrides,
+  type FlagDefinition,
+  type FlagsPathOptions,
+} from "./flags.js";
+
+export const REMOTE_PREFERENCES_VERSION = 1 as const;
+
+/** The small, explicit preference set understood by a linked tool-server. */
+export interface RemotePreferencesSnapshot {
+  version: typeof REMOTE_PREFERENCES_VERSION;
+  flags: Record<string, boolean>;
+  /** Disable-only: false never enables telemetry on the receiving server. */
+  telemetryDisabled: boolean;
+}
+
+export class RemotePreferencesValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RemotePreferencesValidationError";
+  }
+}
+
+/** Build effective values for only flags explicitly marked as live + portable. */
+export function buildRemotePreferencesSnapshot(
+  options: FlagsPathOptions & { telemetryEnabled?: boolean } = {},
+  registry: readonly FlagDefinition[] = FLAG_REGISTRY
+): RemotePreferencesSnapshot {
+  const flags: Record<string, boolean> = {};
+  for (const definition of registry) {
+    if (!definition.syncToRemote) continue;
+    flags[definition.name] = isFeatureEnabled(definition.name, options, registry);
+  }
+  return {
+    version: REMOTE_PREFERENCES_VERSION,
+    flags,
+    telemetryDisabled: options.telemetryEnabled === false,
+  };
+}
+
+/** Validate the complete untrusted HTTP payload before anything is applied. */
+export function parseRemotePreferencesSnapshot(raw: unknown): RemotePreferencesSnapshot {
+  if (!isRecord(raw)) {
+    throw new RemotePreferencesValidationError("Preference snapshot must be a JSON object.");
+  }
+  if (raw.version !== REMOTE_PREFERENCES_VERSION) {
+    throw new RemotePreferencesValidationError(
+      `Unsupported preference snapshot version; expected ${REMOTE_PREFERENCES_VERSION}.`
+    );
+  }
+  if (!isRecord(raw.flags)) {
+    throw new RemotePreferencesValidationError(
+      'Preference snapshot field "flags" must be an object.'
+    );
+  }
+  if (typeof raw.telemetryDisabled !== "boolean") {
+    throw new RemotePreferencesValidationError(
+      'Preference snapshot field "telemetryDisabled" must be boolean.'
+    );
+  }
+
+  const entries = Object.entries(raw.flags);
+  if (entries.length > 100) {
+    throw new RemotePreferencesValidationError("Preference snapshot contains too many flags.");
+  }
+  for (const [name, value] of entries) {
+    if (typeof value !== "boolean") {
+      throw new RemotePreferencesValidationError(`Flag "${name}" must be boolean.`);
+    }
+  }
+
+  return {
+    version: REMOTE_PREFERENCES_VERSION,
+    flags: Object.fromEntries(entries) as Record<string, boolean>,
+    telemetryDisabled: raw.telemetryDisabled,
+  };
+}
+
+/** Replace the runtime overlay with only flags the receiver allowlists. */
+export function applyRemotePreferenceFlags(
+  snapshot: RemotePreferencesSnapshot,
+  registry: readonly FlagDefinition[] = FLAG_REGISTRY
+): void {
+  const syncable = new Set(
+    registry.filter(({ syncToRemote }) => syncToRemote).map(({ name }) => name)
+  );
+  const overrides: Record<string, boolean> = {};
+
+  for (const [name, value] of Object.entries(snapshot.flags)) {
+    if (!syncable.has(name)) continue;
+    overrides[name] = value;
+  }
+
+  replaceRuntimeFlagOverrides(overrides);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/configuration-core/tests/remote-preferences.test.ts
+++ b/packages/configuration-core/tests/remote-preferences.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  applyRemotePreferenceFlags,
+  buildRemotePreferencesSnapshot,
+  clearRuntimeFlagOverrides,
+  isFeatureEnabled,
+  parseRemotePreferencesSnapshot,
+  readFlags,
+  setFlag,
+  type FlagDefinition,
+} from "../src/index.js";
+
+const TEST_REGISTRY: readonly FlagDefinition[] = [
+  { name: "client-only", description: "client" },
+  { name: "remote-opt-in", description: "remote", syncToRemote: true },
+  {
+    name: "remote-opt-out",
+    description: "remote default",
+    syncToRemote: true,
+    defaultEnabled: true,
+  },
+];
+
+let tmpHome: string;
+let tmpProject: string;
+
+beforeEach(() => {
+  clearRuntimeFlagOverrides();
+  tmpHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-sync-home-")));
+  tmpProject = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-sync-project-")));
+  fs.writeFileSync(path.join(tmpProject, "package.json"), "{}");
+});
+
+afterEach(() => {
+  clearRuntimeFlagOverrides();
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpProject, { recursive: true, force: true });
+});
+
+describe("remote preference snapshots", () => {
+  it("contains only effective live flags and the telemetry opt-out", () => {
+    setFlag("client-only", true, "global", { homeDir: tmpHome });
+    setFlag("remote-opt-in", true, "global", { homeDir: tmpHome });
+    setFlag("remote-opt-out", false, "project", { cwd: tmpProject });
+
+    expect(
+      buildRemotePreferencesSnapshot(
+        { homeDir: tmpHome, cwd: tmpProject, telemetryEnabled: false },
+        TEST_REGISTRY
+      )
+    ).toEqual({
+      version: 1,
+      flags: { "remote-opt-in": true, "remote-opt-out": false },
+      telemetryDisabled: true,
+    });
+  });
+
+  it("never asks the remote server to enable telemetry", () => {
+    expect(
+      buildRemotePreferencesSnapshot(
+        { homeDir: tmpHome, cwd: tmpProject, telemetryEnabled: true },
+        TEST_REGISTRY
+      )
+    ).toMatchObject({ telemetryDisabled: false });
+  });
+
+  it("replaces a process overlay above project flags without writing files", () => {
+    setFlag("remote-opt-in", false, "project", { cwd: tmpProject });
+    applyRemotePreferenceFlags(
+      {
+        version: 1,
+        flags: { "remote-opt-in": true, "client-only": true, "unknown": true },
+        telemetryDisabled: false,
+      },
+      TEST_REGISTRY
+    );
+
+    expect(isFeatureEnabled("remote-opt-in", { cwd: tmpProject }, TEST_REGISTRY)).toBe(true);
+    expect(readFlags("project", { cwd: tmpProject })).toEqual({ "remote-opt-in": false });
+    expect(readFlags("global", { homeDir: tmpHome })).toEqual({});
+
+    applyRemotePreferenceFlags({ version: 1, flags: {}, telemetryDisabled: false }, TEST_REGISTRY);
+    expect(isFeatureEnabled("remote-opt-in", { cwd: tmpProject }, TEST_REGISTRY)).toBe(false);
+  });
+
+  it("rejects malformed payloads before application", () => {
+    expect(() =>
+      parseRemotePreferencesSnapshot({ version: 2, flags: {}, telemetryDisabled: false })
+    ).toThrow(/Unsupported preference snapshot version/);
+    expect(() =>
+      parseRemotePreferencesSnapshot({
+        version: 1,
+        flags: { bad: "true" },
+        telemetryDisabled: false,
+      })
+    ).toThrow(/must be boolean/);
+    expect(() =>
+      parseRemotePreferencesSnapshot({ version: 1, flags: {}, telemetryDisabled: "yes" })
+    ).toThrow(/telemetryDisabled.*boolean/);
+  });
+});

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -19,7 +19,12 @@ import {
   peekAnonId,
 } from "./identity.js";
 import { resolveHostFingerprint, resolveHostFingerprintAsync } from "./fingerprint.js";
-import { isEnabled, writeConsentFlag, getConsentState } from "./consent.js";
+import {
+  isEnabled,
+  writeConsentFlag,
+  getConsentState,
+  setSessionConsentOverride,
+} from "./consent.js";
 import { emitDebugError, emitDebugPayload, isDebugEnabled } from "./debug.js";
 import type { EventName, EventPropertyMap } from "./events.js";
 
@@ -304,6 +309,22 @@ export async function markDisabled(): Promise<void> {
     state = null;
   } catch (err) {
     emitDebugError("markDisabled failed", err);
+  }
+}
+
+/**
+ * Disable telemetry for this process without changing the host's config file.
+ * Returns the observed consent state so administrative callers never report a
+ * privacy change that failed to take effect.
+ */
+export async function disableForSession(): Promise<boolean> {
+  try {
+    setSessionConsentOverride(false);
+    await shutdown();
+    return getConsentState().enabled === false;
+  } catch (err) {
+    emitDebugError("disableForSession failed", err);
+    return false;
   }
 }
 

--- a/packages/telemetry/test/index.test.ts
+++ b/packages/telemetry/test/index.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
   _resetConsentCacheForTest,
+  disableForSession,
   getConsentState,
   markDisabled,
   markEnabled,
@@ -137,6 +138,25 @@ describe("telemetry public surface", () => {
     // Opting out emits nothing extra — only the one event that was already queued.
     expect(provider.shutdown).toHaveBeenCalledTimes(1);
     expect(isEnabled()).toBe(false);
+  });
+
+  it("disableForSession is observable, drains the client, and does not rewrite consent", async () => {
+    track("toolserver:start", {});
+    const provider = otelMock.providers[0]!;
+
+    await expect(disableForSession()).resolves.toBe(true);
+
+    expect(provider.shutdown).toHaveBeenCalledTimes(1);
+    expect(getConsentState()).toEqual({
+      enabled: false,
+      source: { source: "session_override" },
+    });
+    expect(JSON.parse(fs.readFileSync(configFilePath(), "utf8"))).toMatchObject({
+      telemetry: { enabled: true },
+    });
+
+    _resetConsentCacheForTest();
+    expect(isEnabled()).toBe(true);
   });
 
   it("does not provision the anon-id file when the ingest token is unusable", () => {

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -31,6 +31,7 @@ import {
 } from "./utils/screen-recording-reminder";
 import { createPreviewRouter } from "./preview";
 import { makeArtifactListRoute, makeArtifactRoute } from "./artifacts";
+import { makeRemotePreferencesSyncRoute } from "./remote-preferences";
 import { FileInputError, resolveFileInputs, type UploadEntry } from "./file-inputs";
 import {
   assertSupported,
@@ -499,6 +500,14 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
   // Hidden (not MCP-exposed) preview UI + stream discovery endpoints.
   // MCP only consumes /tools and /tools/:name, so this subtree is invisible to agents.
   app.use("/preview", createPreviewRouter(registry));
+
+  // Administrative client→server preference sync. This route sits behind the
+  // Host and Bearer-token gates above and is intentionally absent from /tools,
+  // so agents cannot discover or invoke it as an MCP capability.
+  app.put(
+    "/preferences/sync",
+    makeRemotePreferencesSyncRoute({ onActivity: () => idleTimer.touch() })
+  );
 
   // Artifact retrieval: streams files produced by tools (screenshots, profiler
   // exports) over the remote-aware HTTP boundary so the MCP client can fetch

--- a/packages/tool-server/src/remote-preferences.ts
+++ b/packages/tool-server/src/remote-preferences.ts
@@ -1,0 +1,45 @@
+import type { RequestHandler } from "express";
+import {
+  RemotePreferencesValidationError,
+  applyRemotePreferenceFlags,
+  parseRemotePreferencesSnapshot,
+} from "@argent/configuration-core";
+import { disableForSession } from "@argent/telemetry";
+
+export interface RemotePreferencesSyncRouteOptions {
+  onActivity?: () => void;
+  disableTelemetry?: () => Promise<boolean>;
+}
+
+/** Authenticated administrative route used by `argent link`, never exposed as a tool. */
+export function makeRemotePreferencesSyncRoute(
+  options: RemotePreferencesSyncRouteOptions = {}
+): RequestHandler {
+  return async (req, res) => {
+    options.onActivity?.();
+    try {
+      const snapshot = parseRemotePreferencesSnapshot(req.body);
+      let telemetryDisabled = false;
+      if (snapshot.telemetryDisabled) {
+        telemetryDisabled = await (options.disableTelemetry ?? disableForSession)();
+        if (!telemetryDisabled) {
+          throw new Error("Telemetry session opt-out did not take effect.");
+        }
+      }
+
+      applyRemotePreferenceFlags(snapshot);
+      res.json({
+        version: snapshot.version,
+        telemetryDisabled,
+      });
+    } catch (error) {
+      if (error instanceof RemotePreferencesValidationError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      res.status(500).json({
+        error: `Failed to apply remote preferences: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  };
+}

--- a/packages/tool-server/test/remote-preferences.test.ts
+++ b/packages/tool-server/test/remote-preferences.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import express from "express";
+import supertest from "supertest";
+import {
+  clearRuntimeFlagOverrides,
+  isFeatureEnabled,
+  readConfigObject,
+  readFlags,
+  setFlag,
+} from "@argent/configuration-core";
+import { isEnabled as isTelemetryEnabled, setSessionConsentOverride } from "@argent/telemetry";
+import type { Registry } from "@argent/registry";
+import { createHttpApp, type HttpAppHandle } from "../src/http";
+import { makeRemotePreferencesSyncRoute } from "../src/remote-preferences";
+
+// This test exercises the top-level auth boundary, but not the unauthenticated
+// preview UI. Keeping that subtree out of the module graph also keeps the test
+// independent of optional simulator transports such as @moq/net.
+vi.mock("../src/preview", async () => {
+  const express = await import("express");
+  return { createPreviewRouter: () => express.Router() };
+});
+
+vi.mock("../src/utils/update-checker", () => ({
+  getUpdateState: vi.fn(() => ({
+    updateAvailable: false,
+    latestVersion: null,
+    currentVersion: "1.0.0",
+  })),
+  isUpdateNoteSuppressed: vi.fn(() => true),
+  suppressUpdateNote: vi.fn(),
+}));
+
+function stubRegistry(): Registry {
+  return {
+    getSnapshot: vi.fn(() => ({ services: new Map(), namespaces: [], tools: [] })),
+    getTool: vi.fn(() => undefined),
+    invokeTool: vi.fn(async () => ({ ok: true })),
+  } as unknown as Registry;
+}
+
+const TOKEN = "remote-preferences-token";
+let handle: HttpAppHandle;
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalToken: string | undefined;
+
+beforeEach(() => {
+  tmpHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-server-sync-")));
+  originalHome = process.env.HOME;
+  originalToken = process.env.ARGENT_AUTH_TOKEN;
+  process.env.HOME = tmpHome;
+  process.env.ARGENT_AUTH_TOKEN = TOKEN;
+  handle = createHttpApp(stubRegistry());
+});
+
+afterEach(() => {
+  handle.dispose();
+  clearRuntimeFlagOverrides();
+  setSessionConsentOverride(null);
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalToken === undefined) delete process.env.ARGENT_AUTH_TOKEN;
+  else process.env.ARGENT_AUTH_TOKEN = originalToken;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("PUT /preferences/sync", () => {
+  it("is protected by the tool-server bearer token", async () => {
+    const response = await supertest(handle.app)
+      .put("/preferences/sync")
+      .send({ version: 1, flags: {} });
+    expect(response.status).toBe(401);
+  });
+
+  it("overlays portable values for the process without rewriting server files", async () => {
+    setFlag("video-watermark", true, "global", { homeDir: tmpHome });
+    const response = await supertest(handle.app)
+      .put("/preferences/sync")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({
+        version: 1,
+        flags: {
+          "video-watermark": false,
+          "disable-auto-screenshot": true,
+          "unknown": true,
+        },
+        telemetryDisabled: true,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      version: 1,
+      telemetryDisabled: true,
+    });
+    expect(readFlags("global", { homeDir: tmpHome })).toEqual({
+      "video-watermark": true,
+    });
+    expect(readConfigObject()).toEqual({});
+    expect(isFeatureEnabled("video-watermark")).toBe(false);
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it("rejects arbitrary preference values", async () => {
+    const response = await supertest(handle.app)
+      .put("/preferences/sync")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ version: 1, flags: {}, telemetryDisabled: "yes" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatch(/must be boolean/);
+  });
+
+  it("does not activate any overlay when telemetry opt-out cannot be confirmed", async () => {
+    const app = express();
+    app.use(express.json());
+    app.put(
+      "/",
+      makeRemotePreferencesSyncRoute({ disableTelemetry: vi.fn().mockResolvedValue(false) })
+    );
+
+    const response = await supertest(app)
+      .put("/")
+      .send({
+        version: 1,
+        flags: { "video-watermark": false },
+        telemetryDisabled: true,
+      });
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toMatch(/did not take effect/);
+    expect(isFeatureEnabled("video-watermark")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`argent link` now sends a small preference snapshot to the linked tool server: the effective `video-watermark` and `argent-lens` flags, plus a telemetry opt-out when one is active locally.

The server applies those flags as an in-memory process override, so its project and global files remain untouched. Telemetry uses the existing session opt-out path and is never remotely enabled. Older servers still link normally, and `--no-sync-preferences` skips the sync.

This makes local watermark settings work when recording through a remote tool server without overwriting server-owned policy.

## Test plan

Tests
