### PR TITLE
fix(cli): stop `argent mcp --help` starting the server, and `argent tools --help` dumping the catalogue

### DIFF
--- a/packages/argent-cli/src/tools.ts
+++ b/packages/argent-cli/src/tools.ts
@@ -53,9 +53,32 @@ export async function tools(argv: string[], options: ToolsCommandOptions): Promi
     if (meta.outputHint) console.log(`\nOutput hint: ${meta.outputHint}`);
   }
 
+  function printUsage(): void {
+    console.log(`Usage:
+  argent tools                       List available tools
+  argent tools describe <name>       Show one tool's flags and description
+
+Options:
+  --json                             Print machine-readable JSON
+  --help, -h                         Show this help
+
+Listing tools contacts the argent tool-server, starting one if none is running.
+`);
+  }
+
   const json = argv.includes("--json");
-  const positional = argv.filter((a) => !a.startsWith("--"));
+  // A help flag in the subcommand slot is a request for this command's usage.
+  // It has to be recognised before anything contacts the tool-server, and it
+  // must not swallow a later one: `argent tools describe <name> --help` asks
+  // for that tool's flags, which `describeTool` prints.
+  const isHelpFlag = (a: string) => a === "--help" || a === "-h";
+  const positional = argv.filter((a) => !a.startsWith("--") || isHelpFlag(a));
   const sub = positional[0];
+
+  if (sub !== undefined && isHelpFlag(sub)) {
+    printUsage();
+    return;
+  }
 
   if (!sub) {
     await listTools(json);
@@ -69,17 +92,6 @@ export async function tools(argv: string[], options: ToolsCommandOptions): Promi
       process.exit(1);
     }
     await describeTool(name, json);
-    return;
-  }
-
-  if (sub === "--help" || sub === "-h") {
-    console.log(`Usage:
-  argent tools                       List available tools
-  argent tools describe <name>       Show one tool's flags and description
-
-Options:
-  --json                             Print machine-readable JSON
-`);
     return;
   }
 

--- a/packages/argent-cli/test/tools-help.test.ts
+++ b/packages/argent-cli/test/tools-help.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tools } from "../src/tools.js";
+
+// `argent tools --help` used to print the whole tool catalogue — and to contact
+// the tool-server (starting one) to get it — because the help flag was filtered
+// out before the subcommand was read. These drive the real entry point with a
+// mocked client so "did it reach the server" is observable.
+
+const toolsClientMock = vi.hoisted(() => ({
+  fetchTool: vi.fn(),
+  fetchTools: vi.fn(),
+}));
+
+vi.mock("@argent/tools-client", () => ({
+  createToolsClient: vi.fn(() => toolsClientMock),
+}));
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  toolsClientMock.fetchTools.mockResolvedValue([
+    { name: "gesture-tap", description: "Tap the screen" },
+  ]);
+  toolsClientMock.fetchTool.mockResolvedValue({
+    name: "gesture-tap",
+    description: "Tap the screen",
+    inputSchema: { type: "object", properties: { udid: { type: "string" } }, required: ["udid"] },
+  });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+const output = () => (logSpy.mock.calls as unknown[][]).map((c) => String(c[0] ?? "")).join("\n");
+
+const invoke = (argv: string[]) => tools(argv, { paths: {} as never });
+
+describe("argent tools --help", () => {
+  it.each([["--help"], ["-h"], ["--help", "--json"], ["--json", "--help"]])(
+    "prints usage for %j without contacting the tool-server",
+    async (...argv) => {
+      await invoke(argv);
+
+      expect(output()).toContain("argent tools describe <name>");
+      expect(output()).toContain("--help, -h");
+      // The defect: help used to start a tool-server just to list tools.
+      expect(toolsClientMock.fetchTools).not.toHaveBeenCalled();
+      expect(toolsClientMock.fetchTool).not.toHaveBeenCalled();
+    }
+  );
+
+  it("still lists tools when no subcommand is given", async () => {
+    await invoke([]);
+    expect(toolsClientMock.fetchTools).toHaveBeenCalled();
+  });
+
+  it("still describes a named tool", async () => {
+    await invoke(["describe", "gesture-tap"]);
+    expect(toolsClientMock.fetchTool).toHaveBeenCalledWith("gesture-tap");
+  });
+
+  it("leaves a trailing --help for the tool being described", async () => {
+    // `argent tools describe <name> --help` asks for that tool's flags, not for
+    // this command's usage.
+    await invoke(["describe", "gesture-tap", "--help"]);
+
+    expect(toolsClientMock.fetchTool).toHaveBeenCalledWith("gesture-tap");
+    expect(output()).not.toContain("argent tools describe <name>");
+  });
+});

