### PR TITLE
fix(tool-server): derive hidden-window failure_stage, pin keyboard guard exemption

### DIFF
--- a/packages/tool-server/src/tools/gesture-drag/index.ts
+++ b/packages/tool-server/src/tools/gesture-drag/index.ts
@@ -61,7 +61,7 @@ Returns { dragged: true, timestampMs }. Fails if the Chromium CDP session is not
     // A drag interpolates ~60fps mouse moves; on a hidden (throttled) window
     // each one stalls on compositor hit-testing (~5s), turning one drag into
     // minutes of wall clock — refuse up front like gesture-scroll.
-    await assertChromiumWindowVisible(chromium, "drag", "chromium_drag_window_hidden");
+    await assertChromiumWindowVisible(chromium, "drag");
     const vp = chromium.getViewport();
     const startPx = { x: params.fromX * vp.width, y: params.fromY * vp.height };
     const endPx = { x: params.toX * vp.width, y: params.toY * vp.height };

--- a/packages/tool-server/src/tools/gesture-scroll/index.ts
+++ b/packages/tool-server/src/tools/gesture-scroll/index.ts
@@ -84,7 +84,7 @@ Returns { scrolled: true, timestampMs }. Fails if the Chromium CDP session is no
   async execute(services, params) {
     const timestampMs = Date.now();
     const chromium = services.chromium as ChromiumCdpApi;
-    await assertChromiumWindowVisible(chromium, "scroll", "chromium_scroll_window_hidden");
+    await assertChromiumWindowVisible(chromium, "scroll");
     const vp = chromium.getViewport();
     const totalDx = (params.deltaX ?? 0) * vp.width;
     const totalDy = (params.deltaY ?? 0) * vp.height;

--- a/packages/tool-server/src/tools/gesture-tap/index.ts
+++ b/packages/tool-server/src/tools/gesture-tap/index.ts
@@ -115,7 +115,7 @@ Before tapping, determine the correct coordinates by using discovery tools — p
       const chromium = services.chromium as ChromiumCdpApi;
       // Mouse dispatches wait on compositor hit-testing, which a hidden
       // window services at ~5s per event — refuse up front like gesture-scroll.
-      await assertChromiumWindowVisible(chromium, "tap", "chromium_tap_window_hidden");
+      await assertChromiumWindowVisible(chromium, "tap");
       await tapChromium(chromium, params.x, params.y, clickCount);
       return { tapped: true, timestampMs };
     }

--- a/packages/tool-server/src/utils/chromium-visibility.ts
+++ b/packages/tool-server/src/utils/chromium-visibility.ts
@@ -24,10 +24,18 @@ import type { ChromiumCdpApi } from "../blueprints/chromium-cdp";
  * the try: test fakes and mid-navigation contexts may lack `cdp`, and neither
  * says anything about visibility.
  */
