### PR TITLE
fix(flow): let a flow launch an app that can never be instrumented

### DIFF
--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -161,20 +161,20 @@ Record an `await-ui-element` step to **gate** the next step on a screen transiti
    - `tool: gesture-pinch` → `pinch: { on: "<target>", scale: … }`, deriving `scale` as `endDistance / startDistance`. Set `on:` to the element under the pinch center when the pinch was aimed at one (the map or image being zoomed); omit it for a screen-center pinch. Don't carry the recorded distances/angle over — the directive re-derives the geometry (finger placement, system-edge avoidance, chaining of large scales) at run time, so the conversion swaps device-specific coordinates for a portable selector with auto-wait. Keep the raw `tool: gesture-pinch` step when the pinch is anchored at a specific point _inside_ a large element (zooming toward a particular map location, not the map's center) or deliberately pans via `endCenterX`/`endCenterY` — `on:` takes only a selector and re-centers the pinch on the element's frame center, so converting would silently move the zoom anchor.
    - `tool: gesture-rotate` → `rotate: { on: "<target>", by: … }`, deriving `by` as `endAngle − startAngle` (the tool's `endAngle` > `startAngle` turns clockwise, matching the directive's positive `by`). Set `on:` to the element under the rotation center when the rotation was aimed at one (the map or image being rotated); omit it for a screen-center rotation. Don't carry the recorded `centerX`/`centerY`, radii (`radius` or `radiusX`/`radiusY`), `startAngle`, or `durationMs` over — the directive re-derives the geometry (finger placement, physical-circle radius, system-edge avoidance) and runs at a fixed pace (~90° per 300 ms), so the conversion swaps device-specific coordinates for a portable selector with auto-wait. Keep the raw `tool: gesture-rotate` step when the rotation is anchored at a specific point _inside_ a large element rather than its center (the directive re-centers on the element's frame center, so converting would silently move the pivot), when the gesture's speed itself matters (the directive's pace is fixed), or when the sweep exceeds the directive's ±3000° bound.
 
-Every other recorded tool (a velocity-dependent `gesture-swipe`, a fixed-distance `gesture-scroll` not aimed at an element, `button`, `screenshot`, …) has no directive form — leave it as a `tool:` step. The recorder already handles the rest: coordinate `gesture-tap`s are captured as portable `tap:` selector steps, a `restart-app` is captured as a `launch:` step, a `flow-execute` of a sibling fragment is captured as a `run: <name>` composition directive, and device ids are stripped. Captured selectors are emitted in the strict map form (`tap: { text: General }`), never as a loose bare string — the recorder verified the exact element the tap hit, and a bare string would re-parse as loose and route through the identifier-first fallback it was never checked against. After editing, re-run with `flow-execute` to confirm the cleaned flow still passes.
+Every other recorded tool (a velocity-dependent `gesture-swipe`, a fixed-distance `gesture-scroll` not aimed at an element, `button`, `screenshot`, …) has no directive form — leave it as a `tool:` step. The recorder already handles the rest: coordinate `gesture-tap`s are captured as portable `tap:` selector steps, a `restart-app` is captured as a `launch:` step, a `flow-execute` of a sibling fragment is captured as a `run: <name>` composition directive, and device ids are stripped. Captured selectors are emitted in the strict map form (`tap: { text: Settings }`), never as a loose bare string — the recorder verified the exact element the tap hit, and a bare string would re-parse as loose and route through the identifier-first fallback it was never checked against. After editing, re-run with `flow-execute` to confirm the cleaned flow still passes.
 
 ### Example session
 
 ```
 flow-start-recording  { name: "open-about", project_root: "/Users/dev/MyApp" }
-flow-add-echo  { message: "Start Settings from scratch" }
-flow-add-step  { command: "restart-app", args: "{\"udid\": \"ABC\", \"bundleId\": \"com.apple.Preferences\"}" }   # ⇒ captured as `- launch: com.apple.Preferences` — this is now an e2e flow
-flow-add-echo  { message: "On the Settings root list, tapping the 'General' row" }
-flow-add-step  { command: "gesture-tap", args: "{\"udid\": \"ABC\", \"x\": 0.5, \"y\": 0.35}" }   # ⇒ captured as `- tap: { text: General }` (portable selector, no udid)
-flow-add-step  { command: "await-ui-element", args: "{\"udid\": \"ABC\", \"condition\": \"visible\", \"selector\": {\"text\": \"About\"}}" }   # gate the transition
-flow-add-echo  { message: "On Settings > General, tapping 'About'" }
+flow-add-echo  { message: "Start the app from scratch" }
+flow-add-step  { command: "restart-app", args: "{\"udid\": \"ABC\", \"bundleId\": \"com.example.myapp\"}" }   # ⇒ captured as `- launch: com.example.myapp` — this is now an e2e flow
+flow-add-echo  { message: "On the app's root list, tapping the 'Settings' row" }
+flow-add-step  { command: "gesture-tap", args: "{\"udid\": \"ABC\", \"x\": 0.5, \"y\": 0.35}" }   # ⇒ captured as `- tap: { text: Settings }` (portable selector, no udid)
+flow-add-step  { command: "await-ui-element", args: "{\"udid\": \"ABC\", \"condition\": \"visible\", \"selector\": {\"text\": \"Account\"}}" }   # gate the transition
+flow-add-echo  { message: "On Settings, tapping 'Account'" }
 flow-add-step  { command: "gesture-tap", args: "{\"udid\": \"ABC\", \"x\": 0.5, \"y\": 0.17}" }
-flow-add-step  { command: "await-ui-element", args: "{\"udid\": \"ABC\", \"condition\": \"visible\", \"selector\": {\"text\": \"Model Name\"}}" }
+flow-add-step  { command: "await-ui-element", args: "{\"udid\": \"ABC\", \"condition\": \"visible\", \"selector\": {\"text\": \"Email\"}}" }
 flow-finish-recording  {}
 ```
 
