### PR TITLE
fix(installer): only rewrite the skills store the updated install owns

### DIFF
--- a/packages/argent-installer/src/install-runner.ts
+++ b/packages/argent-installer/src/install-runner.ts
@@ -22,8 +22,8 @@ import {
 } from "./utils.js";
 import { runShellCommand, runTrustingDisk, ShellCommandError } from "./shell.js";
 import { PACKAGE_NAME } from "./constants.js";
-import { reportSkillRefresh } from "./skills.js";
-import type { InstallMode } from "./install-record.js";
+import { reportSkillRefresh, skillScopesForTargets } from "./skills.js";
+import { resolveInstallMode, type InstallMode } from "./install-record.js";
 import {
   InitTelemetry,
   INSTALL_GLOBAL_PACKAGE_FAILED,
@@ -370,10 +370,16 @@ async function runGlobal(opts: {
           version = getGloballyInstalledVersion() ?? getInstalledVersion() ?? version;
           await tel.trackPackageAction("init_triggered_update", updateStartedAt, true);
 
-          // Re-sync and prune argent skills in every scope that tracks them —
-          // the only point in init that surfaces orphans from the old version
-          // before Step 2's single-scope `skills add`.
-          reportSkillRefresh(resolveProjectRoot(process.cwd()), "installer_skills_refresh");
+          // Re-sync and prune argent skills in the scopes this bump owns — the
+          // only point in init that surfaces orphans from the old version before
+          // Step 2's single-scope `skills add`. Only the global install moved
+          // here, so the project's lock follows only when it tracks that binary.
+          const skillRoot = resolveProjectRoot(process.cwd());
+          reportSkillRefresh({
+            projectRoot: skillRoot,
+            scopes: skillScopesForTargets(["global"], resolveInstallMode(skillRoot)),
+            stage: "installer_skills_refresh",
+          });
         } catch (err) {
           updateSpinner.stop(pc.red("Update failed."));
           p.log.error(`${err}`);

--- a/packages/argent-installer/src/skills.ts
+++ b/packages/argent-installer/src/skills.ts
@@ -3,13 +3,16 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { track } from "@argent/telemetry";
 import { FAILURE_CODES, type FailureSignal } from "@argent/registry";
+import type { InstallMode } from "./utils.js";
 import {
   buildArgentSkillsSource,
   getGlobalSkillLockPath,
   getInstalledVersion,
   getProjectSkillLockPath,
+  compareVersions,
   listArgentSkillsInLock,
   listBundledSkills,
+  lockedArgentSkillVersion,
   withNpmForce,
   SKILLS_DIR,
 } from "./utils.js";
@@ -42,7 +45,12 @@ interface ScopeSpec {
   removeArgs: string[];
 }
 
-function getScopeSpecs(projectRoot: string): ScopeSpec[] {
+function getScopeSpecs(projectRoot: string, scopes: readonly SkillScope[]): ScopeSpec[] {
+  const wanted = new Set(scopes);
+  return allScopeSpecs(projectRoot).filter((spec) => wanted.has(spec.scope));
+}
+
+function allScopeSpecs(projectRoot: string): ScopeSpec[] {
   return [
     {
       scope: "project",
@@ -59,11 +67,61 @@ function getScopeSpecs(projectRoot: string): ScopeSpec[] {
   ];
 }
 
-// Re-syncs bundled argent skills into every scope that already tracks at
-// least one argent-owned skill, and prunes any argent-prefixed entry that is
-// no longer part of the bundled set. Safe to call from any command — a scope
-// with nothing tracked is skipped, so this never creates a
+/**
+ * Which skill stores a command may rewrite, given the installs it updated.
+ *
+ * A store is owned by exactly one install: the global lock always belongs to the
+ * binary on PATH, and a project's lock belongs to whichever install serves that
+ * project. Only the install that moved may rewrite the store that tracks it —
+ * otherwise a project-scoped update re-pins the machine-wide skills every other
+ * project uses.
+ *
+ * Note the project scope is not "the local install's scope": a non-interactive
+ * global install also writes a project lock, and that lock tracks the global
+ * binary. `installMode` is what distinguishes them.
+ */
+export function skillScopesForTargets(
+  targets: readonly InstallMode[],
+  installMode: InstallMode
+): SkillScope[] {
+  const scopes = new Set<SkillScope>();
+  if (targets.includes("local")) scopes.add("project");
+  if (targets.includes("global")) {
+    scopes.add("global");
+    // A global bump moves the binary this project runs, so its lock follows.
+    if (installMode === "global") scopes.add("project");
+  }
+  return (["project", "global"] as const).filter((scope) => scopes.has(scope));
+}
+
+/**
+ * Whether this package may decide which of a store's argent skills are obsolete.
+ *
+ * The obsolete set is the difference against THIS package's bundled skills, so a
+ * package older than the one that filled the store would classify everything
+ * added since as orphaned and delete it. Judging is allowed only when the store
+ * was last written by a version no newer than ours; an unreadable or unversioned
+ * lock means we cannot tell, so we do not prune.
+ */
+function mayPruneScope(lockPath: string): boolean {
+  const lockedVersion = lockedArgentSkillVersion(lockPath);
+  if (lockedVersion === null) return false;
+  const running = getInstalledVersion();
+  if (!running) return false;
+  return compareVersions(running, lockedVersion) >= 0;
+}
+
+// Re-syncs bundled argent skills into the caller's chosen scopes, and prunes
+// argent-prefixed entries that are no longer part of the bundled set.
+//
+// Two filters apply, and both matter. The caller names the scopes, because only
+// the install that moved may rewrite the store that tracks it. A named scope is
+// then skipped if it tracks no argent skill, so this never creates a
 // `skills-lock.json` in an unrelated working directory.
+//
+// Pruning has a third condition — see `mayPruneScope`. Sync is idempotent and
+// additive, so re-syncing a store from a slightly different version is
+// recoverable; a prune deletes, and is not.
 //
 // Sync prefers the GitHub-pinned source (`<repo>/packages/skills/skills#v<ver>`)
 // so the lockfile entry stays portable across machines. If the
@@ -75,7 +133,11 @@ function getScopeSpecs(projectRoot: string): ScopeSpec[] {
 // previous-version lock written from SKILLS_DIR would never refresh. `skills
 // add` rewrites the entry from the source we pass, which is exactly the
 // behavior we want after `npm i -g @swmansion/argent@new`.
-export function refreshArgentSkills(projectRoot: string): SkillScopeResult[] {
+export function refreshArgentSkills(opts: {
+  projectRoot: string;
+  scopes: readonly SkillScope[];
+}): SkillScopeResult[] {
+  const { projectRoot, scopes } = opts;
   const bundled = new Set(listBundledSkills());
   // An empty bundled set means THIS package's skills dir is unreadable — a
   // pruned pnpm store dir mid-update, a broken install — never "argent ships
@@ -92,7 +154,7 @@ export function refreshArgentSkills(projectRoot: string): SkillScopeResult[] {
     cwd: string;
   };
 
-  for (const spec of getScopeSpecs(projectRoot)) {
+  for (const spec of getScopeSpecs(projectRoot, scopes)) {
     const tracked = listArgentSkillsInLock(spec.lockPath);
     if (tracked.length === 0) continue;
 
@@ -123,7 +185,7 @@ export function refreshArgentSkills(projectRoot: string): SkillScopeResult[] {
       }
     }
 
-    if (orphaned.length > 0) {
+    if (orphaned.length > 0 && mayPruneScope(spec.lockPath)) {
       try {
         execFileSync("npx", withNpmForce([...spec.removeArgs, ...orphaned]), execOpts);
         result.pruned = orphaned;
@@ -183,11 +245,26 @@ export function summarizeSkillRefreshForTelemetry(
 // the failure_stage naming the flow.
 export type SkillRefreshStage = "installer_skills_refresh" | "installer_update_skills_refresh";
 
-export function reportSkillRefresh(projectRoot: string, stage: SkillRefreshStage): void {
-  const results = refreshArgentSkills(projectRoot);
+export function reportSkillRefresh(opts: {
+  projectRoot: string;
+  scopes: readonly SkillScope[];
+  stage: SkillRefreshStage;
+}): void {
+  const { projectRoot, scopes, stage } = opts;
+  const results = refreshArgentSkills({ projectRoot, scopes });
   const summary = formatSkillRefreshSummary(results);
   if (summary) {
     p.note(summary, "Skills Updated");
+  }
+  // A store this command did not update stays on its old version. Say so once,
+  // rather than letting it quietly drift.
+  if (!scopes.includes("global") && listArgentSkillsInLock(getGlobalSkillLockPath()).length > 0) {
+    p.log.info(
+      pc.dim(
+        "Left the machine-wide skills alone — they track the global install. " +
+          "Run `argent update --global` to refresh them."
+      )
+    );
   }
   const telemetrySummary = summarizeSkillRefreshForTelemetry(results);
   if (telemetrySummary.scope_count > 0) {

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -39,7 +39,7 @@ import {
 } from "./utils.js";
 import { parseTargetFlags, decideInstallTargets, promptInstallTargets } from "./install-targets.js";
 import { execShellCommandSync, runTrustingDisk } from "./shell.js";
-import { reportSkillRefresh } from "./skills.js";
+import { reportSkillRefresh, skillScopesForTargets } from "./skills.js";
 import { PACKAGE_NAME } from "./constants.js";
 import { resolveInstallableUpdateTarget } from "./update-target.js";
 import { killToolServer, killToolServerForInstallDir } from "@argent/tools-client";
@@ -810,7 +810,15 @@ export async function update(args: string[]): Promise<void> {
         p.note(ruleResults.join("\n"), "Rules & Agents Updated");
       }
 
-      reportSkillRefresh(projectRoot, "installer_update_skills_refresh");
+      // Scopes follow the installs this run actually updated, not the project's
+      // mode alone — unlike the MCP config refresh above, which encodes which
+      // binary the project should launch. A skills lock records which binary's
+      // bundled skills it is pinned to, so only that binary moving may rewrite it.
+      reportSkillRefresh({
+        projectRoot,
+        scopes: skillScopesForTargets(targets, installMode),
+        stage: "installer_update_skills_refresh",
+      });
     }
 
     if (firstFailure) {

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -145,6 +145,47 @@ export function listArgentSkillsInLock(lockPath: string): string[] {
   }
 }
 
+/**
+ * The newest argent version any argent-owned skill in this lock was installed
+ * from, or null when the lock records none (an older lock shape, a local
+ * source, or no argent skills at all).
+ *
+ * Used to tell whether the running package is new enough to judge which skills
+ * are obsolete in a given store — pruning against an older bundled set deletes
+ * skills the store's real owner still ships.
+ */
+export function lockedArgentSkillVersion(lockPath: string): string | null {
+  try {
+    const lock = JSON.parse(fs.readFileSync(lockPath, "utf8")) as {
+      skills?: Record<string, { ref?: unknown }>;
+    };
+    const refs: string[] = [];
+    for (const [name, entry] of Object.entries(lock.skills ?? {})) {
+      if (!name.startsWith(ARGENT_SKILL_PREFIX)) continue;
+      const ref = entry?.ref;
+      if (typeof ref === "string" && /^v?\d+\.\d+\.\d+/.test(ref)) refs.push(ref.replace(/^v/, ""));
+    }
+    if (refs.length === 0) return null;
+    return refs.sort(compareVersions).at(-1) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric-segment comparison of two `x.y.z` versions. Prerelease tags are ignored. */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) =>
+    v
+      .split("-")[0]!
+      .split(".")
+      .map((n) => Number.parseInt(n, 10) || 0);
+  const [x, y] = [parse(a), parse(b)];
+  for (let i = 0; i < 3; i++) {
+    if ((x[i] ?? 0) !== (y[i] ?? 0)) return (x[i] ?? 0) - (y[i] ?? 0);
+  }
+  return 0;
+}
+
 const PROJECT_ROOT_MARKERS = [
   ".mcp.json",
   ".claude",

--- a/packages/argent-installer/test/skills.test.ts
+++ b/packages/argent-installer/test/skills.test.ts
@@ -37,10 +37,18 @@ vi.mock("../src/utils.js", async (importOriginal) => {
   };
 });
 
-import { refreshArgentSkills, formatSkillRefreshSummary } from "../src/skills.js";
+import {
+  refreshArgentSkills,
+  formatSkillRefreshSummary,
+  skillScopesForTargets,
+} from "../src/skills.js";
 
 let tmpDir: string;
 const originalXdg = process.env.XDG_STATE_HOME;
+
+// Skills a *newer* install wrote are never pruned (see mayPruneScope), so a
+// fixture that expects pruning has to record a version at or below ours.
+const OLD_REF = { ref: "v0.0.1" };
 
 function writeLock(lockPath: string, skills: Record<string, Record<string, unknown>>): void {
   fs.mkdirSync(path.dirname(lockPath), { recursive: true });
@@ -74,7 +82,7 @@ describe("refreshArgentSkills", () => {
       "argent-device-interact": {},
     });
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project", "global"] });
 
     expect(results).toEqual([]);
     expect(execFileSyncMock).not.toHaveBeenCalled();
@@ -87,7 +95,7 @@ describe("refreshArgentSkills", () => {
     listBundledSkillsMock.mockReturnValue(["argent-create-flow"]);
     writeLock(path.join(tmpDir, "skills-lock.json"), { "argent-create-flow": {} });
 
-    refreshArgentSkills(tmpDir);
+    refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project"] });
 
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "npx",
@@ -99,7 +107,10 @@ describe("refreshArgentSkills", () => {
   it("returns an empty array when no scope tracks argent skills", () => {
     listBundledSkillsMock.mockReturnValue(["argent-create-flow"]);
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({
+      projectRoot: tmpDir,
+      scopes: ["project", "global"],
+    });
 
     expect(results).toEqual([]);
     // With no tracked scopes we must not have invoked the skills CLI at all —
@@ -113,7 +124,7 @@ describe("refreshArgentSkills", () => {
       "argent-create-flow": {},
     });
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project"] });
 
     expect(results).toEqual([
       { scope: "project", synced: 2, syncError: null, pruned: [], pruneError: null },
@@ -136,7 +147,7 @@ describe("refreshArgentSkills", () => {
       "argent-create-flow": {},
     });
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["global"] });
 
     expect(results).toEqual([
       { scope: "global", synced: 1, syncError: null, pruned: [], pruneError: null },
@@ -148,11 +159,11 @@ describe("refreshArgentSkills", () => {
   it("prunes argent skills that are no longer bundled", () => {
     listBundledSkillsMock.mockReturnValue(["argent-create-flow"]);
     writeLock(path.join(tmpDir, "skills-lock.json"), {
-      "argent-create-flow": {},
-      "argent-super-workflow": {}, // was removed from bundled set
+      "argent-create-flow": OLD_REF,
+      "argent-super-workflow": OLD_REF, // was removed from bundled set
     });
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project", "global"] });
 
     expect(results).toHaveLength(1);
     expect(results[0]!.pruned).toEqual(["argent-super-workflow"]);
@@ -171,7 +182,7 @@ describe("refreshArgentSkills", () => {
       "my-custom-skill": {},
     });
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project"] });
 
     // Only one scope, and no prune happened because nothing argent-prefixed
     // was missing. The other skills must not appear anywhere in results.
@@ -191,7 +202,7 @@ describe("refreshArgentSkills", () => {
       "argent-create-flow": {},
     });
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project", "global"] });
 
     expect(results.map((r) => r.scope)).toEqual(["project", "global"]);
   });
@@ -199,8 +210,8 @@ describe("refreshArgentSkills", () => {
   it("records sync errors without aborting the scope or skipping prune", () => {
     listBundledSkillsMock.mockReturnValue(["argent-create-flow"]);
     writeLock(path.join(tmpDir, "skills-lock.json"), {
-      "argent-create-flow": {},
-      "argent-old-workflow": {},
+      "argent-create-flow": OLD_REF,
+      "argent-old-workflow": OLD_REF,
     });
 
     execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
@@ -208,7 +219,7 @@ describe("refreshArgentSkills", () => {
       return Buffer.from("");
     });
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project", "global"] });
 
     // Sync failed, but prune still ran and succeeded.
     expect(results[0]).toMatchObject({
@@ -223,8 +234,8 @@ describe("refreshArgentSkills", () => {
   it("records prune errors independently of sync success", () => {
     listBundledSkillsMock.mockReturnValue(["argent-create-flow"]);
     writeLock(path.join(tmpDir, "skills-lock.json"), {
-      "argent-create-flow": {},
-      "argent-old-workflow": {},
+      "argent-create-flow": OLD_REF,
+      "argent-old-workflow": OLD_REF,
     });
 
     execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
@@ -232,7 +243,7 @@ describe("refreshArgentSkills", () => {
       return Buffer.from("");
     });
 
-    const results = refreshArgentSkills(tmpDir);
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project"] });
 
     expect(results[0]).toMatchObject({
       synced: 1,
@@ -284,5 +295,115 @@ describe("formatSkillRefreshSummary", () => {
     expect(summary).toContain("network down");
     expect(summary).toContain("prune failed");
     expect(summary).toContain("permission denied");
+  });
+});
+
+describe("scope containment", () => {
+  // Both stores track argent skills, so anything acting on the wrong one shows up.
+  function stageBothScopes(): void {
+    listBundledSkillsMock.mockReturnValue(["argent-create-flow"]);
+    writeLock(path.join(tmpDir, "skills-lock.json"), {
+      "argent-create-flow": OLD_REF,
+      "argent-old-workflow": OLD_REF,
+    });
+    writeLock(path.join(tmpDir, "xdg", "skills", ".skill-lock.json"), {
+      "argent-create-flow": OLD_REF,
+      "argent-old-workflow": OLD_REF,
+    });
+  }
+
+  const skillCalls = () =>
+    (execFileSyncMock.mock.calls as [string, string[]][]).map(([, args]) => args);
+
+  it("leaves the machine-wide store alone when only the project was asked for", () => {
+    // The reported bug: `argent update --local` rewrote the global store that
+    // every other project on the machine shares.
+    stageBothScopes();
+
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project"] });
+
+    expect(results.map((r) => r.scope)).toEqual(["project"]);
+    expect(skillCalls().every((args) => !args.includes("-g"))).toBe(true);
+  });
+
+  it("never prunes out of a store it was not asked to touch", () => {
+    // The destructive half: prune targets the running package's bundled set, so
+    // an older install would delete skills the store's real owner still ships.
+    stageBothScopes();
+
+    refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project"] });
+
+    const removals = skillCalls().filter((args) => args.includes("remove"));
+    expect(removals.length).toBe(1);
+    expect(removals[0]!).not.toContain("-g");
+  });
+
+  it("leaves the project store alone when only the global was asked for", () => {
+    stageBothScopes();
+
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["global"] });
+
+    expect(results.map((r) => r.scope)).toEqual(["global"]);
+    expect(skillCalls().every((args) => args.includes("-g"))).toBe(true);
+  });
+
+  it("does nothing at all when no scope is requested", () => {
+    stageBothScopes();
+
+    expect(refreshArgentSkills({ projectRoot: tmpDir, scopes: [] })).toEqual([]);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("prune ownership", () => {
+  it("does not delete skills a newer install put there", () => {
+    // Running 0.18.1 against a store filled by a hypothetical 99.x: the extra
+    // skills are not obsolete, they are simply unknown to this package.
+    listBundledSkillsMock.mockReturnValue(["argent-create-flow"]);
+    writeLock(path.join(tmpDir, "skills-lock.json"), {
+      "argent-create-flow": { ref: "v99.0.0" },
+      "argent-from-the-future": { ref: "v99.0.0" },
+    });
+
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project"] });
+
+    expect(results[0]!.pruned).toEqual([]);
+    const removals = (execFileSyncMock.mock.calls as [string, string[]][]).filter(([, args]) =>
+      args.includes("remove")
+    );
+    expect(removals).toEqual([]);
+  });
+
+  it("does not delete when the store records no version at all", () => {
+    // An older lock shape or a local source: we cannot tell who owns it, so we
+    // must not judge which of its skills are obsolete.
+    listBundledSkillsMock.mockReturnValue(["argent-create-flow"]);
+    writeLock(path.join(tmpDir, "skills-lock.json"), {
+      "argent-create-flow": {},
+      "argent-old-workflow": {},
+    });
+
+    const results = refreshArgentSkills({ projectRoot: tmpDir, scopes: ["project"] });
+
+    expect(results[0]!.pruned).toEqual([]);
+  });
+});
+
+describe("skillScopesForTargets", () => {
+  it.each([
+    [["local"], "local", ["project"]],
+    [["local"], "global", ["project"]],
+    [["global"], "global", ["project", "global"]],
+    // A global bump must not re-pin a lock that tracks the project's own install.
+    [["global"], "local", ["global"]],
+    [["global", "local"], "local", ["project", "global"]],
+    [["global", "local"], "global", ["project", "global"]],
+  ])("targets %j in a %s-mode project → %j", (targets, mode, expected) => {
+    expect(skillScopesForTargets(targets as never, mode as never)).toEqual(expected);
+  });
+
+  it("returns scopes in a stable order regardless of target order", () => {
+    expect(skillScopesForTargets(["local", "global"], "global")).toEqual(["project", "global"]);
+    expect(skillScopesForTargets(["global", "local"], "global")).toEqual(["project", "global"]);
   });
 });


### PR DESCRIPTION
## Update 2026-09-17: merged with main

- Merged `origin/main` (no rebase). Two conflicts, both with the comment trim from #931: the `install-runner.ts` init-triggered refresh and the `refreshArgentSkills` header in `skills.ts`. I kept the scoped calls and main's shorter comments. The installer files are the same in v0.25.1 and main, so the bug is still there on main.
- Replaced the hand-rolled `compareVersions` with `semver`, which the installer already depends on. The old helper ignored prerelease tags.
- No docs change: no CLI flag, config key or tool changed.

Live check with a packed tgz. HOME, npm prefix and PATH all point into a sandbox, and a stub `npx skills` edits the lock files the way the real one does. The project is local-mode. The global store holds a foreign skill, the bundled argent skills at `v0.99.0`, and `argent-future-skill@v0.99.0`. The project store holds a foreign skill and `argent-retired-skill@v0.24.0`. The control is npm `0.25.1`, whose installer is the same as main's:

| run | main (0.25.1) | this branch |
|---|---|---|
| `update --local --yes` | also syncs `-g`, re-pins the global store to v0.25.1, and **deletes `argent-future-skill`** | project only (sync + prune `argent-retired-skill`); global store unchanged; prints the "Left the machine-wide skills alone" hint |
| `update --global --yes` (global store newer) | re-syncs and prunes the project lock; **deletes `argent-future-skill`** | syncs global only; no prune; project lock unchanged |
| `update --global --yes` (global store at v0.25.0 with `argent-retired-global`) | prunes | still prunes `argent-retired-global`, so an owned store still refreshes |

Foreign skills survived in every run. Checks: installer vitest 587/587, `typecheck:tests`, `npm run build`, eslint, prettier, knip.

Fixes #637. See [my triage comment there](https://github.com/software-mansion/argent/issues/637#issuecomment-5147964114)
for the full findings — this PR fixes two defects, and the reported one is the milder.

## 1. The reported bug

`refreshArgentSkills(projectRoot)` took no scope and looped both specs, so `argent update --local`
rewrote the machine-wide store. Reproduced against the shipped code with a sandboxed `HOME` and a
stub `npx`:

```
scopes acted on: project(synced=15), global(synced=15)
npx … skills add …#v0.18.1 --skill * -y
npx … skills add …#v0.18.1 --skill * -y -g     ← global, from a --local update
```

Callers now name the stores their update owns, and the scope is **required** — a call site that
forgets one is a compile error rather than a silent write to a shared store. (Both existing call
sites did forget; the compiler caught them.)

This also closes the **mirror** case: `argent update --global` no longer rewrites a project's
*committed* `skills-lock.json` when that project runs a local install.

One trap worth naming: "is there a local install" is the wrong predicate. `chooseScope` returns
`local` for non-interactive **global**-mode installs too, and `init-skills.ts` only passes `-g` for
an explicitly global scope — so a project lock can legitimately track the global binary. The rule
keys on `resolveInstallMode`.

## 2. The worse bug the fix had to also close

Narrowing scopes alone would have closed this issue while leaving a **deletion** path open.

Obsolete skills are computed as the difference against the **running** package's bundled set, and the
global spec's removal carries `-g`. So an install older than the one that filled a store classifies
everything added since as orphaned and deletes it machine-wide. The skew is real — `v0.15.0` ships 13
skills, current ships 15. Reproduced:

```
npx --force skills remove -y -g argent-screen-recording argent-settings-permissions
```

And scope-narrowing does **not** stop it: any run whose targets include `global` still prunes from the
running package's set — including plain `argent update --yes` on a machine with both installs, and the
tool-server's own `update-argent`, which pins `--global` while being served by the local install.

So pruning a store is now gated on **ownership**: allowed only when the store was last written by a
version no newer than ours (the lock records a `ref` per entry). An unreadable or unversioned lock
means we cannot tell, so we leave it alone. Syncing stays unconditional — it is additive and
recoverable; deletion is not.

## Deliberate behaviour changes

- A machine with only a local install stops refreshing a leftover global lock. That is correct — no
  binary owns that store — but it is a change, so the command now says so once rather than letting it
  drift silently: *"Left the machine-wide skills alone — they track the global install."*
- Telemetry `scope_count` legitimately drops from 2 to 1 for local updates. The field still means
  "scopes this refresh acted on", so I left the event schema alone.

## Repair for anyone already affected

A re-pinned global store self-heals on the next run that includes the global target **and** is
executed by a package at least as new as the store's tracked set — i.e. `argent update --global` from
the global binary. It does *not* heal when run by the older local install, which is what caused it.
Worth a line in the release note.

## Verification

The original sandboxed repro, re-run against the fix:

```
update --local                 -> project            (no -g invocation at all)
update --global (global-mode)  -> project, global    (-g appears only here)
```

and the deletion path, against a store written by a newer install:

```
pruned: []      removals issued: 0
```

installer suite 548 passed. Existing scope tests were passing partly by accident — they touched one
store only because the other lock happened not to exist — so each now states the scope it exercises,
and the new containment tests stage **both** stores so acting on the wrong one is visible.

## Not in this PR

- **Version provenance.** `buildArgentSkillsSource(getInstalledVersion())` uses the *running* package,
  so `argent update --local` invoked from the global binary still pins the project lock to the
  global's version. The fix is a per-target version, but an unreadable version falls back to an
  absolute `SKILLS_DIR` path, which would write a machine-specific path into a committed lock — the
  portability problem #208 fixed. Needs its own decision.
- `uninstall.ts` computes orphans from the running package the same way, so it can strand newer skills.
  Same root cause, different command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