--- a/packages/argent/src/cli.ts
+++ b/packages/argent/src/cli.ts
@@ -79,7 +79,7 @@ argent v${version}
 Usage: argent <command> [options]
 
 Commands:
-  mcp         Start the MCP stdio server (used by editors)
+  mcp         ${installerHelpEntry("mcp")}
   init        ${installerHelpEntry("init")}
   install     ${installerHelpEntry("install")}
   update      ${installerHelpEntry("update")}
@@ -122,11 +122,12 @@ async function loadCli(): Promise<typeof Cli> {
 }
 
 async function main(): Promise<void> {
-  // The installer subcommands (init / install / update / uninstall / remove)
-  // forward their argv straight to the side-effecting installer functions,
-  // which do not short-circuit on `--help` — so `argent uninstall --help`
-  // would run the real (destructive) command. Intercept help for exactly that
-  // set before dispatching. All other subcommands handle `--help` themselves.
+  // Some subcommands never look at their own argv: the installers forward it
+  // to side-effecting functions that ignore `--help` (so `argent uninstall
+  // --help` would run the real, destructive command), and `mcp` is handed no
+  // argv at all, so a help flag there starts the stdio server and blocks
+  // reading JSON-RPC from stdin. Intercept help for that set before
+  // dispatching. Every other subcommand parses `--help` itself.
   if (installerHelpRequested(command, rest)) {
     // installerHelpRequested only returns true for an InstallerCommand.
     printInstallerHelp(command as Parameters<typeof printInstallerHelp>[0]);

--- a/packages/argent/src/installer-help.ts
+++ b/packages/argent/src/installer-help.ts
@@ -19,8 +19,20 @@
  * and detail lines from `INSTALLER_COMMAND_META` so the two can't drift.
  */
 
-/** Installer subcommands that lack their own `--help` handling. */
-export const INSTALLER_COMMANDS = ["init", "install", "update", "uninstall", "remove"] as const;
+/**
+ * Subcommands whose argv never reaches a `--help` handler. The installers
+ * forward theirs to side-effecting functions that do not check it; `mcp` is
+ * handed no argv at all — `startMcpServer` takes only its paths — so a help
+ * flag there starts the stdio server and blocks reading JSON-RPC from stdin.
+ */
+export const INSTALLER_COMMANDS = [
+  "init",
+  "install",
+  "update",
+  "uninstall",
+  "remove",
+  "mcp",
+] as const;
 
 export type InstallerCommand = (typeof INSTALLER_COMMANDS)[number];
 
@@ -57,6 +69,9 @@ export const VALUE_TAKING_FLAGS: Record<InstallerCommand, readonly string[]> = {
   update: ["--version", "--project-root"],
   uninstall: [],
   remove: [],
+  // `mcp` parses nothing, so no argument can be a flag's value and a bareword
+  // `help` anywhere is unambiguously a help request.
+  mcp: [],
 };
 
 /**
@@ -100,6 +115,12 @@ interface InstallerCommandMeta {
    * the option descriptions instead.
    */
   details?: string[];
+  /**
+   * Prose rendered under the summary in this command's own `--help` only —
+   * the mirror of `details`, which appears only in the top-level table. Used
+   * where the option list cannot carry what the reader needs to know.
+   */
+  notes?: string[];
   /** Usage line, e.g. `argent init [options]`. */
   usage: string;
   /** Real flags this command parses. Empty for aliases (see `aliasOf`). */
@@ -203,6 +224,28 @@ export const INSTALLER_COMMAND_META: Record<InstallerCommand, InstallerCommandMe
     options: [],
     aliasOf: "uninstall",
   },
+  mcp: {
+    // Byte-identical to the row the top-level table printed by hand, so moving
+    // that row onto this meta changes no output.
+    summary: "Start the MCP stdio server (used by editors)",
+    usage: "argent mcp",
+    notes: [
+      "Speaks the Model Context Protocol over stdio: JSON-RPC requests on stdin,",
+      "responses on stdout. Editors launch it themselves — `argent init` writes the",
+      "`argent mcp` entry into the editor's MCP config — and start one server per",
+      "session. Run by hand it waits for JSON-RPC on stdin and looks like it has",
+      "hung; Ctrl-C to quit.",
+      "",
+      "It takes no options and owns stdout, so diagnostics go to stderr. Calls are",
+      "logged to ~/.argent/mcp-calls.log (override with ARGENT_MCP_LOG). Tools are",
+      "served by the argent tool-server, spawned on demand unless ARGENT_TOOLS_URL",
+      "or `argent link` points at one already running.",
+      "",
+      "To drive the same tools from a terminal, use `argent tools` and",
+      "`argent run <tool>`.",
+    ],
+    options: [{ flag: "--help, -h", description: "Show this help." }],
+  },
 };
 
 /**
@@ -213,6 +256,8 @@ export const INSTALLER_COMMAND_META: Record<InstallerCommand, InstallerCommandMe
 export function printInstallerHelp(command: InstallerCommand): void {
   const meta = INSTALLER_COMMAND_META[command];
   const lines: string[] = ["", `Usage: ${meta.usage}`, "", `${meta.summary}.`];
+
+  if (meta.notes) lines.push("", ...meta.notes);
 
   if (meta.aliasOf) {
     lines.push("", `Run \`argent ${meta.aliasOf} --help\` to see its options.`);

--- a/packages/argent/test/cli-dispatch.test.ts
+++ b/packages/argent/test/cli-dispatch.test.ts
@@ -158,6 +158,35 @@ describe("cli dispatcher: installer-help guard", () => {
     expect(fs.existsSync(marker)).toBe(false);
   });
 
+  it("`mcp --help` prints usage and never starts the server", async () => {
+    // It used to start it: the stdio server then blocked reading JSON-RPC from
+    // stdin, so the command looked like it hung (or, with stdin closed, like it
+    // printed nothing and succeeded).
+    const marker = freshMarker();
+    const { exitCode, stdout } = await runCli(["mcp", "--help"], marker);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage: argent mcp");
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+
+  it("`mcp` with no arguments still starts the server", async () => {
+    // How every editor launches argent. If the help guard ever fired here it
+    // would print usage onto the JSON-RPC channel and break the handshake, so
+    // this control matters more than the case above.
+    const marker = freshMarker();
+    await runCli(["mcp"], marker);
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(fs.readFileSync(marker, "utf8")).toContain("startMcpServer");
+  });
+
+  it("`mcp` with a non-help argument still starts the server", async () => {
+    // Proves the guard keys on help rather than on "any argv" — hand-edited
+    // configs do carry extra arguments.
+    const marker = freshMarker();
+    await runCli(["mcp", "--metro-port", "8082"], marker);
+    expect(fs.existsSync(marker)).toBe(true);
+  });
+
   it("`init --help` prints usage (with real options) and never runs the installer", async () => {
     const marker = freshMarker();
     const { exitCode, stdout } = await runCli(["init", "--help"], marker);

--- a/packages/argent/test/installer-help.test.ts
+++ b/packages/argent/test/installer-help.test.ts
@@ -102,7 +102,6 @@ describe("installerHelpRequested", () => {
     expect(installerHelpRequested("run", ["gesture-tap", "--help"])).toBe(false);
     expect(installerHelpRequested("tools", ["--help"])).toBe(false);
     expect(installerHelpRequested("server", ["-h"])).toBe(false);
-    expect(installerHelpRequested("mcp", ["--help"])).toBe(false);
     // A non-installer command must not be intercepted via the bareword either.
     expect(installerHelpRequested("run", ["help"])).toBe(false);
   });
@@ -115,7 +114,7 @@ describe("installerHelpRequested", () => {
 describe("isInstallerCommand", () => {
   it("recognizes exactly the installer command set", () => {
     expect([...INSTALLER_COMMANDS].sort()).toEqual(
-      ["init", "install", "remove", "uninstall", "update"].sort()
+      ["init", "install", "mcp", "remove", "uninstall", "update"].sort()
     );
     for (const command of INSTALLER_COMMANDS) {
       expect(isInstallerCommand(command)).toBe(true);
@@ -124,7 +123,6 @@ describe("isInstallerCommand", () => {
 
   it("rejects non-installer and undefined commands", () => {
     expect(isInstallerCommand("run")).toBe(false);
-    expect(isInstallerCommand("mcp")).toBe(false);
     expect(isInstallerCommand(undefined)).toBe(false);
   });
 });
@@ -221,5 +219,52 @@ describe("INSTALLER_COMMAND_META", () => {
         expect(meta.options.length).toBeGreaterThan(0);
       }
     }
+  });
+});
+
+describe("mcp is intercepted like the installers", () => {
+  // `argent mcp --help` used to start the stdio server, which then blocked
+  // reading JSON-RPC from stdin — the reason this command joined the set.
+  it.each([
+    ["--help"],
+    ["-h"],
+    ["-H"],
+    ["--HELP"],
+    ["-help"],
+    ["—help"],
+    ["–help"],
+    ["--help=x"],
+    ["help"],
+    ["HELP"],
+    ["--foo", "--help"],
+    ["--foo", "help"],
+  ])("treats %j as a help request", (...rest) => {
+    expect(installerHelpRequested("mcp", rest)).toBe(true);
+  });
+
+  it("leaves a real server launch alone", () => {
+    // Every generated editor config invokes a bare `argent mcp`.
+    expect(installerHelpRequested("mcp", [])).toBe(false);
+  });
+
+  it.each([["--helpme"], ["/help"], ["--metro-port", "8082"]])(
+    "does not treat %j as a help request",
+    (...rest) => {
+      expect(installerHelpRequested("mcp", rest)).toBe(false);
+    }
+  );
+
+  it("documents itself without inviting the reader to run it blind", () => {
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((m) => void logs.push(String(m)));
+    printInstallerHelp("mcp");
+    spy.mockRestore();
+    const out = logs.join("\n");
+
+    expect(out).toContain("Usage: argent mcp");
+    expect(out).toContain("JSON-RPC");
+    // The whole point: say why running it by hand looks like a hang.
+    expect(out).toContain("hung");
+    expect(out).toContain("--help, -h");
   });
 });


### PR DESCRIPTION
Fixes #638.

## The report understated it

The issue says `argent mcp --help` "does not hang and does not start the server — it simply prints
nothing". Reproducing it showed the opposite:

```
$ argent mcp --help < /dev/null ; echo $?
0                          # 0 bytes  ← what the reporter saw
$ argent mcp --help        # stdin open (a pipe, an editor, a CI step)
                           # HANGS — I hit a 300s timeout
```

`--help` **starts the MCP stdio server**, which blocks reading JSON-RPC from stdin. The "prints
nothing, exit 0" is just the server getting an immediate EOF from a closed stdin. So this is the same
"`--help` runs the real command" bug that was fixed for the installers — `mcp` was missed.

`startMcpServer` takes no argv at all (`mcp-server.ts:96` — its only parameter is `{ paths }`), so a
help flag was *structurally* unreachable; there was nowhere downstream that could have handled it.

## Fix

`mcp` joins the existing guarded set rather than growing a second help path. That set's defining
property is "the handler never inspects its argv", and `mcp` qualifies more strongly than the
installers do — it isn't merely ignoring `rest`, it is never handed it.

**It cannot fire on a real launch.** The guard tests `rest`, which is `[]` for every generated editor
config (all four shapes end at `mcp`, and `isArgentManagedEntry` requires exactly that), and
`[].some(...)` evaluates no predicate. This is pinned in both directions, because a guard that *did*
fire here would print usage onto the JSON-RPC channel and break every editor at handshake — the
highest-cost regression in this file, and it was untested.

The top-level table's `mcp` row now reads the same metadata as its own help, so the two cannot drift.

**No rename.** An earlier draft renamed the module and six identifiers (`installer-help` →
`command-help`, etc.) on the grounds that its comments had become false. They hadn't quite: fixing
`mcp` *and* `tools` makes "every other subcommand parses `--help` itself" true again — I checked all
ten siblings. Since #530 and #568 both edit `cli.ts`, a rename would have forced them through churn
for no behavioural gain. Prose-only.

## Second commit: `argent tools --help`

The issue mentions it in passing; it's a different mechanism and a genuinely dead branch.
`argv.filter((a) => !a.startsWith("--"))` dropped `--help` before the subcommand was read, so it fell
through to listing all 77 tools — **contacting the tool-server, starting one if none was running**,
to do it. Only `-h` ever reached the existing help branch.

Scoped to the subcommand position on purpose: a global check would have broken
`argent tools describe <name> --help`, which today prints *that tool's* flags. It still does — there
is a test.

Separate commit so it can be reverted alone.

## Verification

Live, against the built CLI:

| | before | after |
|---|---|---|
| `mcp --help`, stdin open | hangs indefinitely | usage, returns immediately |
| `mcp --help`, stdin closed | 0 bytes, exit 0 | 849 bytes of help, exit 0 |
| `mcp` (real launch) | works | works — verified with an actual `initialize` handshake, server replies with its capabilities |
| `mcp --metro-port 8082` | starts server | starts server (guard keys on help, not on "any argv") |
| `tools --help` | 77-line catalogue | usage |
| `tools describe gesture-tap --help` | tool's flags | tool's flags |
| `argent --help` `mcp` row | — | byte-identical |

argent 80 passed, argent-cli 284 passed.

## Note on the help text

Every claim in it is sourced (stdio/JSON-RPC transport, stdout ownership, the `~/.argent/mcp-calls.log`
default and `ARGENT_MCP_LOG` override, auto-spawn vs `ARGENT_TOOLS_URL`/`argent link`). It deliberately
does **not** suggest running `argent mcp` by hand to check an install — that is the reported hang — and
instead says it will look like it has hung and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)