@@ -198,14 +198,14 @@ The polished result of the example session above:
 
 ```yaml
 steps:
-  - echo: Start Settings from scratch
-  - launch: com.apple.Preferences
-  - echo: On the Settings root list, tapping the 'General' row
-  - tap: { text: General }
-  - await: { visible: About }
-  - echo: On Settings > General, tapping 'About'
-  - tap: { text: About }
-  - await: { visible: Model Name }
+  - echo: Start the app from scratch
+  - launch: com.example.myapp
+  - echo: On the app's root list, tapping the 'Settings' row
+  - tap: { text: Settings }
+  - await: { visible: Account }
+  - echo: On Settings, tapping 'Account'
+  - tap: { text: Account }
+  - await: { visible: Email }
 ```
 
 Note there is **no device id** anywhere in the file — the recorder strips them and the runner injects the bound device.

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -52,12 +52,22 @@ export interface ActionEnv {
   ctx?: ToolContext;
   device: DeviceInfo;
   signal?: AbortSignal;
+  /**
+   * Bundle id of an app the run launched that can never carry the
+   * view-hierarchy instrumentation. Set means every tree read is doomed, so
+   * they fail immediately with a terminal reason instead of polling a source
+   * that will never appear — and, more importantly, instead of auto-targeting
+   * whichever other app happens to still be connected.
+   */
+  nonInjectableApp?: string;
 }
 
 /** Outcome of a selector directive: ok, or a machine-readable reason it failed. */
 export interface DirectiveOutcome {
   ok: boolean;
   reason?: string;
+  /** Caveat carried by a step that still succeeded. */
+  warning?: string;
   /** The run was cancelled mid-step — reported as a skip, not a step failure. */
   aborted?: boolean;
   /**
@@ -314,7 +324,24 @@ function flowSelectorToFrame(tree: DescribeNode, sel: FlowSelector): DescribeFra
  * convert the outage into a misleading "element not found" downstream. The
  * throw lands in the step's structured report via `execLeafStep`'s catch.
  */
+/**
+ * Why no selector can resolve against an app that cannot be instrumented.
+ * Deliberately not the native-devtools recovery text, which tells the caller to
+ * use `describe`/`screenshot` — the answer for a flow is coordinate steps.
+ */
+export function nonInjectableTreeReason(bundleId: string): string {
+  return (
+    `\`${bundleId}\` is an Apple system app, so argent's view-hierarchy instrumentation can never ` +
+    `be injected into it and selector-based steps cannot resolve. This is terminal — relaunching or ` +
+    `restarting the argent server will not change it. Target this screen by coordinate ` +
+    `(\`tap: { x, y }\`) instead.`
+  );
+}
+
 export async function settleTree(env: ActionEnv): Promise<DescribeNode | undefined> {
+  if (env.nonInjectableApp) {
+    throw new Error(nonInjectableTreeReason(env.nonInjectableApp));
+  }
   const deadline = Date.now() + SETTLE_TIMEOUT_MS;
   let prevFp: string | undefined;
   let prevTree: DescribeNode | undefined;
@@ -992,6 +1019,12 @@ async function waitForCondition(
   },
   timeoutMs: number
 ): Promise<DirectiveOutcome> {
+  // Not routed through settleTree, so it needs its own guard — and a `hidden`
+  // wait is the one condition that would otherwise resolve TRUE off an
+  // unreadable screen.
+  if (env.nonInjectableApp) {
+    return { ok: false, reason: nonInjectableTreeReason(env.nonInjectableApp) };
+  }
   const deadline = Date.now() + timeoutMs;
 
   let lastMatches: ReturnType<typeof findAll> = [];

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -41,7 +41,11 @@ import {
   type ActionEnv,
   type DirectiveOutcome,
 } from "./flow-actions";
-import { nativeDevtoolsRef, type NativeDevtoolsApi } from "../../blueprints/native-devtools";
+import {
+  nativeDevtoolsRef,
+  isInjectableBundleId,
+  type NativeDevtoolsApi,
+} from "../../blueprints/native-devtools";
 import { androidDevtoolsRef, type AndroidDevtoolsApi } from "../../blueprints/android-devtools";
 import {
   chromiumCdpRef,
@@ -111,6 +115,12 @@ export interface StepReport {
    * percentage, baseline written/updated).
    */
   reason?: string;
+  /**
+   * A caveat about a step that still passed — currently, launching an app that
+   * can never carry the view-hierarchy instrumentation. Renderers show it as a
+   * `⚠` in place of the pass glyph and count it in the summary.
+   */
+  warning?: string;
   /** Underlying tool id for `tool` steps. */
   tool?: string;
   /** Tool result for `tool` steps. */
@@ -282,6 +292,10 @@ async function treeSourceGate(
   signal?: AbortSignal
 ): Promise<string | null> {
   if (device.platform === "ios" && !signal?.aborted) {
+    // An app that can never be injected will never connect, so waiting the full
+    // timeout only delays advice that cannot work. The flow can still run every
+    // step that does not read the view hierarchy.
+    if (!isInjectableBundleId(bundleId)) return null;
     const connected = await waitForNativeDevtools(registry, device, bundleId, signal);
     if (!connected && !signal?.aborted) {
       return (
@@ -396,11 +410,25 @@ async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcom
     return { ok: false, reason: `restart-app failed: ${errMsg(err)}` };
   }
   if (!(await sleepOrAbort(POST_LAUNCH_SETTLE_MS, signal))) return ABORTED_OUTCOME;
+  // Recorded on every launch, so a later injectable launch clears it.
+  state.nonInjectableApp =
+    device.platform === "ios" && !isInjectableBundleId(bundleId) ? bundleId : undefined;
+
   const gate = await treeSourceGate(registry, device, bundleId, signal);
   // The gate returns null (ready) on abort — check the signal before trusting
   // it, or a cancelled gate would read as a launch that verified readiness.
   if (signal?.aborted) return ABORTED_OUTCOME;
   if (gate) return { ok: false, reason: gate };
+  if (state.nonInjectableApp) {
+    return {
+      ok: true,
+      warning:
+        `${bundleId} is an Apple system app: it is a platform binary with library validation, so ` +
+        `argent's view-hierarchy instrumentation can never be injected into it. The app launched — ` +
+        `coordinate steps (\`tap: { x, y }\`), \`wait\` and \`snapshot\` work; selector-based steps ` +
+        `cannot resolve for this app.`,
+    };
+  }
   return { ok: true };
 }
 
@@ -1052,7 +1080,12 @@ async function execLeafStep(
       // A run cancelled mid-launch is a skip (matching the pre-step guard and
       // the directives), never a step failure — the app did nothing wrong.
       if (r.aborted) return { ...base, status: "skip", reason: r.reason };
-      return { ...base, status: r.ok ? "pass" : "error", reason: r.reason };
+      return {
+        ...base,
+        status: r.ok ? "pass" : "error",
+        reason: r.reason,
+        ...(r.warning ? { warning: r.warning } : {}),
+      };
     }
 
     case "tap":

--- a/packages/tool-server/test/flows/flow-composition.test.ts
+++ b/packages/tool-server/test/flows/flow-composition.test.ts
@@ -321,4 +321,76 @@ describe("flow validation", () => {
     // …while a non-map, non-string body still gets the shape error.
     expect(() => parseFlow("steps:\n  - launch: 42\n")).toThrow(/launch needs an app id/i);
   });
+  it("launches a non-injectable system app and keeps running coordinate steps", async () => {
+    // An Apple system app is a platform binary with library validation, so the
+    // instrumentation can never load. Waiting for it only delayed advice that
+    // could never work, and took the rest of the flow down with it — even when
+    // nothing in the flow needed the view hierarchy.
+    await writeFlow("main", {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "launch", app: "com.apple.Preferences" },
+        { kind: "echo", message: "coordinate work still runs" },
+      ],
+    });
+    const registry = {
+      invokeTool: vi.fn(async (id: string) =>
+        id === "list-devices" ? { devices: [] } : { ok: true }
+      ),
+      getTool: vi.fn(() => undefined),
+      // Would throw if the gate consulted it — it must not for this bundle.
+      resolveService: vi.fn(async () => {
+        throw new Error("native-devtools unavailable");
+      }),
+    } as unknown as Registry;
+
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "main", project_root: tmpDir, device: DEVICE }
+      )
+    );
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["launch:pass", "echo:pass"]);
+    expect(result.steps[0].warning).toMatch(/system app/i);
+    // The advice that can never work must be gone.
+    expect(result.steps[0].warning).not.toMatch(/restart the argent server/i);
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails a selector step against a non-injectable app terminally, not by timing out", async () => {
+    // Without this the step reaches auto-targeting and reports "Launch or
+    // restart the app first" — worse advice than the gate gave — and, if any
+    // other app is still connected, could resolve against ITS tree instead.
+    await writeFlow("main", {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "launch", app: "com.apple.Preferences" },
+        { kind: "await", condition: "visible", selector: { text: "General" } },
+      ],
+    });
+    const registry = {
+      invokeTool: vi.fn(async (id: string) =>
+        id === "list-devices" ? { devices: [] } : { ok: true }
+      ),
+      getTool: vi.fn(() => undefined),
+      resolveService: vi.fn(async () => {
+        throw new Error("native-devtools unavailable");
+      }),
+    } as unknown as Registry;
+
+    const started = Date.now();
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "main", project_root: tmpDir, device: DEVICE }
+      )
+    );
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["launch:pass", "await:fail"]);
+    expect(result.steps[1].reason).toMatch(/can never be injected/i);
+    expect(result.steps[1].reason).toMatch(/terminal/i);
+    // Immediate, not after the selector timeout.
+    expect(Date.now() - started).toBeLessThan(8000);
+  });
 });