+/**
+ * The guarded mouse tools. `failure_stage` is derived as
+ * `chromium_<action>_window_hidden` — "chromium_scroll_window_hidden" is
+ * frozen in telemetry (pre-migration rows join on it), so the stage must
+ * never be hand-written per call site where a typo or transposed argument
+ * would compile and silently land rows in an unqueried bucket.
+ */
+type ChromiumMouseAction = "tap" | "drag" | "scroll";
+
 export async function assertChromiumWindowVisible(
   chromium: ChromiumCdpApi,
-  action: string,
-  failureStage: string
+  action: ChromiumMouseAction
 ): Promise<void> {
   let value: unknown;
   try {
@@ -44,7 +52,7 @@ export async function assertChromiumWindowVisible(
       `Cannot ${action}: the Chromium window is hidden (minimized or fully occluded), so the renderer will not process mouse input. Bring the window to the foreground and retry.`,
       {
         error_code: FAILURE_CODES.CHROMIUM_WINDOW_HIDDEN,
-        failure_stage: failureStage,
+        failure_stage: `chromium_${action}_window_hidden`,
         failure_area: "tool_server",
         error_kind: "validation",
       }

--- a/packages/tool-server/test/chromium-window-hidden-guard.test.ts
+++ b/packages/tool-server/test/chromium-window-hidden-guard.test.ts
@@ -3,6 +3,7 @@ import { FAILURE_CODES, FailureError, getFailureSignal } from "@argent/registry"
 import { gestureTapTool } from "../src/tools/gesture-tap";
 import { gestureDragTool } from "../src/tools/gesture-drag";
 import { gestureScrollTool } from "../src/tools/gesture-scroll";
+import { makeChromiumImpl as makeKeyboardChromiumImpl } from "../src/tools/keyboard/platforms/chromium";
 
 // The hidden-window guard: a minimized / fully occluded Chromium window
 // throttles compositor hit-testing, so every MOUSE dispatch stalls ~5s
@@ -104,5 +105,33 @@ describe("hidden-window guard on chromium mouse tools", () => {
     )) as { tapped: boolean };
     expect(result.tapped).toBe(true);
     expect(api.dispatchMouseEvent).toHaveBeenCalled();
+  });
+
+  it("keyboard types on a hidden window — the guard's absence there is deliberate", async () => {
+    // Key events skip compositor hit-testing: measured on a genuinely
+    // minimized Electron window, Input.dispatchKeyEvent returns in 1-14ms
+    // while mouse dispatches stall ~5s each. Adding the guard to keyboard
+    // would refuse input that demonstrably works, so this test pins the
+    // exemption: an api whose visibility probe WOULD report "hidden" must
+    // still type, and the probe must never even be consulted. (button has no
+    // chromium branch at all, so keyboard is the only tool to pin.)
+    const api = fakeChromiumApi("hidden") as ReturnType<typeof fakeChromiumApi> & {
+      dispatchKeyEvent: ReturnType<typeof vi.fn>;
+    };
+    api.dispatchKeyEvent = vi.fn().mockResolvedValue(undefined);
+    const registry = { resolveService: vi.fn(async () => api) };
+
+    const result = await makeKeyboardChromiumImpl(registry as never).handler(
+      {},
+      { udid: "chromium-cdp-19222", text: "hi", delayMs: 0 },
+      { id: "chromium-cdp-19222", platform: "chromium", kind: "app" } as never
+    );
+
+    expect(result.typed).toBe("hi");
+    expect(api.dispatchKeyEvent).toHaveBeenCalled();
+    expect(api.cdp.send).not.toHaveBeenCalledWith(
+      "Runtime.evaluate",
+      expect.objectContaining({ expression: "document.visibilityState" })
+    );
   });
 });


### PR DESCRIPTION
Follow-up to #605, addressing the two actionable findings from the post-merge review.

## 1. Derive `failure_stage` instead of hand-writing it per call site

`assertChromiumWindowVisible` took adjacent `(action, failureStage)` string params where every call site passed a strictly redundant pair — the stage is always `chromium_<action>_window_hidden`. A typo or transposed argument compiled cleanly and read fine in review; the only symptom would be telemetry landing in an unqueried bucket, breaking exactly the pre/post-migration joinability #605 froze `chromium_scroll_window_hidden` to preserve.

The helper now takes a typed `"tap" | "drag" | "scroll"` action and derives the stage internally, so a drifting stage string can no longer compile. The existing guard tests assert the exact per-tool stage strings at the tool boundary, which pins the derivation (including the frozen `chromium_scroll_window_hidden`).

## 2. Pin the keyboard exemption with a test

The keyboard/button exemption (key events skip compositor hit-testing and stay fast on hidden windows) was enforced only in prose — mutation testing in the review showed adding the guard to those tools would keep the suite green. New test: an api whose visibility probe **would** report `"hidden"` must still type, and the probe must never even be consulted. `button` has no chromium branch at all, so keyboard is the only tool to pin.

**Mutation-verified:** temporarily adding `assertChromiumWindowVisible` to the keyboard chromium impl fails the new test; reverting restores green.

## Verification

- Unit: 3087 tool-server + 87 registry tests green, `typecheck:tests` green, lint + prettier clean on changed files.
- Live (dev tool-server from this branch, Electron testbed, genuinely minimized windows):
  - keyboard types in **~37 ms**, tap lands in **~55–73 ms** on both an argent-booted (flagged) app and an external un-flagged app on `:9222` — no guard false-positives.
  - Confirmed the guard cannot fire while a tool-server session is attached (its focus emulation pins reported visibility even after an external session disables emulation and the window is re-minimized) — consistent with #605's backstop design; the refusal path and derived stage strings are pinned by the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)