### PR TITLE
chore: add server.json for the official MCP registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
-    "test:scripts": "node --test scripts/sync-next-dist-tag.test.mjs scripts/extract-tools.test.mjs scripts/next-canary-version.test.mjs",
+    "test:scripts": "node --test scripts/sync-next-dist-tag.test.mjs scripts/extract-tools.test.mjs scripts/next-canary-version.test.mjs scripts/check-workspace-versions.test.mjs",
     "check:versions": "node scripts/check-workspace-versions.mjs"
   },
   "devDependencies": {

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@swmansion/argent",
   "version": "0.18.0",
+  "mcpName": "io.github.software-mansion/argent",
   "description": "MCP server for iOS Simulator and Android Emulator control",
   "license": "Apache-2.0",
   "repository": {

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -32,7 +32,14 @@ const serverJsonPath = join(repoRoot, "server.json");
 export function serverJsonMismatches(publishedVersion, argentPkg, server) {
   const mismatches = [];
 
-  if (server.version !== publishedVersion) {
+  // Without a version on the manifest there is no target to compare against, and
+  // every comparison below would pass by matching undefined against undefined —
+  // so its absence is a mismatch in its own right, exactly like mcpName's.
+  if (!publishedVersion) {
+    mismatches.push(
+      "packages/argent/package.json has no version — nothing for server.json to be checked against"
+    );
+  } else if (server.version !== publishedVersion) {
     mismatches.push(
       `server.json version is ${server.version}, packages/argent/package.json is ${publishedVersion}`
     );
@@ -141,8 +148,8 @@ function main() {
     failed = true;
   }
 
-  // An empty packages/ never gets past this read, so the version below is always
-  // a real one.
+  // An empty packages/ never gets past this read. It only proves the file parses,
+  // though — a manifest missing its version is caught as a mismatch below.
   const argentPkg = readTrackedJson(argentManifestPath);
   const server = readTrackedJson(serverJsonPath);
 

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -155,7 +155,10 @@ function main() {
     } catch {
       continue; // directory without a package.json
     }
-    if (!manifest.version) continue;
+    // `?.` because JSON.parse succeeds on a file holding `null`, which the catch
+    // above never sees — the same shape readTrackedJson rejects for the two
+    // manifests it reads.
+    if (!manifest?.version) continue;
     const names = byVersion.get(manifest.version) ?? [];
     names.push(manifest.name ?? entry.name);
     byVersion.set(manifest.version, names);

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -119,13 +119,9 @@ function main() {
     byVersion.set(manifest.version, names);
   }
 
-  // An empty packages/ never gets past this read, so the version below is always
-  // a real one.
-  const argentPkg = readTrackedJson(argentManifestPath);
-  const server = readTrackedJson(serverJsonPath);
-
   let failed = false;
 
+  // Reported before the reads below, so a corrupt server.json can't swallow it.
   if (byVersion.size > 1) {
     console.error("Workspace package versions are out of sync:");
     for (const [version, names] of [...byVersion].sort()) {
@@ -136,6 +132,11 @@ function main() {
     );
     failed = true;
   }
+
+  // An empty packages/ never gets past this read, so the version below is always
+  // a real one.
+  const argentPkg = readTrackedJson(argentManifestPath);
+  const server = readTrackedJson(serverJsonPath);
 
   // server.json names the npm coordinates of packages/argent, so that manifest
   // is what it has to agree with. Reported even when packages/* disagree, so a

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -109,18 +109,36 @@ function readTrackedJson(path) {
     console.error(`\nIt is tracked in git — restore it with \`git checkout -- ${shown}\`.`);
     process.exit(1);
   }
+  let parsed;
   try {
-    return JSON.parse(raw);
+    parsed = JSON.parse(raw);
   } catch (error) {
     console.error(`${shown} is not valid JSON: ${error.message}`);
     console.error(`\nIt is tracked in git — restore it with \`git checkout -- ${shown}\`.`);
     process.exit(1);
   }
+
+  // JSON.parse returns whatever the file holds, so a scalar, null or an array
+  // parses cleanly and then either throws or compares equal to undefined on
+  // every field read below. Both callers want an object or nothing.
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    const shape = parsed === null ? "null" : Array.isArray(parsed) ? "an array" : typeof parsed;
+    console.error(`${shown} is ${shape}, not a JSON object`);
+    console.error(`\nIt is tracked in git — restore it with \`git checkout -- ${shown}\`.`);
+    process.exit(1);
+  }
+  return parsed;
 }
 
 function main() {
   const byVersion = new Map(); // version -> package names
-  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+  // Sorted so the scan visits packages/* in the same order on every machine —
+  // readdir order is filesystem-dependent, and a scan that stops early would
+  // otherwise drop a different set of packages each run.
+  const entries = readdirSync(packagesDir, { withFileTypes: true }).sort((a, b) =>
+    a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+  );
+  for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     let manifest;
     try {

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -10,74 +10,112 @@
 // rejects one whose `name` doesn't match the npm package's `mcpName`.
 import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { argv as processArgv } from "node:process";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const packagesDir = join(repoRoot, "packages");
 
-const byVersion = new Map(); // version -> package names
-for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
-  if (!entry.isDirectory()) continue;
-  let manifest;
-  try {
-    manifest = JSON.parse(readFileSync(join(packagesDir, entry.name, "package.json"), "utf8"));
-  } catch {
-    continue; // directory without a package.json
+/**
+ * Everything server.json has to keep in step with the workspace, as one
+ * human-readable line per problem. Pure, separated from the fs reads so it can
+ * be unit-tested.
+ * @param {string | undefined} workspaceVersion the single version every packages/* manifest carries
+ * @param {{ name?: string, mcpName?: string }} argentPkg packages/argent/package.json
+ * @param {{ name?: string, version?: string, packages?: { identifier?: string, version?: string }[] }} server server.json
+ * @returns {string[]} empty when in sync
+ */
+export function serverJsonMismatches(workspaceVersion, argentPkg, server) {
+  const mismatches = [];
+
+  if (server.version !== workspaceVersion) {
+    mismatches.push(`server.json version is ${server.version}, workspace is ${workspaceVersion}`);
   }
-  if (!manifest.version) continue;
-  const names = byVersion.get(manifest.version) ?? [];
-  names.push(manifest.name ?? entry.name);
-  byVersion.set(manifest.version, names);
-}
 
-if (byVersion.size > 1) {
-  console.error("Workspace package versions are out of sync:");
-  for (const [version, names] of [...byVersion].sort()) {
-    console.error(`  ${version}: ${names.sort().join(", ")}`);
-  }
-  console.error(
-    "\nEvery package under packages/* must share one version. Bump the outliers to match."
-  );
-  process.exit(1);
-}
-
-const [workspaceVersion] = byVersion.keys();
-
-const argentPkg = JSON.parse(readFileSync(join(packagesDir, "argent", "package.json"), "utf8"));
-const server = JSON.parse(readFileSync(join(repoRoot, "server.json"), "utf8"));
-
-const mismatches = [];
-if (server.version !== workspaceVersion) {
-  mismatches.push(`server.json version is ${server.version}, workspace is ${workspaceVersion}`);
-}
-if (server.name !== argentPkg.mcpName) {
-  mismatches.push(
-    `server.json name (${server.name}) != packages/argent/package.json mcpName (${argentPkg.mcpName})`
-  );
-}
-for (const [i, pkg] of (server.packages ?? []).entries()) {
-  if (pkg.version !== workspaceVersion) {
+  // mcpName on the published npm tarball is what proves to the registry that the
+  // io.github.software-mansion namespace is ours, so its absence is as fatal as a
+  // mismatch — and an absent one equals an absent server.json name by ===.
+  if (!argentPkg.mcpName) {
     mismatches.push(
-      `server.json packages[${i}].version is ${pkg.version}, workspace is ${workspaceVersion}`
+      "packages/argent/package.json has no mcpName — the registry reads it off the published tarball to prove the namespace"
+    );
+  } else if (server.name !== argentPkg.mcpName) {
+    mismatches.push(
+      `server.json name (${server.name}) != packages/argent/package.json mcpName (${argentPkg.mcpName})`
     );
   }
-  if (pkg.identifier !== argentPkg.name) {
+
+  const packages = server.packages ?? [];
+  if (packages.length === 0) {
     mismatches.push(
-      `server.json packages[${i}].identifier (${pkg.identifier}) != published package name (${argentPkg.name})`
+      "server.json lists no packages — the registry entry would name nothing to install"
     );
   }
+  for (const [i, pkg] of packages.entries()) {
+    if (pkg.version !== workspaceVersion) {
+      mismatches.push(
+        `server.json packages[${i}].version is ${pkg.version}, workspace is ${workspaceVersion}`
+      );
+    }
+    if (pkg.identifier !== argentPkg.name) {
+      mismatches.push(
+        `server.json packages[${i}].identifier (${pkg.identifier}) != published package name (${argentPkg.name})`
+      );
+    }
+  }
+
+  return mismatches;
 }
 
-if (mismatches.length > 0) {
-  console.error("server.json is out of sync with the workspace:");
-  for (const line of mismatches) console.error(`  ${line}`);
-  console.error(
-    "\nserver.json is not under packages/*, so a release bump misses it — keep it in step\n" +
-      "with packages/argent/package.json by hand."
-  );
-  process.exit(1);
+function main() {
+  const byVersion = new Map(); // version -> package names
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    let manifest;
+    try {
+      manifest = JSON.parse(readFileSync(join(packagesDir, entry.name, "package.json"), "utf8"));
+    } catch {
+      continue; // directory without a package.json
+    }
+    if (!manifest.version) continue;
+    const names = byVersion.get(manifest.version) ?? [];
+    names.push(manifest.name ?? entry.name);
+    byVersion.set(manifest.version, names);
+  }
+
+  if (byVersion.size > 1) {
+    console.error("Workspace package versions are out of sync:");
+    for (const [version, names] of [...byVersion].sort()) {
+      console.error(`  ${version}: ${names.sort().join(", ")}`);
+    }
+    console.error(
+      "\nEvery package under packages/* must share one version. Bump the outliers to match."
+    );
+    process.exit(1);
+  }
+
+  const [workspaceVersion] = byVersion.keys();
+
+  const argentPkg = JSON.parse(readFileSync(join(packagesDir, "argent", "package.json"), "utf8"));
+  const server = JSON.parse(readFileSync(join(repoRoot, "server.json"), "utf8"));
+
+  const mismatches = serverJsonMismatches(workspaceVersion, argentPkg, server);
+  if (mismatches.length > 0) {
+    console.error("server.json is out of sync with the workspace:");
+    for (const line of mismatches) console.error(`  ${line}`);
+    console.error(
+      "\nserver.json is not under packages/*, so a release bump misses it — keep it in step\n" +
+        "with packages/argent/package.json by hand."
+    );
+    process.exit(1);
+  }
+
+  // An empty packages/ can't reach here: reading packages/argent/package.json above
+  // throws first, so workspaceVersion is always a real version by this point.
+  console.log(`All workspace packages and server.json are at ${workspaceVersion}.`);
 }
 
-// An empty packages/ can't reach here: reading packages/argent/package.json above
-// throws first, so workspaceVersion is always a real version by this point.
-console.log(`All workspace packages and server.json are at ${workspaceVersion}.`);
+// Run only when invoked directly, not when imported by the test.
+if (processArgv[1] && import.meta.url === pathToFileURL(processArgv[1]).href) {
+  main();
+}

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -3,34 +3,39 @@
 // version. Keeps the monorepo's lockstep versioning from silently drifting when
 // a release bump misses a package.
 //
-// The root server.json (the MCP registry manifest) is held to that same version
-// and to the npm coordinates in packages/argent/package.json. It is checked here
-// because it is the one such file outside packages/*, so a bump that sweeps the
-// workspace leaves it behind — and the registry then rejects the publish, either
-// because `packages[].version` names a version npm has never seen or because
-// `name` doesn't match the tarball's `mcpName`.
-import { readFileSync, readdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+// The root server.json (the MCP registry manifest) is held to the version and
+// the npm coordinates in packages/argent/package.json, the package it points at.
+// It is checked here because it is the one such file outside packages/*, so a
+// bump that sweeps the workspace leaves it behind — and the registry then
+// rejects the publish, either because `packages[].version` names a version npm
+// has never seen or because `name` doesn't match the tarball's `mcpName`.
+import { readFileSync, readdirSync, realpathSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 import { argv as processArgv } from "node:process";
 
-const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const selfPath = realpathSync(fileURLToPath(import.meta.url));
+const repoRoot = join(dirname(selfPath), "..");
 const packagesDir = join(repoRoot, "packages");
+const argentManifestPath = join(packagesDir, "argent", "package.json");
+const serverJsonPath = join(repoRoot, "server.json");
 
 /**
- * Everything server.json has to keep in step with the workspace, as one
- * human-readable line per problem. Pure, separated from the fs reads so it can
- * be unit-tested.
- * @param {string | undefined} workspaceVersion the single version every packages/* manifest carries
+ * Everything server.json has to keep in step with the npm package it points at,
+ * as one human-readable line per problem. Pure, separated from the fs reads so
+ * it can be unit-tested.
+ * @param {string | undefined} publishedVersion the version packages/argent/package.json carries
  * @param {{ name?: string, mcpName?: string }} argentPkg packages/argent/package.json
  * @param {{ name?: string, version?: string, packages?: { identifier?: string, version?: string }[] }} server server.json
  * @returns {string[]} empty when in sync
  */
-export function serverJsonMismatches(workspaceVersion, argentPkg, server) {
+export function serverJsonMismatches(publishedVersion, argentPkg, server) {
   const mismatches = [];
 
-  if (server.version !== workspaceVersion) {
-    mismatches.push(`server.json version is ${server.version}, workspace is ${workspaceVersion}`);
+  if (server.version !== publishedVersion) {
+    mismatches.push(
+      `server.json version is ${server.version}, packages/argent/package.json is ${publishedVersion}`
+    );
   }
 
   // mcpName on the published npm tarball is what proves to the registry that the
@@ -46,16 +51,20 @@ export function serverJsonMismatches(workspaceVersion, argentPkg, server) {
     );
   }
 
-  const packages = server.packages ?? [];
-  if (packages.length === 0) {
+  // Absent, empty and non-array all leave the registry entry naming nothing to
+  // install, so they get one message rather than a TypeError out of the loop.
+  const packages = server.packages;
+  if (!Array.isArray(packages) || packages.length === 0) {
     mismatches.push(
-      "server.json lists no packages — the registry entry would name nothing to install"
+      "server.json has no packages array — the registry entry would name nothing to install"
     );
+    return mismatches;
   }
+
   for (const [i, pkg] of packages.entries()) {
-    if (pkg.version !== workspaceVersion) {
+    if (pkg.version !== publishedVersion) {
       mismatches.push(
-        `server.json packages[${i}].version is ${pkg.version}, workspace is ${workspaceVersion}`
+        `server.json packages[${i}].version is ${pkg.version}, packages/argent/package.json is ${publishedVersion}`
       );
     }
     if (pkg.identifier !== argentPkg.name) {
@@ -66,6 +75,32 @@ export function serverJsonMismatches(workspaceVersion, argentPkg, server) {
   }
 
   return mismatches;
+}
+
+/**
+ * Reads a tracked JSON file, reporting a missing or malformed one as a sentence
+ * instead of a raw stack trace. Both only happen by hand-corrupting a file git
+ * tracks, and the fix is the same either way.
+ * @param {string} path
+ * @returns {any}
+ */
+function readTrackedJson(path) {
+  const shown = relative(repoRoot, path);
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (error) {
+    console.error(`Cannot read ${shown}: ${error.message}`);
+    console.error(`\nIt is tracked in git — restore it with \`git checkout -- ${shown}\`.`);
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error(`${shown} is not valid JSON: ${error.message}`);
+    console.error(`\nIt is tracked in git — restore it with \`git checkout -- ${shown}\`.`);
+    process.exit(1);
+  }
 }
 
 function main() {
@@ -84,39 +119,47 @@ function main() {
     byVersion.set(manifest.version, names);
   }
 
+  // An empty packages/ never gets past this read, so the version below is always
+  // a real one.
+  const argentPkg = readTrackedJson(argentManifestPath);
+  const server = readTrackedJson(serverJsonPath);
+
+  let failed = false;
+
   if (byVersion.size > 1) {
     console.error("Workspace package versions are out of sync:");
     for (const [version, names] of [...byVersion].sort()) {
       console.error(`  ${version}: ${names.sort().join(", ")}`);
     }
     console.error(
-      "\nEvery package under packages/* must share one version. Bump the outliers to match."
+      "\nEvery package under packages/* must share one version. Bump the outliers to match.\n"
     );
-    process.exit(1);
+    failed = true;
   }
 
-  const [workspaceVersion] = byVersion.keys();
-
-  const argentPkg = JSON.parse(readFileSync(join(packagesDir, "argent", "package.json"), "utf8"));
-  const server = JSON.parse(readFileSync(join(repoRoot, "server.json"), "utf8"));
-
-  const mismatches = serverJsonMismatches(workspaceVersion, argentPkg, server);
+  // server.json names the npm coordinates of packages/argent, so that manifest
+  // is what it has to agree with. Reported even when packages/* disagree, so a
+  // half-finished bump surfaces every remaining edit in one run.
+  const mismatches = serverJsonMismatches(argentPkg.version, argentPkg, server);
   if (mismatches.length > 0) {
-    console.error("server.json is out of sync with the workspace:");
+    console.error("server.json is out of sync with packages/argent/package.json:");
     for (const line of mismatches) console.error(`  ${line}`);
     console.error(
       "\nserver.json is not under packages/*, so a workspace bump leaves it behind — edit it\n" +
         "by hand to match packages/argent/package.json."
     );
-    process.exit(1);
+    failed = true;
   }
 
-  // An empty packages/ can't reach here: reading packages/argent/package.json above
-  // throws first, so workspaceVersion is always a real version by this point.
-  console.log(`All workspace packages and server.json are at ${workspaceVersion}.`);
+  if (failed) process.exit(1);
+
+  console.log(`All workspace packages and server.json are at ${argentPkg.version}.`);
 }
 
-// Run only when invoked directly, not when imported by the test.
-if (processArgv[1] && import.meta.url === pathToFileURL(processArgv[1]).href) {
+// Run only when invoked directly, not when imported by the test. Both sides are
+// realpath'd: node realpaths the main module before setting import.meta.url but
+// leaves process.argv[1] as typed, so comparing them raw makes a path through a
+// symlink skip main() and exit 0 with no output — a silent pass.
+if (processArgv[1] && realpathSync(processArgv[1]) === selfPath) {
   main();
 }

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -3,11 +3,12 @@
 // version. Keeps the monorepo's lockstep versioning from silently drifting when
 // a release bump misses a package.
 //
-// The root server.json (the MCP registry manifest) is held to the same version
-// and cross-checked against packages/argent/package.json. It lives outside
-// packages/*, so a release bump does not touch it; the registry rejects a
-// publish whose `packages[].version` names a version npm has never seen, and
-// rejects one whose `name` doesn't match the npm package's `mcpName`.
+// The root server.json (the MCP registry manifest) is held to that same version
+// and to the npm coordinates in packages/argent/package.json. It is checked here
+// because it is the one such file outside packages/*, so a bump that sweeps the
+// workspace leaves it behind — and the registry then rejects the publish, either
+// because `packages[].version` names a version npm has never seen or because
+// `name` doesn't match the tarball's `mcpName`.
 import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -104,8 +105,8 @@ function main() {
     console.error("server.json is out of sync with the workspace:");
     for (const line of mismatches) console.error(`  ${line}`);
     console.error(
-      "\nserver.json is not under packages/*, so a release bump misses it — keep it in step\n" +
-        "with packages/argent/package.json by hand."
+      "\nserver.json is not under packages/*, so a workspace bump leaves it behind — edit it\n" +
+        "by hand to match packages/argent/package.json."
     );
     process.exit(1);
   }

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -2,11 +2,18 @@
 // Fails if the workspace packages under packages/* don't all share the same
 // version. Keeps the monorepo's lockstep versioning from silently drifting when
 // a release bump misses a package.
+//
+// The root server.json (the MCP registry manifest) is held to the same version
+// and cross-checked against packages/argent/package.json. It lives outside
+// packages/*, so a release bump does not touch it; the registry rejects a
+// publish whose `packages[].version` names a version npm has never seen, and
+// rejects one whose `name` doesn't match the npm package's `mcpName`.
 import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const packagesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "packages");
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const packagesDir = join(repoRoot, "packages");
 
 const byVersion = new Map(); // version -> package names
 for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
@@ -23,17 +30,54 @@ for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
   byVersion.set(manifest.version, names);
 }
 
-if (byVersion.size <= 1) {
-  const [version] = byVersion.keys();
-  console.log(`All workspace packages are at ${version ?? "(no versioned packages found)"}.`);
-  process.exit(0);
+if (byVersion.size > 1) {
+  console.error("Workspace package versions are out of sync:");
+  for (const [version, names] of [...byVersion].sort()) {
+    console.error(`  ${version}: ${names.sort().join(", ")}`);
+  }
+  console.error(
+    "\nEvery package under packages/* must share one version. Bump the outliers to match."
+  );
+  process.exit(1);
 }
 
-console.error("Workspace package versions are out of sync:");
-for (const [version, names] of [...byVersion].sort()) {
-  console.error(`  ${version}: ${names.sort().join(", ")}`);
+const [workspaceVersion] = byVersion.keys();
+
+const argentPkg = JSON.parse(readFileSync(join(packagesDir, "argent", "package.json"), "utf8"));
+const server = JSON.parse(readFileSync(join(repoRoot, "server.json"), "utf8"));
+
+const mismatches = [];
+if (server.version !== workspaceVersion) {
+  mismatches.push(`server.json version is ${server.version}, workspace is ${workspaceVersion}`);
 }
-console.error(
-  "\nEvery package under packages/* must share one version. Bump the outliers to match."
-);
-process.exit(1);
+if (server.name !== argentPkg.mcpName) {
+  mismatches.push(
+    `server.json name (${server.name}) != packages/argent/package.json mcpName (${argentPkg.mcpName})`
+  );
+}
+for (const [i, pkg] of (server.packages ?? []).entries()) {
+  if (pkg.version !== workspaceVersion) {
+    mismatches.push(
+      `server.json packages[${i}].version is ${pkg.version}, workspace is ${workspaceVersion}`
+    );
+  }
+  if (pkg.identifier !== argentPkg.name) {
+    mismatches.push(
+      `server.json packages[${i}].identifier (${pkg.identifier}) != published package name (${argentPkg.name})`
+    );
+  }
+}
+
+if (mismatches.length > 0) {
+  console.error("server.json is out of sync with the workspace:");
+  for (const line of mismatches) console.error(`  ${line}`);
+  console.error(
+    "\nserver.json is not under packages/*, so a release bump misses it — keep it in step\n" +
+      "with packages/argent/package.json by hand."
+  );
+  process.exit(1);
+}
+
+// An empty packages/ can't reach here: reading packages/argent/package.json above
+// throws first, so workspaceVersion is always a real version by this point.
+console.log(`All workspace packages and server.json are at ${workspaceVersion}.`);

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -62,6 +62,14 @@ export function serverJsonMismatches(publishedVersion, argentPkg, server) {
   }
 
   for (const [i, pkg] of packages.entries()) {
+    // Same reason as the array check above: an entry that is not an object has
+    // no coordinates to read, and reading through it would throw out of the loop.
+    if (typeof pkg !== "object" || pkg === null) {
+      mismatches.push(
+        `server.json packages[${i}] is ${pkg === null ? "null" : typeof pkg}, not an object naming a registry and identifier`
+      );
+      continue;
+    }
     if (pkg.version !== publishedVersion) {
       mismatches.push(
         `server.json packages[${i}].version is ${pkg.version}, packages/argent/package.json is ${publishedVersion}`

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -58,6 +58,15 @@ export function serverJsonMismatches(publishedVersion, argentPkg, server) {
     );
   }
 
+  // Every packages[].identifier below is compared against this name, so without
+  // it those comparisons pass on undefined === undefined and server.json is free
+  // to name no installable package at all.
+  if (!argentPkg.name) {
+    mismatches.push(
+      "packages/argent/package.json has no name — server.json's identifier has nothing to point at"
+    );
+  }
+
   // Absent, empty and non-array all leave the registry entry naming nothing to
   // install, so they get one message rather than a TypeError out of the loop.
   const packages = server.packages;

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -3,11 +3,29 @@
  * and the npm coordinates it names have to match the workspace, and the ownership
  * proof (mcpName on the published tarball) has to be present on both sides.
  *
+ * Two layers, because the pure function is not what CI runs: unit tests over
+ * serverJsonMismatches(), then spawned runs of the real script against a
+ * miniature repo, which are the only thing that pins main() — its exit codes,
+ * its output and the guard deciding whether it runs at all.
+ *
  * Run: node --test scripts/check-workspace-versions.test.mjs
  */
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { serverJsonMismatches } from "./check-workspace-versions.mjs";
 
@@ -30,14 +48,15 @@ test("an in-sync pair reports nothing", () => {
   assert.deepEqual(serverJsonMismatches(VERSION, ARGENT_PKG, SERVER), []);
 });
 
-test("server.json version drifting from the workspace is caught", () => {
+test("server.json version drifting from the workspace names both versions", () => {
   const problems = serverJsonMismatches(
     VERSION,
     ARGENT_PKG,
     server((s) => (s.version = "0.17.0"))
   );
-  assert.equal(problems.length, 1);
-  assert.match(problems[0], /server\.json version is 0\.17\.0, workspace is 0\.18\.0/);
+  assert.deepEqual(problems, [
+    "server.json version is 0.17.0, packages/argent/package.json is 0.18.0",
+  ]);
 });
 
 test("a packages[] version npm has never seen is caught", () => {
@@ -48,6 +67,21 @@ test("a packages[] version npm has never seen is caught", () => {
   );
   assert.equal(problems.length, 1);
   assert.match(problems[0], /packages\[0\]\.version is 9\.9\.9/);
+});
+
+// Only packages[0] exists today, so nothing else here would notice a check that
+// silently stopped after the first entry — which becomes live the moment a
+// second distribution channel is added.
+test("every packages[] entry is validated, not just the first", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    ARGENT_PKG,
+    server((s) => s.packages.push({ identifier: "@attacker/pkg", version: "6.6.6" }))
+  );
+  assert.deepEqual(problems, [
+    "server.json packages[1].version is 6.6.6, packages/argent/package.json is 0.18.0",
+    "server.json packages[1].identifier (@attacker/pkg) != published package name (@swmansion/argent)",
+  ]);
 });
 
 test("a packages[] identifier that is not the published package is caught", () => {
@@ -88,11 +122,21 @@ test("dropping mcpName and the server.json name together is still caught", () =>
   assert.match(problems[0], /has no mcpName/);
 });
 
-test("a server.json with no packages at all is caught", () => {
-  for (const emptied of [server((s) => delete s.packages), server((s) => (s.packages = []))]) {
+// The object form is what a hand-edit that drops the brackets produces; it used
+// to escape as a `packages.entries is not a function` TypeError.
+test("a server.json with no usable packages array is caught", () => {
+  const unusable = [
+    server((s) => delete s.packages),
+    server((s) => (s.packages = [])),
+    server(
+      (s) =>
+        (s.packages = /** @type {any} */ ({ identifier: "@swmansion/argent", version: VERSION }))
+    ),
+  ];
+  for (const emptied of unusable) {
     const problems = serverJsonMismatches(VERSION, ARGENT_PKG, emptied);
     assert.equal(problems.length, 1);
-    assert.match(problems[0], /lists no packages/);
+    assert.match(problems[0], /no packages array/);
   }
 });
 
@@ -108,4 +152,126 @@ test("every problem is reported at once, not just the first", () => {
     })
   );
   assert.equal(problems.length, 4);
+});
+
+// --- the real script, spawned -----------------------------------------------
+// main() is what repo-hygiene.yml runs and none of the above touches it, so a
+// fail-open edit there (an exit(0) on the failure path, a guard that skips
+// main() altogether) would pass every other check in the repo. These run the
+// script for real against a throwaway repo and assert on exit codes.
+
+const SCRIPT_PATH = fileURLToPath(new URL("./check-workspace-versions.mjs", import.meta.url));
+
+/**
+ * A miniature repo: a copy of the real script, two packages/* manifests and a
+ * server.json. Realpath'd so the tests below isolate the behaviour they name —
+ * macOS's own tmpdir is behind a /var -> /private/var symlink, which the
+ * symlink test then reintroduces deliberately.
+ * @param {import("node:test").TestContext} t
+ * @param {{ argentVersion?: string, otherVersion?: string, serverJson?: unknown }} [options]
+ *   serverJson: an object to write as JSON, a string to write verbatim, or null
+ *   to leave the file out entirely.
+ * @returns {string} the repo root
+ */
+function fixtureRepo(t, { argentVersion = VERSION, otherVersion = VERSION, serverJson } = {}) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "check-workspace-versions-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  mkdirSync(join(root, "scripts"));
+  mkdirSync(join(root, "packages", "argent"), { recursive: true });
+  mkdirSync(join(root, "packages", "registry"), { recursive: true });
+  copyFileSync(SCRIPT_PATH, join(root, "scripts", "check-workspace-versions.mjs"));
+
+  const write = (/** @type {string} */ path, /** @type {unknown} */ value) =>
+    writeFileSync(path, typeof value === "string" ? value : JSON.stringify(value, null, 2));
+
+  write(join(root, "packages", "argent", "package.json"), {
+    ...ARGENT_PKG,
+    version: argentVersion,
+  });
+  write(join(root, "packages", "registry", "package.json"), {
+    name: "@argent/registry",
+    version: otherVersion,
+  });
+  if (serverJson !== null) write(join(root, "server.json"), serverJson ?? SERVER);
+
+  return root;
+}
+
+/** @param {string} root the path to invoke through, which need not be the real one */
+function runScript(root) {
+  return spawnSync(process.execPath, [join(root, "scripts", "check-workspace-versions.mjs")], {
+    encoding: "utf8",
+  });
+}
+
+/** @param {string} stderr */
+function assertNoStackTrace(stderr) {
+  assert.doesNotMatch(stderr, /^\s+at /m, `expected guidance, got a stack trace:\n${stderr}`);
+}
+
+test("[script] an in-sync repo passes quietly", (t) => {
+  const result = runScript(fixtureRepo(t));
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr, "");
+  assert.match(result.stdout, /All workspace packages and server\.json are at 0\.18\.0\./);
+});
+
+test("[script] server.json drift alone exits 1", (t) => {
+  const root = fixtureRepo(t, {
+    serverJson: server((s) => {
+      s.version = "0.17.0";
+      s.packages[0].version = "0.17.0";
+    }),
+  });
+  const result = runScript(root);
+  assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
+  assert.match(result.stderr, /server\.json version is 0\.17\.0/);
+  assert.match(result.stderr, /server\.json packages\[0\]\.version is 0\.17\.0/);
+});
+
+test("[script] a half-finished bump reports packages/* and server.json in one run", (t) => {
+  const root = fixtureRepo(t, {
+    otherVersion: "0.17.0",
+    serverJson: server((s) => {
+      s.version = "0.17.0";
+      s.packages[0].version = "0.17.0";
+    }),
+  });
+  const result = runScript(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Workspace package versions are out of sync/);
+  assert.match(result.stderr, /@argent\/registry/);
+  assert.match(result.stderr, /server\.json version is 0\.17\.0/);
+});
+
+// node realpaths the main module before setting import.meta.url but leaves
+// process.argv[1] as typed, so a self-invocation guard comparing them raw skips
+// main() here and exits 0 with no output — a drifted repo indistinguishable
+// from a clean one.
+test("[script] a run through a symlinked path still catches drift", (t) => {
+  const root = fixtureRepo(t, { serverJson: server((s) => (s.version = "0.17.0")) });
+  const aliasParent = realpathSync(mkdtempSync(join(tmpdir(), "check-workspace-versions-alias-")));
+  t.after(() => rmSync(aliasParent, { recursive: true, force: true }));
+  const alias = join(aliasParent, "repo");
+  symlinkSync(root, alias, "dir");
+
+  const result = runScript(alias);
+  assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
+  assert.match(result.stderr, /server\.json version is 0\.17\.0/);
+});
+
+test("[script] a missing server.json fails on-message", (t) => {
+  const result = runScript(fixtureRepo(t, { serverJson: null }));
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Cannot read server\.json: /);
+  assert.match(result.stderr, /git checkout -- server\.json/);
+  assertNoStackTrace(result.stderr);
+});
+
+test("[script] a malformed server.json fails on-message", (t) => {
+  const result = runScript(fixtureRepo(t, { serverJson: "{ not json" }));
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /server\.json is not valid JSON: /);
+  assertNoStackTrace(result.stderr);
 });

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * Pins the cross-file links a registry publish depends on: server.json's version
+ * and the npm coordinates it names have to match the workspace, and the ownership
+ * proof (mcpName on the published tarball) has to be present on both sides.
+ *
+ * Run: node --test scripts/check-workspace-versions.test.mjs
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { serverJsonMismatches } from "./check-workspace-versions.mjs";
+
+const VERSION = "0.18.0";
+const ARGENT_PKG = { name: "@swmansion/argent", mcpName: "io.github.software-mansion/argent" };
+const SERVER = {
+  name: "io.github.software-mansion/argent",
+  version: VERSION,
+  packages: [{ identifier: "@swmansion/argent", version: VERSION }],
+};
+
+/** @param {(s: typeof SERVER) => void} mutate */
+function server(mutate) {
+  const copy = structuredClone(SERVER);
+  mutate(copy);
+  return copy;
+}
+
+test("an in-sync pair reports nothing", () => {
+  assert.deepEqual(serverJsonMismatches(VERSION, ARGENT_PKG, SERVER), []);
+});
+
+test("server.json version drifting from the workspace is caught", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    ARGENT_PKG,
+    server((s) => (s.version = "0.17.0"))
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /server\.json version is 0\.17\.0, workspace is 0\.18\.0/);
+});
+
+test("a packages[] version npm has never seen is caught", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    ARGENT_PKG,
+    server((s) => (s.packages[0].version = "9.9.9"))
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /packages\[0\]\.version is 9\.9\.9/);
+});
+
+test("a packages[] identifier that is not the published package is caught", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    ARGENT_PKG,
+    server((s) => (s.packages[0].identifier = "@swmansion/argnet"))
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /packages\[0\]\.identifier \(@swmansion\/argnet\)/);
+});
+
+test("a name that no longer matches mcpName is caught", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    ARGENT_PKG,
+    server((s) => (s.name = "com.swmansion/argent"))
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /server\.json name \(com\.swmansion\/argent\)/);
+});
+
+test("dropping mcpName is caught even though server.json still names it", () => {
+  const problems = serverJsonMismatches(VERSION, { name: ARGENT_PKG.name }, SERVER);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /has no mcpName/);
+});
+
+// Both sides absent compares equal by ===, so the presence check is what catches
+// it — the publish would be rejected for an unproven namespace.
+test("dropping mcpName and the server.json name together is still caught", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    { name: ARGENT_PKG.name },
+    server((s) => delete s.name)
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /has no mcpName/);
+});
+
+test("a server.json with no packages at all is caught", () => {
+  for (const emptied of [server((s) => delete s.packages), server((s) => (s.packages = []))]) {
+    const problems = serverJsonMismatches(VERSION, ARGENT_PKG, emptied);
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /lists no packages/);
+  }
+});
+
+test("every problem is reported at once, not just the first", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    ARGENT_PKG,
+    server((s) => {
+      s.version = "0.17.0";
+      s.name = "com.swmansion/argent";
+      s.packages[0].version = "0.17.0";
+      s.packages[0].identifier = "argent";
+    })
+  );
+  assert.equal(problems.length, 4);
+});

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -170,6 +170,27 @@ test("a packages[] entry that is not an object is caught", () => {
   }
 });
 
+// Reporting the bad entry must not cost the entries after it, or one stray null
+// would quietly shrink the report the sibling test above relies on being complete.
+test("a non-object packages[] entry does not stop the entries after it", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    ARGENT_PKG,
+    server(
+      (s) =>
+        (s.packages = [
+          /** @type {any} */ (null),
+          { identifier: "@attacker/pkg", version: "6.6.6" },
+        ])
+    )
+  );
+  assert.deepEqual(problems, [
+    "server.json packages[0] is null, not an object naming a registry and identifier",
+    "server.json packages[1].version is 6.6.6, packages/argent/package.json is 0.18.0",
+    "server.json packages[1].identifier (@attacker/pkg) != published package name (@swmansion/argent)",
+  ]);
+});
+
 test("every problem is reported at once, not just the first", () => {
   const problems = serverJsonMismatches(
     VERSION,
@@ -198,12 +219,18 @@ const SCRIPT_PATH = fileURLToPath(new URL("./check-workspace-versions.mjs", impo
  * macOS's own tmpdir is behind a /var -> /private/var symlink, which the
  * symlink test then reintroduces deliberately.
  * @param {import("node:test").TestContext} t
- * @param {{ argentVersion?: string | null, otherVersion?: string, serverJson?: unknown }} [options]
+ * @param {{ argentVersion?: string | null, otherVersion?: string, serverJson?: unknown,
+ *   extraPackages?: Record<string, unknown> }} [options]
  *   serverJson: an object to write as JSON, a string to write verbatim, or null
  *   to leave the file out entirely. argentVersion: null omits the version key.
+ *   extraPackages: further packages/<dir> entries, a null value creating the
+ *   directory with no package.json in it.
  * @returns {string} the repo root
  */
-function fixtureRepo(t, { argentVersion = VERSION, otherVersion = VERSION, serverJson } = {}) {
+function fixtureRepo(
+  t,
+  { argentVersion = VERSION, otherVersion = VERSION, serverJson, extraPackages = {} } = {}
+) {
   const root = realpathSync(mkdtempSync(join(tmpdir(), "check-workspace-versions-")));
   t.after(() => rmSync(root, { recursive: true, force: true }));
 
@@ -223,6 +250,10 @@ function fixtureRepo(t, { argentVersion = VERSION, otherVersion = VERSION, serve
     name: "@argent/registry",
     version: otherVersion,
   });
+  for (const [dir, manifest] of Object.entries(extraPackages)) {
+    mkdirSync(join(root, "packages", dir), { recursive: true });
+    if (manifest !== null) write(join(root, "packages", dir, "package.json"), manifest);
+  }
   if (serverJson !== null) write(join(root, "server.json"), serverJson ?? SERVER);
 
   return root;
@@ -258,6 +289,44 @@ test("[script] server.json drift alone exits 1", (t) => {
   assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
   assert.match(result.stderr, /server\.json version is 0\.17\.0/);
   assert.match(result.stderr, /server\.json packages\[0\]\.version is 0\.17\.0/);
+});
+
+// The check the script existed for before this PR. Every other failing [script]
+// test here reaches its exit 1 through a server.json problem, so this is the only
+// one that pins the exit code to workspace drift on its own.
+test("[script] packages/* drift alone exits 1", (t) => {
+  const root = fixtureRepo(t, { otherVersion: "0.17.0" });
+  const result = runScript(root);
+  assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
+  assert.match(result.stderr, /Workspace package versions are out of sync/);
+  assert.match(result.stderr, /0\.17\.0: @argent\/registry/);
+  // server.json agrees with packages/argent, so nothing else could have failed it.
+  assert.doesNotMatch(result.stderr, /server\.json is out of sync/);
+});
+
+// packages/argent-private is exactly this in the real repo: a submodule directory
+// carrying no package.json. The scan has to step over an unusable directory and
+// keep going, or every package sorting after it silently leaves the comparison.
+test("[script] an unusable packages/* directory does not stop the scan", (t) => {
+  const root = fixtureRepo(t, {
+    otherVersion: "0.17.0",
+    extraPackages: { nomanifest: null, noversion: { name: "@argent/noversion" } },
+  });
+  const result = runScript(root);
+  assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
+  assert.match(result.stderr, /0\.17\.0: @argent\/registry/);
+});
+
+// The report groups every package sharing a version onto one line, which is what
+// makes a drift report readable at 17 packages.
+test("[script] the drift report lists every package sharing a version", (t) => {
+  const root = fixtureRepo(t, {
+    otherVersion: "0.17.0",
+    extraPackages: { alpha: { name: "@argent/alpha", version: VERSION } },
+  });
+  const result = runScript(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /0\.18\.0: @argent\/alpha, @swmansion\/argent\n/);
 });
 
 // The one shape where every comparison the script makes is vacuously satisfied:
@@ -327,5 +396,22 @@ test("[script] a malformed server.json fails on-message", (t) => {
   const result = runScript(fixtureRepo(t, { serverJson: "{ not json" }));
   assert.equal(result.status, 1);
   assert.match(result.stderr, /server\.json is not valid JSON: /);
+  assert.match(result.stderr, /git checkout -- server\.json/);
   assertNoStackTrace(result.stderr);
+});
+
+// `null`, a bare scalar and an array all parse cleanly, so the read has to reject
+// them itself — every field lookup after it would either throw or quietly match
+// undefined.
+test("[script] a server.json that parses but is not an object fails on-message", (t) => {
+  for (const [content, shape] of [
+    ["null", "null"],
+    ['"0.18.0"', "string"],
+    ["[]", "an array"],
+  ]) {
+    const result = runScript(fixtureRepo(t, { serverJson: content }));
+    assert.equal(result.status, 1, `expected a failure for ${content}, got:\n${result.stdout}`);
+    assert.equal(result.stderr.split("\n")[0], `server.json is ${shape}, not a JSON object`);
+    assertNoStackTrace(result.stderr);
+  }
 });

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -140,6 +140,20 @@ test("a server.json with no usable packages array is caught", () => {
   }
 });
 
+// The name half of the same shape: with neither side naming a package, the
+// identifier comparison is undefined === undefined and server.json passes while
+// pointing at nothing installable.
+test("a packages/argent manifest with no name is caught", () => {
+  const problems = serverJsonMismatches(
+    VERSION,
+    { mcpName: ARGENT_PKG.mcpName },
+    server((s) => delete s.packages[0].identifier)
+  );
+  assert.deepEqual(problems, [
+    "packages/argent/package.json has no name — server.json's identifier has nothing to point at",
+  ]);
+});
+
 // packages/argent/package.json is the sole source of the version everything else
 // is compared against, so losing it turns every comparison below into
 // undefined === undefined and the whole check passes vacuously.

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -122,8 +122,8 @@ test("dropping mcpName and the server.json name together is still caught", () =>
   assert.match(problems[0], /has no mcpName/);
 });
 
-// The object form is what a hand-edit that drops the brackets produces; it used
-// to escape as a `packages.entries is not a function` TypeError.
+// The object form is what a hand-edit that drops the brackets produces. It has no
+// .entries(), so catching it here is what keeps the loop below from throwing.
 test("a server.json with no usable packages array is caught", () => {
   const unusable = [
     server((s) => delete s.packages),
@@ -137,6 +137,25 @@ test("a server.json with no usable packages array is caught", () => {
     const problems = serverJsonMismatches(VERSION, ARGENT_PKG, emptied);
     assert.equal(problems.length, 1);
     assert.match(problems[0], /no packages array/);
+  }
+});
+
+// A hand-edit that empties an entry rather than the array leaves the array shape
+// intact, so the check above passes it through to the loop that reads .version
+// off it.
+test("a packages[] entry that is not an object is caught", () => {
+  for (const [entry, shown] of [
+    [null, "null"],
+    ["@swmansion/argent", "string"],
+  ]) {
+    const problems = serverJsonMismatches(
+      VERSION,
+      ARGENT_PKG,
+      server((s) => (s.packages = [/** @type {any} */ (entry)]))
+    );
+    assert.deepEqual(problems, [
+      `server.json packages[0] is ${shown}, not an object naming a registry and identifier`,
+    ]);
   }
 });
 

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -331,6 +331,19 @@ test("[script] an unusable packages/* directory does not stop the scan", (t) => 
   assert.match(result.stderr, /0\.17\.0: @argent\/registry/);
 });
 
+// JSON.parse succeeds on a file holding `null`, so the scan's try/catch never
+// sees it and the version read below is what would throw.
+test("[script] a packages/* manifest holding null does not crash the scan", (t) => {
+  const root = fixtureRepo(t, {
+    otherVersion: "0.17.0",
+    extraPackages: { corrupt: "null" },
+  });
+  const result = runScript(root);
+  assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
+  assert.match(result.stderr, /0\.17\.0: @argent\/registry/);
+  assertNoStackTrace(result.stderr);
+});
+
 // The report groups every package sharing a version onto one line, which is what
 // makes a drift report readable at 17 packages.
 test("[script] the drift report lists every package sharing a version", (t) => {

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -269,6 +269,13 @@ test("[script] a missing server.json fails on-message", (t) => {
   assertNoStackTrace(result.stderr);
 });
 
+test("[script] a corrupt server.json does not swallow the packages/* drift", (t) => {
+  const result = runScript(fixtureRepo(t, { otherVersion: "0.17.0", serverJson: null }));
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Workspace package versions are out of sync/);
+  assert.match(result.stderr, /Cannot read server\.json/);
+});
+
 test("[script] a malformed server.json fails on-message", (t) => {
   const result = runScript(fixtureRepo(t, { serverJson: "{ not json" }));
   assert.equal(result.status, 1);

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -140,6 +140,17 @@ test("a server.json with no usable packages array is caught", () => {
   }
 });
 
+// packages/argent/package.json is the sole source of the version everything else
+// is compared against, so losing it turns every comparison below into
+// undefined === undefined and the whole check passes vacuously.
+test("a packages/argent manifest with no version is caught", () => {
+  const problems = serverJsonMismatches(undefined, ARGENT_PKG, SERVER);
+  assert.deepEqual(problems, [
+    "packages/argent/package.json has no version — nothing for server.json to be checked against",
+    "server.json packages[0].version is 0.18.0, packages/argent/package.json is undefined",
+  ]);
+});
+
 // A hand-edit that empties an entry rather than the array leaves the array shape
 // intact, so the check above passes it through to the loop that reads .version
 // off it.
@@ -187,9 +198,9 @@ const SCRIPT_PATH = fileURLToPath(new URL("./check-workspace-versions.mjs", impo
  * macOS's own tmpdir is behind a /var -> /private/var symlink, which the
  * symlink test then reintroduces deliberately.
  * @param {import("node:test").TestContext} t
- * @param {{ argentVersion?: string, otherVersion?: string, serverJson?: unknown }} [options]
+ * @param {{ argentVersion?: string | null, otherVersion?: string, serverJson?: unknown }} [options]
  *   serverJson: an object to write as JSON, a string to write verbatim, or null
- *   to leave the file out entirely.
+ *   to leave the file out entirely. argentVersion: null omits the version key.
  * @returns {string} the repo root
  */
 function fixtureRepo(t, { argentVersion = VERSION, otherVersion = VERSION, serverJson } = {}) {
@@ -206,7 +217,7 @@ function fixtureRepo(t, { argentVersion = VERSION, otherVersion = VERSION, serve
 
   write(join(root, "packages", "argent", "package.json"), {
     ...ARGENT_PKG,
-    version: argentVersion,
+    ...(argentVersion === null ? {} : { version: argentVersion }),
   });
   write(join(root, "packages", "registry", "package.json"), {
     name: "@argent/registry",
@@ -247,6 +258,23 @@ test("[script] server.json drift alone exits 1", (t) => {
   assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
   assert.match(result.stderr, /server\.json version is 0\.17\.0/);
   assert.match(result.stderr, /server\.json packages\[0\]\.version is 0\.17\.0/);
+});
+
+// The one shape where every comparison the script makes is vacuously satisfied:
+// with no version on the manifest and none in server.json, each `!==` compares
+// undefined against undefined and the repo passes with nothing checked.
+test("[script] a version-less manifest fails instead of passing vacuously", (t) => {
+  const root = fixtureRepo(t, {
+    argentVersion: null,
+    serverJson: server((s) => {
+      delete s.version;
+      delete s.packages[0].version;
+    }),
+  });
+  const result = runScript(root);
+  assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
+  assert.match(result.stderr, /packages\/argent\/package\.json has no version/);
+  assert.doesNotMatch(result.stdout, /at undefined/);
 });
 
 test("[script] a half-finished bump reports packages/* and server.json in one run", (t) => {

--- a/server.json
+++ b/server.json
@@ -5,7 +5,8 @@
   "description": "Drive iOS Simulators, Android emulators, TVs and Electron/web apps from your coding agent",
   "repository": {
     "url": "https://github.com/software-mansion/argent",
-    "source": "github"
+    "source": "github",
+    "id": "1164885639"
   },
   "websiteUrl": "https://argent.swmansion.com",
   "version": "0.18.0",
@@ -22,7 +23,6 @@
         {
           "type": "positional",
           "value": "mcp",
-          "valueHint": "mcp",
           "isRequired": true
         }
       ]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.software-mansion/argent",
+  "title": "Argent",
+  "description": "Drive iOS Simulators, Android emulators, TVs and Electron/web apps from your coding agent",
+  "repository": {
+    "url": "https://github.com/software-mansion/argent",
+    "source": "github"
+  },
+  "websiteUrl": "https://argent.swmansion.com",
+  "version": "0.18.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@swmansion/argent",
+      "version": "0.18.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "valueHint": "mcp",
+          "isRequired": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the two files the official MCP registry (`registry.modelcontextprotocol.io`) needs in order to list argent. Argent is not in that registry today (`?search=io.github.software-mansion` returns 0 servers).

The registry is metadata-only — it points at the npm package rather than hosting anything.

### `server.json`

Describes the server and how a client starts it: `npx @swmansion/argent mcp`. The `mcp` positional is the dispatcher case in `packages/argent/src/cli.ts:137`, and it is the same subcommand `argent init` writes into every client config — `packages/argent-installer/src/mcp-configs.ts:130-141` spells it four ways (`node <path> mcp`, `yarn argent mcp`, `npx --no-install argent mcp`, and the global `{ command: MCP_BINARY_NAME, args: ["mcp"] }`, where `MCP_BINARY_NAME` is `"argent"`). None of them is literally the npx-by-package-name form in `server.json`, which is the form the registry expects a client to construct from `identifier` + `runtimeHint` — so it is verified below by running it, not by matching a string.

`repository.id` is the GitHub repo id (`1164885639`); the schema recommends it so a registry can detect a delete-and-recreate of the repo.

### `mcpName` in `packages/argent/package.json`

The ownership proof. The registry fetches the npm package and requires `mcpName` to equal the server name in `server.json` before it will accept a publish under `io.github.software-mansion`. It is the field the registry's own quickstart names for npm packages. Nothing in the publish path drops it: `scripts/pack-mcp.cjs` shells out to `npm pack` without rewriting the manifest, and the canary path's `scripts/next-canary-version.mjs --write` round-trips the JSON and only sets `version`.

### Namespace

`io.github.software-mansion/argent` — GitHub OAuth auth. The registry grants an org namespace only to org **Owners**; plain membership is no longer enough. If no Owner is available to run the publish, the alternative is DNS auth via an apex TXT record on `swmansion.com`, which changes the name to `com.swmansion/argent` (and the `mcpName` value with it).

### Version sync

`server.json` sits at the repo root, outside `packages/*`, so a release bump would have left its two `0.18.0`s untouched — and the registry rejects a publish whose `packages[].version` names a version npm has never seen. `scripts/check-workspace-versions.mjs` (already run by the Static checks job) also holds `server.json` to the version in `packages/argent/package.json` — the package it names — and pins the two cross-file links a publish depends on: `name` == `mcpName`, `identifier` == the published package name. Both halves are reported in one run, so a half-finished bump doesn't cost a CI round-trip per file.

### Not in this PR

- **Publishing.** Nothing has been published; this is just the manifest. Publishing is `mcp-publisher login github && mcp-publisher publish`, and it can only succeed **after** a release whose npm tarball carries `mcpName` — i.e. not against `0.18.0`, which is `latest` (published 2026-07-30) and predates `mcpName` — `curl registry.npmjs.org/@swmansion%2Fargent/0.18.0 | jq .mcpName` → `null`. The first publishable release is the next bump.
- **`github.com/mcp`.** A separate, manual step. Onboarding a new server there is hand-curated: per [github/github-mcp-server#1257](https://github.com/github/github-mcp-server/discussions/1257) (trent-j, answering for GitHub — “a few clarifications from our side”, “our product team” — 19 May 2026; GitHub's API reports `authorAssociation: NONE` for them on that repo) "onboarding a new server is still a manual curation process today. Once a server has been onboarded, newly published versions from the OSS registry should sync from there." The nomination channel is `partnerships@github.com`, from GitHub's [registry how-to post](https://github.blog/ai-and-ml/generative-ai/how-to-find-install-and-manage-mcp-servers-with-the-github-mcp-registry/) (24 Oct 2025) — that address does not appear anywhere in the discussion thread.

### Verification

- `mcp-publisher validate` (v1.8.0, which posts the file to the live registry) → `server.json is valid`. Mutation-checked what that actually covers: removing `transport` fails it and removing `$schema` is a 422, but a foreign namespace (`io.github.anthropics/argent`), a nonexistent npm identifier and a `99.0.0` package version all still pass — so it checks shape only, and the ownership/existence checks happen at publish time. Also validated offline against the pinned `2025-12-11` schema.
- Ran the entrypoint the file declares. `npx -y @swmansion/argent@latest mcp` fed an `initialize` over stdio answered `{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"argent","version":"0.18.0"},"instructions":"…"}`, with stderr empty.
- Mutation-checked the new version guard: drifting `server.json` `version`, drifting `packages[0].version`, deleting `mcpName`, and typo-ing `identifier` each fail `check-workspace-versions.mjs` with the specific line; the pre-existing packages/* drift check still fires on its own.
- Asserted across the two files: `mcpName` == `server.json` `name`, `identifier` == package `name`, all three versions equal, description 89 chars (registry limit is 100).
- `prettier --check` and `eslint` clean on both changed files.
- Mutation-checked the guard as a whole — 23 mutants, 2 survivors. Killed: reverting the self-invocation guard to a raw `argv[1]` compare and making it never match; `exit(1)` → `exit(0)` on the failure path; dropping either `failed = true`; exiting early on `packages/*` drift instead of collecting; `packages.slice(0, 1)`; hardcoding `packages[0]` in either message; dropping the no-packages-array guard, the non-object-entry guard, the non-object-JSON guard, and the presence checks for `version`, `name` and `mcpName`; `continue` → `break` on the unparseable-manifest and version-less arms of the `packages/*` scan, and in the entry loop; dropping the on-message read, the `git checkout` hint, and the per-version name accumulator. The two survivors are both scan-order concerns no single run can observe: the `packages/*` readdir sort (there so a scan that stops early drops the same packages on every machine rather than a filesystem-dependent set), and the `!entry.isDirectory()` skip, which no fixture reaches because every fixture puts only directories under `packages/`.
- Reproduced the symlink no-op on the real repo: with `packages/registry` at `9.9.9` and `server.json` at `0.17.0`, `node /tmp/argent-alias/scripts/check-workspace-versions.mjs` now exits 1 and prints both problems, where before it exited 0 with no output at all.
- Closed the vacuous-pass class in `serverJsonMismatches`: all four comparisons it makes were bare `!==`, so a field absent from *both* sides compared equal and passed. A `packages/argent/package.json` with no `version` printed `All workspace packages and server.json are at undefined.` and exited 0; with no `name`, a `server.json` naming nothing installable was reported in sync. `version` and `name` now require presence, as `mcpName` already did.
- `readTrackedJson` guarantees an object, not just parseable bytes — a `server.json` holding `null` used to reach the field reads and throw, and `"0.18.0"` or `[]` produced mismatch lines that never said the file was the wrong shape.
- Full CI parity locally: `test:scripts` 86/86, `tsc -p tsconfig.scripts.json`, `eslint --max-warnings 0`, `prettier --check`.


