### PR TITLE
fix(gestures): reject off-screen finger positions instead of dispatching them

### DIFF
--- a/packages/tool-server/src/tools/gesture-pinch/index.ts
+++ b/packages/tool-server/src/tools/gesture-pinch/index.ts
@@ -2,7 +2,13 @@ import { z } from "zod";
 import type { ToolCapability, ToolDefinition } from "@argent/registry";
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
-import { sendTouchEvent } from "../../utils/gesture-utils";
+import {
+  sendTouchEvent,
+  findOffScreenFinger,
+  describeOffScreenEdge,
+  type TwoFingerFrame,
+} from "../../utils/gesture-utils";
+import { InvalidToolInputError } from "../../utils/capability";
 import { sleep } from "../../utils/timing";
 
 const zodSchema = z.object({
@@ -82,7 +88,7 @@ export const gesturePinchTool: ToolDefinition<Params, Result> = {
 startDistance > endDistance = pinch in (zoom out). startDistance < endDistance = pinch out (zoom in).
 Typical values: startDistance 0.2, endDistance 0.6 for a zoom-in pinch at screen center.
 Auto-generates interpolated frames at ~60fps. The angle parameter controls the axis (0 = horizontal, 90 = vertical). Optional endCenterX/endCenterY drift the centroid linearly over the gesture (omitted = fixed center).
-Use when you need to zoom in or out on a map, image, or zoomable view. Returns { pinched: true, timestampMs }. Fails if the simulator-server / emulator backend is not reachable for the given device.`,
+Use when you need to zoom in or out on a map, image, or zoomable view. Returns { pinched: true, timestampMs }. Fails if the simulator-server / emulator backend is not reachable for the given device, or if the computed finger positions fall outside 0-1 — reduce the distance, move the center, or use endCenterX/endCenterY. Note a finger that merely lands NEAR an edge can still be grabbed by a system gesture (the Android notification shade sits at the top edge), so keep some margin.`,
   zodSchema,
   capability,
   services: (params) => ({
@@ -99,8 +105,10 @@ Use when you need to zoom in or out on a map, image, or zoomable view. Returns {
     const endCenterX = params.endCenterX ?? params.centerX;
     const endCenterY = params.endCenterY ?? params.centerY;
 
-    let timestampMs = 0;
-
+    // Build every frame before touching the device: a finger that leaves the
+    // screen has to be caught while nothing has been dispatched, or the gesture
+    // is already half-sent when it is rejected.
+    const frames: TwoFingerFrame[] = [];
     for (let i = 0; i <= steps; i++) {
       const t = i / steps;
       const dist = params.startDistance + (params.endDistance - params.startDistance) * t;
@@ -108,15 +116,35 @@ Use when you need to zoom in or out on a map, image, or zoomable view. Returns {
       const cx = params.centerX + (endCenterX - params.centerX) * t;
       const cy = params.centerY + (endCenterY - params.centerY) * t;
 
-      const x1 = cx - halfDist * cosA;
-      const y1 = cy - halfDist * sinA;
-      const x2 = cx + halfDist * cosA;
-      const y2 = cy + halfDist * sinA;
+      frames.push({
+        x1: cx - halfDist * cosA,
+        y1: cy - halfDist * sinA,
+        x2: cx + halfDist * cosA,
+        y2: cy + halfDist * sinA,
+      });
+    }
 
+    const offScreen = findOffScreenFinger(frames);
+    if (offScreen) {
+      const when = offScreen.frameIndex === 0 ? "at the start of" : "during";
+      throw new InvalidToolInputError(
+        `gesture-pinch: finger ${offScreen.axis} = ${offScreen.value} ${when} the gesture is ` +
+          `off-screen (must be 0–1). centerX ${params.centerX} / centerY ${params.centerY} with ` +
+          `startDistance ${params.startDistance} at angle ${angleDeg} puts a finger ` +
+          `${describeOffScreenEdge(offScreen.axis, offScreen.value)} — the OS reads an off-screen ` +
+          `touch as a system gesture (on Android, the notification shade) instead of a pinch, so the ` +
+          `app never sees it. Reduce the distance, move the center, or set endCenterX/endCenterY to ` +
+          `drift the centroid inward as the fingers spread.`
+      );
+    }
+
+    let timestampMs = 0;
+
+    for (const [i, frame] of frames.entries()) {
       const type = i === 0 ? "Down" : i === steps ? "Up" : "Move";
       if (i === 0) timestampMs = Date.now();
 
-      sendTouchEvent(api, type, x1, y1, x2, y2);
+      sendTouchEvent(api, type, frame.x1, frame.y1, frame.x2, frame.y2);
       if (i < steps) await sleep(16);
     }
 

--- a/packages/tool-server/src/tools/gesture-rotate/index.ts
+++ b/packages/tool-server/src/tools/gesture-rotate/index.ts
@@ -7,7 +7,13 @@ import {
 } from "@argent/registry";
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
-import { sendTouchEvent } from "../../utils/gesture-utils";
+import {
+  sendTouchEvent,
+  findOffScreenFinger,
+  describeOffScreenEdge,
+  type TwoFingerFrame,
+} from "../../utils/gesture-utils";
+import { InvalidToolInputError } from "../../utils/capability";
 import { sleep } from "../../utils/timing";
 
 const zodSchema = z
@@ -108,7 +114,7 @@ export const gestureRotateTool: ToolDefinition<Params, Result> = {
 endAngle > startAngle = clockwise rotation. Typical values: radius 0.15, startAngle 0, endAngle 90 for a 90° clockwise turn. A single radius applies to both axes, so on a non-square screen it traces a physical ellipse (finger separation varies through the turn); pass radiusX+radiusY (fractions of width/height with radiusX·width = radiusY·height) for a physically circular orbit instead.
 Auto-generates interpolated frames at ~60fps.
 Unlike gesture-pinch which moves fingers linearly to zoom, this orbits fingers in an arc to change orientation.
-Use when you need to rotate a map, image picker, or any rotateable UI element. Returns { rotated: true, timestampMs }. Fails if the simulator-server / emulator backend is not reachable for the given device.`,
+Use when you need to rotate a map, image picker, or any rotateable UI element. Returns { rotated: true, timestampMs }. Fails if the simulator-server / emulator backend is not reachable for the given device, or if any swept finger position falls outside 0-1 — reduce the radius, move the center, or sweep a narrower arc. Note a finger that merely lands NEAR an edge can still be grabbed by a system gesture, so keep some margin.`,
   zodSchema,
   inputSchema,
   capability,
@@ -123,6 +129,39 @@ Use when you need to rotate a map, image picker, or any rotateable UI element. R
     const radiusX = params.radiusX ?? params.radius!;
     const radiusY = params.radiusY ?? params.radius!;
 
+    // Build the swept frames before dispatching. Unlike a pinch, an arc is not
+    // monotonic between its endpoints — 0°→180° starts and ends near the centre
+    // line while passing a full radius away at 90° — so the only reliable check
+    // is over the frames that will actually be sent.
+    const frames: TwoFingerFrame[] = [];
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      const angleDeg = params.startAngle + (params.endAngle - params.startAngle) * t;
+      const angleRad = (angleDeg * Math.PI) / 180;
+
+      frames.push({
+        x1: params.centerX + radiusX * Math.cos(angleRad),
+        y1: params.centerY + radiusY * Math.sin(angleRad),
+        x2: params.centerX - radiusX * Math.cos(angleRad),
+        y2: params.centerY - radiusY * Math.sin(angleRad),
+      });
+    }
+
+    const offScreen = findOffScreenFinger(frames);
+    if (offScreen) {
+      const sweptDeg =
+        params.startAngle +
+        (params.endAngle - params.startAngle) * (offScreen.frameIndex / Math.max(1, steps));
+      throw new InvalidToolInputError(
+        `gesture-rotate: finger ${offScreen.axis} = ${offScreen.value} at ${Math.round(sweptDeg)}° ` +
+          `of the sweep is off-screen (must be 0–1). centerX ${params.centerX} / centerY ` +
+          `${params.centerY} with radiusX ${radiusX} / radiusY ${radiusY} puts a finger ` +
+          `${describeOffScreenEdge(offScreen.axis, offScreen.value)} — the OS reads an off-screen ` +
+          `touch as a system gesture instead of a rotation, so the app never sees it. Reduce the ` +
+          `radius, move the center away from that edge, or sweep a narrower arc.`
+      );
+    }
+
     let timestampMs = 0;
     // Last dispatched finger positions, so an abort can lift from where the
     // fingers actually are.
@@ -131,7 +170,7 @@ Use when you need to rotate a map, image picker, or any rotateable UI element. R
     let lastX2 = 0;
     let lastY2 = 0;
 
-    for (let i = 0; i <= steps; i++) {
+    for (const [i, frame] of frames.entries()) {
       if (ctx?.signal?.aborted) {
         // Once Down has been dispatched, the synthetic fingers are on the glass —
         // send a terminal Up so a cancelled run doesn't leave them held down.
@@ -143,23 +182,14 @@ Use when you need to rotate a map, image picker, or any rotateable UI element. R
         throw err;
       }
 
-      const t = i / steps;
-      const angleDeg = params.startAngle + (params.endAngle - params.startAngle) * t;
-      const angleRad = (angleDeg * Math.PI) / 180;
-
-      const x1 = params.centerX + radiusX * Math.cos(angleRad);
-      const y1 = params.centerY + radiusY * Math.sin(angleRad);
-      const x2 = params.centerX - radiusX * Math.cos(angleRad);
-      const y2 = params.centerY - radiusY * Math.sin(angleRad);
-
       const type = i === 0 ? "Down" : i === steps ? "Up" : "Move";
       if (i === 0) timestampMs = Date.now();
 
-      sendTouchEvent(api, type, x1, y1, x2, y2);
-      lastX1 = x1;
-      lastY1 = y1;
-      lastX2 = x2;
-      lastY2 = y2;
+      sendTouchEvent(api, type, frame.x1, frame.y1, frame.x2, frame.y2);
+      lastX1 = frame.x1;
+      lastY1 = frame.y1;
+      lastX2 = frame.x2;
+      lastY2 = frame.y2;
       if (i < steps) await sleep(16);
     }
 

--- a/packages/tool-server/src/utils/gesture-utils.ts
+++ b/packages/tool-server/src/utils/gesture-utils.ts
@@ -82,3 +82,68 @@ export function sendTouchEvent(
     second_y: y2 ?? null,
   });
 }
+
+/** One dispatched frame of a two-finger gesture, in normalized coordinates. */
+export interface TwoFingerFrame {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/**
+ * Tolerance for the on-screen check. A gesture spanning the full screen lands
+ * exactly on 0 or 1, and the arithmetic that gets there can drift a few ulps
+ * (a real rotate frame produces 0.09999999999999998), so the comparison is
+ * inclusive with a little slack rather than a bare `< 0`.
+ */
+const ON_SCREEN_EPSILON = 1e-9;
+
+/**
+ * First finger position in `frames` that falls outside the screen, or undefined
+ * if every one is on it.
+ *
+ * Checked against the frames that will actually be dispatched rather than
+ * derived analytically: a pinch is affine in time so its endpoints would bound
+ * it, but a rotate sweep is not — an arc from 0° to 180° has both endpoints near
+ * the centre line while the frame at 90° reaches a full radius away.
+ *
+ * Callers must run this BEFORE dispatching anything. A finger that goes
+ * off-screen mid-gesture is reported by Android as a system gesture (the
+ * notification shade, back, or home) instead of reaching the app, and rejecting
+ * after the first `Down` would leave a synthetic finger held on the glass.
+ */
+export function findOffScreenFinger(
+  frames: TwoFingerFrame[]
+):
+  | { frameIndex: number; frameCount: number; finger: 1 | 2; axis: "x" | "y"; value: number }
+  | undefined {
+  for (const [frameIndex, frame] of frames.entries()) {
+    const candidates = [
+      { finger: 1 as const, axis: "x" as const, value: frame.x1 },
+      { finger: 1 as const, axis: "y" as const, value: frame.y1 },
+      { finger: 2 as const, axis: "x" as const, value: frame.x2 },
+      { finger: 2 as const, axis: "y" as const, value: frame.y2 },
+    ];
+    for (const candidate of candidates) {
+      if (candidate.value < -ON_SCREEN_EPSILON || candidate.value > 1 + ON_SCREEN_EPSILON) {
+        // Rounded for the message: the raw sum carries float noise
+        // (-0.025000000000000022), which reads as false precision.
+        return {
+          frameIndex,
+          frameCount: frames.length,
+          ...candidate,
+          value: Number(candidate.value.toFixed(6)),
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
+/** How far past which edge a coordinate went, for an error message. */
+export function describeOffScreenEdge(axis: "x" | "y", value: number): string {
+  const past = value < 0 ? -value : value - 1;
+  const edge = axis === "y" ? (value < 0 ? "top" : "bottom") : value < 0 ? "left" : "right";
+  return `${past.toFixed(3).replace(/\.?0+$/, "")} past the ${edge} edge`;
+}

--- a/packages/tool-server/test/gesture-off-screen-fingers.test.ts
+++ b/packages/tool-server/test/gesture-off-screen-fingers.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/simulator-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/utils/simulator-client")>()),
+  sendCommand: vi.fn(),
+}));
+
+import { gesturePinchTool } from "../src/tools/gesture-pinch";
+import { gestureRotateTool } from "../src/tools/gesture-rotate";
+import { sendCommand } from "../src/utils/simulator-client";
+
+const udid = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA";
+const services = { simulatorServer: {} } as never;
+
+beforeEach(() => {
+  vi.mocked(sendCommand).mockReset();
+});
+
+describe("gesture-pinch — off-screen fingers", () => {
+  it("rejects the reported case instead of dispatching it", async () => {
+    // centerY 0.35 with startDistance 0.75 at 90° puts a finger at y = -0.025.
+    // Dispatched, Android reads it as a status-bar pull and opens the
+    // notification shade while the tool reports success.
+    await expect(
+      gesturePinchTool.execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.35,
+        startDistance: 0.75,
+        endDistance: 0.2,
+        angle: 90,
+      })
+    ).rejects.toThrow(/finger y = -0\.025/);
+  });
+
+  it("sends nothing at all when it rejects", async () => {
+    // The check has to run before the first Down: rejecting mid-gesture would
+    // leave a synthetic finger held on the glass with no matching Up.
+    await gesturePinchTool
+      .execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.35,
+        startDistance: 0.75,
+        endDistance: 0.2,
+        angle: 90,
+      })
+      .catch(() => {});
+
+    expect(vi.mocked(sendCommand)).not.toHaveBeenCalled();
+  });
+
+  it("names the edge and points at the documented remedy", async () => {
+    const err = await gesturePinchTool
+      .execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.35,
+        startDistance: 0.75,
+        endDistance: 0.2,
+        angle: 90,
+      })
+      .catch((e: Error) => e);
+
+    expect(String(err)).toContain("top edge");
+    expect(String(err)).toContain("endCenterX/endCenterY");
+  });
+
+  it("accepts a gesture whose finger lands exactly on the edge", async () => {
+    // A full-width pinch legitimately touches 0 and 1; rejecting that would
+    // forbid the widest valid gesture.
+    await expect(
+      gesturePinchTool.execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.375,
+        startDistance: 0.75,
+        endDistance: 0.2,
+        angle: 90,
+      })
+    ).resolves.toMatchObject({ pinched: true });
+  });
+
+  it("still rejects when only a later frame leaves the screen", async () => {
+    // Fingers start well inside and spread past the left/right edges as the
+    // gesture runs, so an inspection of the first frame alone would miss it.
+    await expect(
+      gesturePinchTool.execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.5,
+        startDistance: 0.2,
+        endDistance: 1.4,
+        angle: 0,
+      })
+    ).rejects.toThrow(/off-screen/);
+  });
+});
+
+describe("gesture-rotate — off-screen fingers", () => {
+  it("rejects an orbit that leaves the screen", async () => {
+    await expect(
+      gestureRotateTool.execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.3,
+        radius: 0.45,
+        startAngle: 270,
+        endAngle: 300,
+      })
+    ).rejects.toThrow(/finger y = -0\.15/);
+  });
+
+  it("sends nothing at all when it rejects", async () => {
+    await gestureRotateTool
+      .execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.3,
+        radius: 0.45,
+        startAngle: 270,
+        endAngle: 300,
+      })
+      .catch(() => {});
+
+    expect(vi.mocked(sendCommand)).not.toHaveBeenCalled();
+  });
+
+  it("accepts a short arc that stays on-screen even though the full circle would not", async () => {
+    // The same center and radius as the rejected case above: only the swept
+    // portion matters, so checking the whole orbit would refuse a valid gesture.
+    await expect(
+      gestureRotateTool.execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.3,
+        radius: 0.45,
+        startAngle: 0,
+        endAngle: 20,
+      })
+    ).resolves.toMatchObject({ rotated: true });
+  });
+
+  it("rejects an arc whose endpoints are on-screen but whose midpoint is not", async () => {
+    // 0° and 180° both put the fingers on the centre line, so an endpoint-only
+    // check passes while the frame near 90° reaches a full radius past the top.
+    await expect(
+      gestureRotateTool.execute(services, {
+        udid,
+        centerX: 0.5,
+        centerY: 0.2,
+        radius: 0.25,
+        startAngle: 0,
+        endAngle: 180,
+      })
+    ).rejects.toThrow(/off-screen/);
+  });
+});


