### PR TITLE
fix(flow): run a device-less flow without a device, and say why its counts are zero

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -215,9 +215,16 @@ export function renderSummary(report: FlowReport, opts: { withDevice?: boolean }
   const warnings = report.steps.filter((s) => s.warning).length;
   const warningsNote = warnings ? `, ${warnings} warning${warnings === 1 ? "" : "s"}` : "";
   // The live renderer prints its header before the runner has resolved a
-  // device, so its summary carries the device instead.
-  const where = opts.withDevice ? ` on ${report.device}` : "";
-  return `${report.ok ? "PASS" : "FAIL"}${where} — ${report.passed} passed, ${report.failed} failed, ${report.errored} errored, ${report.skipped} skipped${warningsNote}`;
+  // device, so its summary carries the device instead. Empty when the flow
+  // needed none.
+  const where = opts.withDevice && report.device ? ` on ${report.device}` : "";
+  // Four zeros on a passing run read as though nothing happened. Say why:
+  // narration is not counted, so a flow of only narration counts nothing.
+  // Only on a pass — on a failure the counts are not what needs explaining.
+  const nothingCounted =
+    report.ok && report.passed + report.failed + report.errored + report.skipped === 0;
+  const note = nothingCounted ? " (no test steps)" : "";
+  return `${report.ok ? "PASS" : "FAIL"}${where} — ${report.passed} passed, ${report.failed} failed, ${report.errored} errored, ${report.skipped} skipped${warningsNote}${note}`;
 }
 
 /**
@@ -370,7 +377,7 @@ export function exitAfterFlush(
 
 export function renderReport(report: FlowReport): string {
   const lines: string[] = [];
-  lines.push(`Flow "${report.flow}" on ${report.device}`);
+  lines.push(`Flow "${report.flow}"${report.device ? ` on ${report.device}` : ""}`);
   // A fragment runs against the device's current state — remind the operator
   // what it assumes was already set up.
   if (report.executionPrerequisite) {

--- a/packages/argent-cli/test/flow-deviceless-render.test.ts
+++ b/packages/argent-cli/test/flow-deviceless-render.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { renderReport, renderSummary, type FlowReport } from "../src/flow.js";
+
+function report(overrides: Partial<FlowReport> = {}): FlowReport {
+  return {
+    flow: "echo-only",
+    device: "",
+    ok: true,
+    passed: 0,
+    failed: 0,
+    skipped: 0,
+    errored: 0,
+    steps: [],
+    ...overrides,
+  } as FlowReport;
+}
+
+describe("rendering a run that resolved no device", () => {
+  it("does not claim the run happened on a device", () => {
+    const line = renderSummary(report(), { withDevice: true });
+
+    expect(line).not.toContain(" on ");
+    expect(line).toBe("PASS — 0 passed, 0 failed, 0 errored, 0 skipped (no test steps)");
+  });
+
+  it("omits the device from the report header too", () => {
+    const lines = renderReport(report()).split("\n");
+
+    expect(lines[0]).toBe('Flow "echo-only"');
+  });
+
+  it("still names a device when the run had one", () => {
+    const line = renderSummary(report({ device: "UDID-1", passed: 2 }), { withDevice: true });
+
+    expect(line).toBe("PASS on UDID-1 — 2 passed, 0 failed, 0 errored, 0 skipped");
+  });
+});
+
+describe("the no-test-steps note", () => {
+  it("explains a passing run whose counters are all zero", () => {
+    expect(renderSummary(report())).toContain("(no test steps)");
+  });
+
+  it("is absent whenever anything was counted", () => {
+    expect(renderSummary(report({ passed: 1 }))).not.toContain("(no test steps)");
+    expect(renderSummary(report({ skipped: 1 }))).not.toContain("(no test steps)");
+  });
+
+  it("is absent on a failure, where the counts are not what needs explaining", () => {
+    // A cancelled run can be a FAIL with every counter still zero; calling that
+    // "no test steps" would read as though the failure had no cause.
+    const line = renderSummary(report({ ok: false }));
+
+    expect(line).toBe("FAIL — 0 passed, 0 failed, 0 errored, 0 skipped");
+    expect(line).not.toContain("(no test steps)");
+  });
+
+  it("leaves an ordinary summary byte-for-byte unchanged", () => {
+    const line = renderSummary(report({ ok: false, passed: 2, failed: 1, skipped: 1 }));
+
+    expect(line).toBe("FAIL — 2 passed, 1 failed, 0 errored, 1 skipped");
+  });
+});

--- a/packages/argent-mcp/src/content.ts
+++ b/packages/argent-mcp/src/content.ts
@@ -334,9 +334,14 @@ export async function flowRunToMcpContent(
   }
 
   if (result.ok !== undefined) {
+    // Narration steps are not counted, so a flow of only narration counts
+    // nothing — say so rather than reporting four zeros on a passing run.
+    const counted =
+      (result.passed ?? 0) + (result.failed ?? 0) + (result.errored ?? 0) + (result.skipped ?? 0);
+    const note = result.ok && counted === 0 ? " (no test steps)" : "";
     blocks.push({
       type: "text",
-      text: `${result.ok ? "PASS" : "FAIL"} — ${result.passed ?? 0} passed, ${result.failed ?? 0} failed, ${result.errored ?? 0} errored, ${result.skipped ?? 0} skipped`,
+      text: `${result.ok ? "PASS" : "FAIL"} — ${result.passed ?? 0} passed, ${result.failed ?? 0} failed, ${result.errored ?? 0} errored, ${result.skipped ?? 0} skipped${note}`,
     });
   } else {
     blocks.push({ type: "text", text: `Flow "${result.flow}" complete.` });

--- a/packages/tool-server/src/tools/flows/flow-device.ts
+++ b/packages/tool-server/src/tools/flows/flow-device.ts
@@ -2,7 +2,7 @@ import type { DeviceInfo, Registry, ToolContext } from "@argent/registry";
 import { FAILURE_CODES, FailureError } from "@argent/registry";
 import { resolveDevice } from "../../utils/device-info";
 import { invokeSubTool } from "../../utils/sub-invoke";
-import type { WhenPlatform } from "./flow-utils";
+import type { FlowStep, WhenPlatform } from "./flow-utils";
 
 /**
  * Device resolution + binding for the flow runner. Flows store no device id
@@ -16,6 +16,14 @@ import type { WhenPlatform } from "./flow-utils";
 export type FlowPlatform = WhenPlatform;
 
 const DEVICE_BIND_KEYS = ["udid", "device_id"] as const;
+
+/**
+ * Keys that mean a tool acts on a device. A superset of the keys the runner
+ * injects: `device` names one without receiving the run's own (a nested flow
+ * takes it that way), and a step that drives a device must count as needing one
+ * even when the runner does not hand it over.
+ */
+const DEVICE_ARG_KEYS = [...DEVICE_BIND_KEYS, "device"] as const;
 
 interface RawDevice {
   platform: FlowPlatform;
@@ -109,6 +117,68 @@ export function stripDeviceKeys(args: Record<string, unknown>): Record<string, u
  * for the device-id keys the tool's input schema declares (so `.strict()`
  * schemas stay valid).
  */