### PR DESCRIPTION
Fixes #623.

## Reproduced

```
[0] launch  error  could not connect to native devtools for com.apple.Preferences.
                   Re-run to relaunch the app and retry… restart the argent server…
[1] echo    skip
[2] tap     skip          ok=false errored=1 skipped=2
```

Control — the identical flow **without** the launch step passes (`ok=true`). So the runner was fine; the gate alone made system apps undriveable, and it gave advice that can never work for them.

The signal already existed: `isInjectableBundleId` is used by `native-devtools-status` (whose docs call `injectable: false` **terminal — do NOT restart/retry**) and by `describe`. The flow gate never consulted it, so it burned the full **8 s** `NATIVE_READY_TIMEOUT_MS` waiting for a connection that cannot occur.

After:

```
[0] launch  pass   ⚠ com.apple.Preferences is an Apple system app… coordinate steps work;
                     selector-based steps cannot resolve for this app.
[1] echo    pass
[2] tap     pass          ok=true, ~3s total
```

## Removing the wait exposes a race the wait was hiding — so this closes it too

This is the part I'd want a reviewer to look at hardest.

Selector steps reach `resolveNativeTargetApp`, which auto-targets whatever app is connected. `chooseFrontmostConnectedApp` has a **weak tier** accepting `applicationState === "inactive"` — exactly what an app reports while it backgrounds. Today the first tree read lands ~9.5 s after launch (8 s gate + 1.5 s settle), comfortably past that window. **Without the wait it lands at ~1.5 s, inside it.**