### PR DESCRIPTION
Fixes #628.

## Reproduced first try

```
gesture-pinch { centerX: 0.5, centerY: 0.35, startDistance: 0.75, endDistance: 0.2, angle: 90 }
→ { "pinched": true }        …and the notification shade is open
```

`0.35 − 0.75/2 = −0.025`. Android reads the off-screen touch as a status-bar pull, so the app never sees the pinch, and the tool reports success.

**`gesture-rotate` has the identical gap** (not in the issue) — verified live at `y = −0.15`, returning `{rotated: true}`. It didn't happen to open the shade on that path, which is what makes it worse to leave: the same invalid input is sometimes silently harmful.

## Clamping — the issue's first suggestion — does not work

I tested the clamped outcome directly, by picking parameters that land a finger exactly where clamping would put it:

```
gesture-pinch { centerY: 0.375, startDistance: 0.75, angle: 90 }   ⇒ y1 = 0.0 exactly
→ { "pinched": true }        …and the notification shade opened again
```

A finger at **exactly y = 0.0** — perfectly in bounds — still trips the system gesture. So clamping `−0.025 → 0.0` converts an off-screen touch into an in-bounds touch with the *same observable failure*, while still reporting success. It would also change the effective separation (0.75 → 0.725) and shift the zoom anchor off `centerY`, so the caller silently gets a different gesture than it asked for.

