### PR TITLE
fix(android): a slow cold launch is a slow launch, not a failed one

### DIFF
--- a/packages/tool-server/src/tools/launch-app/index.ts
+++ b/packages/tool-server/src/tools/launch-app/index.ts
@@ -73,7 +73,7 @@ export function createLaunchAppTool(registry: Registry): ToolDefinition<Params, 
     },
     description: `Open an app by its bundle id (iOS) or package name (Android), or confirm the running renderer (Chromium).
 Use when starting any app — prefer this over tapping home-screen / launcher icons. Also prepares the native-devtools injection before the app starts (the iOS slice on iOS, the tvOS slice on Apple TV); on tvOS, interaction is focus-driven — use the tv-* tools rather than coordinate taps.
-Returns { launched, bundleId }. Fails if the app is not installed on the target device (iOS / Android).
+Returns { launched, bundleId, note? }. Fails if the app is not installed on the target device (iOS / Android). On Android a launch that overruns the platform's wait window is confirmed by checking the app's process instead of failing, and \`note\` then says the app may not be interactive yet.
 For Chromium, the app is already running behind a CDP port; this call simply refreshes the cached viewport and acknowledges the bundleId tag. To change the visible route, use \`open-url\`.
 On Vega (Fire TV), pass the interactive component app id from manifest.toml (e.g. com.example.app.main) as bundleId.
 

--- a/packages/tool-server/src/tools/launch-app/platforms/android.ts
+++ b/packages/tool-server/src/tools/launch-app/platforms/android.ts
@@ -1,25 +1,105 @@
 import { FAILURE_CODES, FailureError } from "@argent/registry";
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
-import { adbShell, shellQuote, isAndroidTv } from "../../../utils/adb";
+import { adbShell, shellQuote, isAndroidTv, isPackageProcessRunning } from "../../../utils/adb";
 import type { LaunchAppParams, LaunchAppResult } from "../types";
 
-// `am start -W` always prints a `Status:` banner. A positive-match check on
-// `Status: ok` is more robust than scanning for keywords like "Error": the old
-// /Error|Exception/ matcher false-failed on benign class names such as
-// `com.example.ErrorReportingActivity` in the "Activity:" line, and
-// false-succeeded on `Status: null` when the activity failed in onCreate.
-export function assertAmStartOk(out: string): void {
-  if (!/Status:\s*ok/i.test(out)) {
-    throw new FailureError(`am start failed: ${out.trim()}`, {
+/**
+ * Did `am start -W` actually launch something?
+ *
+ * The banner is matched positively, against a closed set. A previous
+ * `/Error|Exception/` scan false-failed on benign class names like
+ * `com.example.ErrorReportingActivity` appearing in the `Activity:` line, so
+ * keyword scanning must not come back. Anything unrecognised is rejected, which
+ * covers every `Error:` shape for free — those print *instead of* the `Status:`
+ * banner rather than alongside it.
+ *
+ * `Status:` is rendered from a boolean, so upstream Android can only ever emit
+ * `ok` or `timeout`. (A `Status: null` shape is mentioned in this file's history
+ * but has never been reproduced and is not reachable from that ternary; it is
+ * rejected here simply by not being in the set.)
+ *
+ * Worth being accurate about what this does NOT catch: an activity destroyed
+ * while the launch is still being waited on reports `timeout=false`, i.e.
+ * `Status: ok`. So an app that crashes during startup is accepted today and
+ * remains accepted — this check has never been the thing that caught it.
+ */
+export function classifyAmStartStatus(out: string): "ok" | "timeout" | "rejected" {
+  // Line-anchored and `\w+`: an activity name containing "Status:" must not
+  // match, and a CRLF stream must not smuggle a `\r` into the token.
+  const status = /^\s*Status:\s*(\w+)/im.exec(out)?.[1]?.toLowerCase();
+  if (status === "ok") return "ok";
+  if (status === "timeout") return "timeout";
+  return "rejected";
+}
+
+/**
+ * `Status: timeout` is a latency verdict, not a failure one.
+ *
+ * It is set by a single path in the framework: the activity was resolved,
+ * started and resumed, and then failed to report idle before the launch wait
+ * window elapsed. It cannot be produced by an intent that failed to resolve or
+ * was refused — those return before any waiting happens. A cold React Native
+ * start routinely overruns that window while launching perfectly well, and
+ * treating it as a failure made agents retry or "fix" a launch that had already
+ * succeeded (#615).
+ *
+ * The `Activity:` line is not evidence to lean on here: both call sites launch
+ * an explicit component, and on this path the framework fills that field from
+ * the record being waited on — so it is close to our own input echoed back.
+ * Whether the app is actually alive is asked directly instead, and only on this
+ * branch, which by definition has already spent longer than the wait window.
+ *
+ * Returns a note when the launch was confirmed the slow way, so the caller knows
+ * the app is up but may not be interactive yet.
+ */
+export async function assertAmStartLaunched(
+  udid: string,
+  component: string,
+  out: string
+): Promise<string | undefined> {
+  const status = classifyAmStartStatus(out);
+  if (status === "ok") return undefined;
+
+  const fail = (message: string): never => {
+    throw new FailureError(message, {
       error_code: FAILURE_CODES.ANDROID_LAUNCH_AM_START_FAILED,
       failure_stage: "android_launch_am_start",
       failure_area: "tool_server",
       error_kind: "subprocess",
     });
+  };
+
+  if (status === "rejected") fail(`am start failed: ${out.trim()}`);
+
+  // Probe the package that was actually launched. `activity` may name a
+  // different package than `bundleId` (the `pkg/Class` form is documented and
+  // accepted), and asking about the wrong one could both miss a real launch and
+  // accept a stale process from an earlier session.
+  const launchedPkg = component.split("/")[0] ?? "";
+  let running: boolean;
+  try {
+    running = await isPackageProcessRunning(udid, launchedPkg);
+  } catch (err) {
+    // An unanswerable probe is not evidence of a crash — say only what is known.
+    return fail(
+      `am start could not be confirmed: the launch wait window elapsed and checking whether ` +
+        `${launchedPkg} is running failed (${err instanceof Error ? err.message : String(err)}). ` +
+        `Output: ${out.trim()}`
+    );
   }
-  // "Warning: Activity not started, its current task has been brought to the
-  // front" also comes with Status: ok and means the app is foregrounded.
-  // That's the behavior callers want from launch-app, so we don't reject it.
+
+  if (!running) {
+    return fail(
+      `am start failed: the launch wait window elapsed and no ${launchedPkg} process is running, ` +
+        `so the app did not stay up. Output: ${out.trim()}`
+    );
+  }
+
+  return (
+    "The app took longer than Android's launch wait window to settle, so the launch was confirmed " +
+    "by checking that the app's process is running. It is up but may still be on a splash or " +
+    "loading screen — wait for the expected UI or take a screenshot before interacting."
+  );
 }
 
 // Normalize a user-supplied `activity` into a concrete `pkg/Activity` component
@@ -142,7 +222,7 @@ export const androidImpl: PlatformImpl<
     const out = await adbShell(params.udid, `am start -W -n ${shellQuote(component)}`, {
       timeoutMs: 30_000,
     });
-    assertAmStartOk(out);
-    return { launched: true, bundleId: params.bundleId };
+    const note = await assertAmStartLaunched(params.udid, component, out);
+    return { launched: true, bundleId: params.bundleId, ...(note ? { note } : {}) };
   },
 };

--- a/packages/tool-server/src/tools/launch-app/types.ts
+++ b/packages/tool-server/src/tools/launch-app/types.ts
@@ -11,7 +11,16 @@ export interface LaunchAppParams {
 }
 
 export type LaunchAppResult =
-  | { launched: boolean; bundleId: string }
+  | {
+      launched: boolean;
+      bundleId: string;
+      /**
+       * Android only: set when the launch overran Android's wait window and was
+       * confirmed by checking the app's process instead. The app is up but may not
+       * be interactive yet.
+       */
+      note?: string;
+    }
   | NativeDevtoolsInitFailedResult;
 
 // iOS gets the native-devtools service so launch-app can warm DYLD env before

--- a/packages/tool-server/src/tools/restart-app/index.ts
+++ b/packages/tool-server/src/tools/restart-app/index.ts
@@ -65,7 +65,7 @@ export function createRestartAppTool(registry: Registry): ToolDefinition<Params,
     },
     description: `Terminate then relaunch an app by bundle id / package name.
 Use when you need a clean in-memory state without a full reinstall. Also refreshes the native-devtools injection before the relaunch (the iOS slice on iOS, the tvOS slice on Apple TV); on tvOS, interaction is focus-driven — use the tv-* tools rather than coordinate taps.