So a selector step could resolve against a *different* app's tree. Most conditions then fail noisily, but `hidden`-shaped ones (`assert: { hidden: X }`, `await: { hidden: X }`, a `when: { hidden: X }` guard reporting a green skip) would **pass**. The fix records that the launched app cannot be instrumented and fails tree reads immediately with a terminal reason, which closes it.

Without that guard the later path was also *worse* than the gate it replaced: `NATIVE_TARGET_NO_CONNECTED_APPS` says "**Launch or restart the app first**", after a 3 s settle.

```
[1] await  fail  `com.apple.Preferences` is an Apple system app, so … selector-based steps cannot
                 resolve. This is terminal — relaunching or restarting the argent server will not
                 change it. Target this screen by coordinate (`tap: { x, y }`) instead.
```

## Design choices

**Guard on tree reads, not step kinds** — `settleTree` + `waitForCondition`. That covers `tap`/`long-press`/`await`/`assert`/`scroll-to`/`snapshot` in two places, and leaves selector-less `pinch`/`rotate` working (they degrade to a default aspect and never read a tree). Guarding by step kind would have missed `scroll-to`, which calls `settleTree` directly.

**No pre-flight "does this flow use selectors" scan.** `launch` can appear anywhere, including inside a nested fragment, and `run:` fragments are read lazily at execution time — so "does this flow contain selectors" is ill-posed (which steps? after this launch? under a `when:` that may not be entered?).