The repo already knows `[0,1]` isn't safe: `flow-pinch-geometry.ts:17` defines `SCREEN_EDGE_INSET = 0.02` and `:37-40` encodes system-gesture zones (`top: 0.08`, from a Pixel measurement).

So: **reject**, and additionally say in both tool descriptions that a finger merely *near* an edge can still be taken by a system gesture. I did **not** promote those inset constants into the tool layer — the flow layer that owns them deliberately treats them as "prefer-not-reject no-start zones" and demotes in ranking rather than rejecting, and hard-rejecting them here would refuse deliberate edge gestures.

## Implementation

Both tools build every frame, validate, and only then dispatch — **a rejected call sends zero touch events**. Rejecting after the first `Down` would strand a synthetic finger with no matching `Up`, which `gesture-rotate`'s abort path already guards against and `gesture-pinch` has no protection for.

The check runs over the **frames that will actually be sent**, not the endpoints. A pinch is affine in `t` so endpoints would bound it — but an arc is not: `0°→180°` starts and ends on the centre line while passing a full radius away at 90°. There's a test for exactly that. Checking swept frames also keeps a legitimate short arc near an edge valid, which a "whole circle must fit" check would refuse (also tested).

Bounds are **inclusive** with a small epsilon: a full-width gesture legitimately produces exactly `0` or `1`, and a real rotate frame already yields `0.09999999999999998`.

