### PR TITLE
fix(config): say what a rejected value should have been, and prune the group it left behind

### DIFF
--- a/packages/argent-cli/src/config.ts
+++ b/packages/argent-cli/src/config.ts
@@ -13,6 +13,7 @@ import {
   CONFIG_SCHEMA,
   configDir,
   findProjectRoot,
+  getConfigDefinition,
   getConfigValueByKey,
   getConfigValueAtScope,
   setConfigValue,
@@ -84,6 +85,9 @@ the raw value stored at each scope.`);
 
 function scopeDetail(e: ConfigEntryView): string {
   const parts: string[] = [`scopes: ${e.scopes.join(", ")}`];
+  // What the key accepts, which the description alone does not say — a list-valued
+  // key reads exactly like a string-valued one otherwise.
+  if (e.expected) parts.push(`value: ${e.expected}${e.example ? `, e.g. ${e.example}` : ""}`);
   if (e.project !== undefined) parts.push(`project=${formatValuePlain(e.project)}`);
   if (e.global !== undefined) parts.push(`global=${formatValuePlain(e.global)}`);
   return parts.join("  ·  ");
@@ -158,7 +162,10 @@ parsed (e.g. \`true\`, \`42\`, \`["a","b"]\`); anything else is stored as a stri
     if (warning) console.error(pc.yellow(warning));
     console.log(`Set ${pc.bold(key)} = ${formatValuePlain(stored)} (${scopeLabel(targetScope)}).`);
   } catch (err) {
-    reportError(err);
+    // Built here rather than in reportError because the correction is worth
+    // more when it carries what the user actually typed, and only this frame
+    // knows the value and the scope they chose.
+    reportError(err, () => suggestCorrectedSet(err, key, rawValue, scope));
   }
 }
 
@@ -296,7 +303,41 @@ function formatValue(value: unknown): string {
   return formatValuePlain(value);
 }
 
-function reportError(err: unknown): never {
+/**
+ * Shell-quote a value for a suggested command, so pasting it stores exactly
+ * what it shows. A `~` or a bracket left bare would be expanded or eaten by the
+ * shell, which is how the user got here in the first place.
+ */
+function quoteForShell(value: string): string {
+  if (/^[A-Za-z0-9._/@:+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * The command the user probably meant, or null when there is nothing confident
+ * to suggest.
+ *
+ * Only offered where the correction is mechanical — a value for a list-valued
+ * key that was written as a single item. Nothing is stored on the user's behalf;
+ * the corrected command is shown for them to run.
+ */
+function suggestCorrectedSet(
+  err: unknown,
+  key: string,
+  rawValue: string,
+  scope: FlagScope | null
+): string | null {
+  if (!(err instanceof ConfigValidationError)) return null;
+  const def = getConfigDefinition(key);
+  if (!def) return null;
+  // A single item offered to a list — the mistake this suggestion exists for.
+  const wrapped = def.parse([rawValue]);
+  if (wrapped === undefined) return null;
+  const scopeFlag = scope ? ` --scope ${scope}` : "";
+  return `argent config set ${key} ${quoteForShell(JSON.stringify([rawValue]))}${scopeFlag}`;
+}
+
+function reportError(err: unknown, suggest?: () => string | null): never {
   if (err instanceof ConfigManagedElsewhereError) {
     console.error(`Error: ${err.message} Use \`${err.command}\` instead.`);
   } else if (
@@ -307,6 +348,15 @@ function reportError(err: unknown): never {
     console.error(`Error: ${err.message}`);
     if (err instanceof UnknownConfigKeyError) {
       console.error(`Run \`argent config list\` to see available keys.`);
+    }
+    if (err instanceof ConfigValidationError) {
+      const corrected = suggest?.() ?? null;
+      if (corrected) {
+        console.error(`Did you mean: ${corrected}`);
+      } else if (err.example) {
+        console.error(`Example: argent config set ${err.key} ${quoteForShell(err.example)}`);
+      }
+      console.error(`Run \`argent config list\` to see each key's expected value.`);
     }
   } else {
     console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/argent-cli/test/config-command.test.ts
+++ b/packages/argent-cli/test/config-command.test.ts
@@ -240,3 +240,90 @@ describe("argent config — list & json", () => {
     });
   });
 });
