### PR TITLE
fix(android-profiler): explain an empty CPU section instead of rendering it as an idle app

### DIFF
--- a/packages/tool-server/src/tools/profiler/native-profiler/platforms/android.ts
+++ b/packages/tool-server/src/tools/profiler/native-profiler/platforms/android.ts
@@ -261,5 +261,7 @@ export async function analyzeNativeProfilerAndroid(
     // the metadata sidecar, restored by profiler-load). A large gap to "now"
     // means we're analyzing a trace from an earlier session, not a fresh capture.
     freshnessNote: formatTraceFreshness(api.wallClockStartMs, Date.now()) ?? undefined,
+    // Explains an absent CPU section when samples exist but carry no stacks.
+    cpuDiagnostic: pipelineResult.cpuDiagnostic,
   });
 }

--- a/packages/tool-server/src/utils/android-profiler/pipeline/index.ts
+++ b/packages/tool-server/src/utils/android-profiler/pipeline/index.ts
@@ -65,6 +65,12 @@ export interface AndroidPipelineResult {
   uiHangs: UiHang[];
   rssGrowth: MemoryRssGrowth[];
   exportErrors: Record<string, string>;
+  /**
+   * Set when CPU samples exist but none carry a usable stack. Deliberately NOT
+   * an exportErrors entry: no query failed, and the renderer counts those as
+   * failures ("N of 3 queries errored"), which would be untrue here.
+   */
+  cpuDiagnostic?: string;
 }
 
 /**
@@ -124,12 +130,26 @@ export async function runAndroidProfilerPipeline(
   if (cpuRows.length === 0 && hangRows.length === 0 && !exportErrors.cpu) {
     exportErrors.cpu =
       `No CPU samples were captured for cmdline \`${appPackage}\`. ` +
-      `The most common cause is the target app being non-debuggable (release build) ` +
-      `without a \`<profileable shell="true">\` entry in its AndroidManifest.xml. ` +
-      `Without that, Perfetto silently drops the linux.perf data source. ` +
-      `Add \`<profileable android:shell="true"/>\` to the \`<application>\` element ` +
-      `and rebuild, or run a debug variant of the app.`;
+      `The trace contains no perf_sample rows for a process with that name, so no CPU ` +
+      `analysis is possible. Either the name never matched a running process (it must equal ` +
+      `the process cmdline exactly), or the app was never scheduled on-CPU during the ` +
+      `recording. If it was running, it must be a debug build or declare ` +
+      `\`<profileable android:shell="true"/>\` under \`<application>\` in its ` +
+      `AndroidManifest.xml — then re-record.`;
   }
+
+  // Samples were recorded but none carry a usable stack. Distinct from the case
+  // above: the rows exist, they just aggregate to nothing, and every one is
+  // dropped further down for having no leaf function. Saying nothing here is
+  // what makes the report read as "the app did no CPU work".
+  const stacklessSamples = cpuRows.reduce(
+    (sum, r) => (r.leaf_function ? sum : sum + Number(r.sample_count)),
+    0
+  );
+  const cpuDiagnostic =
+    cpuRows.length > 0 && !cpuRows.some((r) => r.leaf_function) && stacklessSamples > 0
+      ? describeStacklessSamples(appPackage, cpuRows, stacklessSamples)
+      : undefined;
 
   const cpuHotspots = aggregateCpuHotspots(cpuRowsToAggregatorRows(cpuRows, traceStartNs), {
     platform: "android",
@@ -173,7 +193,14 @@ export async function runAndroidProfilerPipeline(
   const rssGrowth = rssRowsToBottlenecks(rssRows);
 
   const bottlenecks: Bottleneck[] = [...cpuHotspots, ...uiHangs, ...rssGrowth];
-  return { bottlenecks, cpuHotspots, uiHangs, rssGrowth, exportErrors };
+  return {
+    bottlenecks,
+    cpuHotspots,
+    uiHangs,
+    rssGrowth,
+    exportErrors,
+    ...(cpuDiagnostic ? { cpuDiagnostic } : {}),
+  };
 }
 
 /**
@@ -535,6 +562,38 @@ async function renderThreadBreakdownAndroid(
 // ---------------------------------------------------------------------------
 // Row → Bottleneck transformers
 // ---------------------------------------------------------------------------
+
+/**
+ * Explain a trace whose perf samples carry no usable stack.
+ *
+ * Two causes, told apart by whether a frame row existed at all: `leaf_mapping`
+ * comes from the same LEFT JOIN chain as `leaf_function`, so a mapping without a
+ * name means the stack was unwound and only the symbol is missing, while neither
+ * means nothing was ever unwound.
+ */
+function describeStacklessSamples(
+  appPackage: string,
+  cpuRows: AndroidCpuHotspotRow[],
+  stacklessSamples: number
+): string {
+  const unwound = cpuRows.some((r) => r.leaf_mapping);
+  const head =
+    `${stacklessSamples} CPU sample${stacklessSamples === 1 ? "" : "s"} were captured for ` +
+    `\`${appPackage}\`, but none carry a usable call stack, so no CPU hotspots could be ` +
+    `computed and \`profiler-stack-query\` mode=\`function_callers\` / mode=\`hang_stacks\` ` +
+    `will find nothing. The app was running — this is a capture limitation, not an idle app. ` +
+    `mode=\`thread_breakdown\` still works, since it counts samples and needs no stacks.`;
+
+  return unwound
+    ? `${head} The stacks were unwound but no frame resolved to a symbol, which points at ` +
+        `stripped native libraries. Profile a build that keeps its symbols (a debug build, or a ` +
+        `release build with unstripped \`.so\`s).`
+    : `${head} No stack was unwound at all: Perfetto only unwinds a process it can read ` +
+        `\`/proc/<pid>/mem\` for. Profile a debug build, or add ` +
+        `\`<profileable android:shell="true"/>\` to \`<application>\` and rebuild — verify with ` +
+        `\`adb shell dumpsys package ${appPackage}\`, which shows \`DEBUGGABLE\` for a profileable ` +
+        `target. Platform packages such as \`com.android.settings\` are never profileable.`;
+}
 
 function cpuRowsToAggregatorRows(
   rows: AndroidCpuHotspotRow[],

--- a/packages/tool-server/src/utils/ios-profiler/render.ts
+++ b/packages/tool-server/src/utils/ios-profiler/render.ts
@@ -25,6 +25,13 @@ interface RenderInput {
   /** Optional markdown warning shown in the header when the trace is stale. */
   freshnessNote?: string;
   /**
+   * Optional markdown warning about the CPU data itself — e.g. samples were
+   * captured but carry no call stacks. Rendered alongside freshnessNote rather
+   * than in exportErrors, because nothing errored and the all-clear banner
+   * counts exportErrors entries as failed queries.
+   */
+  cpuDiagnostic?: string;
+  /**
    * Whether the capture cold-launched the app with MallocStackLogging=1
    * (native-profiler-start's malloc_stack_logging flag). Null/undefined when
    * unknown — a session restored from disk has no capture-mode sidecar — in
@@ -47,7 +54,7 @@ interface InlineCap {
 export async function renderNativeProfilerReport(
   input: RenderInput
 ): Promise<NativeProfilerAnalyzeResult> {
-  const { payload, traceFile, freshnessNote, mallocStackLogging } = input;
+  const { payload, traceFile, freshnessNote, cpuDiagnostic, mallocStackLogging } = input;
   const exportErrors = input.exportErrors ?? {};
   const bottlenecksTotal = payload.bottlenecks.length;
   const status: "ok" | "analysis_failed" =
@@ -58,7 +65,7 @@ export async function renderNativeProfilerReport(
 
   const fullReport =
     bottlenecksTotal === 0
-      ? renderAllClear(payload, exportErrors, freshnessNote)
+      ? renderAllClear(payload, exportErrors, freshnessNote, cpuDiagnostic)
       : renderFullReport(
           payload,
           exportErrors,
@@ -67,7 +74,8 @@ export async function renderNativeProfilerReport(
             hangLimit: Infinity,
           },
           freshnessNote,
-          mallocStackLogging
+          mallocStackLogging,
+          cpuDiagnostic
         );
 
   const reportFile = traceFile ? deriveReportPath(traceFile) : null;
@@ -75,7 +83,7 @@ export async function renderNativeProfilerReport(
 
   const inlineReport =
     bottlenecksTotal === 0
-      ? renderAllClear(payload, exportErrors, freshnessNote)
+      ? renderAllClear(payload, exportErrors, freshnessNote, cpuDiagnostic)
       : renderFullReport(
           payload,
           exportErrors,
@@ -84,7 +92,8 @@ export async function renderNativeProfilerReport(
             hangLimit: MAX_INLINE_HANGS,
           },
           freshnessNote,
-          mallocStackLogging
+          mallocStackLogging,
+          cpuDiagnostic
         );
 
   const shownHotspots = Math.min(MAX_INLINE_HOTSPOTS, cpuHotspotsCount);
@@ -95,7 +104,7 @@ export async function renderNativeProfilerReport(
   const report =
     wroteFile && reportFile
       ? inlineReport +
-        `\n\n> Full report saved — ${bottlenecksTotal} bottleneck(s) total, showing top ${shownHotspots} CPU hotspots and top ${shownHangs} hangs inline. Use the Read tool on the \`reportFile\` path in this result to view all details.`
+        `\n\n> Full report saved — ${bottlenecksTotal} bottleneck(s) total, showing ${shownHotspots > 0 ? `top ${shownHotspots} CPU hotspots and ` : ``}top ${shownHangs} hangs inline. Use the Read tool on the \`reportFile\` path in this result to view all details.`
       : inlineReport;
 
   return {
@@ -163,7 +172,8 @@ function reportTitle(payload: ProfilerPayload): string {
 function renderAllClear(
   payload: ProfilerPayload,
   exportErrors?: Record<string, string>,
-  freshnessNote?: string
+  freshnessNote?: string,
+  cpuDiagnostic?: string
 ): string {
   const traceName = payload.metadata.traceFile
     ? `\`${path.basename(payload.metadata.traceFile)}\``
@@ -176,6 +186,7 @@ function renderAllClear(
   ];
 
   if (freshnessNote) lines.push(freshnessNote, ``);
+  if (cpuDiagnostic) lines.push(`> ⚠️ **CPU sampling:** ${cpuDiagnostic}`, ``);
 
   const errorLines = renderExportErrors(exportErrors);
   if (errorLines.length > 0) {
@@ -209,7 +220,8 @@ function renderFullReport(
   exportErrors?: Record<string, string>,
   cap: InlineCap = { hotspotLimit: Infinity, hangLimit: Infinity },
   freshnessNote?: string,
-  mallocStackLogging?: boolean | null
+  mallocStackLogging?: boolean | null,
+  cpuDiagnostic?: string
 ): string {
   const traceName = payload.metadata.traceFile
     ? `\`${path.basename(payload.metadata.traceFile)}\``
@@ -230,6 +242,7 @@ function renderFullReport(
   ];
 
   if (freshnessNote) lines.push(freshnessNote, ``);
+  if (cpuDiagnostic) lines.push(`> ⚠️ **CPU sampling:** ${cpuDiagnostic}`, ``);
 
   const errorLines = renderExportErrors(exportErrors);
   if (errorLines.length > 0) {

--- a/packages/tool-server/src/utils/ios-profiler/render.ts
+++ b/packages/tool-server/src/utils/ios-profiler/render.ts
@@ -98,13 +98,22 @@ export async function renderNativeProfilerReport(
 
   const shownHotspots = Math.min(MAX_INLINE_HOTSPOTS, cpuHotspotsCount);
   const shownHangs = Math.min(MAX_INLINE_HANGS, uiHangsCount);
+  // Name only the categories that are actually shown — "top 0 CPU hotspots" /
+  // "top 0 hangs" read as report artifacts. Both can be 0 at once (e.g. an
+  // RSS-growth-only trace still has bottlenecks), hence the fallback.
+  const shownParts = [
+    ...(shownHotspots > 0 ? [`top ${shownHotspots} CPU hotspots`] : []),
+    ...(shownHangs > 0 ? [`top ${shownHangs} hangs`] : []),
+  ];
+  const shownSummary =
+    shownParts.length > 0 ? `showing ${shownParts.join(" and ")} inline` : `summary inline`;
   // Reference the result field rather than embedding the host path: the
   // client materializes `reportFile` to a path on ITS machine, and the raw
   // server path would dangle when the tool-server runs remotely.
   const report =
     wroteFile && reportFile
       ? inlineReport +
-        `\n\n> Full report saved — ${bottlenecksTotal} bottleneck(s) total, showing ${shownHotspots > 0 ? `top ${shownHotspots} CPU hotspots and ` : ``}top ${shownHangs} hangs inline. Use the Read tool on the \`reportFile\` path in this result to view all details.`
+        `\n\n> Full report saved — ${bottlenecksTotal} bottleneck(s) total, ${shownSummary}. Use the Read tool on the \`reportFile\` path in this result to view all details.`
       : inlineReport;
 
   return {

--- a/packages/tool-server/test/android-perfetto/report-footer-shown-counts.test.ts
+++ b/packages/tool-server/test/android-perfetto/report-footer-shown-counts.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { renderNativeProfilerReport } from "../../src/utils/ios-profiler/render";
+import type {
+  CpuHotspot,
+  MemoryRssGrowth,
+  ProfilerPayload,
+  UiHang,
+} from "../../src/utils/ios-profiler/types";
+
+// The "Full report saved" footer must only name the bottleneck categories it
+// actually shows. "top 0 CPU hotspots" (the issue #629 stackless trace) and its
+// mirror "top 0 hangs" (a hotspot/RSS-only trace) both read as report
+// artifacts. The footer only renders when a report file is written, hence the
+// real temp traceFile.
+
+function cpuHotspot(): CpuHotspot {
+  return {
+    type: "cpu_hotspot",
+    platform: "android",
+    dominantFunction: "writel",
+    totalWeightMs: 120,
+    weightPercentage: 42,
+    sampleCount: 60,
+    thread: "RenderThread",
+    severity: "RED",
+    topCallChain: [],
+    topCallChains: [],
+    duringHang: false,
+    timeRangeMs: { first: 0, last: 1000 },
+    burstWindows: [],
+  };
+}
+
+function uiHang(): UiHang {
+  return {
+    type: "ui_hang",
+    platform: "android",
+    hangType: "jank",
+    durationMs: 40,
+    startTimeFormatted: "00:01.000",
+    startNs: 1_000_000_000,
+    endNs: 1_040_000_000,
+    suspectedFunctions: [],
+    appCallChains: [],
+    severity: "YELLOW",
+  };
+}
+
+function rssGrowth(): MemoryRssGrowth {
+  return {
+    type: "memory_rss_growth",
+    platform: "android",
+    startMb: 100,
+    peakMb: 180,
+    growthMb: 80,
+    severity: "YELLOW",
+  };
+}
+
+function payload(bottlenecks: ProfilerPayload["bottlenecks"], traceFile: string): ProfilerPayload {
+  return {
+    metadata: { traceFile, platform: "android", timestamp: "2026-01-01T00:00:00Z" },
+    bottlenecks,
+  };
+}
+
+describe("report footer — shown-count phrasing", () => {
+  let tempDir: string;
+  let traceFile: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "argent-footer-"));
+    traceFile = join(tempDir, "native-profiler-x.pftrace");
+    await writeFile(traceFile, "", "utf8");
+  });
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function footerFor(bottlenecks: ProfilerPayload["bottlenecks"]): Promise<string> {
+    const { report } = await renderNativeProfilerReport({
+      payload: payload(bottlenecks, traceFile),
+      traceFile,
+    });
+    const footer = report.split("\n").find((l) => l.includes("Full report saved"));
+    expect(footer).toBeDefined();
+    return footer as string;
+  }
+
+  it("names both categories when both are shown", async () => {
+    const footer = await footerFor([cpuHotspot(), uiHang()]);
+    expect(footer).toContain("showing top 1 CPU hotspots and top 1 hangs inline");
+  });
+
+  it("omits CPU hotspots from a hangs-only footer (the issue #629 stackless trace)", async () => {
+    const footer = await footerFor([uiHang(), uiHang()]);
+    expect(footer).toContain("showing top 2 hangs inline");
+    expect(footer).not.toContain("top 0 CPU hotspots");
+  });
+
+  it("omits hangs from a hotspots-only footer (the mirror case)", async () => {
+    const footer = await footerFor([cpuHotspot(), rssGrowth()]);
+    expect(footer).toContain("showing top 1 CPU hotspots inline");
+    expect(footer).not.toContain("top 0 hangs");
+  });
+
+  it("falls back cleanly when neither category is shown (RSS-growth-only trace)", async () => {
+    const footer = await footerFor([rssGrowth()]);
+    expect(footer).toContain("1 bottleneck(s) total, summary inline");
+    expect(footer).not.toContain("top 0");
+    expect(footer).not.toContain("showing  inline");
+  });
+});

--- a/packages/tool-server/test/android-perfetto/stackless-samples.test.ts
+++ b/packages/tool-server/test/android-perfetto/stackless-samples.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const queryResponses: Array<{ name: string; rows: unknown[] }> = [];
+
+vi.mock("@argent/native-devtools-android", () => {
+  const path = require("node:path");
+  return {
+    ensureTraceProcessorReady: vi.fn(async () => {}),
+    traceProcessorQueriesDir: () =>
+      path.resolve(__dirname, "../../../native-devtools-android/assets/queries"),
+  };
+});
+vi.mock("../../src/utils/android-profiler/pipeline/run-tp", () => ({
+  runTpQuery: vi.fn(async (opts: { query: string }) => {
+    const next = queryResponses.shift();
+    if (!next) throw new Error(`runTpQuery called for "${opts.query}" with no queued response`);
+    return next.rows;
+  }),
+  runTpInline: vi.fn(async () => []),
+}));
+
+import { runAndroidProfilerPipeline } from "../../src/utils/android-profiler/pipeline/index";
+
+/**
+ * A cpu-hotspots.sql row for a thread whose samples carried no usable stack.
+ * `leaf_mapping` is what separates "nothing was ever unwound" (null) from
+ * "unwound, but no symbol" (a module path).
+ */
+function stacklessRow(threadName: string, sampleCount: number, leafMapping: string | null = null) {
+  return {
+    thread_name: threadName,
+    is_main_thread: 0,
+    leaf_function: null,
+    leaf_mapping: leafMapping,
+    sample_count: sampleCount,
+    first_ts_ns: 0,
+    last_ts_ns: 1_000_000,
+    total_samples: sampleCount,
+    burst_windows: "0:1:1",
+  };
+}
+
+function namedRow(fn: string, sampleCount: number) {
+  return {
+    thread_name: "RenderThread",
+    is_main_thread: 0,
+    leaf_function: fn,
+    leaf_mapping: "/system/lib64/libhwui.so",
+    sample_count: sampleCount,
+    first_ts_ns: 0,
+    last_ts_ns: 1_000_000,
+    total_samples: sampleCount,
+    burst_windows: "0:1:1",
+  };
+}
+
+function queue(cpuRows: unknown[], hangRows: unknown[] = []) {
+  queryResponses.push(
+    { name: "trace-bounds.sql", rows: [{ start_ts: 0 }] },
+    { name: "cpu-hotspots.sql", rows: cpuRows },
+    { name: "ui-hangs.sql", rows: hangRows },
+    { name: "memory-rss.sql", rows: [] }
+  );
+}
+
+describe("Android pipeline — samples captured but no call stacks", () => {
+  beforeEach(() => {
+    queryResponses.length = 0;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains an empty CPU section instead of leaving it silently absent", async () => {
+    // The reported case: perf samples exist for the app (thread_breakdown counts
+    // them) but every one is dropped for having no leaf function, so the report
+    // read as though the app did no CPU work.
+    queue([stacklessRow("RenderThread", 238), stacklessRow("main", 44)]);
+
+    const result = await runAndroidProfilerPipeline("/fake.pftrace", "com.example.app");
+
+    expect(result.cpuHotspots).toHaveLength(0);
+    expect(result.cpuDiagnostic).toBeDefined();
+    expect(result.cpuDiagnostic).toContain("282 CPU samples");
+    expect(result.cpuDiagnostic).toContain("com.example.app");
+    expect(result.cpuDiagnostic).toContain("not an idle app");
+  });
+
+  it("is not an exportErrors entry, so the report cannot claim a query errored", async () => {
+    // exportErrors entries are counted as failed queries by the all-clear
+    // banner ("N of 3 queries errored"). Nothing errored here.
+    queue([stacklessRow("RenderThread", 100)]);
+
+    const result = await runAndroidProfilerPipeline("/fake.pftrace", "com.example.app");
+
+    expect(result.cpuDiagnostic).toBeDefined();
+    expect(result.exportErrors).toEqual({});
+  });
+
+  it("blames profileability when no frame was unwound at all", async () => {
+    queue([stacklessRow("RenderThread", 296, null)]);
+
+    const result = await runAndroidProfilerPipeline("/fake.pftrace", "com.example.app");
+
+    expect(result.cpuDiagnostic).toContain("profileable");
+    expect(result.cpuDiagnostic).toContain("dumpsys package com.example.app");
+    expect(result.cpuDiagnostic).not.toContain("stripped");
+  });
+
+  it("blames stripped symbols when frames were unwound but unnamed", async () => {
+    // A mapping without a name means the stack WAS unwound — only the symbol is
+    // missing, which is a different problem with a different fix.
+    queue([stacklessRow("RenderThread", 296, "/data/app/lib/arm64/libapp.so")]);
+
+    const result = await runAndroidProfilerPipeline("/fake.pftrace", "com.example.app");
+
+    expect(result.cpuDiagnostic).toContain("stripped");
+    expect(result.cpuDiagnostic).not.toContain("profileable");
+  });
+
+  it("says nothing when any sample carried a usable stack", async () => {
+    // Healthy traces must be untouched — including partially stackless ones,
+    // where a kernel leaf routinely fails to resolve.
+    queue([namedRow("writel", 38), stacklessRow("main", 5)]);
+
+    const result = await runAndroidProfilerPipeline("/fake.pftrace", "com.example.app");
+
+    expect(result.cpuHotspots.length).toBeGreaterThan(0);
+    expect(result.cpuDiagnostic).toBeUndefined();
+  });
+
+  it("leaves the no-samples-at-all case to the existing manifest hint", async () => {
+    queue([], []);
+
+    const result = await runAndroidProfilerPipeline("/fake.pftrace", "com.example.app");
+
+    expect(result.cpuDiagnostic).toBeUndefined();
+    expect(result.exportErrors.cpu).toContain("profileable");
+  });
+
+  it("still fires when the trace also has hangs", async () => {
+    // The manifest hint is deliberately suppressed once hangs exist, because
+    // "your app is not profileable" would be wrong advice for a traced app.
+    // This diagnostic describes a different state and must not inherit that gate
+    // — a real capture almost always has hangs.
+    queue(
+      [stacklessRow("RenderThread", 296)],
+      [
+        {
+          kind: "jank",
+          ts_ns: 1_000_000_000,
+          dur_ns: 40_000_000,
+          process_name: "com.example.app",
+          reason: "App Deadline Missed",
+          error_id: null,
+        },
+      ]
+    );
+
+    const result = await runAndroidProfilerPipeline("/fake.pftrace", "com.example.app");
+
+    expect(result.cpuDiagnostic).toBeDefined();
+    expect(result.exportErrors.cpu).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #629.

## Reproduced, then diagnosed harder than the report

Pixel_9 / API 36, `com.android.settings`, real interaction — all three symptoms reproduced:

```
native-profiler-analyze  → 70 hangs + RSS populated, NO CPU section,
                           "showing top 0 CPU hotspots", exportErrors: {}
thread_breakdown         → 296 samples across 9 threads
function_callers epoll_wait → not found
```

The report infers "unsymbolized frames". It's stronger than that — I queried the `.pftrace` directly:

| | value |
|---|---|
| samples for the process | 296 |
| samples with a `callsite_id` | **0** |
| `stack_profile_frame` rows (trace-wide) | **0** |
| `stats.perf_samples_skipped` | **296** |
| `unwind_error` | NULL on every row |

**The unwinder never ran.** There are no frames to symbolize. That's why `thread_breakdown` — which counts `perf_sample` rows and never joins the symbol tables — reports 296 while every stack-dependent view is empty.

## Positive control: same emulator, debuggable app

```
adb shell getprop ro.build.type                      → user
dumpsys package com.android.settings | grep pkgFlags → [ SYSTEM HAS_CODE … ]   ← no DEBUGGABLE
dumpsys package com.anonymous.myapp  | grep pkgFlags → [ DEBUGGABLE HAS_CODE … ]
```

| | com.android.settings | com.anonymous.myapp (debuggable) |
|---|---|---|
| samples / with callsite / named leaf | 296 / **0** / **0** | 86 / **86** / **78** |
| frames in trace | **0** | **723** |
| `perf_samples_skipped` | **296** | **0** |
| analyze | no CPU section | `writel` 48.72%, `internal_get_user_pages_fast` 6.41% |

So this is **not** an emulator limitation and **not** symbolization — it's target profileability. The remedy the message gives is verified to work on the very device it describes.

## The fix

The pipeline detects "samples exist, none carry a usable stack" and says so. It names the count and the package, and distinguishes two causes using **`leaf_mapping`, already on the row** — no new query needed. It comes from the same join chain as `leaf_function`, so a mapping with no name means the stack *was* unwound and only the symbol is missing (stripped `.so`s), while neither means nothing was unwound (not profileable). Different problems, different fixes.

Live output on the bad trace:

> ⚠️ **CPU sampling:** 296 CPU samples were captured for `com.android.settings`, but none carry a usable call stack, so no CPU hotspots could be computed and `profiler-stack-query` mode=`function_callers` / mode=`hang_stacks` will find nothing. The app was running — this is a capture limitation, not an idle app. mode=`thread_breakdown` still works, since it counts samples and needs no stacks. No stack was unwound at all: Perfetto only unwinds a process it can read `/proc/<pid>/mem` for. Profile a debug build, or add `<profileable android:shell="true"/>` to `<application>` and rebuild — verify with `adb shell dumpsys package com.android.settings`, which shows `DEBUGGABLE` for a profileable target.

**Not routed through `exportErrors`.** That looked free — it renders above the Summary with no plumbing — but `renderAllClear` counts its entries as failed queries and would print *"1 of 3 queries errored"* about three queries that all succeeded. It goes through a `cpuDiagnostic` note instead, alongside the existing `freshnessNote`, and `status` stays `ok`.

**Also fixed:** the footer no longer says "showing top 0 CPU hotspots" — the literal artifact in the report title.

## What I deliberately did NOT touch

The existing no-samples-at-all manifest hint stays gated on `hangRows.length === 0`. That gate is intentional and pinned by `manifest-hint.test.ts:52` ("does NOT emit a manifest hint when hangs were found but CPU was empty") — once hangs come back the app clearly *was* traced, so blaming the manifest is wrong advice.

It also wouldn't have helped: in the reported case `cpuRows.length` is **9, not 0**, so state A is never reached. Ungating it would have fired the hint on ~6 more existing fixtures and flipped their `status`, for no benefit. I only corrected its text, which claimed "Perfetto silently drops the linux.perf data source" — this issue proves a non-profileable app still yields samples.

## Verified live, both directions

| trace | CPU warning | CPU section | footer | status |
|---|---|---|---|---|
| stackless (`com.android.settings`) | ✅ shown | absent | `showing top 3 hangs` | `ok`, `exportErrors: {}` |
| healthy (debuggable app) | ✅ absent | present | `showing top 2 CPU hotspots and top 3 hangs` | `ok` |

## Deliberately deferred (filed separately)

- `thread_breakdown` / `function_callers` notes — the issue's "and ideally" half. Needs a new `thread-breakdown.sql` aggregate plus fixture updates in two test files.
- A partially-stackless trace renders percentages that **sum to 100%** while describing only the surviving fraction — arguably more misleading than the empty case here, and a distinct defect.
- Repo docs assert the behaviour this PR only now implements.

## Checks

- 3093 tests pass; 7 new. **All 200 existing android-perfetto tests pass unmodified**, including the manifest-hint gate.
- `tool-description-quality.yml` doesn't run (path-filtered to `src/tools/**`); prettier, eslint, both typechecks clean; lock untouched.