### PR TITLE
fix(screenshot-diff): say when two screenshots were resized to be compared

### DIFF
--- a/packages/tool-server/src/tools/screenshot-diff/screenshot-diff-summary.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/screenshot-diff-summary.ts
@@ -8,7 +8,23 @@ type ScreenshotDiffSummaryInput = Omit<PngDiffResult, "summary">;
 type TextSummaryChange = TextChange & {
   appearanceChange?: TextChange;
 };
-type SummaryStatus = "unchanged" | "changed" | "dimension_mismatch" | "unknown";
+/**
+ * `resized_no_change` is the normalized comparison's green: the inputs differed
+ * in resolution, one was resampled, and nothing differed afterwards. It is a
+ * distinct status because "unchanged" claims the two images are the same, while
+ * this claims they are the same once resolution was discarded from one of them —
+ * a difference a regression gate cannot see from the status alone (#617).
+ *
+ * Deliberately not named `unchanged_after_resize`: that string CONTAINS
+ * "unchanged", so the one naive gate this protects — `includes("status:
+ * unchanged")` — would still read it as a plain pass.
+ */
+type SummaryStatus =
+  | "unchanged"
+  | "changed"
+  | "resized_no_change"
+  | "dimension_mismatch"
+  | "unknown";
 type CoordinateSpace = { imageSize: Size } | undefined;
 
 export function formatScreenshotDiffSummary(result: ScreenshotDiffSummaryInput): string {
@@ -23,6 +39,19 @@ export function formatScreenshotDiffSummary(result: ScreenshotDiffSummaryInput):
 
   const lines: string[] = ["Screenshot diff summary", "", "Overall:"];
   lines.push(`- status: ${status}`);
+
+  if (result.sizeNormalization) {
+    // Placed directly under the status so it frames every figure below it, and
+    // worded to stay true on both paths: when nothing differed there are no
+    // pixel or text differences to caveat, and when something did they may be
+    // resampling artifacts rather than real changes.
+    const { baseline, current, comparedAt } = result.sizeNormalization;
+    lines.push(
+      `- size_normalized: baseline=${formatSize(baseline)} current=${formatSize(current)} compared_at=${formatSize(comparedAt)}`,
+      "  - the inputs share an aspect ratio but not a resolution, so the larger was downscaled before comparing; any pixel or text differences below may include resampling artifacts, and the diff images are at compared_at rather than full size",
+      "  - re-capture the baseline at the same scale as the current image (screenshot with scale: 1.0) to compare without resampling"
+    );
+  }
 
   if (result.dimensionMismatch) {
     lines.push(
@@ -98,6 +127,10 @@ function screenshotDiffStatus(result: ScreenshotDiffSummaryInput): SummaryStatus
   if (result.textAnalysis?.status === "ok" && result.textAnalysis.changes.length > 0) {
     return "changed";
   }
+  // Checked last on purpose: a normalized comparison that DID find a difference
+  // is still a plain `changed`, because the caveat must never soften a real
+  // regression into a status that reads like a caveat.
+  if (result.sizeNormalization) return "resized_no_change";
   return "unchanged";
 }
 

--- a/packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/screenshot-diff.ts
@@ -54,6 +54,18 @@ export interface PngDiffResult {
     expected: Size;
     actual: Size;
   };
+  /**
+   * Set only when the inputs differed in resolution and were resampled to a
+   * common size in order to compare. Absent when the sizes already matched, so
+   * its presence IS the signal that the comparison carries resampling
+   * uncertainty — and that a green result means "equal after rescaling one of
+   * them", not "equal".
+   */
+  sizeNormalization?: {
+    baseline: Size;
+    current: Size;
+    comparedAt: Size;
+  };
   regions: DiffRegion[];
   textAnalysis?: TextAnalysis;
 }
@@ -154,6 +166,19 @@ export async function diffPngFiles(options: DiffPngFilesOptions): Promise<PngDif
   const baseline = normalized.baseline;
   const current = normalized.current;
 
+  // Both operands are still in hand here, so the rescale can be reported without
+  // widening normalizeToCommonSize's contract. Undefined when nothing was
+  // resampled — callers key off presence, not a flag.
+  const sizeNormalization =
+    decodedBaseline.width === decodedCurrent.width &&
+    decodedBaseline.height === decodedCurrent.height
+      ? undefined
+      : {
+          baseline: { width: decodedBaseline.width, height: decodedBaseline.height },
+          current: { width: decodedCurrent.width, height: decodedCurrent.height },
+          comparedAt: { width: baseline.width, height: baseline.height },
+        };
+
   const totalPixels = baseline.width * baseline.height;
   const pixelDiff = markChangedPixels({
     baseline,
@@ -209,6 +234,7 @@ export async function diffPngFiles(options: DiffPngFilesOptions): Promise<PngDif
     contextDiffPath: artifactPaths.contextDiffPath,
     regions,
     textAnalysis,
+    ...(sizeNormalization && { sizeNormalization }),
   });
 }
 

