### PR TITLE
fix(describe): flag an Android read that saw only system chrome

### DIFF
--- a/packages/tool-server/src/tools/await-ui-element/index.ts
+++ b/packages/tool-server/src/tools/await-ui-element/index.ts
@@ -154,13 +154,16 @@ export function evaluateMatches(params: Params, matches: DescribeNode[]): boolea
 // ways an empty tree is untrustworthy:
 //   - the adapter flagged it as unreliable: iOS AX down or native injection
 //     pending → `describeIos` returns an empty tree plus a hint / should_restart
-//     instead of throwing. Android / Chromium never set these flags.
+//     instead of throwing. Android does the same when every node on screen was
+//     system chrome (display off, or a lock screen). Chromium still sets
+//     neither: it throws on an unreadable page, though a page that legitimately
+//     renders no children reaches here unflagged.
 //   - the selector matched on an EARLIER poll (`everMatched`) yet the whole tree
 //     is now empty. A genuinely-hidden element leaves the rest of the screen
 //     behind; a wholly empty tree after we'd already read content is a transient
 //     blank frame mid-navigation, not the element being hidden. This is the only
-//     guard that fires on Android / Chromium, where an empty tree is otherwise
-//     taken at face value — without it an `everMatched` `hidden` wait would
+//     guard that fires on Chromium, where an empty tree is otherwise taken at
+//     face value — without it an `everMatched` `hidden` wait would
 //     falsely resolve on a one-frame blink and release a gated tap against a
 //     screen that only briefly went blank.
 function isBlindRead(data: DescribeTreeData, everMatched: boolean): boolean {

--- a/packages/tool-server/src/tools/describe/platforms/android/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/index.ts
@@ -16,6 +16,37 @@ export const androidRequires: ToolDependency[] = ["adb"];
 // don't short-circuit describe the way iOS does for tvOS), but the agent
 // shouldn't tap coordinates — it should move the D-pad focus instead. Surface
 // the tv-* tools as a hint rather than blocking the (still-useful) tree.
+/**
+ * A read that saw only system chrome — the screen is off, or a lock screen is
+ * up — and therefore says nothing about the app.
+ *
+ * Decided from counts the helper already returns, so it costs no extra round
+ * trip: `nodeCount` is what the accessibility layer handed over, and
+ * `renderedChildren` is what survived pruning. Everything pruned means the only
+ * window on screen was `com.android.systemui`, which is exactly what both a
+ * powered-off display and a keyguard look like. Measured on a Pixel_9 emulator:
+ * app 62/2, launcher 64/7, screen off 28/0, keyguard 73/0.
+ *
+ * Note `windowCount` is NOT the signal — it stays 1 with the display off,
+ * because the keyguard window is still there.
+ */
+function blindReadHint(
+  nodeCount: number | undefined,
+  renderedChildren: number
+): string | undefined {
+  // Fail open on an unknown count — an older helper that does not report one
+  // must not turn every sparse screen into a blind read.
+  if (renderedChildren > 0 || !Number.isFinite(nodeCount) || (nodeCount ?? 0) <= 0) {
+    return undefined;
+  }
+  return (
+    "This read is BLIND, not empty: every node on screen belonged to the system UI, which is what " +
+    "a powered-off display or a lock screen looks like. An element missing from this tree is NOT " +
+    "evidence that it is hidden or gone, and this is NOT a screen with nothing on it. Wake the " +
+    "device (`button` with button `power`) and dismiss the lock screen, then read again."
+  );
+}
+
 const ANDROID_TV_HINT =
   "This is an Android TV (leanback) device — it is focus-driven and has no touch. " +
   "Prefer the `describe` tool to read the focused / focusable elements, `tv-remote` " +
@@ -51,12 +82,17 @@ export async function describeAndroid(
       const device = resolveDevice(serial);
       const ref = androidDevtoolsRef(device);
       const devtools = await registry.resolveService<AndroidDevtoolsApi>(ref.urn, ref.options);
-      const [{ xml }, size] = await Promise.all([
+      const [hierarchy, size] = await Promise.all([
         devtools.getHierarchy(),
         devtools.getScreenSize(),
       ]);
-      const tree = parseUiAutomatorDump(xml, size.width, size.height);
-      return { tree, source: "android-devtools", hint };
+      const tree = parseUiAutomatorDump(hierarchy.xml, size.width, size.height);
+      const blindHint = blindReadHint(hierarchy.nodeCount, tree.children.length);
+      return {
+        tree,
+        source: "android-devtools",
+        hint: [hint, blindHint].filter(Boolean).join(" ") || undefined,
+      };
     } catch (serviceErr) {
       // Fall through to the legacy uiautomator path. Every error here is
       // recoverable because the legacy path has independent failure modes.

--- a/packages/tool-server/test/await-ui-element-android-blind-read.test.ts
+++ b/packages/tool-server/test/await-ui-element-android-blind-read.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/utils/adb", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/utils/adb")>()),
+  adbShell: vi.fn(async () => ({ stdout: "", stderr: "", code: 0 })),
+}));
+
+import { createAwaitUiElementTool } from "../src/tools/await-ui-element";
+import type { AndroidDevtoolsApi } from "../src/blueprints/android-devtools";
+
+const SERIAL = "emulator-5554";
+
+/** What a powered-off display looks like: real nodes, all system chrome. */
+const SYSTEM_CHROME_XML = `<hierarchy rotation="0"><node class="android.widget.FrameLayout" package="com.android.systemui" bounds="[0,0][1080,2400]"><node class="android.view.View" package="com.android.systemui" bounds="[0,0][1080,120]" /></node></hierarchy>`;
+
+function registryWith(xml: string, nodeCount: number) {
+  const android = {
+    getHierarchy: async () => ({ xml, nodeCount, windowCount: 1 }),
+    getScreenSize: async () => ({ width: 1080, height: 2400, rotation: 0 }),
+  } as unknown as AndroidDevtoolsApi;
+  return {
+    resolveService: async () => android,
+  } as never;
+}
+
+describe("await-ui-element — a blind Android read cannot confirm `hidden`", () => {
+  it("does not report an element hidden when the screen could not be read", async () => {
+    // Measured on a device: with the display off, `await-ui-element hidden`
+    // returned success in 5ms for an element that was still on the screen —
+    // the same element `visible` had matched moments earlier. An agent gating
+    // an action on "the dialog is gone" got a green light against a screen
+    // nobody could see.
+    const tool = createAwaitUiElementTool(registryWith(SYSTEM_CHROME_XML, 28));
+
+    const result = await tool.execute(
+      {},
+      {
+        udid: SERIAL,
+        condition: "hidden",
+        selector: { text: "Go to home screen" },
+        timeoutMs: 300,
+        pollIntervalMs: 50,
+      }
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("says the read was blind rather than blaming the selector", async () => {
+    const tool = createAwaitUiElementTool(registryWith(SYSTEM_CHROME_XML, 73));
+
+    const result = await tool.execute(
+      {},
+      {
+        udid: SERIAL,
+        condition: "hidden",
+        selector: { text: "Go to home screen" },
+        timeoutMs: 300,
+        pollIntervalMs: 50,
+      }
+    );
+
+    expect(result.note).toContain("BLIND, not empty");
+  });
+});

--- a/packages/tool-server/test/describe-android-blind-read.test.ts
+++ b/packages/tool-server/test/describe-android-blind-read.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/utils/adb", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/utils/adb")>()),
+  // isAndroidTv shells out; this suite is not about TV detection.
+  adbShell: vi.fn(async () => ({ stdout: "", stderr: "", code: 0 })),
+}));
+
+import { describeAndroid } from "../src/tools/describe/platforms/android";
+import type { AndroidDevtoolsApi } from "../src/blueprints/android-devtools";
+
+const SERIAL = "emulator-5554";
+
+/**
+ * Counts taken from a Pixel_9 emulator, API 36:
+ *   app visible   nodeCount 62, 2 rendered children
+ *   launcher      nodeCount 64, 7 rendered children
+ *   screen off    nodeCount 28, 0 rendered children
+ *   keyguard      nodeCount 73, 0 rendered children
+ * The system-chrome XML below is what the last two look like: real nodes, all
+ * belonging to com.android.systemui, so all pruned.
+ */
+const SYSTEM_CHROME_XML = `<hierarchy rotation="0"><node class="android.widget.FrameLayout" package="com.android.systemui" bounds="[0,0][1080,2400]"><node class="android.view.View" package="com.android.systemui" bounds="[0,0][1080,120]" /></node></hierarchy>`;
+
+const APP_XML = `<hierarchy rotation="0"><node class="android.widget.FrameLayout" package="com.example.app" bounds="[0,0][1080,2400]"><node class="android.widget.TextView" package="com.example.app" text="Sign in" bounds="[100,200][500,260]" /></node></hierarchy>`;
+
+function registryFor(xml: string, nodeCount: number | undefined) {
+  const android = {
+    getHierarchy: async () => ({
+      xml,
+      ...(nodeCount === undefined ? {} : { nodeCount }),
+      windowCount: 1,
+      captureMode: "interactive-windows",
+    }),
+    getScreenSize: async () => ({ width: 1080, height: 2400, rotation: 0 }),
+  } as unknown as AndroidDevtoolsApi;
+
+  return {
+    resolveService: async () => android,
+  } as unknown as Parameters<typeof describeAndroid>[0];
+}
+
+describe("describeAndroid — blind reads (display off / lock screen)", () => {
+  it("flags a tree whose every node was system chrome", async () => {
+    // The reported case: the screen is off, so the only window is the system
+    // UI, everything prunes away, and the tree looks identical to an empty app.
+    const data = await describeAndroid(
+      registryFor(SYSTEM_CHROME_XML, 28),
+      SERIAL,
+      undefined,
+      false
+    );
+
+    expect(data.tree.children).toHaveLength(0);
+    expect(data.hint).toBeDefined();
+    expect(data.hint).toContain("BLIND, not empty");
+  });
+
+  it("tells the caller what to do about it", async () => {
+    const data = await describeAndroid(
+      registryFor(SYSTEM_CHROME_XML, 73),
+      SERIAL,
+      undefined,
+      false
+    );
+
+    expect(data.hint).toContain("power");
+    expect(data.hint).toContain("lock screen");
+    // The distinction the whole fix exists for.
+    expect(data.hint).toContain("NOT evidence that it is hidden or gone");
+  });
+
+  it("says nothing about a screen that really has content", async () => {
+    const data = await describeAndroid(registryFor(APP_XML, 62), SERIAL, undefined, false);
+
+    expect(data.tree.children.length).toBeGreaterThan(0);
+    expect(data.hint).toBeUndefined();
+  });
+
+  it("fails open when the helper reports no node count", async () => {
+    // An older device helper does not send one. Guessing "blind" there would
+    // mark every sparse screen unreadable, which is worse than the bug.
+    const data = await describeAndroid(
+      registryFor(SYSTEM_CHROME_XML, undefined),
+      SERIAL,
+      undefined,
+      false
+    );
+
+    expect(data.hint).toBeUndefined();
+  });
+
+  it("fails open when the accessibility layer handed over nothing at all", async () => {
+    // nodeCount 0 is a genuinely empty capture, not a screen full of chrome —
+    // there is no evidence of a blind read to report.
+    const data = await describeAndroid(
+      registryFor(`<hierarchy rotation="0" />`, 0),
+      SERIAL,
+      undefined,
+      false
+    );
+
+    expect(data.hint).toBeUndefined();
+  });
+
+  it("keeps the Android TV hint alongside it", async () => {
+    const data = await describeAndroid(registryFor(SYSTEM_CHROME_XML, 28), SERIAL, undefined, true);
+
+    expect(data.hint).toContain("leanback");
+    expect(data.hint).toContain("BLIND, not empty");
+  });
+});


