### PR TITLE
fix(profiler): accept the component names the analyze report actually prints

### DIFF
--- a/packages/skills/skills/argent-react-native-profiler/references/diagnostic-tools.md
+++ b/packages/skills/skills/argent-react-native-profiler/references/diagnostic-tools.md
@@ -45,6 +45,13 @@ Call `profiler-cpu-query`. Modes:
 - `call_tree` — callers and callees of a specific `function_name`.
 - `component_cpu` — aggregate CPU during all commits of a `component_name`.
 
+> **Component names:** pass the name exactly as the report shows it. The report strips
+> `Forget(...)` / `Memo(...)` / `ForwardRef(...)` wrappers and marks them with a
+> `[React Compiler]` / `[React.memo] `/ `[forwardRef]` tag; both that displayed name and the
+> underlying wrapped name resolve. If a name maps to several distinct fibers the tool lists
+> the exact names to retry with rather than merging them — a combined total would not describe
+> any real component.
+
 ## Commit query
 
 ```json

--- a/packages/tool-server/src/tools/profiler/query/profiler-commit-query.ts
+++ b/packages/tool-server/src/tools/profiler/query/profiler-commit-query.ts
@@ -8,6 +8,11 @@ import type {
 } from "../../../utils/react-profiler/types/input";
 import { deriveReason } from "../../../utils/react-profiler/pipeline/utils";
 import { readCommitTree } from "../../../utils/react-profiler/debug/dump";
+import {
+  resolveComponentName,
+  renderComponentNameMiss,
+  describeResolution,
+} from "../../../utils/react-profiler/component-names";
 
 const timeRangeSchema = z.object({
   start: z.coerce.number().describe("Start of range in ms (performance.now clock)"),
@@ -92,9 +97,23 @@ function renderByComponent(
   componentName: string,
   topN: number
 ): string {
-  const matching = commits.filter((c) => c.componentName === componentName);
+  // Accept the display name the report prints, not just the raw DevTools name.
+  const resolution = resolveComponentName(
+    componentName,
+    commits.map((c) => c.componentName)
+  );
+  if (resolution.kind === "ambiguous" || resolution.kind === "missing") {
+    return renderComponentNameMiss(resolution, {
+      fiberRenders: commits.length,
+      commits: new Set(commits.map((c) => c.commitIndex)).size,
+    });
+  }
+  const resolvedName = resolution.rawName;
+  const resolutionNote = describeResolution(resolution);
+
+  const matching = commits.filter((c) => c.componentName === resolvedName);
   if (matching.length === 0) {
-    return `_Component \`${componentName}\` not found in commit data._`;
+    return `_Component \`${resolvedName}\` not found in commit data._`;
   }
 
   // Group by commitIndex