--- a/packages/tool-server/test/screenshot-diff.test.ts
+++ b/packages/tool-server/test/screenshot-diff.test.ts
@@ -126,11 +126,74 @@ describe("diffPngFiles", () => {
 
     expect(result.dimensionMismatch).toBeUndefined();
     expect(result.summary).not.toContain("dimension_mismatch");
+    // …but the rescale is now disclosed rather than absorbed silently.
+    expect(result.sizeNormalization).toBeDefined();
     expect(result.imageSize).toEqual({ width: 10, height: 20 });
     expect(result.diffPath).toBe(path.join(dir, "current-diff.png"));
     const diff = PNG.sync.read(await fs.readFile(result.diffPath!));
     expect(diff.width).toBe(10);
     expect(diff.height).toBe(20);
+  });
+
+  it("does not call a rescaled comparison `unchanged` (issue #617)", async () => {
+    const dir = await makeTempDir();
+    const baselinePath = path.join(dir, "baseline.png");
+    const currentPath = path.join(dir, "current.png");
+    // A solid fill downscales to the identical colour under Lanczos3, so this is
+    // a genuine zero-diff — the false green exactly as reported: same aspect,
+    // different resolution, nothing said about it.
+    await writePng(baselinePath, 20, 40, { r: 30, g: 60, b: 90 });
+    await writePng(currentPath, 10, 20, { r: 30, g: 60, b: 90 });
+
+    const result = await diffPngFiles({ baselinePath, currentPath, outputDir: dir });
+
+    expect(result.differentPixels).toBe(0);
+    expect(result.dimensionMismatch).toBeUndefined();
+    expect(result.sizeNormalization).toEqual({
+      baseline: { width: 20, height: 40 },
+      current: { width: 10, height: 20 },
+      comparedAt: { width: 10, height: 20 },
+    });
+    // A gate reading the status must not see a plain pass.
+    expect(result.summary).toContain("- status: resized_no_change");
+    expect(result.summary).not.toContain("- status: unchanged");
+    expect(result.summary).toContain(
+      "- size_normalized: baseline=20x40 current=10x20 compared_at=10x20"
+    );
+  });
+
+  it("still reports a real difference as `changed` when sizes were normalized", async () => {
+    const dir = await makeTempDir();
+    const baselinePath = path.join(dir, "baseline.png");
+    const currentPath = path.join(dir, "current.png");
+    // The caveat must never soften an actual regression into a caveat status —
+    // this pins the ordering inside screenshotDiffStatus.
+    await writePng(baselinePath, 20, 40, { r: 20, g: 20, b: 20 });
+    await writePng(currentPath, 10, 20, { r: 20, g: 20, b: 20 }, [
+      // Clear of the ignored top band (ceil(20 * 0.06) = 2 rows).
+      ...rectPixels(2, 12, 4, 4, { r: 255, g: 0, b: 0 }),
+    ]);
+
+    const result = await diffPngFiles({ baselinePath, currentPath, outputDir: dir });
+
+    expect(result.differentPixels).toBeGreaterThan(0);
+    expect(result.summary).toContain("- status: changed");
+    // …and the rescale is still disclosed, so the figures can be read correctly.
+    expect(result.summary).toContain("- size_normalized:");
+  });
+
+  it("says nothing about normalization when the sizes already matched", async () => {
+    const dir = await makeTempDir();
+    const baselinePath = path.join(dir, "baseline.png");
+    const currentPath = path.join(dir, "current.png");
+    await writePng(baselinePath, 10, 20, { r: 30, g: 60, b: 90 });
+    await writePng(currentPath, 10, 20, { r: 30, g: 60, b: 90 });
+
+    const result = await diffPngFiles({ baselinePath, currentPath, outputDir: dir });
+
+    expect(result.sizeNormalization).toBeUndefined();
+    expect(result.summary).not.toContain("size_normalized");
+    expect(result.summary).toContain("- status: unchanged");
   });
 
   it("hard-fails same-aspect resolution differences when normalizeSizes is false", async () => {


### PR DESCRIPTION
Fixes #617.

## Reproduced three ways

**The reported false green**, using an image whose 2× downscale is lossless so no resampling noise can mask it:

```
baseline 800x1600   current 400x800 (exact half)
→ status: unchanged   pixel_mismatch: 0%   (size difference never mentioned)
```

**Worse on real screenshots** — a 1152×648 capture vs its aspect-preserving half:

```
→ status: changed   pixel_mismatch: 0.35%   changed_areas: 8
   Text changes: Disappeared "General" / Appeared "Remotes and Devices"
```

The content is identical; every region and both OCR "text changes" are resampling artifacts. So the tool doesn't merely stay silent about the size difference — it manufactures a plausible-looking regression report out of noise.

**The control shows the asymmetry is the bug** — aspect-*breaking* correctly reports `dimension_mismatch: expected=1,152x648 actual=1,152x400`. Sizes are disclosed exactly when the tool refuses to compare, and never when it silently rescales.

## The fix

`PngDiffResult` gains `sizeNormalization` (both original sizes plus the size compared at), populated only when a rescale actually happened — so its presence *is* the signal that the comparison carries resampling uncertainty. The summary prints it directly under the status:

```
- status: resized_no_change
- size_normalized: baseline=800x1,600 current=400x800 compared_at=400x800
  - the inputs share an aspect ratio but not a resolution, so the larger was downscaled before
    comparing; any pixel or text differences below may include resampling artifacts, and the diff
    images are at compared_at rather than full size
  - re-capture the baseline at the same scale as the current image (screenshot with scale: 1.0)
    to compare without resampling
```

**`resized_no_change` is checked last**, after the difference checks, so a rescaled comparison that *did* find something is still a plain `changed` — a caveat status must never soften a real regression. There's a test pinning that ordering specifically.

**The name matters.** `unchanged_after_resize` contains `"unchanged"`, so the one naive gate this protects — `summary.includes("status: unchanged")` — would still read it green. `resized_no_change` contains neither `"unchanged"` nor `"changed"`.

## What I deliberately did not do

**Report `dimension_mismatch` whenever sizes differ** — the issue's primary suggestion. The normalization is deliberate: `screenshot-diff/index.ts:292-294` states that same-aspect normalization *"keeps a scaled capture diff-compatible with a baseline saved at any scale"*. The `screenshot` tool defaults to **0.3** for iOS/Android while the diff's live capture is full-res, and on Android the live side falls back to the default scale when full-res capture fails. Hard-failing would break the case this code exists for.

**Expose the internal `normalizeSizes` flag.** `screenshot-diff-tool.test.ts:10-23` is titled *"rejects public tuning options so defaults stay internal"* and asserts exactly this kind of param is refused. And the better remedy is the one the summary now gives — re-capture the baseline at the same scale, which the skill already instructs and which removes the resampling rather than reporting it. Worth reconsidering separately if a user actually wants "green means byte-identical".

*(An earlier draft proposed exposing it via `z.coerce.boolean()`. Worth recording why that was dropped beyond the posture conflict: in zod, `z.coerce.boolean("false")` is **`true`** — so a user asking for strict comparison would have silently got normalization anyway, re-creating this exact bug through the fix's own escape hatch.)*

**Suppress the OCR noise.** Text analysis runs on each *original file at its own resolution* and only rescales the resulting bounds, so a diff-time filter cannot separate "OCR read a 576px image badly" from a real text change. Suppressing it whenever normalization occurred would silence text analysis on every scaled comparison — a new, worse false green of exactly the class this issue is about. Disclosure is the honest treatment; running OCR on the normalized pair is a separate change to `text-diff`'s contract.

## Tests

Three new cases plus three strengthened ones: the false green now discloses and no longer reads `unchanged`; a normalized comparison with a real change still reports `changed` *and* still discloses; equal sizes say nothing; and the retina case still compares rather than hard-failing.

Mutation-verified both halves — removing the status fails the #617 regression test; moving its check before the difference checks fails the ordering test.

Full tool-server suite green — 3089 passed. No existing assertion needed changing, which is also why this survived: nothing pinned it.

## Notes for the reviewer

- The flow snapshot path is untouched and **cannot** reach normalization: full-screen baselines key on the capture's own pixel dimensions (`flow-visual.ts:212`), so a differently-sized capture misses the baseline entirely and fails; `cropOn` diffs already pass `normalizeSizes: false`.
- `SummaryStatus` is unexported and nothing switches on it — the status reaches the outside only as text inside `summary`, which the MCP layer passes through verbatim. No skill doc, flow assertion or e2e script matches on a status string.
- The diff artifacts were already produced at the normalized size; that was simply never stated. The caveat now says so.