Live output:

```
gesture-pinch: finger y = -0.025 at the start of the gesture is off-screen (must be 0–1).
centerX 0.5 / centerY 0.35 with startDistance 0.75 at angle 90 puts a finger 0.025 past the
top edge — the OS reads an off-screen touch as a system gesture (on Android, the notification
shade) instead of a pinch, so the app never sees it. Reduce the distance, move the center, or
set endCenterX/endCenterY to drift the centroid inward as the fingers spread.   [HTTP 400]
```

Uses `InvalidToolInputError`, which surfaces the **bare** message at HTTP 400. A zod `.refine()` would have been JSON-serialized into zod's issue array, burying the coordinate — and refinements are dropped from the advertised JSON Schema anyway, as `gesture-rotate/index.ts:65-67` already notes.

## Scope

Only the two tools that *derive* positions the caller can't see. `gesture-tap`/`swipe`/`custom` take coordinates directly — there the value is the caller's stated intent, nothing is computed and hidden.

Worth a follow-up, noted while checking: `gesture-tap`'s Chromium path clamps to the viewport while its native path doesn't. And `run-sequence` catches a step throw and returns **HTTP 200** with partial results, so a rejected gesture inside a sequence stops the remainder — the message is written to read standalone.

## Verified live on a Pixel_9

| call | result |
|---|---|
| reported pinch | HTTP 400, coordinate named, **no shade**, nothing dispatched |
| rotate at y = −0.15 | HTTP 400, coordinate named |
| valid pinch (0.5/0.5, 0.2→0.6) | `{pinched: true}`, gesture reached the app |

## Checks

- 3095 tests pass; 9 new. **All 8 pre-existing gesture tests pass unmodified**, including rotate's abort test.
- SpiderShield 9.08 avg (both tools 9.2, up from the description gaining explicit failure guidance); extract-tools 46/46; prettier, eslint, both typechecks clean; lock untouched.