**Pass, not fail.** The launch genuinely succeeded — the issue's own control proves the rest of such a flow runs. Failing it would re-introduce the bug for coordinate flows.

**No 5th status.** The CLI maps status with no fallback, so an unknown value renders `undefined`. Used the existing `warning` field instead: ⚠ replaces the pass glyph, the text prints under the step, and it's counted in the summary. Both renderers already handle it as legacy wire-compat, so an old CLI renders it correctly — those comments are updated, since it's now actually produced.

## Also fixed

The create-flow skill's recording walkthrough used `com.apple.Preferences` **with selector steps** (`tap: { text: General }`). That could never have been captured (selector capture reads the same tree) or replayed. Switched to a third-party app.

## Not fixed, deliberately

A *fragment* with no `launch` step, run while a system app is frontmost, never sets the flag and still gets the raw message. That's the issue's own control case.

## Checks

- 3088 tests pass; 2 new, both failing against the pre-fix source. **All 542 existing flow tests pass unmodified**, including `flow-composition.test.ts:213`, which pins the retry-worded failure for a genuinely injectable app.
- CLI (277) and MCP (78) renderer suites pass.
- One unrelated flake on a first full run that passed on re-run.
- Skills gate 10.0; extract-tools 46/46; prettier, eslint, both typechecks clean; lock untouched.