### PR TITLE
fix(flags): stop reporting success for a flag that cannot take effect on this host

### DIFF
--- a/packages/argent-cli/src/flags.ts
+++ b/packages/argent-cli/src/flags.ts
@@ -13,6 +13,7 @@
 import pc from "picocolors";
 import {
   FLAG_REGISTRY,
+  flagSupportsPlatform,
   getFlagDefinition,
   getFlagsPath,
   readFlags,
@@ -98,19 +99,55 @@ function parseScope(raw: string): FlagScope {
   throw new Error(`--scope must be "project" or "global", got "${raw}"`);
 }
 
+// Platform names as users know them, for messages. Anything unlisted falls
+// through to the raw `process.platform` value rather than being hidden.
+const PLATFORM_NAMES: Record<string, string> = {
+  darwin: "macOS",
+  win32: "Windows",
+  linux: "Linux",
+};
+
+function platformName(platform: string): string {
+  return PLATFORM_NAMES[platform] ?? platform;
+}
+
+/**
+ * A short note that a flag's feature does not exist everywhere, or "" when it
+ * does. Rendered from the flag's declared platforms rather than written into
+ * its description, so the two can never disagree.
+ */
+function platformBadge(def: FlagDefinition, platform: NodeJS.Platform): string {
+  if (def.platforms === undefined) return "";
+  const supported = def.platforms.map(platformName).join(", ");
+  return flagSupportsPlatform(def, platform)
+    ? `[${supported} only]`
+    : `[${supported} only — unavailable on ${platformName(platform)}]`;
+}
+
 // Renders the registry as an indented "Available flags:" block for --help
 // output: one line per flag, `name <padding> description`, so users can see
 // what they can toggle without running `argent flags` first.
-function formatAvailableFlags(registry: readonly FlagDefinition[]): string {
+function formatAvailableFlags(
+  registry: readonly FlagDefinition[],
+  platform: NodeJS.Platform
+): string {
   if (registry.length === 0) {
     return "Available flags:\n  (none defined)";
   }
   const maxName = registry.reduce((m, def) => Math.max(m, def.name.length), 0);
-  const lines = registry.map((def) => `  ${def.name.padEnd(maxName)}  ${def.description}`);
+  const lines = registry.map((def) => {
+    // Prefixed so a truncated read still carries the constraint.
+    const badge = platformBadge(def, platform);
+    return `  ${def.name.padEnd(maxName)}  ${badge ? `${badge} ` : ""}${def.description}`;
+  });
   return ["Available flags:", ...lines].join("\n");
 }
 
-function printToggleHelp(command: "enable" | "disable", registry: readonly FlagDefinition[]): void {
+function printToggleHelp(
+  command: "enable" | "disable",
+  registry: readonly FlagDefinition[],
+  platform: NodeJS.Platform
+): void {
   const summary =
     command === "enable"
       ? "Enable a predefined feature flag (see `argent flags`) at the chosen scope."
@@ -120,7 +157,7 @@ function printToggleHelp(command: "enable" | "disable", registry: readonly FlagD
 
 ${summary}
 
-${formatAvailableFlags(registry)}
+${formatAvailableFlags(registry, platform)}
 
 Storage:
   ~/.argent/flags.json                 (global, default)
@@ -135,10 +172,11 @@ Options:
 function runToggle(
   argv: string[],
   command: "enable" | "disable",
-  registry: readonly FlagDefinition[]
+  registry: readonly FlagDefinition[],
+  platform: NodeJS.Platform
 ): void {
   if (argv.includes("--help") || argv.includes("-h")) {
-    printToggleHelp(command, registry);
+    printToggleHelp(command, registry, platform);
     return;
   }
 
@@ -178,29 +216,51 @@ function runToggle(
 
   if (command === "enable") {
     console.log(`Enabled flag "${parsed.name}" (${parsed.scope}). Stored at ${filePath}.`);
+    // The flag is stored either way — it may well be authored here for a
+    // teammate or a CI host that does support it. Say plainly that nothing
+    // changes *here*, and claim nothing about machines this one cannot see.
+    const def = getFlagDefinition(parsed.name, registry);
+    if (def && !flagSupportsPlatform(def, platform)) {
+      const supported = def.platforms!.map(platformName).join(", ");
+      console.error(
+        `Note: "${parsed.name}" is ${supported}-only, so enabling it has no effect on ${platformName(platform)}.`
+      );
+    }
   } else {
     console.log(`Disabled flag "${parsed.name}" (${parsed.scope}).`);
   }
 }
 
-export function enable(argv: string[], registry: readonly FlagDefinition[] = FLAG_REGISTRY): void {
-  runToggle(argv, "enable", registry);
+export function enable(
+  argv: string[],
+  registry: readonly FlagDefinition[] = FLAG_REGISTRY,
+  platform: NodeJS.Platform = process.platform
+): void {
+  runToggle(argv, "enable", registry, platform);
 }
 
-export function disable(argv: string[], registry: readonly FlagDefinition[] = FLAG_REGISTRY): void {
-  runToggle(argv, "disable", registry);
+export function disable(
+  argv: string[],
+  registry: readonly FlagDefinition[] = FLAG_REGISTRY,
+  platform: NodeJS.Platform = process.platform
+): void {
+  runToggle(argv, "disable", registry, platform);
 }
 
 // `argent flags` — list every registry flag with its description and effective
 // state (project overrides global; unset flags read as disabled).
-export function flags(argv: string[], registry: readonly FlagDefinition[] = FLAG_REGISTRY): void {
+export function flags(
+  argv: string[],
+  registry: readonly FlagDefinition[] = FLAG_REGISTRY,
+  platform: NodeJS.Platform = process.platform
+): void {
   if (argv.includes("--help") || argv.includes("-h")) {
     console.log(`Usage: argent flags [--json]
 
 List the available feature flags and their current state. Flags are
 predefined; project-scoped values override global ones.
 
-${formatAvailableFlags(registry)}
+${formatAvailableFlags(registry, platform)}
 
 Options:
   --json   Print machine-readable JSON
@@ -226,6 +286,10 @@ Options:
       // An unset opt-out flag reads as on (its declared default).
       enabled: eff?.value ?? def.defaultEnabled ?? false,
       scope: eff?.scope ?? null,
+      // Null when the feature works everywhere. Deliberately the durable fact
+      // rather than a "supported here" boolean, which would be wrong the moment
+      // the output is read on another host.
+      platforms: def.platforms ? [...def.platforms] : null,
     };
   });
 
@@ -266,7 +330,13 @@ Options:
     const maxName = registryView.reduce((m, f) => Math.max(m, f.name.length), 0);
     for (const f of registryView) {
       const scopeLabel = f.scope ? ` (${f.scope})` : "";
-      console.log(`  ${f.name.padEnd(maxName, " ")}  ${colorState(f.enabled)}${scopeLabel}`);
+      const def = getFlagDefinition(f.name, registry);
+      // Beside the "enabled" word, which is exactly what misleads without it.
+      const badge = def ? platformBadge(def, platform) : "";
+      const badgeLabel = badge ? `  ${badge}` : "";
+      console.log(
+        `  ${f.name.padEnd(maxName, " ")}  ${colorState(f.enabled)}${scopeLabel}${badgeLabel}`
+      );
       console.log(`  ${" ".repeat(maxName)}  ${f.description}`);
     }
   }

--- a/packages/argent-cli/test/flags.test.ts
+++ b/packages/argent-cli/test/flags.test.ts
@@ -27,6 +27,11 @@ const TEST_REGISTRY: readonly FlagDefinition[] = [
     description: "On by default; disable persists off.",
     defaultEnabled: true,
   },
+  {
+    name: "mac-only-flag",
+    description: "Only exists on macOS.",
+    platforms: ["darwin"],
+  },
 ];
 
 // All tests redirect global+project storage into tmp dirs by mutating
@@ -312,6 +317,7 @@ describe("flags (list) CLI", () => {
     expect(a).toEqual({
       name: "a",
       description: "Listing flag A.",
+      platforms: null,
       enabled: false,
       scope: "project",
     });
@@ -389,5 +395,76 @@ describe("deprecating a flag (removed from FLAG_REGISTRY)", () => {
       enabled: true,
       scope: "global",
     });
+  });
+});
+
+describe("a flag whose feature does not exist on this platform", () => {
+  it("stores the flag but says it changes nothing here", () => {
+    const out = captureConsole(() => enable(["mac-only-flag"], TEST_REGISTRY, "linux"));
+
+    // Still stored: the flag may well be authored here for a teammate or a CI
+    // host that does support it.
+    expect(readFlags("global")).toEqual({ "mac-only-flag": true });
+    expect(out.stdout).toContain('Enabled flag "mac-only-flag" (global)');
+    expect(out.stderr).toContain("macOS-only");
+    expect(out.stderr).toContain("no effect on Linux");
+  });
+
+  it("says nothing on a platform that does support it", () => {
+    const out = captureConsole(() => enable(["mac-only-flag"], TEST_REGISTRY, "darwin"));
+
+    expect(out.stderr).toBe("");
+    expect(readFlags("global")).toEqual({ "mac-only-flag": true });
+  });
+
+  it("can still be authored at project scope from an unsupported host", () => {
+    const out = captureConsole(() =>
+      enable(["mac-only-flag", "--scope", "project"], TEST_REGISTRY, "linux")
+    );
+
+    expect(out.stderr).toContain("macOS-only");
+    expect(readFlags("project")).toEqual({ "mac-only-flag": true });
+    expect(readFlags("global")).toEqual({});
+  });
+
+  it("says nothing extra for a flag that works everywhere", () => {
+    const out = captureConsole(() => enable(["my-feature-flag"], TEST_REGISTRY, "linux"));
+
+    expect(out.stderr).toBe("");
+  });
+
+  it("says nothing on disable, which cannot raise a false expectation", () => {
+    captureConsole(() => enable(["mac-only-flag"], TEST_REGISTRY, "linux"));
+    const out = captureConsole(() => disable(["mac-only-flag"], TEST_REGISTRY, "linux"));
+
+    expect(out.stderr).toBe("");
+    expect(readFlags("global")).toEqual({});
+  });
+
+  it("marks the constraint in the listing, on supported and unsupported hosts alike", () => {
+    const onLinux = captureConsole(() => flagsCmd([], TEST_REGISTRY, "linux"));
+    expect(onLinux.stdout).toContain("[macOS only — unavailable on Linux]");
+
+    // Kept on macOS too: it warns a mac user this will not work for their CI.
+    const onMac = captureConsole(() => flagsCmd([], TEST_REGISTRY, "darwin"));
+    expect(onMac.stdout).toContain("[macOS only]");
+    expect(onMac.stdout).not.toContain("unavailable");
+  });
+
+  it("reports the platforms it needs, not whether this host happens to match", () => {
+    // A boolean would be wrong the moment the output is read on another host.
+    const out = captureConsole(() => flagsCmd(["--json"], TEST_REGISTRY, "linux"));
+    const parsed = JSON.parse(out.stdout);
+
+    const macOnly = parsed.flags.find((f: { name: string }) => f.name === "mac-only-flag");
+    expect(macOnly.platforms).toEqual(["darwin"]);
+    const everywhere = parsed.flags.find((f: { name: string }) => f.name === "my-feature-flag");
+    expect(everywhere.platforms).toBeNull();
+  });
+
+  it("carries the constraint into the help text", () => {
+    const out = captureConsole(() => enable(["--help"], TEST_REGISTRY, "linux"));
+
+    expect(out.stdout).toContain("[macOS only — unavailable on Linux] Only exists on macOS.");
   });
 });

--- a/packages/configuration-core/src/flags.ts
+++ b/packages/configuration-core/src/flags.ts
@@ -45,6 +45,25 @@ export interface FlagDefinition {
   // entry both read as on. Omit (falsey) for the usual opt-IN flags, which are
   // off until enabled. Runtime callers get the default via `isFeatureEnabled`.
   readonly defaultEnabled?: boolean;
+  // Platforms the underlying feature exists on. Omit when it works everywhere.
+  // Listing them lets `argent enable` and `argent flags` say so, instead of
+  // reporting success for a flag that cannot take effect on this host.
+  //
+  // Reads stay platform-blind on purpose: a flag committed to a project by a
+  // teammate on a supported host must not behave differently here, so this
+  // affects what the CLI *says*, never what `isFlagEnabled` answers.
+  readonly platforms?: readonly NodeJS.Platform[];
+}
+
+/**
+ * Whether a flag's feature exists on a platform. A flag that lists no platforms
+ * works everywhere.
+ */
+export function flagSupportsPlatform(
+  def: FlagDefinition,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  return def.platforms === undefined || def.platforms.includes(platform);
 }
 
 // The flags argent recognizes. Adding one entry here is the only change needed
@@ -58,6 +77,11 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     name: "argent-lens",
     description:
       "Argent Lens — the propose_variant / await_user_selection tools and the Electron preview window for staging UI design variants and letting a human pick among them. Off by default while the feature is in development.",
+    // The Lens window and `argent lens` drive Terminal/iTerm and the simulator
+    // stream through macOS-only paths, so the tools are not registered at all
+    // elsewhere. Must stay in step with the platform gate in the tool-server's
+    // setup-registry, which a test pins.
+    platforms: ["darwin"],
   },
   {
     name: "artifacts-list-endpoint",

--- a/packages/configuration-core/src/index.ts
+++ b/packages/configuration-core/src/index.ts
@@ -1,5 +1,6 @@
 export {
   FLAG_REGISTRY,
+  flagSupportsPlatform,
   getFlagDefinition,
   findProjectRoot,
   resolveProjectRoot,

--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -162,7 +162,7 @@ Prompt keywords: flow, repeat, test X times
 
 PROPOSING DESIGN VARIANTS FOR HUMAN SELECTION
 Use skill: `argent-lens`
-When: The user asks for design alternatives / options / A-B choices for a screen or component, or you have produced more than one candidate look for an element and want a human to pick before committing. Covers the build → navigate → screenshot → propose_variant loop and the single blocking await_user_selection call. (Gated behind the `argent-lens` flag, off by default — run `argent enable argent-lens` first.)
+When: The user asks for design alternatives / options / A-B choices for a screen or component, or you have produced more than one candidate look for an element and want a human to pick before committing. Covers the build → navigate → screenshot → propose_variant loop and the single blocking await_user_selection call. (macOS only — the tools are not registered on other platforms and enabling the flag there does nothing. Gated behind the `argent-lens` flag, off by default — run `argent enable argent-lens` first.)
 Prompt keywords: variant, design option, alternative, A/B, "let me pick", "show me options"
 </skill_routing>
 

--- a/packages/skills/skills/argent-lens/SKILL.md
+++ b/packages/skills/skills/argent-lens/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: argent-lens
-description: Propose multiple visual design variants for on-screen elements and let the human pick in the Argent Lens window. Use when the user asks for design alternatives / options / A-B choices for a screen or component, or any time you have produced more than one candidate look for an element and want a human decision before committing.
+description: macOS only. Propose multiple visual design variants for on-screen elements and let the human pick in the Argent Lens window. Use when the user asks for design alternatives / options / A-B choices for a screen or component, or any time you have produced more than one candidate look for an element and want a human decision before committing.
 ---
 
-> **Prerequisite — feature flag.** This workflow is gated behind the `argent-lens` flag (off by default). Run `argent enable argent-lens` once before using it. If `propose_variant` / `await_user_selection` come back not-found, the flag is off — enable it and retry.
+> **Prerequisite — macOS, and a feature flag.** This workflow is gated behind the `argent-lens` flag (off by default). Run `argent enable argent-lens` once before using it. If `propose_variant` / `await_user_selection` come back not-found, the flag is off — enable it and retry.
+>
+> **On any other platform these tools do not exist**, and enabling the flag will not create them: they are only registered on macOS. `argent enable` there stores the setting and says so. If you are not on macOS, do not retry — tell the user Argent Lens is macOS-only and pick a different approach.
 
 ## 1. Overview
 

--- a/packages/skills/skills/argent-lens/SKILL.md
+++ b/packages/skills/skills/argent-lens/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: argent-lens
-description: macOS only. Propose multiple visual design variants for on-screen elements and let the human pick in the Argent Lens window. Use when the user asks for design alternatives / options / A-B choices for a screen or component, or any time you have produced more than one candidate look for an element and want a human decision before committing.
+description: Propose multiple visual design variants for on-screen elements and let the human pick in the Argent Lens window (macOS only — the tools do not exist on other platforms). Use when the user asks for design alternatives / options / A-B choices for a screen or component, or any time you have produced more than one candidate look for an element and want a human decision before committing.
 ---
 
 > **Prerequisite — macOS, and a feature flag.** This workflow is gated behind the `argent-lens` flag (off by default). Run `argent enable argent-lens` once before using it. If `propose_variant` / `await_user_selection` come back not-found, the flag is off — enable it and retry.

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -200,6 +200,13 @@ export function createRegistry(): Registry {
   // enable/disable argent-lens` takes effect on the next tools/list WITHOUT
   // restarting the long-lived tool-server. Platform gates at registration; the
   // flag gates at the exposure boundary.
+  //
+  // The same macOS-only fact is declared on the flag itself (`platforms` in
+  // FLAG_REGISTRY) so `argent enable` and `argent flags` can say so instead of
+  // reporting success for a flag that cannot take effect. The two are kept
+  // separate rather than derived from one another: reading the registry here
+  // would register these tools on every platform the day the flag graduates and
+  // its entry is removed. A test pins them together.
   if (process.platform === "darwin") {
     registry.registerTool(createProposeVariantTool(registry));
     registry.registerTool(awaitUserSelectionTool);

--- a/packages/tool-server/test/lens-tools-platform-gate.test.ts
+++ b/packages/tool-server/test/lens-tools-platform-gate.test.ts
@@ -46,3 +46,24 @@ describe("Argent Lens tools — macOS-only registration gate", () => {
     expect(registry.getTool("list-devices")).toBeDefined();
   });
 });
+
+/**
+ * The registration gate and the flag's declared platforms are two statements of
+ * the same fact, in two packages. They are kept separate deliberately — deriving
+ * registration from the registry would register the tools everywhere the day the
+ * flag graduates and its entry is removed — so this pins them together instead.
+ */
+describe("the flag's declared platforms match where the tools actually register", () => {
+  it("declares darwin, and registers exactly there", async () => {
+    const { getFlagDefinition } = await import("@argent/configuration-core");
+    const declared = getFlagDefinition("argent-lens")?.platforms;
+    expect(declared).toEqual(["darwin"]);
+
+    for (const platform of ["darwin", "linux", "win32"] as NodeJS.Platform[]) {
+      setPlatform(platform);
+      const createRegistry = await freshCreateRegistry();
+      const registered = createRegistry().getTool("propose_variant") !== undefined;
+      expect(registered, `platform: ${platform}`).toBe(declared!.includes(platform));
+    }
+  });
+});


### PR DESCRIPTION
Fixes #642.

Reproduced on a real Linux VM (Ubuntu aarch64, Node 20, published `0.18.0`), not simulated:

```
$ argent tools | wc -l                          75
$ argent enable argent-lens
Enabled flag "argent-lens" (global). Stored at /home/filip.guest/.argent/flags.json.
$ argent tools | wc -l                          75      ← unchanged
$ argent tools | grep -c 'propose_variant'       0
```

After, on the same VM:

```
$ argent enable argent-lens                     # exit 0
stdout: Enabled flag "argent-lens" (global). Stored at /home/filip.guest/.argent/flags.json.
stderr: Note: "argent-lens" is macOS-only, so enabling it has no effect on Linux.

$ argent flags
  argent-lens   enabled  (global)  [macOS only — unavailable on Linux]
```

## The gap

The darwin registration gate is deliberate and well-commented. What was missing is that
`FLAG_REGISTRY` carried no platform information, so the CLI could not know. A flag can now declare
`platforms`, and `argent flags` / `enable` render from it.

Note `argent lens` **already** told the truth on Linux ("macOS-only — it drives Terminal/iTerm via
osascript"). That asymmetry is the whole bug.

## Decisions a reviewer should weigh

**Warn and store, exit 0 — not refuse.** `enable` authors portable state rather than performing an
action: `flags.json` gets committed, and a Linux teammate must be able to author project-scope config
for macOS colleagues. Refusing would also turn a silent no-op into a hard failure for any shared
bootstrap script running under `set -e` — a behaviour regression well beyond a message fix. The
counter-argument (exit 2 is unambiguous and machine-readable) is real; I weighted the regression
higher for a truthfulness fix.

**The note claims nothing about other machines.** An earlier draft ended "…and will apply on macOS."
That is false in the default global scope — `~/.argent/flags.json` on this Linux box will never be
read by a mac — and wrong again under `argent link`, where registration and flag reads happen on the
*remote* host. The note now states only what is true of the host in front of you.

**Reads stay platform-blind, permanently.** `isFlagEnabled` sits in the per-request exposure path and
its package is documented as having no console I/O; more importantly, a flag committed by a macOS
teammate must behave identically here. There is a named test pinning this so a later "improvement"
gets caught with its reason attached.

**The registration gate is NOT derived from the registry**, though that was tempting for
single-source-of-truth. Deriving fails in the wrong direction: `getFlagDefinition` returns undefined
once the flag graduates and its entry is removed — and this flag's own description says "while the
feature is in development", so removal is the expected end state — which would register the Lens
tools on *every* platform, exactly what the gate exists to prevent. The two statements are pinned
together by a test that asserts registration matches the declared platforms across darwin/linux/win32.

**`flags --json` reports `platforms`, not `supportedOnThisPlatform`.** A per-host boolean encodes
process state as flag data and is wrong the moment the output is read elsewhere or under `link`.
Additive field; the one in-repo consumer is a test, updated here.

## Also fixed: an infinite loop in the Lens skill

`skills/argent-lens/SKILL.md` told the model: if the tools come back not-found, the flag is off —
enable it and retry. On Linux enabling never creates them, and there was no terminal condition. It
now states the platform in the frontmatter `description` (the line a router reads *before* invoking
the skill, so a Linux agent isn't handed it in the first place) and gives the exit condition: do not
retry, tell the user.

## Verification

**Linux VM:** exit 0 with the Enabled line on stdout and the note on stderr; `flags.json` written;
`flags` badge; `--json` `platforms: ["darwin"]` vs `null` for an unconstrained flag; **`tools | wc -l`
still 75**, proving registration was untouched; `disable` silent; an unconstrained flag gets no note.

**macOS:** `enable` silent on stderr, exit 0, both Lens tools still registered, badge renders
`[macOS only]` with no "unavailable" suffix.

configuration-core 93 passed, argent-cli 285 passed, tool-server 3087 passed.
Unchanged and still passing: `registry-feature-flag-gate.test.ts`, `variant-flag-gate.test.ts` and the
HTTP exposure tests — exposure semantics do not change.

## Update (2026-09-17): merged current main

- Merged `origin/main`; resolved conflicts with the declarative option parser (#953) and the comment audit (#931).
- `microinteractions` (added in #803 after this PR was opened) now also declares `platforms: ["darwin"]`: its window animation is inert off-darwin, so it had the same false-success problem. "macOS only" moved out of its description into the rendered badge.
- `docs/reference/configuration.mdx` documents the badge, the stderr note, and the `platforms` field of `flags --json`.
- The registry/registration pinning test got a 30 s timeout (three cold imports of the registry).

Re-verified on macOS with a sandboxed HOME and `process.platform` forced to `linux`: 0.25.0 prints plain success for `argent-lens` / `microinteractions`; this branch still exits 0 and stores the flag, adds the stderr note, and badges both in `flags` and `enable --help`. `boot-sound` is unchanged. On real darwin stderr stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