+
+describe("argent config — a rejected value says what to type instead", () => {
+  it("names the expected shape and suggests the user's own value, correctly wrapped", () => {
+    // The reported case: a list-valued key given a single path.
+    expect(() =>
+      config([
+        "set",
+        "ios.additionalDeviceSets",
+        "~/Library/Developer/Radon/Devices",
+        "--scope",
+        "project",
+      ])
+    ).toThrow(ExitError);
+
+    const err = errors();
+    expect(err).toContain("expected an array of strings");
+    // The suggestion carries the path they typed, not a stand-in from the docs,
+    // and keeps them on the scope they asked for.
+    expect(err).toContain(
+      `Did you mean: argent config set ios.additionalDeviceSets '["~/Library/Developer/Radon/Devices"]' --scope project`
+    );
+    expect(err).toContain("argent config list");
+  });
+
+  it("suggests nothing beyond the shape when wrapping would not help", () => {
+    expect(() => config(["set", "lens.agent", "42"])).toThrow(ExitError);
+
+    const err = errors();
+    expect(err).toContain("expected a non-empty string");
+    expect(err).not.toContain("Did you mean");
+    expect(err).toContain("Example: argent config set lens.agent claude");
+  });
+
+  it("keeps the global default out of the suggestion when no scope was given", () => {
+    expect(() => config(["set", "ios.additionalDeviceSets", "/a"])).toThrow(ExitError);
+
+    expect(errors()).toContain(`Did you mean: argent config set ios.additionalDeviceSets '["/a"]'`);
+    expect(errors()).not.toContain("--scope");
+  });
+
+  it("shows each key's expected value in list", () => {
+    config(["list"]);
+    expect(output()).toContain("an array of strings");
+    expect(output()).toContain('e.g. ["~/DeviceSets/ci"]');
+  });
+
+  it("carries the expected shape through list --json", () => {
+    config(["list", "--json"]);
+    const parsed = JSON.parse(output());
+    const entry = parsed.config.find((e: { key: string }) => e.key === "ios.additionalDeviceSets");
+    expect(entry.expected).toBe("an array of strings");
+    expect(entry.example).toBe('["~/DeviceSets/ci"]');
+  });
+});
+
+describe("argent config — unset leaves no empty parent behind", () => {
+  const projectConfig = () =>
+    fs.readFileSync(path.join(projectDir, ".argent", "config.json"), "utf8");
+
+  it("restores the document rather than leaving an empty group", () => {
+    config(["set", "ios.additionalDeviceSets", '["/a"]', "--scope", "project"]);
+    config(["unset", "ios.additionalDeviceSets", "--scope", "project"]);
+
+    expect(JSON.parse(projectConfig())).toEqual({});
+  });
+
+  it("keeps sibling keys and their groups", () => {
+    config(["set", "lens.agent", "codex", "--scope", "project"]);
+    config(["set", "ios.additionalDeviceSets", '["/a"]', "--scope", "project"]);
+    config(["unset", "ios.additionalDeviceSets", "--scope", "project"]);
+
+    expect(JSON.parse(projectConfig())).toEqual({ lens: { agent: "codex" } });
+  });
+
+  it("does not rewrite a file to tidy an empty group it did not create", () => {
+    // A no-op unset must not touch the file at all — that guarantee is why the
+    // fast path exists, and tidying would quietly break it.
+    const dir = path.join(projectDir, ".argent");
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "config.json");
+    fs.writeFileSync(file, '{"ios":{}}');
+
+    config(["unset", "ios.additionalDeviceSets", "--scope", "project"]);
+
+    expect(fs.readFileSync(file, "utf8")).toBe('{"ios":{}}');
+  });
+});

--- a/packages/configuration-core/src/config-access.ts
+++ b/packages/configuration-core/src/config-access.ts
@@ -12,7 +12,12 @@ import { resolveProjectRoot, type FlagScope } from "./flags.js";
 import { resolveHomeDir, type ConfigPathOptions } from "./paths.js";
 import { readConfigObject, updateConfig, getAtPath, setAtPath, deleteAtPath } from "./config.js";
 import { applyMergePolicy } from "./merge.js";
