### PR TITLE
fix(chromium-tabs): say why a tab cannot be opened in an Electron app

### DIFF
--- a/packages/tool-server/src/chromium-server/tabs.ts
+++ b/packages/tool-server/src/chromium-server/tabs.ts
@@ -166,7 +166,30 @@ export function createTabsManager(deps: TabsManagerDeps): TabsManager {
   }): Promise<TabInfo[]> {
     const url = opts?.url ?? "about:blank";
     const created = await withBrowserClient(async (browser) => {
-      const out = (await browser.send("Target.createTarget", { url })) as { targetId?: string };
+      let out: { targetId?: string };
+      try {
+        out = (await browser.send("Target.createTarget", { url })) as { targetId?: string };
+      } catch (err) {
+        // Electron answers this with a bare "Not supported": it embeds a
+        // renderer but no browser shell, so there is nothing to create a target
+        // in. Said plainly the message reads as if the whole tool were broken,
+        // when in fact only this action is unavailable — and the app can open
+        // the window itself. The underlying error is kept so a different cause
+        // (a dropped connection, a real Chrome refusing the url) is still legible.
+        throw new FailureError(
+          `Could not open a tab: ${err instanceof Error ? err.message : String(err)}. ` +
+            `An Electron app has no browser-level target creation, so a tab cannot be made from ` +
+            `outside it — have the app open one (e.g. \`window.open()\` through ` +
+            `\`debugger-evaluate\`) and it will show up in \`chromium-tabs list\`. ` +
+            `The list, select and close actions are unaffected.`,
+          {
+            error_code: FAILURE_CODES.CHROMIUM_TAB_OPEN_FAILED,
+            failure_stage: "chromium_tab_open",
+            failure_area: "tool_server",
+            error_kind: "unknown",
+          }
+        );
+      }
       if (!out.targetId)
         throw new FailureError("Target.createTarget returned no targetId.", {
           error_code: FAILURE_CODES.CHROMIUM_TAB_OPEN_FAILED,

--- a/packages/tool-server/test/chromium-tabs.test.ts
+++ b/packages/tool-server/test/chromium-tabs.test.ts
@@ -111,6 +111,26 @@ describe("TabsManager", () => {
     expect(created.label).toBe("docs");
   });
 
+  it("open() explains an Electron refusal instead of passing its bare error through", async () => {
+    // Electron answers Target.createTarget with a bare "Not supported", which
+    // reads as though the whole tool were unavailable.
+    browserSend.mockRejectedValueOnce(new Error("Not supported"));
+    const mgr = createTabsManager(9222, cdp as never);
+
+    const err = await mgr.open({ url: "https://x.test" }).catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    // The cause is kept, so a different failure stays legible...
+    expect(message).toContain("Not supported");
+    // ...alongside what is actually unavailable, why, and what to do instead.
+    expect(message).toContain("Electron");
+    expect(message).toContain("window.open()");
+    expect(message).toContain("chromium-tabs list");
+    // And that the rest of the tool still works, which the bare error hid.
+    expect(message).toMatch(/list, select and close/);
+  });
+
   it("close() closes the target and re-activates a remaining tab when the active one closed", async () => {
     // active is "A" (initialTargetId). Close it; fall back to "B".
     listMock

--- a/packages/tool-server/test/chromium-tabs.test.ts
+++ b/packages/tool-server/test/chromium-tabs.test.ts
@@ -115,7 +115,6 @@ describe("TabsManager", () => {
     // Electron answers Target.createTarget with a bare "Not supported", which
     // reads as though the whole tool were unavailable.
     browserSend.mockRejectedValueOnce(new Error("Not supported"));
-    const mgr = createTabsManager(9222, cdp as never);
 
     const err = await mgr.open({ url: "https://x.test" }).catch((e: Error) => e);
 


### PR DESCRIPTION
Fixes #634.

```
before:  [Tool:chromium-tabs] Not supported

after:   [Tool:chromium-tabs] Could not open a tab: Not supported. An Electron app has no
         browser-level target creation, so a tab cannot be made from outside it — have the app open
         one (e.g. `window.open()` through `debugger-evaluate`) and it will show up in
         `chromium-tabs list`. The list, select and close actions are unaffected.
```

The old text is Electron's own CDP answer to `Target.createTarget`, passed through untouched. The
limitation is real, but the message names neither the cause nor a way forward, and reads as though the
tool were unavailable — when only this one action is.

## Two things I checked before writing the message

- **The workaround actually works.** On the Electron testbed I ran `window.open('about:blank')` via
  `debugger-evaluate` and the new window appeared in `chromium-tabs list` as `t2`. I didn't want to
  ship advice I hadn't run.
- **The rest of the tool really is fine** — `list` returns correctly both before and after.

## Why the cause is kept rather than matched on

`Target.createTarget` can fail for reasons other than Electron's missing browser shell — a dropped
connection, or a real Chrome refusing the url. The CDP client keeps only the error's `message` and
discards its numeric code, so branching would mean matching on the string `"Not supported"`, which
breaks the moment Electron rephrases it.

Instead any failure is wrapped, with the original message embedded. The explanation is worded as a
property of Electron rather than a claim about *this* failure, so it stays accurate when the cause is
something else — and the underlying error is still right there to read.

## Verification

Live against the Electron testbed (Electron 42 / Chrome 148): the message above is the real output,
and `list` still works alongside it. tool-server 3087 passed, plus a new test asserting the message
keeps the original cause *and* carries the reason, the workaround, and the note that the other actions
are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)