@@ -122,8 +141,9 @@ function renderByComponent(
     .slice(0, topN);
 
   const lines: string[] = [
-    `## Commits for \`${componentName}\``,
+    `## Commits for \`${resolvedName}\``,
     "",
+    ...(resolutionNote ? [resolutionNote, ""] : []),
     `**Total occurrences:** ${matching.length} across ${byCommit.size} commits`,
     "",
     "| Commit | Instances | Duration (ms) | Commit Total (ms) | Time (ms) | Reason | Parent |",

--- a/packages/tool-server/src/tools/profiler/query/profiler-cpu-query.ts
+++ b/packages/tool-server/src/tools/profiler/query/profiler-cpu-query.ts
@@ -14,6 +14,11 @@ import {
 } from "../../../utils/react-profiler/pipeline/00-cpu-correlate";
 import type { HermesProfileNode } from "../../../utils/react-profiler/types/input";
 import { readCpuProfile, readCommitTree } from "../../../utils/react-profiler/debug/dump";
+import {
+  resolveComponentName,
+  renderComponentNameMiss,
+  describeResolution,
+} from "../../../utils/react-profiler/component-names";
 import { promises as fs } from "fs";
 
 const timeWindowSchema = z.object({
@@ -267,11 +272,25 @@ function renderComponentCpu(
     return "_No commit data available. Run react-profiler-analyze first._";
   }
 
-  // Find all commits where this component rendered
-  const componentCommits = commitTree.commits.filter((c) => c.componentName === componentName);
+  // The report prints display names (wrappers stripped), so accept those too —
+  // otherwise the tool refuses the name analyze just told the caller to use.
+  const resolution = resolveComponentName(
+    componentName,
+    commitTree.commits.map((c) => c.componentName)
+  );
+  if (resolution.kind === "ambiguous" || resolution.kind === "missing") {
+    return renderComponentNameMiss(resolution, {
+      fiberRenders: commitTree.commits.length,
+      commits: new Set(commitTree.commits.map((c) => c.commitIndex)).size,
+    });
+  }
+  const resolvedName = resolution.rawName;
+  const resolutionNote = describeResolution(resolution);
+
+  const componentCommits = commitTree.commits.filter((c) => c.componentName === resolvedName);
 
   if (componentCommits.length === 0) {
-    return `_Component \`${componentName}\` not found in commit data._`;
+    return `_Component \`${resolvedName}\` not found in commit data._`;
   }
 
   // Group by commitIndex to get unique commit windows
@@ -313,14 +332,15 @@ function renderComponentCpu(
   const sorted = [...aggregated.entries()].sort((a, b) => b[1].selfMs - a[1].selfMs).slice(0, topN);
 
   if (sorted.length === 0) {
-    return `_No CPU samples found during \`${componentName}\` commits._`;
+    return `_No CPU samples found during \`${resolvedName}\` commits._`;
   }
 
   const totalCommitMs = [...commitWindows.values()].reduce((sum, w) => sum + w.duration, 0);
 
   const lines: string[] = [
-    `## CPU During \`${componentName}\` Commits`,
+    `## CPU During \`${resolvedName}\` Commits`,
     "",
+    ...(resolutionNote ? [resolutionNote, ""] : []),
     `**Commits:** ${commitWindows.size}  **Total commit time:** ${totalCommitMs.toFixed(1)}ms`,
     "",
     "| Function | Self (ms) | Total (ms) | Location |",

--- a/packages/tool-server/src/tools/profiler/react/react-profiler-analyze.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-analyze.ts
@@ -12,6 +12,7 @@ import type {
   DevToolsCommitTree,
 } from "../../../utils/react-profiler/types/input";
 import { runPipeline } from "../../../utils/react-profiler/pipeline/index";
+import { astLookupCandidates } from "../../../utils/react-profiler/component-names";
 import { buildAstIndexWithDiagnostics } from "../../../utils/react-profiler/pipeline/06-resolve/ast-index";
 import { renderProfilingReport } from "../../../utils/react-profiler/pipeline/05-render";
 import {
@@ -179,7 +180,13 @@ Fails if react-profiler-stop has not been called or no profiling data is stored.
     try {
       const astIndex = await buildAstIndexWithDiagnostics(params.project_root);
       for (const finding of pipelineOutput.componentFindings) {
-        const entry = astIndex.index.get(finding.component);
+        // `finding.component` is the raw DevTools name; the index is keyed on
+        // source identifiers. Without the fallback every compiler/memo/forwardRef
+        // component silently loses its source location and the File column
+        // renders "—" even when the file is right there in the project.
+        const entry = astLookupCandidates(finding.component)
+          .map((k) => astIndex.index.get(k))
+          .find(Boolean);
         if (entry) {
           finding.sourceLocation = {
             file: entry.file,

--- a/packages/tool-server/src/tools/profiler/react/react-profiler-component-source.ts
+++ b/packages/tool-server/src/tools/profiler/react/react-profiler-component-source.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "fs";
 import type { FileInputSpec, ToolDefinition } from "@argent/registry";
 import { buildAstIndexWithDiagnostics } from "../../../utils/react-profiler/pipeline/06-resolve/ast-index";
 import { RN_ONLY_TOOL_CAPABILITY } from "../../debugger/debugger-service-ref";
+import { astLookupCandidates } from "../../../utils/react-profiler/component-names";
 
 const zodSchema = z.object({
   component_name: z.string().describe("Name of the React component to look up"),
@@ -47,7 +48,12 @@ When several files define a component with the same name (e.g. platform variants
   services: () => ({}),
   async execute(_services, params) {
     const astIndex = await buildAstIndexWithDiagnostics(params.project_root);
-    const entry = astIndex.index.get(params.component_name);
+    // The profiler reports DevTools names (`Forget(Foo)`); the index is keyed on
+    // source identifiers (`Foo`). Without this, the one name the query tools
+    // accept is the one name this tool can never find.
+    const lookupKeys = astLookupCandidates(params.component_name);
+    const matchedKey = lookupKeys.find((k) => astIndex.index.has(k));
+    const entry = matchedKey ? astIndex.index.get(matchedKey) : undefined;
 
     if (!entry) {
       if (!astIndex.treeSitterAvailable) {
@@ -63,7 +69,14 @@ When several files define a component with the same name (e.g. platform variants
       return {
         found: false,
         component: params.component_name,
-        message: `Component "${params.component_name}" not found in ${params.project_root} (searched ${astIndex.indexedFiles} files).`,
+        message:
+          `Component "${params.component_name}" not found in ${params.project_root} ` +
+          `(searched ${astIndex.indexedFiles} files; also tried ${
+            lookupKeys
+              .slice(1)
+              .map((k) => `"${k}"`)
+              .join(", ") || "no variants"
+          }).`,
       };
     }
 
@@ -80,7 +93,10 @@ When several files define a component with the same name (e.g. platform variants
 
     return {
       found: true,
-      component: params.component_name,
+      // The key that actually matched, so the caller can tell which name hit
+      // when a wrapped name resolved through to a bare source identifier.
+      component: matchedKey ?? params.component_name,
+      requested: params.component_name,
       file: entry.file,
       line: entry.line,
       col: entry.col,

--- a/packages/tool-server/src/utils/react-profiler/component-names.ts
+++ b/packages/tool-server/src/utils/react-profiler/component-names.ts
@@ -1,0 +1,217 @@
+/**
+ * Component-name handling shared by the report renderer and the query tools.
+ *
+ * This codebase carries several component-name namespaces at once: React
+ * DevTools display names in commit data (`Forget(Foo)`, `Memo(Foo)`), and bare
+ * source identifiers in the tree-sitter AST index (`Foo`). The report prints
+ * the stripped form for readability, so the name an agent reads is not the name
+ * the commit data is keyed on — which is why the strip primitive and the
+ * resolver that depends on it live together here rather than inside a render
+ * stage. Two copies of the wrapper list is exactly how they drift apart.
+ */
+
+/** Wrappers React DevTools adds around a component's own name. */
+const WRAPPER_PATTERNS = [/^Forget\((.+)\)$/, /^Memo\((.+)\)$/, /^ForwardRef\((.+)\)$/] as const;
+
+/**
+ * Deliberately NOT stripped: `Animated(View)`, `AnimatedComponent(View)`,
+ * `Motion(View)`, `Context.Provider`, and the expo-router `Screen(./path.tsx)`
+ * form. The report never displays those stripped, so no agent will ever hold a
+ * stripped form of them — and stripping `Animated(View)` would make a query for
+ * `View` ambiguous in almost every session.
+ */
+const MAX_WRAPPER_DEPTH = 4;
+
+export interface StrippedName {
+  baseName: string;
+  hasForget: boolean;
+  hasMemo: boolean;
+  hasForwardRef: boolean;
+}
+
+export function stripComponentWrappers(raw: string): StrippedName {
+  let name = raw;
+  let hasForget = false;
+  let hasMemo = false;
+  let hasForwardRef = false;
+
+  for (let i = 0; i < MAX_WRAPPER_DEPTH; i++) {
+    const m = WRAPPER_PATTERNS.map((re) => name.match(re)).find(Boolean);
+    if (!m) break;
+    if (name.startsWith("Forget(")) hasForget = true;
+    else if (name.startsWith("Memo(")) hasMemo = true;
+    else if (name.startsWith("ForwardRef(")) hasForwardRef = true;
+    name = m[1]!;
+  }
+
+  return { baseName: name, hasForget, hasMemo, hasForwardRef };
+}
+
+export interface ComponentAnnotation {
+  displayName: string;
+  tag: string;
+  rawName: string;
+}
+
+/**
+ * The display form used throughout the report. `rawName` is what commit data is
+ * keyed on; `displayName` is what a reader sees — and therefore what they will
+ * type back, which is why the resolver below accepts it.
+ */
+export function annotateComponentName(raw: string): ComponentAnnotation {
+  const { baseName, hasForget, hasMemo, hasForwardRef } = stripComponentWrappers(raw);
+
+  const parts: string[] = [];
+  if (hasMemo) parts.push("React.memo");
+  if (hasForget) parts.push("React Compiler");
+  if (hasForwardRef) parts.push("forwardRef");
+  const tag = parts.length > 0 ? ` [${parts.join(" + ")}]` : "";
+
+  return { displayName: baseName, tag, rawName: raw };
+}
+
+export type ComponentNameResolution =
+  | { kind: "exact"; rawName: string; alsoMatching: string[] }
+  | { kind: "display"; rawName: string; query: string }
+  | { kind: "ambiguous"; query: string; candidates: string[] }
+  | { kind: "missing"; query: string; suggestions: string[] };
+
+/**
+ * Resolve a user-supplied component name against the names actually recorded in
+ * a session.
+ *
+ * Matching is against each recorded name's DISPLAY form, not a stripped form of
+ * the query. Stripping both sides would quietly cross-resolve wrappers — a query
+ * for `Forget(Foo)` would land on `Memo(Foo)` when only the latter exists — and
+ * it would not even be reliable, because the display stripper stops after
+ * MAX_WRAPPER_DEPTH, so a deeply wrapped name's display form still carries a
+ * wrapper. Comparing against the display form compares against exactly the
+ * string the report printed.
+ *
+ * Exact matches always win and are never widened.
+ */
+export function resolveComponentName(
+  query: string,
+  recordedNames: Iterable<string>
+): ComponentNameResolution {
+  const names = [...new Set(recordedNames)];
+
+  const sharingDisplayName = (raw: string): string[] => {
+    const display = annotateComponentName(raw).displayName;
+    return names.filter((n) => n !== raw && annotateComponentName(n).displayName === display);
+  };
+
+  if (names.includes(query)) {
+    // A wrapped sibling can share this display name (e.g. `StaticContainer` and
+    // `Memo(StaticContainer)` both exist). Resolve to what was asked for, but
+    // say the other one is there — otherwise the caller silently sees one of two.
+    return { kind: "exact", rawName: query, alsoMatching: sharingDisplayName(query) };
+  }
+
+  const candidates = names.filter((n) => annotateComponentName(n).displayName === query);
+  if (candidates.length === 1) {
+    return { kind: "display", rawName: candidates[0]!, query };
+  }
+  if (candidates.length > 1) {
+    return { kind: "ambiguous", query, candidates };
+  }
+
+  return { kind: "missing", query, suggestions: suggestNames(query, names) };
+}
+
+/**
+ * Loose, display-aware suggestions for a miss. Deliberately looser than the
+ * matcher: a suggestion only costs a retry, whereas loose matching would return
+ * data for a component nobody asked about.
+ */
+function suggestNames(query: string, names: string[], limit = 5): string[] {
+  const needle = query.toLowerCase();
+  if (needle.length < 2) return [];
+  return names
+    .filter((n) => {
+      const hay = `${n} ${annotateComponentName(n).displayName}`.toLowerCase();
+      return (
+        hay.includes(needle) || needle.includes(annotateComponentName(n).displayName.toLowerCase())
+      );
+    })
+    .slice(0, limit);
+}
+
+/**
+ * One-line note explaining a resolution that was not a plain exact hit, so the
+ * numbers below it are attributable to a specific recorded name.
+ */
+export function describeResolution(
+  resolution: Extract<ComponentNameResolution, { kind: "exact" | "display" }>
+): string {
+  if (resolution.kind === "display") {
+    const { tag } = annotateComponentName(resolution.rawName);
+    const why = tag ? ` (${tag.trim().slice(1, -1)})` : "";
+    return (
+      `> Resolved \`${resolution.query}\` to the recorded component ` +
+      `\`${resolution.rawName}\`${why}. Either name works here.`
+    );
+  }
+  if (resolution.alsoMatching.length > 0) {
+    const others = resolution.alsoMatching.map((n) => `\`${n}\``).join(", ");
+    return (
+      `> Showing \`${resolution.rawName}\` only. ${others} also appear${resolution.alsoMatching.length === 1 ? "s" : ""} ` +
+      `under this name once wrappers are stripped; they are separate fibers, so pass the exact name to target one.`
+    );
+  }
+  return "";
+}
+
+/** Shared markdown for the two non-resolving outcomes, so the tools cannot drift. */
+export function renderComponentNameMiss(
+  resolution: Extract<ComponentNameResolution, { kind: "ambiguous" | "missing" }>,
+  context: { fiberRenders?: number; commits?: number } = {}
+): string {
+  if (resolution.kind === "ambiguous") {
+    const list = resolution.candidates.map((c) => `- \`${c}\``).join("\n");
+    return (
+      `_Component \`${resolution.query}\` is ambiguous: ${resolution.candidates.length} recorded ` +
+      `components share this name once \`Memo(...)\` / \`ForwardRef(...)\` / \`Forget(...)\` wrappers ` +
+      `are stripped. They are separate fibers and are not merged, because a combined total would not ` +
+      `describe any real component. Re-run with one of these exact \`component_name\` values:_\n\n${list}`
+    );
+  }
+
+  const recorded =
+    context.fiberRenders != null && context.commits != null
+      ? ` The session recorded ${context.fiberRenders} fiber renders across ${context.commits} commits.`
+      : "";
+  const suggestions =
+    resolution.suggestions.length > 0
+      ? `\n\nClosest recorded names — pass one verbatim as \`component_name\`:\n` +
+        resolution.suggestions.map((s) => `- \`${s}\``).join("\n")
+      : "";
+
+  return (
+    `_Component \`${resolution.query}\` not found in this profiling session — no exact match, and no ` +
+    `component whose displayed name is \`${resolution.query}\` once \`Memo(...)\` / \`ForwardRef(...)\` / ` +
+    `\`Forget(...)\` wrappers are stripped.${recorded}_${suggestions}\n\n` +
+    `To list every component in a commit instead, run \`profiler-commit-query mode=by_index commit_index=<n>\`.`
+  );
+}
+
+/**
+ * Candidate keys for the tree-sitter AST index, which is keyed on bare source
+ * identifiers. Ordered most- to least-specific; callers take the first hit.
+ *
+ * The third form drops an expo-router style file suffix — the report shows
+ * `TabTwoScreen(./(tabs)/explore.tsx)` but the source declares `TabTwoScreen`.
+ * Loosening is safe here in a way it is not for commit-data matching: a wrong
+ * guess against the AST index simply misses and returns `found: false`.
+ */
+export function astLookupCandidates(raw: string): string[] {
+  const keys = [raw];
+  const { baseName } = stripComponentWrappers(raw);
+  if (baseName !== raw) keys.push(baseName);
+
+  const withoutSuffix = baseName.replace(/\(.*\)$/, "");
+  if (withoutSuffix !== baseName && /^[A-Za-z_$][\w$]*$/.test(withoutSuffix)) {
+    keys.push(withoutSuffix);
+  }
+  return keys;
+}

--- a/packages/tool-server/src/utils/react-profiler/pipeline/05-render.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/05-render.ts
@@ -13,46 +13,10 @@ import { promises as fs } from "fs";
 import { join } from "path";
 import type { HotCommitSummary, ComponentFinding } from "../types/output";
 import type { SessionContext } from "../types/pipeline";
+import { annotateComponentName } from "../component-names";
 
 const MAX_INLINE_COMMITS = 10;
 const REPORT_FILENAME = "react-profiler-report.md";
-
-interface ComponentAnnotation {
-  displayName: string;
-  tag: string;
-  rawName: string;
-}
-
-// Strips Forget/Memo/ForwardRef wrappers from display names and returns a
-// human-readable annotation for each wrapper found. rawName must be used in all
-// query tool suggestions — every pipeline stage keys on the original DevTools
-// string. Only apply displayName + tag in markdown text.
-function annotateComponentName(raw: string): ComponentAnnotation {
-  let name = raw;
-  let hasForget = false;
-  let hasMemo = false;
-  let hasForwardRef = false;
-
-  for (let i = 0; i < 4; i++) {
-    const m =
-      name.match(/^Forget\((.+)\)$/) ||
-      name.match(/^Memo\((.+)\)$/) ||
-      name.match(/^ForwardRef\((.+)\)$/);
-    if (!m) break;
-    if (name.startsWith("Forget(")) hasForget = true;
-    else if (name.startsWith("Memo(")) hasMemo = true;
-    else if (name.startsWith("ForwardRef(")) hasForwardRef = true;
-    name = m[1]!;
-  }
-
-  const parts: string[] = [];
-  if (hasMemo) parts.push("React.memo");
-  if (hasForget) parts.push("React Compiler");
-  if (hasForwardRef) parts.push("forwardRef");
-  const tag = parts.length > 0 ? ` [${parts.join(" + ")}]` : "";
-
-  return { displayName: name, tag, rawName: raw };
-}
 
 export interface RenderInput {
   hotCommitSummaries: HotCommitSummary[];

--- a/packages/tool-server/test/react-profiler/component-names.test.ts
+++ b/packages/tool-server/test/react-profiler/component-names.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripComponentWrappers,
+  annotateComponentName,
+  resolveComponentName,
+  renderComponentNameMiss,
+  astLookupCandidates,
+} from "../../src/utils/react-profiler/component-names";
+
+/**
+ * Names taken verbatim from a real Expo SDK 54 profiling session (RN 0.81.5,
+ * React Compiler on) — the session that produced issue #632. Includes the one
+ * genuine collision it contained and a router name whose inner text has
+ * parentheses, dots and slashes.
+ */
+const REAL_SESSION_NAMES = [
+  "Forget(ParallaxScrollView)",
+  "Forget(Collapsible)",
+  "Forget(IconSymbol)",
+  "Forget(ThemedText)",
+  "Forget(BottomTabItem)",
+  "Forget(TabTwoScreen(./(tabs)/explore.tsx))",
+  "StaticContainer",
+  "Memo(StaticContainer)",
+  "Anonymous",
+  "Animated(Anonymous)",
+  "Animated(View)",
+  "View",
+  "Context.Provider",
+  "InnerScreen",
+  "ForwardRef(InnerScreen)",
+];
+
+describe("stripComponentWrappers", () => {
+  it("strips the three wrappers React DevTools adds, including nested ones", () => {
+    expect(stripComponentWrappers("Forget(Foo)").baseName).toBe("Foo");
+    expect(stripComponentWrappers("Memo(Foo)").baseName).toBe("Foo");
+    expect(stripComponentWrappers("ForwardRef(Foo)").baseName).toBe("Foo");
+    expect(stripComponentWrappers("Memo(Forget(Foo))").baseName).toBe("Foo");
+    expect(stripComponentWrappers("Forget(Memo(ForwardRef(Memo(Deep))))").baseName).toBe("Deep");
+  });
+
+  it("handles an inner name containing parens, dots and slashes", () => {
+    // expo-router names a screen after its file, so the greedy anchored match
+    // must not stop at the first inner ")".
+    expect(stripComponentWrappers("Forget(TabTwoScreen(./(tabs)/explore.tsx))").baseName).toBe(
+      "TabTwoScreen(./(tabs)/explore.tsx)"
+    );
+  });
+
+  it("leaves wrappers the report never strips alone", () => {
+    // Stripping these would make a query for `View` ambiguous in almost every
+    // session, and no agent ever holds a stripped form of them.
+    for (const n of ["Animated(View)", "AnimatedComponent(View)", "Motion(View)", "Anonymous"]) {
+      expect(stripComponentWrappers(n).baseName).toBe(n);
+    }
+    expect(stripComponentWrappers("Context.Provider").baseName).toBe("Context.Provider");
+  });
+
+  it("reports which wrappers were present", () => {
+    const s = stripComponentWrappers("Memo(Forget(Foo))");
+    expect(s.hasMemo).toBe(true);
+    expect(s.hasForget).toBe(true);
+    expect(s.hasForwardRef).toBe(false);
+  });
+});
+
+describe("annotateComponentName", () => {
+  it("keeps the tag wording and ordering the report has always used", () => {
+    expect(annotateComponentName("Forget(Foo)")).toEqual({
+      displayName: "Foo",
+      tag: " [React Compiler]",
+      rawName: "Forget(Foo)",
+    });
+    expect(annotateComponentName("Memo(Forget(ForwardRef(Foo)))").tag).toBe(
+      " [React.memo + React Compiler + forwardRef]"
+    );
+    expect(annotateComponentName("View").tag).toBe("");
+  });
+});
+
+describe("resolveComponentName", () => {
+  it("resolves the display name the report prints — the issue", () => {
+    const r = resolveComponentName("ParallaxScrollView", REAL_SESSION_NAMES);
+    expect(r.kind).toBe("display");
+    expect(r.kind === "display" && r.rawName).toBe("Forget(ParallaxScrollView)");
+  });
+
+  it("still resolves the raw name unchanged", () => {
+    const r = resolveComponentName("Forget(ParallaxScrollView)", REAL_SESSION_NAMES);
+    expect(r.kind).toBe("exact");
+    expect(r.kind === "exact" && r.rawName).toBe("Forget(ParallaxScrollView)");
+  });
+
+  it("lets an exact match win over a wrapped sibling, and never widens it", () => {
+    // Both `StaticContainer` and `Memo(StaticContainer)` were recorded in one
+    // real session. Asking for the bare one must return the bare one.
+    const r = resolveComponentName("StaticContainer", REAL_SESSION_NAMES);
+    expect(r.kind).toBe("exact");
+    expect(r.kind === "exact" && r.rawName).toBe("StaticContainer");
+    // ...but the caller is told the other fiber exists, instead of silently
+    // seeing one of two.
+    expect(r.kind === "exact" && r.alsoMatching).toEqual(["Memo(StaticContainer)"]);
+  });
+
+  it("does not cross-resolve one wrapper into another", () => {
+    // Matching on the recorded name's DISPLAY form (not a stripped query)
+    // means asking for a Forget() fiber never silently returns a Memo() one.
+    const r = resolveComponentName("Forget(StaticContainer)", REAL_SESSION_NAMES);
+    expect(r.kind).toBe("missing");
+  });
+
+  it("does not resolve a non-stripped wrapper from its inner name", () => {
+    const r = resolveComponentName("View", REAL_SESSION_NAMES);
+    expect(r.kind).toBe("exact");
+    expect(r.kind === "exact" && r.rawName).toBe("View");
+    // `Animated(View)` is a different component and must not be pulled in.
+    expect(r.kind === "exact" && r.alsoMatching).toEqual([]);
+  });
+
+  it("refuses rather than merging when several fibers share a display name", () => {
+    const names = ["Memo(Widget)", "ForwardRef(Widget)"];
+    const r = resolveComponentName("Widget", names);
+    expect(r.kind).toBe("ambiguous");
+    expect(r.kind === "ambiguous" && r.candidates.sort()).toEqual([
+      "ForwardRef(Widget)",
+      "Memo(Widget)",
+    ]);
+  });
+
+  it("reports a miss with re-queryable suggestions", () => {
+    const r = resolveComponentName("ParallaxScroll", REAL_SESSION_NAMES);
+    expect(r.kind).toBe("missing");
+    expect(r.kind === "missing" && r.suggestions).toContain("Forget(ParallaxScrollView)");
+  });
+});
+
+describe("renderComponentNameMiss", () => {
+  it("hands back exact strings to retry with on an ambiguity", () => {
+    const r = resolveComponentName("Widget", ["Memo(Widget)", "ForwardRef(Widget)"]);
+    const out = renderComponentNameMiss(r as never);
+    expect(out).toContain("ambiguous");
+    expect(out).toContain("`Memo(Widget)`");
+    expect(out).toContain("`ForwardRef(Widget)`");
+    expect(out).toContain("are not merged");
+  });
+
+  it("quantifies the session so a miss can be told from an empty capture", () => {
+    const r = resolveComponentName("Nope", REAL_SESSION_NAMES);
+    const out = renderComponentNameMiss(r as never, { fiberRenders: 313, commits: 16 });
+    expect(out).toContain("313 fiber renders across 16 commits");
+    expect(out).toContain("profiler-commit-query");
+  });
+});
+
+describe("astLookupCandidates", () => {
+  it("offers the bare source identifier for a wrapped name", () => {
+    expect(astLookupCandidates("Forget(IconSymbol)")).toEqual(["Forget(IconSymbol)", "IconSymbol"]);
+  });
+
+  it("offers the declared identifier for an expo-router screen name", () => {
+    // The report shows `TabTwoScreen(./(tabs)/explore.tsx)`; the source declares
+    // `export default function TabTwoScreen()`.
+    expect(astLookupCandidates("Forget(TabTwoScreen(./(tabs)/explore.tsx))")).toEqual([
+      "Forget(TabTwoScreen(./(tabs)/explore.tsx))",
+      "TabTwoScreen(./(tabs)/explore.tsx)",
+      "TabTwoScreen",
+    ]);
+  });
+
+  it("does not invent variants for a plain name", () => {
+    expect(astLookupCandidates("IconSymbol")).toEqual(["IconSymbol"]);
+  });
+
+  it("only drops a suffix when what remains is a valid identifier", () => {
+    expect(astLookupCandidates("Context.Provider")).toEqual(["Context.Provider"]);
+  });
+});


### PR DESCRIPTION
Fixes #632.

## The problem

`react-profiler-analyze` strips `Forget()` / `Memo()` / `ForwardRef()` wrappers for readability, then the drill-down tools matched the raw DevTools name with `===`. The report names a component and the very next call refuses it. React Compiler is on by default in Expo SDK 54, so this hits essentially every new Expo app.

## Reproduced live

Real session on an Expo SDK 54 app (`experiments.reactCompiler: true`, RN 0.81.5) — 821 fiber renders, 16 commits. The report printed `` `ParallaxScrollView` [React Compiler] ``:

```
profiler-cpu-query component_cpu ParallaxScrollView         → "_Component `ParallaxScrollView` not found in commit data._"
profiler-cpu-query component_cpu Forget(ParallaxScrollView) → "_No CPU samples found during `Forget(...)` commits._"
```

The two messages differ, and that is the proof: "not found in commit data" means the name never matched; the other is emitted only *after* a match.

**Two things beyond the report:**

1. **`profiler-commit-query mode=by_component` has the same bug** — same refusal, full table under the raw name.
2. **It is not React-Compiler-specific.** `Memo()` and `ForwardRef()` are stripped too; the same report printed `` `InnerScreen` [forwardRef] ``.

## The workflow was a deadlock

The AST index is keyed on bare source identifiers, so `react-profiler-component-source` accepts only the name the query tools reject:

| name | query tools | component-source |
|---|---|---|
| `IconSymbol` | ✗ not found | ✓ file + line + source |
| `Forget(IconSymbol)` | ✓ resolves | ✗ not found |

There was **no single name an agent could carry** from analyze → drill-down → read source. Fixing only the query half would have left the issue's stated workflow broken.

## Approach

Match a query against each recorded name's **display form**, rather than stripping both sides.

Stripping both sides looks equivalent and is not:
- it would quietly answer a query for `Forget(Foo)` with `Memo(Foo)` when only the latter exists — the agent asked about the compiler-wrapped fiber and silently got the memo one;
- it isn't even reliable, because the display stripper stops after 4 wrappers, so a deeply wrapped name still *displays* with a wrapper and would never match.

Comparing against the display form compares against exactly the string that was printed.

**Exact matches always win and are never widened.** `StaticContainer` and `Memo(StaticContainer)` both appear in one ordinary 18-second session — I checked all 70 distinct names in the dump, and that is the one real collision. Asking for the bare name returns the bare fiber, and the output now names the sibling instead of silently showing one of two.

**Ambiguity is refused, not merged.** Where a display name maps to several distinct fibers the tools list the exact strings to retry with. `Memo(X)` and `X` are often one component's two fibers whose durations nest, so a merged total describes no real component; and picking the largest silently picks the memo wrapper's inclusive time, which is the wrong fiber for self-cost analysis.

The AST lookups get the reverse fallback: raw → stripped → expo-router file suffix removed (the report shows `TabTwoScreen(./(tabs)/explore.tsx)`; the source declares `TabTwoScreen`). Loosening is safe there in a way it is not for commit data — a wrong guess against the index simply misses and returns `found: false`.

## Verified against the live session

| Case | Result |
|---|---|
| `component_cpu ParallaxScrollView` | resolves to `Forget(ParallaxScrollView)` — was refused |
| `by_component ParallaxScrollView` | full table + `> Resolved … (React Compiler). Either name works here.` |
| `by_component Forget(ParallaxScrollView)` | **byte-identical to before**, no note |
| `by_component ParallaxScroll` (typo) | miss + `Forget(ParallaxScrollView)` as a re-queryable suggestion |
| `component-source Forget(IconSymbol)` | `found: true`, `icon-symbol.tsx:28` — was `found: false` |
| `component-source Forget(TabTwoScreen(./(tabs)/explore.tsx))` | `found: true`, `app/(tabs)/explore.tsx:12` |

## Visible report change (intentional)

Fixing the analyze-side lookup means wrapped components stop losing their source location. In the live session exactly one row changes — every other row is a node_modules component with no user source:

```
before:  | `IconSymbol` [React Compiler] | 6 | 0.1ms | … | — |
after:   | `IconSymbol` [React Compiler] | 6 | 0.1ms | … | `ui/icon-symbol.tsx:28` |
```

## Deliberately out of scope

- **`profiler-combined-report.ts:448`** correlates leaks to components by substring-matching raw names into native symbols, so wrapped components are structurally excluded. Same bug class — *affected, deferred*, not unaffected.
- **A deeper namespace bug, filed separately:** `react-profiler-stop` joins fiber metadata by name across two different namespaces, so wrapped fibers lose `parentName`, `hookTypes` and `isCompilerOptimized` entirely. Measured on this session: **41 wrapped fibers, 0 with any of the three**, versus 181/272 bare fibers carrying `parentName`. That is why the report's header says `React Compiler: ✗` while the same document tags six components `[React Compiler]`.

## Checks

- 3104 tests pass (298 files); 18 new, built on names taken verbatim from the real session
- the `annotateComponentName` move is a pure refactor — verified output-identical before anything else changed
- `03-tag.ts`'s `ANIMATED_PATTERN` deliberately left alone (it matches unanchored and covers `Motion`/`Transition`, which the stripper must not)
- tool `description:` fields unchanged, so the SpiderShield average is untouched; skills gate 10.0; prettier, eslint, both typechecks clean

---

> **#687 is stacked on this branch** — it conflicts with this one in `profiler-commit-query.ts`'s imports, so it was rebased on top. Merge this first.