+/**
+ * Whether a step acts on a device.
+ *
+ * Answered per kind rather than by trying and failing, so a flow that touches no
+ * device never has to have one. The default is that a step DOES need one: a kind
+ * added later inherits today's behaviour instead of silently running against no
+ * device, and the `never` binding makes leaving it unclassified a compile error.
+ *
+ * Two of the classifications are worth stating outright:
+ *
+ * - `when` needs a device whatever its body contains, because the guard itself
+ *   reads one — the device's platform, or its view tree.
+ * - `run` needs one without the fragment being read here. The flow it names is
+ *   resolved at run time; resolving it a second time would duplicate that lookup
+ *   and could disagree with it if the file changed in between. The cost is that
+ *   composing a narration-only fragment still resolves a device.
+ */
+export function stepRequiresDevice(registry: Registry, step: FlowStep): boolean {
+  switch (step.kind) {
+    case "echo":
+    case "wait":
+      return false;
+    case "tool":
+      return toolRequiresDevice(registry, step.name);
+    case "when":
+    case "run":
+    case "launch":
+    case "tap":
+    case "long-press":
+    case "type":
+    case "await":
+    case "assert":
+    case "scroll-to":
+    case "pinch":
+    case "rotate":
+    case "snapshot":
+      return true;
+    default: {
+      const unclassified: never = step;
+      void unclassified;
+      return true;
+    }
+  }
+}
+
+/** Whether any step in a flow acts on a device. */
+export function flowRequiresDevice(registry: Registry, steps: FlowStep[]): boolean {
+  return steps.some((step) => stepRequiresDevice(registry, step));
+}
+
+function toolRequiresDevice(registry: Registry, toolName: string): boolean {
+  const toolDef = registry.getTool(toolName);
+  // An unknown tool is assumed to need a device: the step is going to fail
+  // either way, and it fails more usefully with one resolved.
+  if (!toolDef) return true;
+  const props = (toolDef.inputSchema as { properties?: Record<string, unknown> } | undefined)
+    ?.properties;
+  // A tool with no declared input takes no device.
+  if (!props) return false;
+  return DEVICE_ARG_KEYS.some((k) => k in props);
+}
+
 export function bindDeviceArgs(
   registry: Registry,
   toolName: string,

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -32,7 +32,13 @@ import type { TextMatchMode, WaitCondition } from "../../utils/ui-tree-match";
 import { sleepOrAbort } from "../../utils/timing";
 import { invokeSubTool } from "../../utils/sub-invoke";
 import { isUnmetUiWaitResult } from "../await-ui-element";
-import { resolveFlowDevice, bindDeviceArgs, type FlowPlatform } from "./flow-device";
+import {
+  resolveFlowDevice,
+  bindDeviceArgs,
+  flowRequiresDevice,
+  stepRequiresDevice,
+  type FlowPlatform,
+} from "./flow-device";
 import {
   runDirective,
   invokeOnDevice,
@@ -338,7 +344,8 @@ async function treeSourceGate(
  * already-launched app (see `state.chromiumLaunched`).
  */
 async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcome> {
-  const { registry, device, signal } = state;
+  const env = deviceEnv(state);
+  const { registry, device, signal } = env;
 
   if (device.platform === "chromium") {
     // Only the top-level flow's leading launch is honored: the runner boots that
@@ -388,7 +395,7 @@ async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcom
     };
   }
   try {
-    await invokeOnDevice(state, "restart-app", { bundleId });
+    await invokeOnDevice(env, "restart-app", { bundleId });
   } catch (err) {
     // A cancellation makes the sub-tool itself reject; that rejection is the
     // abort, not an app failure, so it must not be attributed to restart-app.
@@ -404,7 +411,11 @@ async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcom
   return { ok: true };
 }
 
-interface ExecState extends ActionEnv {
+// `device` is null for a run whose flow touches none. Narrowed rather than
+// inherited from ActionEnv so every site that acts on the device has to say so
+// (via `deviceEnv`) and the compiler can find the ones that don't.
+interface ExecState extends Omit<ActionEnv, "device"> {
+  device: DeviceInfo | null;
   flowsDir: string;
   topFlowName: string;
   updateBaselines: boolean;
@@ -422,6 +433,21 @@ interface ExecState extends ActionEnv {
   chromiumLaunched: boolean;
   /** Live progress hook: receives every report the moment it is appended. */
   onStepReport?: (report: StepReport) => void;
+}
+
+/**
+ * The run state as an environment that acts on a device.
+ *
+ * Only reached from a step classified as needing one, which is why the device is
+ * resolved at all. The throw is a contradiction guard, not an expected path: it
+ * fires only if the classification and the executor ever disagree, and says so
+ * rather than dereferencing null somewhere further in.
+ */
+function deviceEnv(state: ExecState): ActionEnv {
+  if (!state.device) {
+    throw new Error("internal: a step that acts on a device ran in a flow resolved as device-free");
+  }
+  return { ...state, device: state.device };
 }
 
 /** A chromium instance the runner booted and must tear down after the run. */
@@ -500,7 +526,6 @@ returns a notice with the prerequisite instead of running.`,
       // resolveRunDevice). Any instance it booted is torn down in the finally.
       const resolved = await resolveRunDevice(registry, ctx, flow, params, flowsDir);
       const device = resolved.device;
-      const env: ActionEnv = { registry, ctx, device, signal };
 
       // Normalize the status bar (clock/battery/signal) for the whole run so it
       // never drives a snapshot diff and every screenshot is consistent. Pinned
@@ -508,17 +533,20 @@ returns a notice with the prerequisite instead of running.`,
       // an e2e flow's leading launch step (relaunch + settle) doubles as
       // propagation headroom before anything is captured. No-op (returns false)
       // on chromium/vega; restored on teardown.
-      const statusBarPinned = await pinStatusBar(device);
+      const statusBarPinned = device !== null && (await pinStatusBar(device));
 
       // The chromium equivalent of that normalization: front the page once so
       // a backgrounded window doesn't throttle rendering for the whole run —
       // wheel-event acks (scroll steps) stall on a throttled compositor.
       // Best-effort: bringToFront can focus a page but cannot unhide a
       // minimized window (gesture-scroll fails fast on that case itself).
-      if (device.platform === "chromium") await frontChromiumPage(registry, device);
+      if (device?.platform === "chromium") await frontChromiumPage(registry, device);
 
       const state: ExecState = {
-        ...env,
+        registry,
+        ctx,
+        device,
+        signal,
         flowsDir,
         topFlowName: params.name,
         updateBaselines: Boolean(params.updateBaselines),
@@ -542,11 +570,19 @@ returns a notice with the prerequisite instead of running.`,
         // status-bar restore / chromium teardown lands after every step
         // already ran, and must not flip a finished run to FAIL.
         aborted = state.signal?.aborted === true;
-        if (state.pinned) await restoreStatusBar(device);
+        if (state.pinned && device) await restoreStatusBar(device);
         if (resolved.booted) await teardownBootedChromium(registry, resolved.booted);
       }
 
-      return summarize(params.name, device.id, flow.executionPrerequisite, state.reports, aborted);
+      // Empty when the flow needed no device — the run is not attributed to one
+      // it never touched.
+      return summarize(
+        params.name,
+        device?.id ?? "",
+        flow.executionPrerequisite,
+        state.reports,
+        aborted
+      );
     },
   };
 }
@@ -558,6 +594,11 @@ returns a notice with the prerequisite instead of running.`,
  * attaches to an already-booted device. An explicit `device` always attaches —
  * never boots or tears down. `flowDir` is the flow file's directory — the base
  * for a relative chromium app path.
+ *
+ * Returns null when no step in the flow acts on a device: such a run needs none,
+ * so demanding one would fail a flow that could have succeeded — and picking
+ * whichever device happens to be booted would make the report depend on what
+ * else is running on the machine.
  */
 async function resolveRunDevice(
   registry: Registry,
@@ -565,12 +606,17 @@ async function resolveRunDevice(
   flow: FlowFile,
   params: Params,
   flowDir: string
-): Promise<{ device: DeviceInfo; booted: BootedChromium | null }> {
+): Promise<{ device: DeviceInfo | null; booted: BootedChromium | null }> {
   if (!params.device) {
     const spec = chromiumBootSpec(flow, params.platform);
     if (spec) {
       const booted = await bootChromiumForFlow(spec, flowDir);
       return { device: resolveDevice(booted.deviceId), booted };
+    }
+    // Checked after the chromium boot path, which only applies to a flow led by
+    // a `launch` step — and a launch needs a device, so the two never compete.
+    if (!flowRequiresDevice(registry, flow.steps)) {
+      return { device: null, booted: null };
     }
   }
   const device = await resolveFlowDevice(registry, ctx, {
@@ -842,6 +888,23 @@ async function execSteps(state: ExecState, steps: FlowStep[], scope: StepScope):
       if (step.kind === "when") reportBlockSkipped(state, step.steps, childScope(scope));
       continue;
     }
+    // The flow was resolved as needing no device, yet a step that acts on one
+    // reached execution — the two decisions disagree. Report it as this step's
+    // error and stop, rather than letting it fail obscurely further in.
+    if (!state.device && stepRequiresDevice(state.registry, step)) {
+      state.stopped = true;
+      pushReport(state, {
+        index,
+        kind: step.kind,
+        status: "error",
+        flow: scope.flow,
+        target: stepTarget(step),
+        ...depthOf(scope),
+        reason: `step needs a device but the flow was resolved as device-free — pass an explicit device`,
+      });
+      if (step.kind === "when") reportBlockSkipped(state, step.steps, childScope(scope));
+      continue;
+    }
     if (state.signal?.aborted) {
       state.stopped = true;
       pushReport(state, {
@@ -943,10 +1006,11 @@ async function execWhenStep(
     // platform guard it IS ios. The parser deliberately rejects "ios-remote"
     // as a guard spelling, so without this fold no guard could ever match on
     // a remote sim and iOS-only blocks would silently skip there.
-    const platform = state.device.platform === "ios-remote" ? "ios" : state.device.platform;
+    const guardEnv = deviceEnv(state);
+    const platform = guardEnv.device.platform === "ios-remote" ? "ios" : guardEnv.device.platform;
     met = platform === step.condition.platform;
   } else {
-    const probe = await probeWhenCondition(state, step.condition);
+    const probe = await probeWhenCondition(deviceEnv(state), step.condition);
     if (probe.aborted) {
       pushReport(state, { ...marker, status: "skip", reason: "run aborted" });
       reportBlockSkipped(state, step.steps, inner, "run aborted");
@@ -1067,7 +1131,7 @@ async function execLeafStep(
       // touch gesture on a focus-driven TV target — must still land in the
       // structured report rather than abort the whole run unreported.
       try {
-        const r = await runDirective(state, step);
+        const r = await runDirective(deviceEnv(state), step);
         // A run cancelled mid-directive is a skip (matching the pre-step guard
         // and `wait`), never a step failure — the app did nothing wrong.
         if (r.aborted) return { ...base, status: "skip", reason: r.reason };
@@ -1086,7 +1150,7 @@ async function execLeafStep(
 
     case "snapshot": {
       try {
-        const r = await runSnapshot(state, {
+        const r = await runSnapshot(deviceEnv(state), {
           flowsDir: state.flowsDir,
           flowName: state.topFlowName,
           name: step.name,
@@ -1107,7 +1171,10 @@ async function execLeafStep(
     }
 
     case "tool": {
-      const args = bindDeviceArgs(registry, step.name, device.id, step.args);
+      // With no device, the step reached here only because its tool declares no
+      // device argument, so there is nothing to inject — binding still strips
+      // any device key the recorded args carried.
+      const args = bindDeviceArgs(registry, step.name, device?.id ?? "", step.args);
       const outputHint = registry.getTool(step.name)?.outputHint;
       if (step.delayMs && !(await sleepOrAbort(step.delayMs, signal))) {
         return { ...base, status: "skip", tool: step.name, reason: "run aborted during delay" };

--- a/packages/tool-server/test/flows/flow-deviceless.test.ts
+++ b/packages/tool-server/test/flows/flow-deviceless.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+import { serializeFlow, type FlowStep } from "../../src/tools/flows/flow-utils";
+import { stepRequiresDevice } from "../../src/tools/flows/flow-device";
+
+const DEVICE = "00000000-0000-0000-0000-0000000000ab";
+let tmpDir: string;
+
+/**
+ * Tools keyed by the device argument they declare — what decides whether a step
+ * acts on a device. `undefined` models a tool the registry does not know.
+ */
+const TOOLS: Record<string, { inputSchema?: unknown } | undefined> = {
+  "tap": { inputSchema: { properties: { udid: {}, x: {}, y: {} } } },
+  "stop-metro": { inputSchema: { properties: { port: {} } } },
+  // A real tool that declares no input at all.
+  "stop-all-simulator-servers": {},
+  // Takes a device without receiving the run's own.
+  "flow-execute": { inputSchema: { properties: { name: {}, device: {} } } },
+};
+
+function mockRegistry(opts: { booted?: string[] } = {}) {
+  const invokeTool = vi.fn(async (id: string) => {
+    if (id === "list-devices") {
+      return {
+        devices: (opts.booted ?? []).map((udid) => ({ platform: "ios", udid, state: "Booted" })),
+      };
+    }
+    return { ok: true };
+  });
+  const registry = {
+    invokeTool,
+    getTool: vi.fn((name: string) => TOOLS[name]),
+    resolveService: vi.fn(async () => ({
+      isConnected: () => true,
+      listConnectedBundleIds: () => [],
+    })),
+  } as unknown as Registry;
+  return { registry, invokeTool };
+}
+
+async function writeFlow(name: string, steps: FlowStep[]): Promise<void> {
+  const dir = path.join(tmpDir, ".argent", "flows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, `${name}.yaml`),
+    serializeFlow({ executionPrerequisite: "", steps }),
+    "utf8"
+  );
+}
+
+function asRun(r: FlowRunResult | { notice: string }): FlowRunResult {
+  if (!("steps" in r)) throw new Error(`expected a run result, got notice: ${r.notice}`);
+  return r;
+}
+
+/** Run without an explicit device, the case where auto-detection would kick in. */
+async function runAuto(registry: Registry, name: string) {
+  const runFlow = createRunFlowTool(registry);
+  return runFlow.execute({}, { name, project_root: tmpDir });
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-deviceless-"));
+});
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("a flow that touches no device", () => {
+  it("runs with nothing booted, and never looks for a device", async () => {
+    await writeFlow("echo-only", [
+      { kind: "echo", message: "first step" },
+      { kind: "echo", message: "second step" },
+    ]);
+    const { registry, invokeTool } = mockRegistry({ booted: [] });
+
+    const result = asRun(await runAuto(registry, "echo-only"));
+
+    expect(result.ok).toBe(true);
+    expect(result.device).toBe("");
+    expect(result.steps.map((s) => [s.kind, s.status])).toEqual([
+      ["echo", "pass"],
+      ["echo", "pass"],
+    ]);
+    expect(invokeTool).not.toHaveBeenCalledWith(
+      "list-devices",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("is not attributed to a device that merely happens to be booted", async () => {
+    // Otherwise an identical flow reports differently on a laptop with a
+    // simulator open than in CI with none.
+    await writeFlow("echo-only", [{ kind: "echo", message: "hi" }]);
+    const { registry, invokeTool } = mockRegistry({ booted: [DEVICE] });
+
+    const result = asRun(await runAuto(registry, "echo-only"));
+
+    expect(result.device).toBe("");
+    expect(invokeTool).not.toHaveBeenCalledWith(
+      "list-devices",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("still names the device when one was asked for explicitly", async () => {
+    await writeFlow("echo-only", [{ kind: "echo", message: "hi" }]);
+    const { registry } = mockRegistry({ booted: [DEVICE] });
+    const runFlow = createRunFlowTool(registry);
+
+    const result = asRun(
+      await runFlow.execute({}, { name: "echo-only", project_root: tmpDir, device: DEVICE })
+    );
+
+    expect(result.device).toBe(DEVICE);
+  });
+
+  it("runs a wait-only flow", async () => {
+    await writeFlow("waiting", [{ kind: "wait", ms: 1 }]);
+    const { registry } = mockRegistry({ booted: [] });
+
+    expect(asRun(await runAuto(registry, "waiting")).ok).toBe(true);
+  });
+
+  it("runs a tool step whose tool takes no device", async () => {
+    await writeFlow("stop", [{ kind: "tool", name: "stop-metro", args: { port: 8081 } }]);
+    const { registry } = mockRegistry({ booted: [] });
+
+    const result = asRun(await runAuto(registry, "stop"));
+    expect(result.ok).toBe(true);
+    expect(result.device).toBe("");
+  });
+
+  it("runs a tool step whose tool declares no input at all", async () => {
+    // A tool with no schema must not be mistaken for one that needs a device,
+    // and reading its absent schema must not throw.
+    await writeFlow("stop-all", [{ kind: "tool", name: "stop-all-simulator-servers", args: {} }]);
+    const { registry } = mockRegistry({ booted: [] });
+
+    expect(asRun(await runAuto(registry, "stop-all")).ok).toBe(true);
+  });
+
+  it("runs an empty flow", async () => {
+    await writeFlow("nothing", []);
+    const { registry } = mockRegistry({ booted: [] });
+
+    const result = asRun(await runAuto(registry, "nothing"));
+    expect(result.ok).toBe(true);
+    expect(result.device).toBe("");
+    expect(result.steps).toEqual([]);
+  });
+});
+
+describe("a flow that does touch a device still demands one", () => {
+  const expectDemandsDevice = async (name: string) => {
+    const { registry } = mockRegistry({ booted: [] });
+    await expect(runAuto(registry, name)).rejects.toThrow(/No booted device found/);
+  };
+
+  it("when a directive step is mixed in with narration", async () => {
+    await writeFlow("mixed", [
+      { kind: "echo", message: "about to tap" },
+      { kind: "tap", x: 0.5, y: 0.5 },
+    ]);
+    await expectDemandsDevice("mixed");
+  });
+
+  it("when the only device step is inside a when block", async () => {
+    await writeFlow("guarded", [
+      { kind: "echo", message: "checking" },
+      {
+        kind: "when",
+        condition: { kind: "ui", condition: "visible", selector: { text: "Settings" } },
+        steps: [{ kind: "tap", x: 0.5, y: 0.5 }],
+      },
+    ]);
+    await expectDemandsDevice("guarded");
+  });
+
+  it("when a when block guards on platform and contains only narration", async () => {
+    // The guard reads the device's platform, so the block's contents are beside
+    // the point.
+    await writeFlow("platform-guarded", [
+      {
+        kind: "when",
+        condition: { kind: "platform", platform: "ios" },
+        steps: [{ kind: "echo", message: "on ios" }],
+      },
+    ]);
+    await expectDemandsDevice("platform-guarded");
+  });
+
+  it("when it launches an app", async () => {
+    await writeFlow("launcher", [{ kind: "launch", app: { ios: "com.example.app" } }]);
+    await expectDemandsDevice("launcher");
+  });
+
+  it("when a tool step's tool declares a device argument", async () => {
+    await writeFlow("tapping", [{ kind: "tool", name: "tap", args: { x: 0.5 } }]);
+    await expectDemandsDevice("tapping");
+  });
+
+  it("when a tool step's tool takes a device without being given the run's own", async () => {
+    // A nested flow drives a device even though the runner does not hand it one.
+    await writeFlow("nested", [{ kind: "tool", name: "flow-execute", args: { name: "inner" } }]);
+    await expectDemandsDevice("nested");
+  });
+
+  it("when the tool is unknown to the registry", async () => {
+    await writeFlow("mystery", [{ kind: "tool", name: "not-a-tool", args: {} }]);
+    await expectDemandsDevice("mystery");
+  });
+
+  it("when it composes another flow, even a narration-only one", async () => {
+    // The fragment is resolved at run time, so composition is taken to need a
+    // device rather than resolved twice and risking disagreement.
+    await writeFlow("child", [{ kind: "echo", message: "quiet" }]);
+    await writeFlow("parent", [
+      { kind: "echo", message: "calling child" },
+      { kind: "run", flow: "child" },
+    ]);
+    await expectDemandsDevice("parent");
+  });
+});
+
+describe("stepRequiresDevice", () => {
+  it("classifies every step kind", () => {
+    // Keyed on the union, so a new step kind fails to compile until it is
+    // classified here as well as in the implementation.
+    const expected: Record<FlowStep["kind"], boolean> = {
+      "echo": false,
+      "wait": false,
+      "tool": true,
+      "run": true,
+      "when": true,
+      "launch": true,
+      "tap": true,
+      "long-press": true,
+      "type": true,
+      "await": true,
+      "assert": true,
+      "scroll-to": true,
+      "pinch": true,
+      "rotate": true,
+      "snapshot": true,
+    };
+    const samples: Record<FlowStep["kind"], FlowStep> = {
+      "echo": { kind: "echo", message: "x" },
+      "wait": { kind: "wait", ms: 1 },
+      "tool": { kind: "tool", name: "tap", args: {} },
+      "run": { kind: "run", flow: "other" },
+      "when": { kind: "when", condition: { kind: "platform", platform: "ios" }, steps: [] },
+      "launch": { kind: "launch", app: { ios: "com.example" } },
+      "tap": { kind: "tap", x: 0, y: 0 },
+      "long-press": { kind: "long-press", x: 0, y: 0 },
+      "type": { kind: "type", into: { text: "f" }, text: "hi" },
+      "await": { kind: "await", condition: "visible", selector: { text: "f" } },
+      "assert": { kind: "assert", condition: "visible", selector: { text: "f" } },
+      "scroll-to": { kind: "scroll-to", target: { text: "f" }, direction: "down" },
+      "pinch": { kind: "pinch", scale: 2 },
+      "rotate": { kind: "rotate", by: 90 },
+      "snapshot": { kind: "snapshot", name: "s" },
+    };
+
+    const { registry } = mockRegistry();
+    for (const kind of Object.keys(expected) as FlowStep["kind"][]) {
+      expect(stepRequiresDevice(registry, samples[kind]), `kind: ${kind}`).toBe(expected[kind]);
+    }
+  });
+
+  it("distinguishes tool steps by the device argument their tool declares", () => {
+    const { registry } = mockRegistry();
+    const toolStep = (name: string): FlowStep => ({ kind: "tool", name, args: {} });
+
+    expect(stepRequiresDevice(registry, toolStep("tap"))).toBe(true);
+    expect(stepRequiresDevice(registry, toolStep("flow-execute"))).toBe(true);
+    expect(stepRequiresDevice(registry, toolStep("stop-metro"))).toBe(false);
+    expect(stepRequiresDevice(registry, toolStep("stop-all-simulator-servers"))).toBe(false);
+    expect(stepRequiresDevice(registry, toolStep("not-a-tool"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #644.

## Before

```
$ argent flow run echo-only          # .argent/flows/echo-only.yaml: two `echo` steps
[Tool:flow-execute] No booted device found. Pass a device id or platform explicitly.
Available devices: 18BE573F-… (ios, Shutdown), <70 more>
```

and when a device *was* booted:

```
PASS on 18BE573F-… — 0 passed, 0 failed, 0 errored, 0 skipped
```

## After

```
$ argent flow run echo-only          # nothing booted
Flow "echo-only"
  › first step
  › second step

PASS — 0 passed, 0 failed, 0 errored, 0 skipped (no test steps)
```

## Symptom 1 — the device

Whether a device is needed is decided from the flow's own steps, before resolution.

Classification is **per step kind and defaults to needing one**, so a kind added later inherits
today's behaviour instead of silently running against no device — and the `never` binding makes
leaving a new kind unclassified a compile error, backed by a test keyed on the step union so it
fails to build rather than to run.

Two classifications worth calling out:

- **`when` always needs a device**, whatever its body contains, because the guard reads one itself
  (its platform, or its view tree). A `when: {platform: ios}` block containing only narration still
  resolves.
- **`run` needs one without the fragment being read here.** The named flow is resolved at run time;
  resolving it a second time would duplicate that lookup and could disagree with it if the file
  changed in between. A deliberate over-approximation: composing a narration-only fragment still
  resolves a device. Stated in the code and in the tool description.

For `tool:` steps the tool's own schema decides, via a superset of the keys the runner injects —
`device` is included because a nested `flow-execute` step drives a device without being handed the
run's own. A tool that declares no input at all (`stop-all-simulator-servers`) is device-free, and
reading its absent schema must not throw — it previously would have.

`ExecState.device` is nullable, which is the safety mechanism rather than just typing: the compiler
enumerates every site that acts on a device, each of which now says so via one `deviceEnv()`
narrowing. `flow-actions.ts`, `flow-visual.ts` and `ActionEnv` are untouched. The executor also
re-checks each step against the **same predicate**, so if the scan and the executor ever disagree
the step reports it instead of failing obscurely deeper in.

A run that resolved no device reports `device: ""`, and neither renderer claims it ran somewhere.

## Symptom 2 — the counters

Reproducing this showed the issue's framing is slightly off: `--json` doesn't only disagree with the
text, it disagrees with **itself** — counters all zero while its own `steps[]` marks both steps
`"pass"`. So the CLI text was a faithful rendering of the server's counters.

**The counters are right and stay as they are.** Narration is deliberately excluded, and it should
be: after a hard stop every remaining step *including narration* is reported skipped, so counting it
would inflate `skipped` on every real failing run — a worse and far more common lie than the vacuous
one being reported here. It would also contradict the JUnit model in #578, where echo is
`<system-out>` and not a `<testcase>`.

What was missing was saying *why* zero. Both the CLI and the MCP renderer now append
`(no test steps)`, and only on a pass — a cancelled run can be a FAIL with all four counters zero,
where "no test steps" would read as though the failure had no cause.

No wire format changes: `steps[].kind === "echo"` already distinguishes counted from uncounted steps,
so the JSON is self-describing without widening the status enum.

## Conflicts, for whoever lands second

This is a hot area — seven open PRs touch `flow-run.ts`.

- **#578** rewrites the CLI summary line I also change (one hunk, one 7-line function, semantically
  independent — resolution is keep-both), and its `attachFailureDiagnostics` dereferences
  `env.device.platform`. **It will need a null-device guard**, or every failure in a device-less flow
  silently degrades to `read-failed` diagnostics. Happy to rebase onto it rather than the reverse.
- **#585** rewrites `resolveRunDevice` at the same seam and edits the same description sentence.
- **#538** rewrites `flow-device.ts`. Worth noting it makes `resolveFlowDevice` reject a physical
  iPhone for flows — skipping resolution means a narration-only flow now passes on a
  physical-iPhone-only host, which I think is desirable but is a second behaviour change on this seam.

All new tests are in new files, since every existing flow test file in the blast radius is rewritten
by an open PR.

## Behaviour changes a reviewer should weigh

- A device-free flow no longer prints `PASS on <id>` **even when a device is booted**. That is the
  point: otherwise an identical flow reports differently in CI (no simulator) than on a laptop with
  one open. An explicit `--device` is still honoured and still named.
- `--platform` is ignored for a device-free flow, where it previously errored with nothing booted.
- A 0.18.1 CLI against a newer server would print `Flow "x" on ` — cosmetic version skew.

## Verification

Live against the built CLI: device-less flow with nothing booted (the reported bug) and with a device
booted (identical output, no ambient attribution); `--json` showing `device: ""`; explicit `--device`
still naming it; a mixed flow and a composed flow both still demanding a device; a mixed flow with a
device booted still reporting `PASS on <id> — 1 passed`.

24 new tests. tool-server 3103 passed, CLI 284 passed, MCP 78 passed — no existing test modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> **#697 is stacked on this branch** — it conflicts with this one in `flow-run.ts`'s import block, so it was rebased on top. Merge this first.