### PR DESCRIPTION
Fixes #627.

## The false pass, measured

With the display off, `describe` returns a bare `ROOT Screen (0,0,1,1)` — no error, no hint. The same element, never moved:

| screen | call | result |
|---|---|---|
| on | `await-ui-element visible "Go to home screen"` | `{"success": true, "elapsed": 5}` |
| **off** | `await-ui-element hidden "Go to home screen"` | `{"success": true, "elapsed": 5}` |

An agent gating an action on "the dialog is gone" gets a green light against a screen nobody can read. `await-ui-element`'s `isBlindRead` has no flag to key on here — its only Android guard is `everMatched`, which is false when the wait starts after the screen is already dark. The code comment said as much: *"Android / Chromium never set these flags."*

## The signal was already on the wire

`getHierarchy()` returns `nodeCount` alongside `xml`, and `describe` destructured only `xml`. `nodeCount > 0` with **zero** rendered children means every node on screen belonged to `com.android.systemui` and pruned away — which is exactly what a powered-off display and a lock screen look like.

Measured across four states on a Pixel_9 / API 36:

| state | nodeCount | rendered children | blind? |
|---|---|---|---|
| app visible | 62 | 2 | no |
| home screen (launcher) | 64 | 7 | no |
| **screen off** | 28 | **0** | **yes** |
| **keyguard, display on** | 73 | **0** | **yes** |