-Returns { restarted, bundleId }. Fails if the app is not installed.`,
+Returns { restarted, bundleId, note? }. Fails if the app is not installed. On Android a launch that overruns the platform's wait window is confirmed by checking the app's process instead of failing, and \`note\` then says the app may not be interactive yet.`,
     alwaysLoad: true,
     searchHint:
       "terminate relaunch restart reset app bundle id package simulator emulator vega tvos fire tv",

--- a/packages/tool-server/src/tools/restart-app/platforms/android.ts
+++ b/packages/tool-server/src/tools/restart-app/platforms/android.ts
@@ -2,7 +2,7 @@ import { FAILURE_CODES, FailureError } from "@argent/registry";
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
 import { adbShell, shellQuote, isAndroidTv } from "../../../utils/adb";
 import {
-  assertAmStartOk,
+  assertAmStartLaunched,
   normalizeActivityComponent,
   resolveLauncherActivity,
 } from "../../launch-app/platforms/android";
@@ -20,8 +20,8 @@ export const androidImpl: PlatformImpl<
     // Match launch-app's relaunch path: `monkey` returns as soon as the intent
     // is injected and its /No activities found|Error:/ scrape false-failed on
     // legitimate class names like `com.example.ErrorReportingActivity`. Use
-    // `am start -W -n <component>` with the same `Status: ok` positive-match
-    // assertion launch-app moved to.
+    // `am start -W -n <component>` with the same launch assertion launch-app
+    // uses, so both tools agree on what counts as a successful start.
     let component: string;
     if (activity) {
       // Shared with launch-app so a bare class name ("MainActivity") becomes a
@@ -35,8 +35,12 @@ export const androidImpl: PlatformImpl<
     const out = await adbShell(udid, `am start -W -n ${shellQuote(component)}`, {
       timeoutMs: 30_000,
     });
+    let note: string | undefined;
     try {
-      assertAmStartOk(out);
+      // `await` inside the try is load-bearing: without it the rejection would
+      // escape this handler entirely and a failed relaunch would return
+      // `restarted: true`.
+      note = await assertAmStartLaunched(udid, component, out);
     } catch (err) {
       throw new FailureError(
         `relaunch failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -49,6 +53,6 @@ export const androidImpl: PlatformImpl<
         { cause: err instanceof Error ? err : new Error(String(err)) }
       );
     }
-    return { restarted: true, bundleId };
+    return { restarted: true, bundleId, ...(note ? { note } : {}) };
   },
 };

--- a/packages/tool-server/src/tools/restart-app/types.ts
+++ b/packages/tool-server/src/tools/restart-app/types.ts
@@ -10,7 +10,16 @@ export interface RestartAppParams {
 }
 
 export type RestartAppResult =
-  | { restarted: boolean; bundleId: string }
+  | {
+      restarted: boolean;
+      bundleId: string;
+      /**
+       * Android only: set when the launch overran Android's wait window and was
+       * confirmed by checking the app's process instead. The app is up but may not
+       * be interactive yet.
+       */
+      note?: string;
+    }
   | NativeDevtoolsInitFailedResult;
 
 // iOS gets the native-devtools service so restart-app can refresh the DYLD env

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -617,6 +617,26 @@ const TERMINAL_ADB_ERROR_PATTERNS: RegExp[] = [
  * which should propagate with adb's own cause — apart from a command-level
  * rejection they can classify themselves (e.g. `pm` refusing a permission).
  */
+/**
+ * Is any process for `pkg` alive right now?
+ *
+ * Matches on the process name, which defaults to the package name — an app that
+ * sets `android:process` on its launcher activity will read as not running. That
+ * direction is safe for every current caller: they use this only to *upgrade* a
+ * result they would otherwise reject, so a miss simply leaves the stricter
+ * answer in place.
+ *
+ * `|| true` because `pidof` exits non-zero when nothing matches and `adbShell`
+ * rejects on a non-zero exit — the same idiom the Android profiler's app
+ * detection uses. On an image old enough to lack `pidof` the error goes to
+ * stderr and stdout is empty, which reads as "not running" and again degrades to
+ * the stricter answer.
+ */
+export async function isPackageProcessRunning(serial: string, pkg: string): Promise<boolean> {
+  const out = await adbShell(serial, `pidof ${shellQuote(pkg)} || true`, { timeoutMs: 10_000 });
+  return out.trim().length > 0;
+}
+
 export function isTerminalAdbError(message: string): boolean {
   return TERMINAL_ADB_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }

--- a/packages/tool-server/test/android-am-start-timeout-615.test.ts
+++ b/packages/tool-server/test/android-am-start-timeout-615.test.ts
@@ -139,8 +139,11 @@ describe("launch-app on a slow cold start", () => {
       { id: UDID, platform: "android", kind: "emulator" } as never
     );
 
-    expect(result).toMatchObject({ launched: true, bundleId: B });
-    expect(result.note).toMatch(/wait window/i);
+    expect(result).toMatchObject({
+      launched: true,
+      bundleId: B,
+      note: expect.stringMatching(/wait window/i),
+    });
     expect(probeCalls()).toHaveLength(1);
     expect(probeCalls()[0]).toBe(B);
   });
@@ -235,8 +238,11 @@ describe("restart-app shares the behaviour", () => {
       { id: UDID, platform: "android", kind: "emulator" } as never
     );
 
-    expect(result).toMatchObject({ restarted: true, bundleId: B });
-    expect(result.note).toMatch(/wait window/i);
+    expect(result).toMatchObject({
+      restarted: true,
+      bundleId: B,
+      note: expect.stringMatching(/wait window/i),
+    });
     const stopAt = shellCalls.findIndex((c) => c.includes("force-stop"));
     const startAt = shellCalls.findIndex((c) => c.includes("am start -W"));
     expect(stopAt).toBeGreaterThanOrEqual(0);

--- a/packages/tool-server/test/android-am-start-timeout-615.test.ts
+++ b/packages/tool-server/test/android-am-start-timeout-615.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getFailureSignal } from "@argent/registry";
+
+/**
+ * Issue #615: a cold React Native launch routinely overruns Android's launch
+ * wait window, which prints `Status: timeout`. The tool required `Status: ok`,
+ * so a launch that had visibly succeeded was reported as a failure and agents
+ * retried or "fixed" a non-problem.
+ *
+ * `Status: timeout` is a latency verdict — the activity was resolved, started
+ * and resumed, then failed to report idle in time. It cannot be produced by an
+ * intent that failed to resolve. What it cannot tell us is whether the app is
+ * still alive, so that is asked directly, and only on this branch.
+ */
+
+const shellCalls: string[] = [];
+let amStartOut = "Status: ok\n";
+/** What the liveness check answers, and which package it was asked about. */
+let processRunning = false;
+let probeThrows = false;
+const probedPackages: string[] = [];
+
+vi.mock("../src/utils/adb", async (importActual) => {
+  const actual = await importActual<typeof import("../src/utils/adb")>();
+  return {
+    ...actual,
+    isAndroidTv: vi.fn(async () => false),
+    adbShell: vi.fn(async (_serial: string, cmd: string) => {
+      shellCalls.push(cmd);
+      return amStartOut;
+    }),
+    // Mocked directly rather than through adbShell: the real helper closes over
+    // the module's own adbShell, so replacing adbShell alone would not reach it.
+    // Asserting on the argument also states the property that matters — which
+    // package was asked about — more directly than matching a command string.
+    isPackageProcessRunning: vi.fn(async (_serial: string, pkg: string) => {
+      probedPackages.push(pkg);
+      if (probeThrows) throw new Error("adb: device 'emulator-5554' not found");
+      return processRunning;
+    }),
+  };
+});
+
+import {
+  androidImpl as launchAndroid,
+  classifyAmStartStatus,
+} from "../src/tools/launch-app/platforms/android";
+import { androidImpl as restartAndroid } from "../src/tools/restart-app/platforms/android";
+
+const UDID = "emulator-5554";
+const B = "com.anonymous.myapp";
+
+/** The reporter's verbatim output, including the fingerprints of the timeout path. */
+const REPORTED_TIMEOUT = `Starting: Intent { cmp=com.anonymous.myapp/.MainActivity }
+Status: timeout
+LaunchState: UNKNOWN (-1)
+Activity: com.anonymous.myapp/.MainActivity
+WaitTime: 11639
+Complete`;
+
+/** A successful launch, captured from an emulator. */
+const OK_OUT = `Starting: Intent { cmp=com.anonymous.myapp/.MainActivity }
+Status: ok
+LaunchState: UNKNOWN (0)
+Activity: com.anonymous.myapp/.MainActivity
+TotalTime: 0
+WaitTime: 2073
+Complete`;
+
+/** A component that does not exist: no Status: line at all. */
+const ERROR_OUT = `Starting: Intent { cmp=com.anonymous.myapp/.NoSuchActivity }
+Error type 3
+Error: Activity class {com.anonymous.myapp/com.anonymous.myapp.NoSuchActivity} does not exist.`;
+
+const probeCalls = () => probedPackages;
+
+beforeEach(() => {
+  shellCalls.length = 0;
+  probedPackages.length = 0;
+  amStartOut = "Status: ok\n";
+  processRunning = false;
+  probeThrows = false;
+});
+
+describe("classifyAmStartStatus", () => {
+  it("reads the reported cold-launch output as a timeout, not a failure", () => {
+    expect(classifyAmStartStatus(REPORTED_TIMEOUT)).toBe("timeout");
+  });
+
+  it("reads a normal launch as ok", () => {
+    expect(classifyAmStartStatus(OK_OUT)).toBe("ok");
+  });
+
+  it("does not fail on a benign class name containing 'Error'", () => {
+    // The reason this check is a positive match rather than a keyword scan: an
+    // earlier /Error|Exception/ matcher rejected launches like this one.
+    expect(classifyAmStartStatus("Status: ok\nActivity: com.example/.ErrorReportingActivity")).toBe(
+      "ok"
+    );
+  });
+
+  it("accepts a launch that only brought an existing task to the front", () => {
+    expect(
+      classifyAmStartStatus(
+        "Warning: Activity not started, its current task has been brought to the front\nStatus: ok"
+      )
+    ).toBe("ok");
+  });
+
+  it("rejects an unresolved component, which prints no status at all", () => {
+    expect(classifyAmStartStatus(ERROR_OUT)).toBe("rejected");
+  });
+
+  it("rejects anything it does not recognise", () => {
+    // Closed set, so an unfamiliar or vendor-specific banner fails closed
+    // instead of being guessed at.
+    expect(classifyAmStartStatus("Status: null")).toBe("rejected");
+    expect(classifyAmStartStatus("Status: weird")).toBe("rejected");
+    expect(classifyAmStartStatus("")).toBe("rejected");
+  });
+
+  it("is not fooled by a status-like string inside an activity name", () => {
+    expect(classifyAmStartStatus("Activity: com.example/.Status: ok")).toBe("rejected");
+  });
+
+  it("handles the CRLF output a Windows host sees", () => {
+    expect(classifyAmStartStatus(REPORTED_TIMEOUT.replace(/\n/g, "\r\n"))).toBe("timeout");
+  });
+});
+
+describe("launch-app on a slow cold start", () => {
+  it("succeeds when the app is running, and says the launch was slow", async () => {
+    amStartOut = REPORTED_TIMEOUT;
+    processRunning = true;
+
+    const result = await launchAndroid.handler(
+      {},
+      { udid: UDID, bundleId: B, activity: ".MainActivity" } as never,
+      { id: UDID, platform: "android", kind: "emulator" } as never
+    );
+
+    expect(result).toMatchObject({ launched: true, bundleId: B });
+    expect(result.note).toMatch(/wait window/i);
+    expect(probeCalls()).toHaveLength(1);
+    expect(probeCalls()[0]).toBe(B);
+  });
+
+  it("fails when the app is not running — it started and did not stay up", async () => {
+    amStartOut = REPORTED_TIMEOUT;
+    processRunning = false;
+
+    const err = await launchAndroid
+      .handler(
+        {},
+        { udid: UDID, bundleId: B, activity: ".MainActivity" } as never,
+        { id: UDID, platform: "android", kind: "emulator" } as never
+      )
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(getFailureSignal(err!)?.error_code).toBe("ANDROID_LAUNCH_AM_START_FAILED");
+    expect(err!.message).toMatch(/no com\.anonymous\.myapp process is running/);
+  });
+
+  it("probes the package that was actually launched, not the one named in bundleId", async () => {
+    // `activity` may name a different package, and asking about the wrong one
+    // could accept a stale process from an earlier session.
+    amStartOut = REPORTED_TIMEOUT;
+    processRunning = true;
+
+    await launchAndroid.handler(
+      {},
+      { udid: UDID, bundleId: B, activity: "com.other.app/.Main" } as never,
+      { id: UDID, platform: "android", kind: "emulator" } as never
+    );
+
+    expect(probeCalls()[0]).toBe("com.other.app");
+  });
+
+  it("does not claim a crash when the check itself could not be answered", async () => {
+    amStartOut = REPORTED_TIMEOUT;
+    probeThrows = true;
+
+    const err = await launchAndroid
+      .handler(
+        {},
+        { udid: UDID, bundleId: B, activity: ".MainActivity" } as never,
+        { id: UDID, platform: "android", kind: "emulator" } as never
+      )
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(err!.message).toMatch(/could not be confirmed/);
+    expect(err!.message).not.toMatch(/did not stay up/);
+  });
+});
+
+describe("launch-app on the ordinary path", () => {
+  it("returns no note and never probes when the launch reports ok", async () => {
+    amStartOut = OK_OUT;
+
+    const result = await launchAndroid.handler(
+      {},
+      { udid: UDID, bundleId: B, activity: ".MainActivity" } as never,
+      { id: UDID, platform: "android", kind: "emulator" } as never
+    );
+
+    expect(result).toEqual({ launched: true, bundleId: B });
+    expect(probeCalls()).toHaveLength(0);
+  });
+
+  it("still fails an unresolved component, without probing", async () => {
+    // A shape we do not trust must not be upgraded by a liveness check.
+    amStartOut = ERROR_OUT;
+
+    await expect(
+      launchAndroid.handler(
+        {},
+        { udid: UDID, bundleId: B, activity: ".NoSuchActivity" } as never,
+        { id: UDID, platform: "android", kind: "emulator" } as never
+      )
+    ).rejects.toThrow(/am start failed/);
+    expect(probeCalls()).toHaveLength(0);
+  });
+});
+
+describe("restart-app shares the behaviour", () => {
+  it("succeeds on a slow relaunch, after force-stopping first", async () => {
+    amStartOut = REPORTED_TIMEOUT;
+    processRunning = true;
+
+    const result = await restartAndroid.handler(
+      {},
+      { udid: UDID, bundleId: B, activity: ".MainActivity" } as never,
+      { id: UDID, platform: "android", kind: "emulator" } as never
+    );
+
+    expect(result).toMatchObject({ restarted: true, bundleId: B });
+    expect(result.note).toMatch(/wait window/i);
+    const stopAt = shellCalls.findIndex((c) => c.includes("force-stop"));
+    const startAt = shellCalls.findIndex((c) => c.includes("am start -W"));
+    expect(stopAt).toBeGreaterThanOrEqual(0);
+    expect(stopAt).toBeLessThan(startAt);
+  });
+
+  it("still fails a genuinely broken relaunch", async () => {
+    // The assertion became async; without awaiting it inside restart-app's own
+    // try/catch the rejection would escape and a failed relaunch would report
+    // success. This is the test that catches that.
+    amStartOut = ERROR_OUT;
+
+    const err = await restartAndroid
+      .handler(
+        {},
+        { udid: UDID, bundleId: B, activity: ".NoSuchActivity" } as never,
+        { id: UDID, platform: "android", kind: "emulator" } as never
+      )
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(getFailureSignal(err!)?.error_code).toBe("ANDROID_RESTART_FAILED");
+  });
+
+  it("fails a slow relaunch whose app did not stay up", async () => {
+    amStartOut = REPORTED_TIMEOUT;
+    processRunning = false;
+
+    const err = await restartAndroid
+      .handler(
+        {},
+        { udid: UDID, bundleId: B, activity: ".MainActivity" } as never,
+        { id: UDID, platform: "android", kind: "emulator" } as never
+      )
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(getFailureSignal(err!)?.error_code).toBe("ANDROID_RESTART_FAILED");
+  });
+});


### PR DESCRIPTION
Fixes #615.

## The bug

`am start -W` reports a timeout when an app doesn't settle inside Android's launch wait window. A cold React Native start routinely overruns it while launching perfectly well — the reporter's app was on screen and their screenshot proves it — but the success check required `Status: ok`, so the tool reported a failure.

Proven deterministically against the built code: the reporter's verbatim output is rejected.

```
Starting: Intent { cmp=com.anonymous.myapp/.MainActivity }
Status: timeout
LaunchState: UNKNOWN (-1)
Activity: com.anonymous.myapp/.MainActivity
WaitTime: 11639
→ am start failed: …
```

## Why a timeout isn't a failure

`Status:` is rendered from a boolean, so the platform can only ever emit `ok` or `timeout`, and `timeout=true` is set from exactly one place: the activity was resolved, started and **resumed**, and then failed to report itself idle before the window elapsed. It cannot be produced by an intent that failed to resolve or was refused — those return before any waiting happens, printing an `Error:` shape *instead of* the status banner.

Two fingerprints in the reporter's output corroborate that path specifically: `LaunchState: UNKNOWN (-1)` (only that call site passes `-1`) and the absent `TotalTime:` line (printed only for a non-negative time). A successful control run on an emulator shows `TotalTime: 0`.

*(Verified against AOSP: [ActivityManagerShellCommand.java](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/services/core/java/com/android/server/am/ActivityManagerShellCommand.java) and [ActivityTaskSupervisor.java](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/services/core/java/com/android/server/wm/ActivityTaskSupervisor.java). `WaitResult.java` is in the local SDK sources; the shell command and supervisor are not, so those were read from upstream.)*

## The fix

Status parsing becomes an explicit allowlist that **fails closed** — `ok` accepted, `timeout` conditionally accepted, everything else rejected. Every "cannot resolve" shape is rejected for free because it carries no status banner at all. Keyword scanning stays out: it's what used to reject launches of classes merely *named* something like `ErrorReportingActivity`, and there's a test pinning that.

A timeout is confirmed by asking whether the app is actually alive — only on that branch, which has by definition already spent longer than the window. Alive ⇒ success plus a `note` that the app may still be on a splash screen. Not alive ⇒ still fails, saying the app *did not stay up* rather than guessing why. An unanswerable check says *"could not be confirmed"* rather than claiming a crash.

**The issue's proposed rule — accept a timeout when the output names a resolved activity — is not the safeguard it appears to be.** Both call sites launch an explicit component, and on this path the platform fills that field from the record being waited on, so it's close to our own input echoed back. The rule reduces to "accept every timeout".

**The probe asks about the package that was actually launched**, not the one in `bundleId`. An `activity` may name a different package (the `pkg/Class` form is documented and accepted), and asking about the wrong one could both miss a real launch and accept a stale process from an earlier session. A review caught this — my first design would have shipped that bug.

## A correction to this file's own history

The comment claimed the strict check guarded against an activity that failed during startup (`Status: null`). **It does not.** An activity destroyed while the launch is still being waited on reports `timeout=false` ⇒ `Status: ok` — so that case was accepted before this change and is accepted after it. The comment now states what is actually guarded, and the PR doesn't claim a protection that never existed. (`Status: null` itself traces back to the initial Android-support commit with no reproduction; it's rejected here simply by not being in the allowlist.)

## Not reproducible on this host — stated plainly

Every cold start I could stage landed at 1.4–2.1 s against the reporter's 11.6 s; their environment is a freshly-installed Expo app. So the *timing* is theirs and the *handling* is proven here, with every behavioural claim pinned by a hermetic test rather than a live repro.

Also worth flagging: the wait window is `10s × ro.hw_timeout_multiplier`, so on a slow CI emulator with a multiplier ≥ 3 the launch would outlive argent's own 30 s adb budget and fail earlier, before this code runs. That case is not covered here.

## Tests

17 new cases. Classifier: the reporter's verbatim output, a captured successful launch, the benign `ErrorReportingActivity` guard, brought-to-front, an unresolved component, unrecognised banners, a `Status:`-like string inside an activity name, and CRLF. Handler: alive ⇒ success + note + exactly one probe; dead ⇒ failure; the probed package is the launched one; an unanswerable probe doesn't claim a crash; the `ok` path returns the identical object and **never probes**; an unresolved component isn't probed at all; and restart-app covered for all three outcomes.

Mutation-verified: restoring the strict gate fails 7; probing `bundleId` instead of the launched component fails the test written for it.

Full tool-server suite green — 3103 passed.

## Notes for the reviewer

- The assertion became **async**, and the `await` inside restart-app's own try/catch is load-bearing — without it a failed relaunch would return `restarted: true` and the rejection would escape unhandled. There's a dedicated test.
- `note` is deliberately Android-only. Two existing suites assert `toEqual({ launched: true, bundleId })` on the iOS/tvOS paths, so mirroring the field onto the shared or iOS platforms would break them.
- The ordinary path is byte-identical: same object, no probe, no extra round trip.
- `open-url` also shells `am start` but without `-W`, so it has no status banner and is a separate concern — untouched.
- I considered a dedicated failure code for the timeout-and-dead case, but restart-app re-wraps every error into its own code, so half the telemetry signal wouldn't exist. Reused the existing code instead.