-import { CONFIG_SCHEMA, getConfigDefinition, type ConfigDefinition } from "./config-schema.js";
+import {
+  CONFIG_SCHEMA,
+  describeExpectedValue,
+  getConfigDefinition,
+  type ConfigDefinition,
+} from "./config-schema.js";
 
 /** Read + parse one scope's value for a definition (no merge, no default). */
 function readScopeValue<T>(
@@ -93,10 +98,23 @@ export class ConfigScopeError extends Error {
   }
 }
 
-/** Thrown when a value fails the schema's `parse` validator. */
+/**
+ * Thrown when a value fails the schema's `parse` validator.
+ *
+ * Carries what the key accepts and an example of it, so a caller can tell the
+ * user what to type instead of only that they were wrong.
+ */
 export class ConfigValidationError extends Error {
-  constructor(public readonly key: string) {
-    super(`Invalid value for config key "${key}".`);
+  constructor(
+    public readonly key: string,
+    public readonly expected?: string,
+    public readonly example?: string
+  ) {
+    super(
+      expected
+        ? `Invalid value for config key "${key}": expected ${expected}.`
+        : `Invalid value for config key "${key}".`
+    );
     this.name = "ConfigValidationError";
   }
 }
@@ -133,7 +151,8 @@ export function setConfigValue(
   if (def.manageCommand) throw new ConfigManagedElsewhereError(key, def.manageCommand);
   if (!def.scopes.includes(scope)) throw new ConfigScopeError(key, scope, def.scopes);
   const parsed = def.parse(rawValue);
-  if (parsed === undefined) throw new ConfigValidationError(key);
+  if (parsed === undefined)
+    throw new ConfigValidationError(def.key, describeExpectedValue(def), def.example);
   updateConfig((config) => setAtPath(config, key, parsed), scope, options);
   return parsed;
 }
@@ -174,6 +193,10 @@ export interface ConfigEntryView {
   description: string;
   scopes: readonly FlagScope[];
   manageCommand?: string;
+  /** What a valid value looks like, in words. */
+  expected?: string;
+  /** An example of a valid value, as it would be typed. */
+  example?: string;
   /** Effective (merged + defaulted) value. */
   effective: unknown;
   /** Raw parsed value stored at the project scope, or undefined. */
@@ -192,6 +215,8 @@ export function listConfig(
     description: def.description,
     scopes: def.scopes,
     ...(def.manageCommand ? { manageCommand: def.manageCommand } : {}),
+    ...(describeExpectedValue(def) ? { expected: describeExpectedValue(def)! } : {}),
+    ...(def.example ? { example: def.example } : {}),
     effective: getConfigValue(def, options),
     project: readScopeValue(def, "project", options),
     global: readScopeValue(def, "global", options),

--- a/packages/configuration-core/src/config-schema.ts
+++ b/packages/configuration-core/src/config-schema.ts
@@ -41,6 +41,12 @@ export interface ConfigDefinition<T = unknown> {
   readonly manageCommand?: string;
   /** Optional example value shown in help/usage. */
   readonly example?: string;
+  /**
+   * What a valid value looks like, in words ("an array of strings"), for the
+   * message shown when one is rejected. Only needed when `parse` is a bespoke
+   * function — a shared helper describes itself, see {@link describeExpectedValue}.
+   */
+  readonly expected?: string;
 }
 
 // ── parse/normalize helpers ──────────────────────────────────────────────
@@ -72,6 +78,29 @@ export function asStringArray(raw: unknown): string[] | undefined {
     if (typeof item === "string" && item.trim() !== "") out.push(item.trim());
   }
   return out;
+}
+
+/**
+ * How each shared validator describes the value it accepts.
+ *
+ * Keyed on the validator itself rather than restated per entry, so the wording
+ * cannot drift from what is actually enforced: swapping a key's `parse` swaps
+ * its description with it.
+ */
+const PARSER_EXPECTATIONS = new Map<ConfigDefinition["parse"], string>([
+  [asBoolean, "a boolean (true or false)"],
+  [asString, "a non-empty string"],
+  [asNumber, "a number"],
+  [asStringArray, "an array of strings"],
+]);
+
+/**
+ * What a valid value for this key looks like, in words — or undefined for a
+ * bespoke validator that has not said, in which case callers describe nothing
+ * rather than guessing.
+ */
+export function describeExpectedValue(def: ConfigDefinition): string | undefined {
+  return def.expected ?? PARSER_EXPECTATIONS.get(def.parse);
 }
 
 // ── The registry ─────────────────────────────────────────────────────────

--- a/packages/configuration-core/src/config.ts
+++ b/packages/configuration-core/src/config.ts
@@ -83,20 +83,32 @@ export function setAtPath(obj: Record<string, unknown>, dottedKey: string, value
 
 /**
  * Delete the leaf at a dotted key. Returns true when something was removed.
- * Intermediate objects are left in place (an emptied parent stays as `{}`),
- * matching how the previous per-key clearers behaved.
+ *
+ * A container left empty by the delete is removed along with it, so unsetting
+ * the last key under a group restores the document to what it was before the
+ * group existed rather than leaving `{ "ios": {} }` behind — noise in a project
+ * config that gets committed. Only containers this delete emptied are removed:
+ * the walk stops at the first ancestor that still holds something, and the root
+ * object always survives (an emptied config is `{}`, never a deleted file).
  */
 export function deleteAtPath(obj: Record<string, unknown>, dottedKey: string): boolean {
   const parts = splitKey(dottedKey);
-  let cur = obj;
+  // Every container on the way to the leaf, so the emptied ones can be unwound
+  // afterwards. chain[i] holds parts[i].
+  const chain: Record<string, unknown>[] = [obj];
   for (let i = 0; i < parts.length - 1; i++) {
-    const next = cur[parts[i]!];
+    const next = chain[i]![parts[i]!];
     if (!isPlainObject(next)) return false;
-    cur = next;
+    chain.push(next);
   }
+  const parent = chain[parts.length - 1]!;
   const leaf = parts[parts.length - 1]!;
-  if (!Object.hasOwn(cur, leaf)) return false;
-  delete cur[leaf];
+  if (!Object.hasOwn(parent, leaf)) return false;
+  delete parent[leaf];
+  for (let i = chain.length - 1; i >= 1; i--) {
+    if (Object.keys(chain[i]!).length > 0) break;
+    delete chain[i - 1]![parts[i - 1]!];
+  }
   return true;
 }
 

--- a/packages/configuration-core/src/index.ts
+++ b/packages/configuration-core/src/index.ts
@@ -37,6 +37,7 @@ export {
 // The configuration schema: the registry of recognized values + parse helpers.
 export {
   CONFIG_SCHEMA,
+  describeExpectedValue,
   getConfigDefinition,
   asBoolean,
   asString,

--- a/packages/configuration-core/tests/config-access.test.ts
+++ b/packages/configuration-core/tests/config-access.test.ts
@@ -17,7 +17,11 @@ import {
   ConfigValidationError,
   ConfigManagedElsewhereError,
 } from "../src/config-access.js";
-import type { ConfigDefinition } from "../src/config-schema.js";
+import {
+  CONFIG_SCHEMA,
+  describeExpectedValue,
+  type ConfigDefinition,
+} from "../src/config-schema.js";
 
 // Sandbox both scopes: `homeDir` for global (~/.argent), `cwd` for the project
 // root (a tmp dir seeded with a `.git` marker so resolveProjectRoot stops there).
@@ -44,7 +48,8 @@ describe("dotted-path helpers", () => {
     expect(obj).toEqual({ ios: { deviceSet: "/tmp/set" } });
     expect(getAtPath(obj, "ios.deviceSet")).toBe("/tmp/set");
     expect(deleteAtPath(obj, "ios.deviceSet")).toBe(true);
-    expect(obj).toEqual({ ios: {} });
+    // The emptied parent goes with it, so unset restores the prior document.
+    expect(obj).toEqual({});
     expect(deleteAtPath(obj, "ios.deviceSet")).toBe(false);
   });
 
@@ -305,5 +310,74 @@ describe("getConfigValue — direct definition + custom-typed default", () => {
       default: "fallback",
     };
     expect(getConfigValue(def, opts())).toBe("fallback");
+  });
+});
+
+describe("every schema entry can describe itself", () => {
+  it("says what value it expects", () => {
+    for (const def of CONFIG_SCHEMA) {
+      expect(describeExpectedValue(def), `key: ${def.key}`).toBeTruthy();
+    }
+  });
+
+  it("offers an example for every key a user may set", () => {
+    for (const def of CONFIG_SCHEMA) {
+      if (def.manageCommand) continue;
+      expect(def.example, `key: ${def.key}`).toBeTruthy();
+    }
+  });
+
+  it("offers examples that are actually accepted", () => {
+    // An example that its own validator rejects would hand the user a command
+    // reproducing the error it exists to fix.
+    for (const def of CONFIG_SCHEMA) {
+      if (!def.example) continue;
+      expect(def.parse(coerceCliValue(def.example)), `key: ${def.key}`).not.toBeUndefined();
+    }
+  });
+});
+
+describe("deleteAtPath prunes only what it emptied", () => {
+  it("removes a container the delete emptied", () => {
+    const obj: Record<string, unknown> = { ios: { additionalDeviceSets: ["/a"] } };
+    expect(deleteAtPath(obj, "ios.additionalDeviceSets")).toBe(true);
+    expect(obj).toEqual({});
+  });
+
+  it("stops at the first ancestor that still holds something", () => {
+    const obj: Record<string, unknown> = { ios: { deviceSet: "x", additionalDeviceSets: ["/a"] } };
+    expect(deleteAtPath(obj, "ios.additionalDeviceSets")).toBe(true);
+    expect(obj).toEqual({ ios: { deviceSet: "x" } });
+  });
+
+  it("unwinds a chain deeper than one level", () => {
+    const obj: Record<string, unknown> = { a: { b: { c: { d: 1 } } } };
+    expect(deleteAtPath(obj, "a.b.c.d")).toBe(true);
+    expect(obj).toEqual({});
+  });
+
+  it("keeps a sibling group intact while unwinding", () => {
+    const obj: Record<string, unknown> = { a: { b: { c: 1 } }, keep: { x: 1 } };
+    expect(deleteAtPath(obj, "a.b.c")).toBe(true);
+    expect(obj).toEqual({ keep: { x: 1 } });
+  });
+
+  it("leaves an empty array sibling alone", () => {
+    const obj: Record<string, unknown> = { a: { list: [], gone: 1 } };
+    expect(deleteAtPath(obj, "a.gone")).toBe(true);
+    expect(obj).toEqual({ a: { list: [] } });
+  });
+
+  it("empties the root object rather than removing it", () => {
+    const obj: Record<string, unknown> = { lens: { agent: "claude" } };
+    expect(deleteAtPath(obj, "lens.agent")).toBe(true);
+    expect(obj).toEqual({});
+  });
+
+  it("changes nothing when the path does not resolve", () => {
+    const obj: Record<string, unknown> = { ios: { deviceSet: "x" } };
+    expect(deleteAtPath(obj, "ios.missing")).toBe(false);
+    expect(deleteAtPath(obj, "nope.missing")).toBe(false);
+    expect(obj).toEqual({ ios: { deviceSet: "x" } });
   });
 });

--- a/packages/configuration-core/tests/config.test.ts
+++ b/packages/configuration-core/tests/config.test.ts
@@ -106,7 +106,8 @@ describe("remembered agent (lens config)", () => {
     setRememberedAgent("claude");
     clearRememberedAgent();
     expect(getRememberedAgent()).toBeNull();
-    expect(readConfigFile()).toEqual({ telemetry: { enabled: true }, lens: {} });
+    // Siblings survive; the emptied `lens` container does not.
+    expect(readConfigFile()).toEqual({ telemetry: { enabled: true } });
   });
 
   it("clearing when nothing is stored is a no-op that doesn't throw", () => {


### PR DESCRIPTION
Fixes #643.

## Before / after

```
$ argent config set ios.additionalDeviceSets "~/Library/Developer/Radon/Devices" --scope project
Error: Invalid value for config key "ios.additionalDeviceSets".        # ← the whole message
```
```
$ argent config set ios.additionalDeviceSets "~/Library/Developer/Radon/Devices" --scope project
Error: Invalid value for config key "ios.additionalDeviceSets": expected an array of strings.
Did you mean: argent config set ios.additionalDeviceSets '["~/Library/Developer/Radon/Devices"]' --scope project
Run `argent config list` to see each key's expected value.
```
```
$ argent config unset ios.additionalDeviceSets --scope project
$ cat .argent/config.json
{ "ios": {} }        →        {}
```

## Symptom 1 — the message

The issue names three gaps: no expected type, no example, no pointer to `config list`. All three are
closed, plus one the issue didn't ask for and I think is the actual fix.

**The suggestion carries the user's own value.** A generic `Example: … '["~/DeviceSets/ci"]'` would
hand someone a path they have never heard of and expect them to spot the difference. Where the
correction is mechanical — a single item offered to a list-valued key — the error offers back what
they typed, wrapped, shell-quoted, and **on the scope they asked for**. Pasting it works; verified
live that it lands in project scope, not global.

Nothing is coerced. The issue floated accepting a bare string and storing it wrapped; I didn't,
because `config set` persists, gets committed, and is read by other machines, so a value silently
stored in a shape the user didn't type is expensive to debug and `coerceCliValue` already has one
silent fallback. Showing the corrected command costs the user one keystroke and keeps the store
honest. If a reviewer prefers coercion, this is the smaller change to build on.

**The expected shape comes from the validator, not a per-key string** — `asStringArray` *is* "an
array of strings", so swapping a key's `parse` swaps its description with it and the two cannot
drift. A bespoke validator can override via a new optional `expected`, and degrades to today's exact
message if it says nothing.

**`config list` states it too.** The issue notes `list` doesn't close the gap either — its
description describes the *elements* but never says the value is a list. It now shows
`value: an array of strings, e.g. ["~/DeviceSets/ci"]`, and `list --json` carries both fields.

`telemetry.enabled` deliberately gets no example: `setConfigValue` refuses it before validating
(it's managed by `argent telemetry`), so a "here's how to set it" hint would point at a command you
may not run. A schema guard test keeps that honest as keys are added — and asserts every example
**actually round-trips through its own validator**, so an example can never ship that reproduces the
error it exists to fix.

## Symptom 2 — the empty group

Deleting a key now removes any container the delete emptied, stopping at the first ancestor that
still holds something.

**This is file hygiene, not a behaviour change.** I traced every raw reader of the document —
`readConfigObject`, and telemetry's `consent.ts` and `notice.ts`, which each do their own read — and
an empty parent is already indistinguishable from an absent one: `getAtPath` returns `undefined`
either way, before `parse`, so the merge layer never sees a container at all. The only observable
difference is the bytes on disk, which is exactly the complaint.

Guards worth noting:

- **The root always survives** — an emptied config is `{}`, never a deleted file. `.argent/` is
  itself a project-root marker, so removing the file wouldn't restore the prior state anyway, and
  `updateConfig` is a shared publish path with a lock/rename protocol that has no defined meaning for
  file removal.
- **A no-op unset still doesn't touch the file.** That fast path exists so an unset that removes
  nothing can't materialise a project config and dirty git status; pruning lives inside the mutate
  callback, which the fast path returns before reaching. So a group someone deliberately left empty
  by hand is never tidied away — pinned by a test asserting the file stays byte-identical.
- Siblings at any level stop the unwind, including an empty array value, which is preserved.

**Two existing tests asserted the old behaviour and now assert the new one** —
`config-access.test.ts:47` and `config.test.ts:109` (the latter is `clearRememberedAgent`'s
sibling-preservation test, so it doubles as proof siblings survive).

## Known same-class case, not fixed here

`resetFirstRunNotice` (`packages/telemetry/src/notice.ts`) does its own inline delete and still
leaves `{"notices":{}}`. It doesn't go through `deleteAtPath`, so it doesn't inherit this. It's a
one-line change to route it through the same function — happy to do it here or as a follow-up, but
it pulls the telemetry package into a config PR so I left it out by default.

## Verification

Live against the built CLI: the reported case; pasting the suggestion back and confirming it lands in
**project** scope; unset leaving `{}`; a sibling key surviving; a non-array key correctly getting the
generic example and *no* bogus "Did you mean"; `config list` output; `telemetry.enabled` still
delegating unchanged.

configuration-core 103 passed, argent-cli 285 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)