### PR TITLE
fix(screenshot): say when scale or rotation was not applied

### DIFF
--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -500,6 +500,13 @@ fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
 // back to a literal and then chokes on dtrace-provider's own dynamic native
 // binding require. External restores bunyan's intent: the published package
 // never declares it, so the require misses and bunyan nulls it out.
+//
+// `sharp` is the optional Chromium screenshot post-processor: the tool-server
+// `require("sharp")`s it inside a try/catch and skips scale / rotation when it
+// is absent. It is never declared here, so in CI esbuild leaves the require
+// alone — but a developer with sharp in node_modules (e.g. installed to test
+// that path) would have the bundle inline its native addon and fail. External
+// keeps the runtime require resolving against whatever the user installed.
 buildBundle({
   entry: TOOLS_ENTRY,
   out: OUT_FILE,
@@ -512,6 +519,7 @@ buildBundle({
     "@fails-components/webtransport",
     "@fails-components/webtransport-transport-http3-quiche",
     "dtrace-provider",
+    "sharp",
   ],
 });
 

--- a/packages/tool-server/src/chromium-server/screenshot.ts
+++ b/packages/tool-server/src/chromium-server/screenshot.ts
@@ -90,6 +90,7 @@ export async function captureScreenshot(
   const scale = opts.scale != null && opts.scale > 0 && opts.scale < 1 ? opts.scale : null;
 
   const dropped: ("rotation" | "scale")[] = [];
+  let dropReason: MediaReady["dropReason"];
 
   if (rotation || scale) {
     const sharp = tryLoadSharp();
@@ -98,6 +99,7 @@ export async function captureScreenshot(
       warnSharpMissingOnce(features);
       if (rotation) dropped.push("rotation");
       if (scale) dropped.push("scale");
+      dropReason = "sharp-missing";
     } else {
       let pipeline = sharp(bytes);
       if (rotation) pipeline = pipeline.rotate(ROTATION_DEGREES[rotation]);
@@ -122,6 +124,7 @@ export async function captureScreenshot(
           // Header unreadable: the rotation still runs, but the resize cannot
           // be sized, so the scale the caller asked for is lost.
           dropped.push("scale");
+          dropReason = "png-header-unreadable";
         }
       }
       bytes = Buffer.from(await pipeline.png({ compressionLevel: 6 }).toBuffer());
@@ -135,7 +138,7 @@ export async function captureScreenshot(
   return {
     url: `file://${filePath}`,
     path: filePath,
-    ...(dropped.length > 0 ? { droppedFeatures: dropped } : {}),
+    ...(dropped.length > 0 ? { droppedFeatures: dropped, dropReason } : {}),
   };
 }
 

--- a/packages/tool-server/src/chromium-server/screenshot.ts
+++ b/packages/tool-server/src/chromium-server/screenshot.ts
@@ -105,15 +105,22 @@ export async function captureScreenshot(
         // Cheaper than asking sharp for `.metadata()`.
         const dims = readPngSize(bytes);
         if (dims) {
-          const targetW = Math.max(1, Math.round(dims.width * scale));
-          const targetH = Math.max(1, Math.round(dims.height * scale));
+          // sharp runs the rotation ahead of the resize regardless of call
+          // order, so a quarter turn means the resize sees swapped dimensions.
+          // Sizing the target from the unrotated header with `fit: "fill"`
+          // would squash the rotated image into the wrong aspect ratio.
+          const quarterTurn = rotation === "LandscapeLeft" || rotation === "LandscapeRight";
+          const rotatedW = quarterTurn ? dims.height : dims.width;
+          const rotatedH = quarterTurn ? dims.width : dims.height;
+          const targetW = Math.max(1, Math.round(rotatedW * scale));
+          const targetH = Math.max(1, Math.round(rotatedH * scale));
           pipeline = pipeline.resize(targetW, targetH, {
             kernel: DOWNSCALER_TO_KERNEL[opts.downscaler ?? "lanczos3"],
             fit: "fill",
           });
         } else {
-          // Header unreadable: rotation below still applies, but the resize
-          // cannot be sized, so the scale the caller asked for is lost.
+          // Header unreadable: the rotation still runs, but the resize cannot
+          // be sized, so the scale the caller asked for is lost.
           dropped.push("scale");
         }
       }

--- a/packages/tool-server/src/chromium-server/screenshot.ts
+++ b/packages/tool-server/src/chromium-server/screenshot.ts
@@ -89,11 +89,15 @@ export async function captureScreenshot(
   const rotation = opts.rotation && opts.rotation !== "Portrait" ? opts.rotation : null;
   const scale = opts.scale != null && opts.scale > 0 && opts.scale < 1 ? opts.scale : null;
 
+  const dropped: ("rotation" | "scale")[] = [];
+
   if (rotation || scale) {
     const sharp = tryLoadSharp();
     if (!sharp) {
       const features = [rotation && "rotation", scale && "scale"].filter(Boolean).join(" + ");
       warnSharpMissingOnce(features);
+      if (rotation) dropped.push("rotation");
+      if (scale) dropped.push("scale");
     } else {
       let pipeline = sharp(bytes);
       if (rotation) pipeline = pipeline.rotate(ROTATION_DEGREES[rotation]);
@@ -107,6 +111,10 @@ export async function captureScreenshot(
             kernel: DOWNSCALER_TO_KERNEL[opts.downscaler ?? "lanczos3"],
             fit: "fill",
           });
+        } else {
+          // Header unreadable: rotation below still applies, but the resize
+          // cannot be sized, so the scale the caller asked for is lost.
+          dropped.push("scale");
         }
       }
       bytes = Buffer.from(await pipeline.png({ compressionLevel: 6 }).toBuffer());
@@ -117,10 +125,18 @@ export async function captureScreenshot(
   const safeDeviceId = ctx.deviceId.replace(/[^A-Za-z0-9_-]/g, "_");
   const filePath = path.join(mediaDir(), `argent-screenshot-${safeDeviceId}-${stem}.png`);
   fs.writeFileSync(filePath, bytes);
-  return { url: `file://${filePath}`, path: filePath };
+  return {
+    url: `file://${filePath}`,
+    path: filePath,
+    ...(dropped.length > 0 ? { droppedFeatures: dropped } : {}),
+  };
 }
 
-/** Width / height from the PNG IHDR chunk; null if `buf` is not a valid PNG. */
+/**
+ * Read width / height from a PNG IHDR chunk without spinning up a decoder.
+ * Returns null on a malformed or non-PNG buffer. The caller skips the resize in
+ * that case and reports `scale` as dropped — there is no metadata fallback.
+ */
 function readPngSize(buf: Buffer): { width: number; height: number } | null {
   const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
   if (buf.length < 24) return null;

--- a/packages/tool-server/src/chromium-server/types.ts
+++ b/packages/tool-server/src/chromium-server/types.ts
@@ -51,12 +51,19 @@ export interface MediaReady {
   /** Absolute path on the tool-server host. */
   path: string;
   /**
-   * Geometry the caller asked for that this capture could not apply — the
-   * optional `sharp` package is missing, or the PNG header could not be read.
-   * The image is still returned untouched; the tool turns this into a note so
-   * the omission is visible to the caller rather than only on stderr.
+   * Geometry the caller asked for that this capture could not apply — see
+   * `dropReason` for why. The image is still returned; the tool turns this
+   * into a note so the omission is visible to the caller rather than only on
+   * stderr.
    */
   droppedFeatures?: ("rotation" | "scale")[];
+  /**
+   * Why `droppedFeatures` were dropped. `sharp-missing`: no transform ran at
+   * all and installing `sharp` fixes it. `png-header-unreadable`: `sharp` IS
+   * installed and a requested rotation still ran, but the resize could not be
+   * sized from the capture's PNG header, so only the scale was lost.
+   */
+  dropReason?: "sharp-missing" | "png-header-unreadable";
 }
 
 export interface ViewportSize {

--- a/packages/tool-server/src/chromium-server/types.ts
+++ b/packages/tool-server/src/chromium-server/types.ts
@@ -50,6 +50,13 @@ export interface MediaReady {
   url: string;
   /** Absolute path on the tool-server host. */
   path: string;
+  /**
+   * Geometry the caller asked for that this capture could not apply — the
+   * optional `sharp` package is missing, or the PNG header could not be read.
+   * The image is still returned untouched; the tool turns this into a note so
+   * the omission is visible to the caller rather than only on stderr.
+   */
+  droppedFeatures?: ("rotation" | "scale")[];
 }
 
 export interface ViewportSize {

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -348,15 +348,16 @@ const MAX_PENDING_UPLOAD_BYTES = 8 * 1024 * 1024 * 1024; // 8 GiB
 /**
  * Pull a tool's per-call note off its result so it can ride the response
  * envelope. Mutates `data` so the reserved key never reaches the client, where
- * it would otherwise surface in `--json` output and in non-image results.
+ * it would otherwise surface in `--json` output and in non-image results. The
+ * key is stripped whatever its value; only a non-empty string becomes a note.
  */
 function takeToolNote(data: unknown): string | undefined {
   if (typeof data !== "object" || data === null) return undefined;
   const bag = data as Record<string, unknown>;
+  if (!(RESULT_NOTE_KEY in bag)) return undefined;
   const note = bag[RESULT_NOTE_KEY];
-  if (typeof note !== "string" || note.length === 0) return undefined;
   delete bag[RESULT_NOTE_KEY];
-  return note;
+  return typeof note === "string" && note.length > 0 ? note : undefined;
 }
 
 export function createHttpApp(registry: Registry, options?: HttpAppOptions): HttpAppHandle {

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -54,6 +54,7 @@ import {
   createChromiumServerRouter,
 } from "./chromium-server/http-api";
 import { resolveDevice as resolveDeviceForWs } from "./utils/device-info";
+import { RESULT_NOTE_KEY } from "./tools/screenshot/dropped-geometry";
 
 const AUTO_SUPPRESS_MS = 30 * 60 * 1000; // 30 minutes
 
@@ -343,6 +344,20 @@ const UPLOAD_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const MAX_UPLOAD_STREAM_BYTES = 2 * 1024 * 1024 * 1024; // 2 GiB
 // Bounds the total of unconsumed uploads, so many small ones can't do the same.
 const MAX_PENDING_UPLOAD_BYTES = 8 * 1024 * 1024 * 1024; // 8 GiB
+
+/**
+ * Pull a tool's per-call note off its result so it can ride the response
+ * envelope. Mutates `data` so the reserved key never reaches the client, where
+ * it would otherwise surface in `--json` output and in non-image results.
+ */
+function takeToolNote(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const bag = data as Record<string, unknown>;
+  const note = bag[RESULT_NOTE_KEY];
+  if (typeof note !== "string" || note.length === 0) return undefined;
+  delete bag[RESULT_NOTE_KEY];
+  return note;
+}
 
 export function createHttpApp(registry: Registry, options?: HttpAppOptions): HttpAppHandle {
   const app = express();
@@ -876,6 +891,12 @@ export function createHttpApp(registry: Registry, options?: HttpAppOptions): Htt
         if (activeRecordings.length > 0) {
           notes.push(buildScreenRecordingNote(activeRecordings, Date.now()));
         }
+        // A tool can raise a per-call note by returning this reserved key. It
+        // rides the envelope rather than the result body because clients render
+        // image results as image blocks plus a "Saved:" line and drop every
+        // other field — a note inside `data` would never be seen.
+        const toolNote = takeToolNote(data);
+        if (toolNote) notes.push(toolNote);
         const notePayload = notes.length > 0 ? { note: notes.join("\n\n") } : {};
         if (wantsStream) {
           writeLine({ event: "result", data, ...notePayload });

--- a/packages/tool-server/src/tools/screenshot/dropped-geometry.ts
+++ b/packages/tool-server/src/tools/screenshot/dropped-geometry.ts
@@ -40,10 +40,23 @@ function subject(dropped: DroppedGeometry[]): string {
 
 /**
  * Chromium can do both transforms — it just needs `sharp`, which is optional
- * and not shipped — so this case is worth telling the caller how to fix.
+ * and not shipped — so the common case is worth telling the caller how to fix.
+ * The rarer `png-header-unreadable` reason gets different wording: there,
+ * `sharp` IS installed and a requested rotation still ran, so "unmodified
+ * capture" and "install sharp" would both be wrong.
  */
-export function chromiumDropNote(dropped: DroppedGeometry[]): string | undefined {
+export function chromiumDropNote(
+  dropped: DroppedGeometry[],
+  reason: "sharp-missing" | "png-header-unreadable" = "sharp-missing"
+): string | undefined {
   if (dropped.length === 0) return undefined;
+  if (reason === "png-header-unreadable") {
+    return (
+      `${subject(dropped)} not applied — the captured PNG's header could not be read, so the ` +
+      `resize could not be sized. A rotation requested on the same call was still applied. ` +
+      `\`sharp\` is already installed; retrying the same call will likely lose the scale again.`
+    );
+  }
   return (
     `${subject(dropped)} not applied — this is the unmodified capture. Chromium image ` +
     `post-processing needs the optional \`sharp\` package: run \`npm install sharp\` in the ` +

--- a/packages/tool-server/src/tools/screenshot/dropped-geometry.ts
+++ b/packages/tool-server/src/tools/screenshot/dropped-geometry.ts
@@ -1,0 +1,67 @@
+/**
+ * Notes for geometry the caller asked for that a capture could not apply.
+ *
+ * `screenshot` takes `scale` and `rotation` on every target, but several
+ * backends cannot honour them: Chromium needs the optional `sharp` package,
+ * and the Apple TV and Vega captures have no rotation step at all. Without a
+ * note the caller gets a full-size, un-rotated PNG that looks like a successful
+ * transform, and the only existing signal — a stderr line — is written once per
+ * process and never reaches whoever asked.
+ */
+export type DroppedGeometry = "rotation" | "scale";
+
+/** Reserved result key hoisted into the response envelope's `note` by http.ts. */
+export const RESULT_NOTE_KEY = "__argentNote";
+
+/**
+ * Which of the caller's geometry parameters were requested but not applied.
+ *
+ * A parameter counts only when the caller actually asked for something the
+ * backend then ignored. Two no-ops are deliberately not reported: `rotation:
+ * "Portrait"` is the identity rotation, and `scale: 1` is full size — a visual
+ * snapshot passes `scale: 1` on every step, and flagging that would attach a
+ * note to captures where nothing was lost. The `ARGENT_SCREENSHOT_SCALE`
+ * default is likewise never reported, because the caller never asked for it.
+ */
+export function requestedGeometry(params: {
+  rotation?: string | undefined;
+  scale?: number | undefined;
+}): DroppedGeometry[] {
+  const requested: DroppedGeometry[] = [];
+  if (params.rotation !== undefined && params.rotation !== "Portrait") requested.push("rotation");
+  if (params.scale !== undefined && params.scale > 0 && params.scale < 1) requested.push("scale");
+  return requested;
+}
+
+function list(dropped: DroppedGeometry[]): string {
+  return dropped.length === 2 ? "scale and rotation" : dropped[0]!;
+}
+
+/**
+ * Chromium can do both transforms — it just needs `sharp`, which is optional
+ * and not shipped — so this case is worth telling the caller how to fix.
+ */
+export function chromiumDropNote(dropped: DroppedGeometry[]): string | undefined {
+  if (dropped.length === 0) return undefined;
+  return (
+    `${list(dropped)} was not applied — this is the unmodified capture. Chromium image ` +
+    `post-processing needs the optional \`sharp\` package: run \`npm install sharp\` in the ` +
+    `tool-server's environment and retry, or work with the full-size image.`
+  );
+}
+
+/**
+ * The TV backends have no rotation step. Worded so it does not read as
+ * retryable — the same call will always come back the same way.
+ */
+export function unsupportedDropNote(
+  dropped: DroppedGeometry[],
+  target: string
+): string | undefined {
+  if (dropped.length === 0) return undefined;
+  return (
+    `${list(dropped)} was not applied — ${target} screenshots cannot be transformed that way, ` +
+    `so retrying with the same parameter will not change the result. The image is the ` +
+    `untransformed capture.`
+  );
+}

--- a/packages/tool-server/src/tools/screenshot/dropped-geometry.ts
+++ b/packages/tool-server/src/tools/screenshot/dropped-geometry.ts
@@ -33,8 +33,9 @@ export function requestedGeometry(params: {
   return requested;
 }
 
-function list(dropped: DroppedGeometry[]): string {
-  return dropped.length === 2 ? "scale and rotation" : dropped[0]!;
+/** "scale was" / "scale and rotation were" — subject and verb agree. */
+function subject(dropped: DroppedGeometry[]): string {
+  return dropped.length === 2 ? "scale and rotation were" : `${dropped[0]!} was`;
 }
 
 /**
@@ -44,7 +45,7 @@ function list(dropped: DroppedGeometry[]): string {
 export function chromiumDropNote(dropped: DroppedGeometry[]): string | undefined {
   if (dropped.length === 0) return undefined;
   return (
-    `${list(dropped)} was not applied — this is the unmodified capture. Chromium image ` +
+    `${subject(dropped)} not applied — this is the unmodified capture. Chromium image ` +
     `post-processing needs the optional \`sharp\` package: run \`npm install sharp\` in the ` +
     `tool-server's environment and retry, or work with the full-size image.`
   );
@@ -52,7 +53,9 @@ export function chromiumDropNote(dropped: DroppedGeometry[]): string | undefined
 
 /**
  * The TV backends have no rotation step. Worded so it does not read as
- * retryable — the same call will always come back the same way.
+ * retryable — the same call will always come back the same way. It says
+ * "unrotated" rather than "untransformed" because a `scale` on the same call
+ * IS applied (server-side); only the rotation is missing.
  */
 export function unsupportedDropNote(
   dropped: DroppedGeometry[],
@@ -60,8 +63,8 @@ export function unsupportedDropNote(
 ): string | undefined {
   if (dropped.length === 0) return undefined;
   return (
-    `${list(dropped)} was not applied — ${target} screenshots cannot be transformed that way, ` +
-    `so retrying with the same parameter will not change the result. The image is the ` +
-    `untransformed capture.`
+    `${subject(dropped)} not applied — ${target} screenshots cannot be transformed that way, ` +
+    `so retrying with the same parameter will not change the result. The image is returned ` +
+    `unrotated.`
   );
 }

--- a/packages/tool-server/src/tools/screenshot/dropped-geometry.ts
+++ b/packages/tool-server/src/tools/screenshot/dropped-geometry.ts
@@ -8,7 +8,7 @@
  * transform, and the only existing signal — a stderr line — is written once per
  * process and never reaches whoever asked.
  */
-export type DroppedGeometry = "rotation" | "scale";
+type DroppedGeometry = "rotation" | "scale";
 
 /** Reserved result key hoisted into the response envelope's `note` by http.ts. */
 export const RESULT_NOTE_KEY = "__argentNote";

--- a/packages/tool-server/src/tools/screenshot/index.ts
+++ b/packages/tool-server/src/tools/screenshot/index.ts
@@ -7,6 +7,12 @@ import type { Registry, ToolCapability, ToolDefinition } from "@argent/registry"
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-cdp";
 import { resolveDevice } from "../../utils/device-info";
+import {
+  RESULT_NOTE_KEY,
+  requestedGeometry,
+  chromiumDropNote,
+  unsupportedDropNote,
+} from "./dropped-geometry";
 import { getScreenshotScale } from "../../utils/simulator-client";
 import { captureScreenshotUpright } from "../../utils/rotation-aware-capture";
 import { androidDevtoolsRotationPeek } from "../../utils/android-devtools-rotation-peek";
@@ -27,7 +33,13 @@ const zodSchema = z.object({
     .enum(["Portrait", "LandscapeLeft", "LandscapeRight", "PortraitUpsideDown"])
     .optional()
     .describe(
-      "Orientation override for the screenshot (rotates the captured image after Page.captureScreenshot on Chromium). On Android the capture already follows the device's rotation."
+      "Orientation override. Rarely needed: on Android the capture already follows the device's " +
+        "current rotation, so it is upright without this. Setting it replaces that with a fixed " +
+        "rotation, which on a rotated device produces an image whose geometry no longer matches " +
+        "`describe` frames or gesture coordinates. On Chromium it rotates the captured image after " +
+        "Page.captureScreenshot, which requires the optional `sharp` dependency. Apple TV and Vega " +
+        "captures cannot be rotated at all. When a rotation is requested but not applied, the " +
+        "response carries a note saying so — the image is returned unrotated either way."
     ),
   scale: z
     .number()
@@ -57,9 +69,17 @@ type Params = z.infer<typeof zodSchema>;
 
 interface Result {
   /**
-   * Captured PNG as an artifact handle: the MCP client materializes it locally
-   * rather than fetching the simulator server's `127.0.0.1` media URL, which is
-   * unreachable when the tool-server is remote.
+   * Set only when the caller asked for geometry the backend could not apply.
+   * `http.ts` hoists this reserved key into the response envelope's `note`,
+   * which every client already renders — the result body itself is discarded
+   * for image-output tools.
+   */
+  [RESULT_NOTE_KEY]?: string;
+  /**
+   * The captured PNG as an artifact handle. The MCP client materializes it to
+   * a local file and renders it inline — no second fetch of the simulator
+   * server's `127.0.0.1` media URL, which is unreachable when the tool-server
+   * is remote.
    */
   image: ArtifactHandle;
 }
@@ -151,17 +171,22 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
       if (device.platform === "chromium") {
         const ref = chromiumCdpRef(device);
         const chromium = (await registry.resolveService(ref.urn, ref.options)) as ChromiumCdpApi;
-        const { path: capturedPath } = await chromium.captureScreenshot({
+        const captured = await chromium.captureScreenshot({
           rotation: params.rotation,
           scale: params.scale,
           downscaler: params.downscaler,
         });
         const image = await requireArtifacts(ctx).register({
-          hostPath: capturedPath,
+          hostPath: captured.path,
           kind: "screenshot",
           mimeType: "image/png",
         });
-        return { image };
+        // Only report what the caller asked for AND the backend dropped: a
+        // visual snapshot passes scale 1, which is a no-op, not a loss.
+        const requested = requestedGeometry(params);
+        const dropped = (captured.droppedFeatures ?? []).filter((f) => requested.includes(f));
+        const note = chromiumDropNote(dropped);
+        return { image, ...(note ? { [RESULT_NOTE_KEY]: note } : {}) };
       }
 
       // Shape alone can't tell tvOS from iOS, and tvOS has no simulator-server
@@ -173,7 +198,13 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
           kind: "screenshot",
           mimeType: "image/png",
         });
-        return { image };
+        // tvScreenshot has no rotation step at all, so an explicit rotation is
+        // dropped before any capture happens.
+        const note = unsupportedDropNote(
+          requestedGeometry(params).filter((f) => f === "rotation"),
+          "Apple TV"
+        );
+        return { image, ...(note ? { [RESULT_NOTE_KEY]: note } : {}) };
       }
 
       // Vega captures host-side via the Android emulator console (`adb emu`);
@@ -185,7 +216,11 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
           kind: "screenshot",
           mimeType: "image/png",
         });
-        return { image };
+        const note = unsupportedDropNote(
+          requestedGeometry(params).filter((f) => f === "rotation"),
+          "Vega (Fire TV)"
+        );
+        return { image, ...(note ? { [RESULT_NOTE_KEY]: note } : {}) };
       }
 
       const ref = simulatorServerRef(device);

--- a/packages/tool-server/src/tools/screenshot/index.ts
+++ b/packages/tool-server/src/tools/screenshot/index.ts
@@ -185,7 +185,7 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
         // visual snapshot passes scale 1, which is a no-op, not a loss.
         const requested = requestedGeometry(params);
         const dropped = (captured.droppedFeatures ?? []).filter((f) => requested.includes(f));
-        const note = chromiumDropNote(dropped);
+        const note = chromiumDropNote(dropped, captured.dropReason);
         return { image, ...(note ? { [RESULT_NOTE_KEY]: note } : {}) };
       }
 

--- a/packages/tool-server/test/http-tool-note.test.ts
+++ b/packages/tool-server/test/http-tool-note.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import supertest from "supertest";
+import { createHttpApp, type HttpAppHandle } from "../src/http";
+import type { Registry } from "@argent/registry";
+import { RESULT_NOTE_KEY } from "../src/tools/screenshot/dropped-geometry";
+
+// Keep the update note out of these assertions (same approach as the other
+// http-*.test.ts files): no update available, never suppressed.
+vi.mock("../src/utils/update-checker", () => ({
+  getUpdateState: vi.fn(() => ({
+    updateAvailable: false,
+    updateInstallable: false,
+    installableVersion: null,
+    latestVersion: null,
+    latestPublishedAt: null,
+    minReleaseAgeMs: 0,
+    currentVersion: "1.0.0",
+  })),
+  isUpdateNoteSuppressed: vi.fn(() => false),
+  suppressUpdateNote: vi.fn(),
+}));
+
+function stubRegistry(toolResult: () => unknown): Registry {
+  return {
+    getSnapshot: vi.fn(() => ({ services: new Map(), namespaces: [], tools: ["test-tool"] })),
+    getTool: vi.fn((name: string) =>
+      name === "test-tool"
+        ? {
+            id: "test-tool",
+            description: "A stub tool for testing",
+            inputSchema: { type: "object", properties: {} },
+            services: () => ({}),
+            execute: async () => toolResult(),
+          }
+        : undefined
+    ),
+    invokeTool: vi.fn(async () => toolResult()),
+  } as unknown as Registry;
+}
+
+describe("HTTP per-call tool note", () => {
+  let handle: HttpAppHandle;
+
+  afterEach(() => {
+    handle?.dispose();
+    vi.clearAllMocks();
+  });
+
+  it("hoists the reserved key into the envelope note and strips it from data", async () => {
+    handle = createHttpApp(
+      stubRegistry(() => ({ image: "x", [RESULT_NOTE_KEY]: "scale was not applied" }))
+    );
+    const res = await supertest(handle.app).post("/tools/test-tool").send({});
+    expect(res.status).toBe(200);
+    expect(res.body.note).toBe("scale was not applied");
+    expect(res.body.data).toEqual({ image: "x" });
+  });
+
+  it("does the same on the NDJSON stream path", async () => {
+    handle = createHttpApp(stubRegistry(() => ({ image: "x", [RESULT_NOTE_KEY]: "dropped" })));
+    const res = await supertest(handle.app)
+      .post("/tools/test-tool")
+      .set("Accept", "application/x-ndjson")
+      .send({});
+    expect(res.status).toBe(200);
+    const lines = res.text
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as { event: string; data?: unknown; note?: string });
+    const result = lines.find((l) => l.event === "result");
+    expect(result?.note).toBe("dropped");
+    expect(result?.data).toEqual({ image: "x" });
+  });
+
+  it("strips an empty or non-string value without raising a note", async () => {
+    handle = createHttpApp(stubRegistry(() => ({ image: "x", [RESULT_NOTE_KEY]: "" })));
+    const res = await supertest(handle.app).post("/tools/test-tool").send({});
+    expect(res.body.note).toBeUndefined();
+    expect(res.body.data).toEqual({ image: "x" });
+  });
+
+  it("leaves results without the key untouched", async () => {
+    handle = createHttpApp(stubRegistry(() => ({ image: "x" })));
+    const res = await supertest(handle.app).post("/tools/test-tool").send({});
+    expect(res.body.note).toBeUndefined();
+    expect(res.body.data).toEqual({ image: "x" });
+  });
+});

--- a/packages/tool-server/test/screenshot-dropped-geometry.test.ts
+++ b/packages/tool-server/test/screenshot-dropped-geometry.test.ts
@@ -41,7 +41,7 @@ describe("drop notes", () => {
 
   it("tells a Chromium caller how to make it work", () => {
     const note = chromiumDropNote(["scale", "rotation"]);
-    expect(note).toContain("scale and rotation was not applied");
+    expect(note).toContain("scale and rotation were not applied");
     expect(note).toContain("npm install sharp");
     expect(note).toContain("unmodified capture");
   });
@@ -54,6 +54,10 @@ describe("drop notes", () => {
     const note = unsupportedDropNote(["rotation"], "Apple TV");
     expect(note).toContain("Apple TV");
     expect(note).toContain("will not change the result");
+    // A scale on the same call is still applied server-side, so the note must
+    // not claim the whole image is untransformed.
+    expect(note).toContain("returned unrotated");
+    expect(note).not.toContain("untransformed");
     // The Chromium remedy must not leak into a case where it cannot help.
     expect(note).not.toContain("npm install");
   });

--- a/packages/tool-server/test/screenshot-dropped-geometry.test.ts
+++ b/packages/tool-server/test/screenshot-dropped-geometry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  requestedGeometry,
+  chromiumDropNote,
+  unsupportedDropNote,
+  RESULT_NOTE_KEY,
+} from "../src/tools/screenshot/dropped-geometry";
+
+describe("requestedGeometry", () => {
+  it("reports what the caller actually asked for", () => {
+    expect(requestedGeometry({ rotation: "LandscapeLeft", scale: 0.25 })).toEqual([
+      "rotation",
+      "scale",
+    ]);
+  });
+
+  it("ignores an absent parameter", () => {
+    // The ARGENT_SCREENSHOT_SCALE default arrives as an absent param, and the
+    // caller never asked for it — reporting it would put a note on captures
+    // nobody requested a transform for (auto-screenshot passes only udid).
+    expect(requestedGeometry({})).toEqual([]);
+  });
+
+  it("ignores the identity rotation", () => {
+    expect(requestedGeometry({ rotation: "Portrait" })).toEqual([]);
+  });
+
+  it("ignores a full-size scale", () => {
+    // A visual snapshot passes scale 1 on every step; nothing is lost there,
+    // so flagging it would attach a note to every one of them.
+    expect(requestedGeometry({ scale: 1 })).toEqual([]);
+    expect(requestedGeometry({ scale: 0 })).toEqual([]);
+  });
+});
+
+describe("drop notes", () => {
+  it("says nothing when nothing was dropped", () => {
+    expect(chromiumDropNote([])).toBeUndefined();
+    expect(unsupportedDropNote([], "Apple TV")).toBeUndefined();
+  });
+
+  it("tells a Chromium caller how to make it work", () => {
+    const note = chromiumDropNote(["scale", "rotation"]);
+    expect(note).toContain("scale and rotation was not applied");
+    expect(note).toContain("npm install sharp");
+    expect(note).toContain("unmodified capture");
+  });
+
+  it("names the single dropped parameter", () => {
+    expect(chromiumDropNote(["scale"])).toContain("scale was not applied");
+  });
+
+  it("does not invite a pointless retry on a target that cannot transform", () => {
+    const note = unsupportedDropNote(["rotation"], "Apple TV");
+    expect(note).toContain("Apple TV");
+    expect(note).toContain("will not change the result");
+    // The Chromium remedy must not leak into a case where it cannot help.
+    expect(note).not.toContain("npm install");
+  });
+
+  it("keeps the reserved key stable", () => {
+    // http.ts hoists this off the result into the response envelope; renaming
+    // it silently drops every note.
+    expect(RESULT_NOTE_KEY).toBe("__argentNote");
+  });
+});

--- a/packages/tool-server/test/screenshot-dropped-geometry.test.ts
+++ b/packages/tool-server/test/screenshot-dropped-geometry.test.ts
@@ -50,6 +50,16 @@ describe("drop notes", () => {
     expect(chromiumDropNote(["scale"])).toContain("scale was not applied");
   });
 
+  it("does not blame a missing sharp when the PNG header was the problem", () => {
+    // sharp is installed in this case and a requested rotation still ran, so
+    // neither "unmodified capture" nor "npm install sharp" would be true.
+    const note = chromiumDropNote(["scale"], "png-header-unreadable")!;
+    expect(note).toContain("scale was not applied");
+    expect(note).toContain("rotation requested on the same call was still applied");
+    expect(note).not.toContain("npm install");
+    expect(note).not.toContain("unmodified capture");
+  });
+
   it("does not invite a pointless retry on a target that cannot transform", () => {
     const note = unsupportedDropNote(["rotation"], "Apple TV");
     expect(note).toContain("Apple TV");


### PR DESCRIPTION
Fixes #626.

## Reproduced live (Electron testbed)

```
screenshot { scale: 0.25 }               → 1600×1136   (unscaled)
screenshot { rotation: "LandscapeLeft" } → 1600×1136   (unrotated)
```
Both returned nothing but the saved path.

`sharp` really is absent from the published package (no `node_modules/sharp`, not in `package.json`), so this is every user's default. And the existing stderr line is guarded by a **once-per-process** flag — after the first Chromium screenshot there was no signal *anywhere*, not even on stderr.

## The suggested one-liner wouldn't have worked

The issue proposes attaching a `note` to the tool result. I checked `argent-mcp/src/content.ts:75-83`: for an image-output tool the renderer returns **only** image blocks plus a `Saved: <path>` line and discards every other result field. A `note` on the result would have been silently dropped by the very client the issue is about.

**The delivery that does work is still tool-server-only.** `http.ts` already builds a response-envelope `note` (update reminders, active recordings) and has the tool's `data` in scope where it does it. So the tool returns a reserved key, `http.ts` pops it off and pushes it into that note — and `mcp-server.ts:369`, `argent-cli/run.ts:310` and `argent-tools-client` all render it **today**. No client change, and an older client works against a newer server immediately.

## The gate: explicitly asked **and** actually dropped

Both halves matter, and each alone is a bug:

- Gating on the parameter alone would fire on every visual-snapshot step — `flow-visual.ts` passes `scale: 1.0`, which is a no-op, not a loss. `rotation: "Portrait"` is likewise the identity.
- Gating on the effective value would report the `ARGENT_SCREENSHOT_SCALE` default the caller never asked for.

Verified live, all five cases:

| call | note |
|---|---|
| no geometry param (auto-screenshot shape) | — |
| `scale: 1.0` (visual-snapshot shape) | — |
| `rotation: "Portrait"` | — |
| `rotation: "LandscapeLeft"` | ✅ |
| `scale: 0.3` on Android (applied server-side) | — |

And `data` stays `{ image }` — the reserved key is stripped before it reaches the client, so `--json` output and non-image results are unchanged.

```
note: scale was not applied — this is the unmodified capture. Chromium image post-processing
needs the optional `sharp` package: run `npm install sharp` in the tool-server's environment
and retry, or work with the full-size image.
```

## Scope

The issue names Chromium and tvOS. **Vega has the identical gap** — `captureVegaScreenshotPng({ scale })` never receives rotation, same as `tvScreenshot(udid, scale, signal)` — so a Chromium-only fix would leave two silent droppers behind. The physical-iPhone runner capture (added on main later) has the same gap and is covered the same way. Both TV notes are worded so they don't read as retryable.

Two further drop sites covered while the plumbing was here:
- Chromium also loses `scale` when the PNG header can't be read — and that path's comment claimed a "falls back to sharp metadata" that the caller doesn't do. Comment corrected.
- `rotation`'s schema description promised Chromium rotation unconditionally while `scale` already carried the honest caveat.

## Deliberately not done

- **Implementing** rotation for tvOS/Vega. Both are cheap (`sips -r`; Vega already decodes with `pngjs`), but rotation on a fixed-landscape TV is close to meaningless — an agent asking for it is confused, and saying so is more useful than a sideways image.
- **Making `sharp` a real dependency** — ~30 MB of native binary for every consumer, most of whom never touch Chromium. `optionalDependencies` isn't a middle ground either (npm installs them by default). The real fix is to move the Chromium post-process onto the in-repo `pngjs` + `resizeDecodedPng` and delete the sharp branch — worth a follow-up, with the caveat that `resizeDecodedPng` is lanczos3-only, so the other three `downscaler` kernels would need writing or trimming.
- A **flow-nested** `screenshot` step won't surface the note, since the envelope is request-scoped. Accepted: a flow step passing explicit geometry to a TV/Chromium target is a corner case, and a result-field path can be layered on later without undoing this.

## Checks

- 3094 tests pass; 9 new. All 11 pre-existing screenshot tests pass unmodified.
- One unrelated flake on the first full run (`http-recording-note.test.ts`) that passed in isolation and on re-run — not from this change.
- SpiderShield 9.10; extract-tools 46/46; prettier, eslint, both typechecks clean; lock untouched.

## Docs

No docs update needed: `reference/tools.mdx` carries only a one-line row for `screenshot`, and the parameter-level caveats live in the tool description itself.

## Review follow-up (live-tested from the packed tarball, Electron + Apple TV sim)

- **Fixed a pre-existing squash on Chromium with `sharp` present:** `scale: 0.5 + rotation: LandscapeRight` returned 800×568 (rotated content forced into the unrotated aspect ratio) because sharp rotates before it resizes and the target was sized from the unrotated header with `fit: "fill"`. Now 568×800.
- "scale and rotation **were** not applied"; the TV note says "returned unrotated" (scale on the same call is still applied).
- `takeToolNote` strips the reserved key whatever its value.
- Added `http-tool-note.test.ts` for the envelope hoist itself (JSON + NDJSON, key stripped, empty value ignored).
- `bundle-tools.cjs` marks `sharp` external so a dev install of it no longer breaks the tool-server bundle.
- The `png-header-unreadable` corner case now gets honest wording: `sharp` is installed and a requested rotation still ran, so the note no longer claims an unmodified capture or prescribes `npm install sharp` (drop reason threaded through `MediaReady`).

---

## Revived 2026-09-17 (merged `main` at 2ed075602)

- #693 has merged; this now targets `main` directly. Conflicts in `http.ts` (main added the physical-iPhone signing-detection note in the same spot: both notes are kept, signing note first) and `screenshot/index.ts` (imports + the `rotation` description, where this PR's longer wording replaces main's one-liner).
- **New drop site from main:** the physical-iPhone path (#944) downscales but never rotates, and only the schema said "Ignored on physical iPhones". It now gets the same "cannot be transformed" note as Apple TV and Vega (0940692e4).
- Re-verified live on the merged branch: Electron testbed without `sharp`: `rotation: LandscapeLeft`, `scale: 0.25` and both together each return the note, while no param / `scale: 1` / `rotation: Portrait` return none, and `data` stays `{ image }`. The same calls on a `main` server return no note (bug still present). With `sharp` on `NODE_PATH`: 400×284, 1136×1600, and 568×800 for `scale 0.5 + LandscapeRight`, all without a note. Apple TV 4K sim: `LandscapeLeft + scale 0.5` → 1920×1080 plus the Apple TV note, and `Portrait` → no note. The physical-iPhone path was not live-tested because no phone was reachable.
- Checks: tool-server vitest 6335 passed, `typecheck:tests`, eslint, prettier, `npm run build`.