### PR TITLE
chore: bump to 0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6126,7 +6126,7 @@
     },
     "packages/archive": {
       "name": "@argent/archive",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6135,7 +6135,7 @@
     },
     "packages/argent": {
       "name": "@swmansion/argent",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fails-components/webtransport": "^1.6.3",
@@ -6173,7 +6173,7 @@
     },
     "packages/argent-cli": {
       "name": "@argent/cli",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/registry": "file:../registry",
@@ -6190,7 +6190,7 @@
     },
     "packages/argent-installer": {
       "name": "@argent/installer",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@argent/registry": "file:../registry",
         "@argent/telemetry": "file:../telemetry",
@@ -6225,7 +6225,7 @@
     },
     "packages/argent-mcp": {
       "name": "@argent/mcp",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/telemetry": "file:../telemetry",
@@ -6240,7 +6240,7 @@
     },
     "packages/argent-tools-client": {
       "name": "@argent/tools-client",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@argent/archive": "file:../archive",
         "@argent/configuration-core": "file:../configuration-core"
@@ -6253,7 +6253,7 @@
     },
     "packages/configuration-core": {
       "name": "@argent/configuration-core",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6262,7 +6262,7 @@
     },
     "packages/native-devtools-android": {
       "name": "@argent/native-devtools-android",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6271,7 +6271,7 @@
     },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6280,7 +6280,7 @@
     },
     "packages/preview-window": {
       "name": "@argent/preview-window",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "electron": "^42.5.0",
@@ -6289,7 +6289,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "zod": "^4.0.0"
       },
@@ -6300,14 +6300,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/telemetry": {
       "name": "@argent/telemetry",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
@@ -6323,7 +6323,7 @@
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@argent/archive": "file:../archive",
         "@argent/configuration-core": "file:../configuration-core",
@@ -6373,11 +6373,11 @@
     },
     "packages/ui": {
       "name": "@argent/ui",
-      "version": "0.17.0"
+      "version": "0.18.0"
     },
     "packages/update-core": {
       "name": "@argent/update-core",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "semver": "^7.8.5"
       },

--- a/packages/archive/package.json
+++ b/packages/archive/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/archive",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Shared tar.gz helpers for the file boundary: create an archive of a path and extract one back to its top-level member.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-cli/package.json
+++ b/packages/argent-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Shell CLI commands for argent: tools, run, server, enable, disable, flags",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/installer",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Workspace setup logic for argent: init, update, uninstall",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-mcp/package.json
+++ b/packages/argent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/mcp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "MCP stdio protocol adapter — talks to the argent tool-server and forwards calls",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-tools-client/package.json
+++ b/packages/argent-tools-client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tools-client",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Spawn-and-talk client for the argent tool-server (used by MCP and CLI)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "MCP server for iOS Simulator and Android Emulator control",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/configuration-core/package.json
+++ b/packages/configuration-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/configuration-core",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Source of truth for argent feature flags: registry, JSON storage, and isFlagEnabled",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/native-devtools-android/package.json
+++ b/packages/native-devtools-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-android",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/native-devtools-ios/package.json
+++ b/packages/native-devtools-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-ios",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/preview-window/package.json
+++ b/packages/preview-window/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/preview-window",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "description": "Electron host for Argent Lens — the variant preview & selection UI.",
   "main": "dist/main.js",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "description": "Claude Code skills for iOS simulator and Android emulator interaction via argent",
   "scripts": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/telemetry",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Opt-out telemetry client for Argent CLI / installer / tool-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Framework-agnostic tool registry for iOS simulator and Android emulator control",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/ui",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Simple browser UI that streams a simulator and forwards taps/gestures directly to the argent simulator-server.",
   "files": [
     "index.html"

--- a/packages/update-core/package.json
+++ b/packages/update-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/update-core",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Shared npm release-age detection and installable-target resolution for argent updates",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
bump

debated myself whether this should be a QoL patch or a minor release and i think the latter makes more sense

| Commit | Change |
| --- | --- |
| `7189333a` | `feat(tool-server)`: human-readable log message (#582) |
| `5ac69349` | `feat(flow)`: CSS combinator scopes for flow selectors (#569) |
| `e23f0e28` | `feat(flow)`: snapshot `cropOn` for single-element visual diffs (#516) |
| `6a53e66a` | `feat(flow)`: rotate directive (#546) |
| `68ceb314` | `ci`: cut over npm publishing to the unified trusted-publishing workflow (#571) |
| `2546788a` | `ci`: unified publish-npm workflow (#565) |
