### PR TITLE
style: fix prettier formatting on main

### DIFF
--- a/packages/argent-tools-client/test/artifacts.test.ts
+++ b/packages/argent-tools-client/test/artifacts.test.ts
@@ -556,9 +556,7 @@ describe("durableSaveTarget", () => {
 
   it("a blank configured value reads as unset — default location kept", async () => {
     await writeScopedConfig(projectRoot, "   ");
-    expect(durableSaveTarget(recordingHandle())!.dir).toBe(
-      join(projectRoot, ".argent/recordings")
-    );
+    expect(durableSaveTarget(recordingHandle())!.dir).toBe(join(projectRoot, ".argent/recordings"));
   });
 
   it("config never resurrects a hostile wire saveDir — the allowlist still gates first", async () => {


### PR DESCRIPTION
## Summary

`npx prettier --check .` fails on current `main` with one violation: `packages/argent-tools-client/test/artifacts.test.ts` (a single `expect` line wrapped where it now fits the 100-char print width). This PR is the `prettier --write` output for that file — whitespace-only, no behavior change.

## Test plan

- [x] `npx prettier --check .` passes on the branch (was failing on `main`)
- [x] Diff is whitespace-only (1 file, 1 reflowed statement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)