### PR TITLE
build: keep the local daemon builds universal, matching CI

### DIFF
--- a/packages/native-devtools-ios/scripts/build.sh
+++ b/packages/native-devtools-ios/scripts/build.sh
@@ -212,6 +212,8 @@ else
     ${EXTRA_CFLAGS[@]+"${EXTRA_CFLAGS[@]}"} \
     -isysroot "${SDK_PATH}" \
     -target arm64-apple-ios17.0-simulator \
+    -arch arm64 \
+    -arch x86_64 \
     -framework Foundation -framework UIKit -framework CoreGraphics \
     -lobjc \
     -o "${AX_DEST}" "${AX_SRC_DIR}/ax_service.m"
@@ -312,6 +314,8 @@ if [[ "$TRANSPORT" == "unix" ]]; then
       ${EXTRA_CFLAGS[@]+"${EXTRA_CFLAGS[@]}"} \
       -isysroot "${TVOS_SDK_PATH}" \
       -target arm64-apple-tvos17.0-simulator \
+      -arch arm64 \
+      -arch x86_64 \
       -framework Foundation -framework UIKit -framework CoreGraphics \
       -lobjc \
       -o "${TVOS_AX_DEST}" "${TVOS_SRC_DIR}/tvos_ax_service.m"
@@ -324,6 +328,9 @@ if [[ "$TRANSPORT" == "unix" ]]; then
     clang \
       -fobjc-arc \
       ${EXTRA_CFLAGS[@]+"${EXTRA_CFLAGS[@]}"} \
+      -mmacosx-version-min=14.0 \
+      -arch arm64 \
+      -arch x86_64 \
       -framework Foundation -framework AppKit -framework CoreGraphics \
       -o "${TVOS_HID_DEST}" "${TVOS_SRC_DIR}/tvos_hid_daemon.m"
   fi


### PR DESCRIPTION
Companion to software-mansion/argent-private#29. Together they fix #639.

## Split of work

The binaries users install are **not** built by this script — they come from
`build-native-binaries.yml` in `argent-private`, which duplicates the compile commands inline. So the
load-bearing fix is [argent-private#29](https://github.com/software-mansion/argent-private/pull/29);
this PR keeps `build.sh` (the `pack:mcp:local` path) in step, which that workflow's own comment
promises it mirrors. Letting them drift is how the gap appeared.

## The change

The three daemon compiles built arm64 only while the dylibs five lines away already cross-compile
both slices, so a locally packed tarball had a universal `simulator-server` next to an arm64-only
`ax-service`. `-target` is kept and `-arch arm64 -arch x86_64` added — identical output, but the
platform stays pinned by something that fails loudly rather than by a flag whose loss would silently
yield a macOS binary that packs fine and only dies at `simctl spawn`.

`tvos-hid-daemon` also gets `-mmacosx-version-min=14.0`. It was the only compile with no deployment
target, so its floor was whatever Xcode built it — on a current machine that is macOS 26, which would
exclude nearly every Intel Mac the x86_64 slice exists for. 14.0 is what the shipped binary already
reports, so this is a no-op against the current artifact.

## Verification

Ran this script end to end against the real private sources:

```
ax-service        x86_64 arm64     IOSSIMULATOR 17.0  (both slices)
tvos-ax-service   x86_64 arm64     TVOSSIMULATOR 17.0 (both slices)
tvos-hid-daemon   x86_64 arm64     MACOS 14.0         (both slices, was 26.0 locally)
libNativeDevtoolsIos.dylib  x86_64 arm64  (unchanged)
```

**Not verified:** that the x86_64 slices *run* — no Intel Mac and no x86_64 simulator runtime here.
This restores a build pattern the repo already uses everywhere else; it is not a tested claim of Intel
support, and no doc is changed to say otherwise.

## Note for whoever merges

Merging both PRs is still not enough for the fix to reach an npm release: `publish-npm.yml` pins a
frozen `argent-<ref>` binaries tag built by a manual dispatch of the private workflow. After
argent-private#29 lands, that workflow needs a dispatch against the tag the next release will use.