So: no adb probe, no new module, no extra round trip, no `dumpsys` parsing to go stale across OEMs, and nothing added to the hot path.

**`windowCount` is deliberately not the signal.** The obvious guess is "no windows ⇒ blind", but it stays **1** with the display off, because the keyguard window is still there — it would never fire. Worth measuring rather than assuming.

I verified the keyguard case separately (set a PIN and disabled the screen timeout so the device couldn't sleep mid-test, since an earlier attempt was unattributable): `mWakefulness=Awake`, `SCREEN_STATE_ON`, `mIsShowing=true`, lock screen visibly on the display — and the tree still comes back empty. A display-power-only check would have missed it entirely.

## Fails open

Unknown or zero `nodeCount` ⇒ no hint. An older device helper that reports no count must not turn every sparse screen into a blind read — that is worse than the bug. This is not hypothetical: the existing `hidden` succeeds when the node is gone test uses a stub with no `nodeCount`, and my first draft flagged it, because `undefined <= 0` is `false`. It now passes unmodified.

## `hint`, not a throw

`hint` already flows into **both** `isBlindRead` (so `hidden` can no longer resolve) and the timeout note — so the false pass closes with **zero consumer changes**, and the six callers of `describeAndroid` keep working. On a sleeping device an empty tree plus "wake it" is more useful than a hard error.

Live, after the fix:

```
describe (screen off) → hint: "This read is BLIND, not empty: every node on screen belonged to the
system UI… An element missing from this tree is NOT evidence that it is hidden or gone… Wake the
device (`button` with button `power`) and dismiss the lock screen, then read again."

await-ui-element hidden → success: false
   note: "could not confirm the element is hidden — the UI tree was empty or unreadable at timeout
          (This read is BLIND, not empty: …)"
```

Screen on: no hint, full tree, unchanged.

## Behaviour change to know about

A `hidden` wait that previously returned instantly now runs to its timeout and fails, and an unmet wait **halts** a `run-sequence`. That is the intent, but it will change any recorded sequence that (wrongly) depended on the instant pass.

## Update 2026-09-17: merged main

Merged `origin/main` (no rebase). Main had since moved `isBlindRead` into `describe/blind-read.ts` (shared with flows) and added the WebView re-read (#1052) to `describeAndroid`, so:

- `await-ui-element/index.ts` now has **no diff** — main's shared `isBlindRead` already keys off `hint`, and the stale comment this PR corrected no longer exists there.
- `describeAndroid` computes the blind hint on the tree *after* `awaitWebViewPublished`. A blind read has no WebView node, so the re-read never runs on one and `nodeCount` from the first read still describes the tree returned.
- The await-ui-element test's adb mock no longer stopped `isAndroidTv` (it no longer goes through `adbShell`), so it timed out; it now pins `isAndroidTv` and primes the adb dependency gate like `await-ui-element.test.ts` does.

Re-verified live on a fresh Medium_Phone API 36 emulator: screen off and PIN keyguard (display on, `isKeyguardShowing=true`) both return the hint and `hidden` fails with `cause: "unreadable"`; Settings and launcher return no hint. Same device on main's `describeAndroid`: no hint, `hidden` succeeds in 4–6 ms in both states.

No docs change: no tool, parameter or config key changed.

#519 is the iOS half of this class; it throws inside `flow-ios-tree.ts`, whose contract is "helpers throw". The true Android mirror is `flows/flow-android-tree.ts`, which does **not** route through `describeAndroid` — so flow `assert hidden` still false-passes there. Left as a follow-up so it can be reviewed next to #519.

## Checks

- 3094 tests pass; 8 new, of which 5 fail against the pre-fix source (the 3 that pass on both are the fail-open invariance checks).
- All pre-existing `await-ui-element` / `describe-tv` / `await-screen-idle` tests pass **unmodified**.
- extract-tools 46/46; prettier, eslint, both typechecks clean; lock untouched.
