### PR TITLE
fix(init): install the skills we already ship when the pinned source can't be reached

### DIFF
--- a/packages/argent-installer/src/init-skills.ts
+++ b/packages/argent-installer/src/init-skills.ts
@@ -1,6 +1,5 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { spawn } from "node:child_process";
 import { track } from "@argent/telemetry";
 import {
   SKILLS_DIR,
@@ -8,22 +7,75 @@ import {
   isOnline,
   isSkillsCliAvailable,
   withNpmForce,
+  listBundledSkills,
 } from "./utils.js";
 import { InitCancelled } from "./init-args.js";
 import type { Scope } from "./init-scope.js";
+import { runNpxSkills } from "./npx-skills.js";
 
 export type SkillsMethod = "default" | "interactive" | "manual";
+/** Where the skills were actually installed from. */
+export type SkillsSource = "pinned" | "bundled";
+
+export interface SkillsStepResult {
+  method: SkillsMethod;
+  outcome: "success" | "failure" | "skipped";
+  /** Null when nothing was attempted (manual instructions only). */
+  source: SkillsSource | null;
+  /** True only when the pinned source failed and the bundled copy rescued it. */
+  usedFallback: boolean;
+}
 
 // Step 2 — install skills via `npx skills`. Emits the skill_install telemetry
 // event itself (it owns all the inputs). Throws InitCancelled("skills") on a
 // cancelled method prompt.
+
+/** Matches the usual missing-ref wording. Used for telemetry only — never to decide. */
+const REF_MISSING =
+  /Remote branch .* not found in upstream|couldn't find remote ref|unknown revision/i;
+
+/**
+ * The line worth showing out of a wall of subprocess output. The first line is
+ * usually an npm warning about `--force`, so prefer the one that names the
+ * actual failure and fall back to the first non-noise line.
+ */
+function meaningfulLine(err: unknown): string {
+  const lines = (err instanceof Error ? err.message : String(err))
+    .split("\n")
+    .map((l) => l.replace(/^[│┌└■◇\s]+/, "").trim())
+    .filter(Boolean);
+  return (
+    lines.find((l) => /^fatal:|^Error:|Failed to|not found|Could not/i.test(l)) ??
+    lines.find((l) => !/^npm (WARN|notice)/i.test(l)) ??
+    lines[0] ??
+    "unknown error"
+  );
+}
+
+/**
+ * Report a skills install that could not be rescued. The manual command names
+ * the source that could still work, not the one that just failed — printing the
+ * failing command back as the remedy is what made the original report so
+ * confusing.
+ */
+function reportSkillsFailure(
+  method: SkillsMethod,
+  spinner: { stop: (msg?: string) => void },
+  err: unknown,
+  attempted: string
+): void {
+  if (method === "default") spinner.stop(pc.red("Skills installation failed."));
+  p.log.error(`Failed to install skills from ${attempted}: ${meaningfulLine(err)}`);
+  p.log.info(`You can install them manually:\n  npx skills add ${SKILLS_DIR} --skill '*' -y`);
+}
+
 export async function runSkillsStep(args: {
   nonInteractive: boolean;
   fromTar: string | null;
   version: string;
   scope: Scope;
   customRoot?: string;
-}): Promise<SkillsMethod> {
+}): Promise<SkillsStepResult> {
   const { nonInteractive, fromTar, version, scope, customRoot } = args;
 
   p.log.step(pc.bold("Step 2: Skills Installation"));
@@ -74,11 +126,17 @@ export async function runSkillsStep(args: {
     skillsMethod = choice as SkillsMethod;
   }
 
-  // Prefer the GitHub-pinned source. SKILLS_DIR as a fallback.
+  // Prefer the GitHub-pinned source: it keeps skills-lock.json portable by
+  // recording a shared ref rather than a path on this machine. The bundled copy
+  // is the same version's skills either way (it ships inside this package), so
+  // falling back to it below costs provenance, not content.
   const useGitHubSource = online && !fromTar && version !== "unknown";
   const skillsSource = useGitHubSource ? buildArgentSkillsSource(version) : SKILLS_DIR;
 
   let skillOutcome: "success" | "failure" | "skipped";
+  // Which source the skills actually came from, and why the pinned one lost.
+  let skillsSourceUsed: SkillsSource = skillsSource === SKILLS_DIR ? "bundled" : "pinned";
+  let fallbackReason: "ref_missing" | "unclassified" | null = null;
 
   if (skillsMethod === "manual") {
     p.note(
@@ -101,85 +159,108 @@ export async function runSkillsStep(args: {
     );
     skillOutcome = "skipped";
   } else {
-    const skillsArgs = ["skills", "add", skillsSource];
+    // Rebuilt per source rather than string-swapped, so a retry keeps the scope
+    // flag and the offline `--no-install` prefix it was going to run with.
+    const buildSkillsArgs = (source: string): string[] => {
+      const args = ["skills", "add", source];
+      if (scope === "global") args.push("-g");
+      if (skillsMethod === "default") args.push("--skill", "*", "-y");
+      return offlineWithCache ? ["--no-install", ...args] : args;
+    };
 
-    if (scope === "global") {
-      skillsArgs.push("-g");
-    }
-
-    if (skillsMethod === "default") {
-      skillsArgs.push("--skill", "*", "-y");
-    }
-
-    const baseArgs = offlineWithCache ? ["--no-install", ...skillsArgs] : skillsArgs;
     // `--force` softens the host project's npm engine gate (see withNpmForce /
     // issue #298); the displayed and manual-fallback commands stay clean.
-    const npxArgs = withNpmForce(baseArgs);
-
-    p.log.info(`Running: ${pc.dim("npx")} ${pc.cyan(baseArgs.join(" "))}`);
+    p.log.info(`Running: ${pc.dim("npx")} ${pc.cyan(buildSkillsArgs(skillsSource).join(" "))}`);
 
     const spinner = p.spinner();
     if (skillsMethod === "default") {
       spinner.start("Installing skills...");
     }
 
+    const skillsCwd = scope === "custom" ? customRoot : undefined;
+    const runWith = (source: string) =>
+      runNpxSkills(
+        withNpmForce(buildSkillsArgs(source)),
+        skillsMethod === "interactive",
+        skillsCwd
+      );
+
     try {
-      const skillsCwd = scope === "custom" ? customRoot : undefined;
-      await runNpxSkills(npxArgs, skillsMethod === "interactive", skillsCwd);
+      await runWith(skillsSource);
       if (skillsMethod === "default") {
         spinner.stop("Skills installed.");
       }
       skillOutcome = "success";
     } catch (err) {
-      if (skillsMethod === "default") {
-        spinner.stop(pc.red("Skills installation failed."));
+      // Retry against the copy bundled with this package. The decision is
+      // deliberately structural rather than a match on the error text: the
+      // interactive path captures no output to match against, and the usual
+      // cause — git reporting a missing ref — is a translated string, so a text
+      // rule would quietly stop working for anyone not running an English
+      // toolchain. Every failure the retry cannot rescue simply fails again,
+      // cheaply and locally.
+      const bundledUsable = skillsSource !== SKILLS_DIR && listBundledSkills().length > 0;
+
+      if (bundledUsable) {
+        // Not a red "failed" yet — that would contradict a retry that is about
+        // to succeed, which is the same class of lie this fixes.
+        if (skillsMethod === "default") {
+          spinner.message("Pinned source unavailable — installing the bundled copy...");
+        }
+        p.log.warn(
+          `Could not install skills from ${skillsSource}: ${meaningfulLine(err)}\n` +
+            "Falling back to the copy bundled with this package."
+        );
+        fallbackReason = REF_MISSING.test(String(err)) ? "ref_missing" : "unclassified";
+        try {
+          await runWith(SKILLS_DIR);
+          if (skillsMethod === "default") {
+            spinner.stop("Skills installed from the bundled copy.");
+          }
+          skillOutcome = "success";
+          skillsSourceUsed = "bundled";
+          p.note(
+            [
+              "Skills came from the copy bundled with this package, because the",
+              "pinned source could not be resolved.",
+              "",
+              "skills-lock.json now records a path on this machine rather than a",
+              "shared source. A later `argent update` on a tagged release restores",
+              "the portable entry.",
+            ].join("\n"),
+            "Skills installed locally"
+          );
+        } catch (fallbackErr) {
+          reportSkillsFailure(skillsMethod, spinner, fallbackErr, SKILLS_DIR);
+          skillOutcome = "failure";
+        }
+      } else {
+        reportSkillsFailure(skillsMethod, spinner, err, skillsSource);
+        skillOutcome = "failure";
       }
-      p.log.error(`Failed to run npx skills: ${err}`);
-      p.log.info(`You can install skills manually:\n  npx ${skillsArgs.join(" ")}`);
-      skillOutcome = "failure";
     }
   }
+
+  const usedFallback = fallbackReason !== null && skillOutcome === "success";
 
   track("installation:skill_install", {
     method: skillsMethod,
     is_online: online,
     has_offline_cache: offlineWithCache,
     outcome: skillOutcome,
+    // A release whose tag was never pushed makes every install fall back. That
+    // is invisible once the fallback rescues it, so it has to be measurable.
+    source: skillOutcome === "skipped" ? null : skillsSourceUsed,
+    used_fallback: usedFallback,
+    ...(fallbackReason ? { fallback_reason: fallbackReason } : {}),
   });
 
-  return skillsMethod;
+  return {
+    method: skillsMethod,
+    outcome: skillOutcome,
+    source: skillOutcome === "skipped" ? null : skillsSourceUsed,
+    usedFallback,
+  };
 }
 
-export function runNpxSkills(args: string[], interactive: boolean, cwd?: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const npxCmd = process.platform === "win32" ? "npx.cmd" : "npx";
-    const child = spawn(npxCmd, args, {
-      stdio: interactive ? "inherit" : ["ignore", "pipe", "pipe"],
-      shell: process.platform === "win32",
-      ...(cwd ? { cwd } : {}),
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    if (!interactive) {
-      child.stdout?.on("data", (chunk: Buffer) => {
-        stdout += chunk.toString();
-      });
-      child.stderr?.on("data", (chunk: Buffer) => {
-        stderr += chunk.toString();
-      });
-    }
-
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        const output = [stderr, stdout].filter(Boolean).join("\n").trim();
-        reject(new Error(output || `npx skills exited with code ${code}`));
-      }
-    });
-
-    child.on("error", reject);
-  });
-}
+export { runNpxSkills } from "./npx-skills.js";

--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -31,7 +31,7 @@ import { chooseScope, type Scope } from "./init-scope.js";
 import { writeMcpConfigs } from "./init-mcp-write.js";
 import { cleanupStaleMcpConfigs } from "./init-stale-config.js";
 import { configureAllowlist } from "./init-allowlist.js";
-import { runSkillsStep, type SkillsMethod } from "./init-skills.js";
+import { runSkillsStep, type SkillsStepResult } from "./init-skills.js";
 
 // `argent init` orchestrator: each phase is a thin call into a dedicated
 // module, telemetry bookkeeping lives in the shared InitTelemetry context.
@@ -257,7 +257,7 @@ export async function init(args: string[]): Promise<void> {
 
     // ── Step 2: Skills Installation ─────────────────────────────────────────────
 
-    const skillsMethod = await runSkillsStep({
+    const skills = await runSkillsStep({
       nonInteractive: parsed.nonInteractive,
       fromTar: parsed.fromTar,
       version,
@@ -290,7 +290,7 @@ export async function init(args: string[]): Promise<void> {
       selectedAdapters: writtenAdapters,
       scope,
       allowlistEnabled: allowlist.enabled,
-      skillsMethod,
+      skills,
       copiedRules: copyResults.length > 0,
     });
 
@@ -346,8 +346,29 @@ interface SummaryArgs {
   selectedAdapters: McpConfigAdapter[];
   scope: Scope;
   allowlistEnabled: boolean;
-  skillsMethod: SkillsMethod;
+  skills: SkillsStepResult;
   copiedRules: boolean;
+}
+
+/**
+ * The skills line of the summary, keyed on what actually happened rather than on
+ * which method was chosen. Reporting "installed" after a visible failure is the
+ * defect this fixes (#614), and a silent fallback is its quieter twin: the user
+ * ends up with a machine-local lock entry and no idea why.
+ *
+ * A bundled source chosen deliberately — offline, `--from <tgz>`, unknown
+ * version — is an ordinary success and must read as one; only a pinned attempt
+ * that failed first is worth calling out.
+ */
+export function formatSkillsSummaryLine(skills: SkillsStepResult): string {
+  if (skills.method === "manual") return `${pc.green("Skills")} instructions printed`;
+  if (skills.outcome === "failure") {
+    return `${pc.yellow("Skills")} NOT installed — see the error above`;
+  }
+  if (skills.usedFallback) {
+    return `${pc.yellow("Skills")} installed from the bundled copy — the pinned source was unavailable`;
+  }
+  return `${pc.green("Skills")} installed`;
 }
 
 function printSummary({
@@ -355,7 +376,7 @@ function printSummary({
   selectedAdapters,
   scope,
   allowlistEnabled,
-  skillsMethod,
+  skills,
   copiedRules,
 }: SummaryArgs): void {
   const summaryLines = [
@@ -364,7 +385,7 @@ function printSummary({
       ? `${pc.green("MCP server")} configured for ${selectedAdapters.map((a) => a.name).join(", ")} (${scope})`
       : `${pc.yellow("MCP server")} NOT configured — no editor config was written`,
     `${pc.green("Auto-approve")} ${allowlistEnabled ? "enabled" : "skipped"}`,
-    `${pc.green("Skills")} ${skillsMethod === "manual" ? "instructions printed" : "installed"}`,
+    formatSkillsSummaryLine(skills),
     `${pc.green("Rules & agents")} ${copiedRules ? "copied" : "n/a"}`,
   ];
 

--- a/packages/argent-installer/src/npx-skills.ts
+++ b/packages/argent-installer/src/npx-skills.ts
@@ -1,0 +1,42 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Run the skills CLI through npx.
+ *
+ * A leaf module on purpose: `init-skills` retries this against a second source
+ * when the first fails, and a test can only assert *which source each attempt
+ * used* if the runner can be replaced independently of the step that calls it.
+ */
+export function runNpxSkills(args: string[], interactive: boolean, cwd?: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const npxCmd = process.platform === "win32" ? "npx.cmd" : "npx";
+    const child = spawn(npxCmd, args, {
+      stdio: interactive ? "inherit" : ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
+      ...(cwd ? { cwd } : {}),
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    if (!interactive) {
+      child.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+    }
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        const output = [stderr, stdout].filter(Boolean).join("\n").trim();
+        reject(new Error(output || `npx skills exited with code ${code}`));
+      }
+    });
+
+    child.on("error", reject);
+  });
+}

--- a/packages/argent-installer/test/init-skills.test.ts
+++ b/packages/argent-installer/test/init-skills.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Issue #614: skills are installed from a GitHub ref pinned to the running
+ * version. Publishing and tagging are decoupled, so a published version whose
+ * tag was never pushed can never resolve — the clone fails, nothing is
+ * installed, and the run still reported "Skills installed" and exited 0.
+ *
+ * The package already ships every skill, so the bytes were on disk the whole
+ * time; only the decision to use them was missing.
+ */
+
+const runNpxSkills = vi.hoisted(() => vi.fn(async (_args: string[]) => {}));
+vi.mock("../src/npx-skills.js", () => ({ runNpxSkills }));
+
+const isOnline = vi.hoisted(() => vi.fn(async () => true));
+const isSkillsCliAvailable = vi.hoisted(() => vi.fn(() => true));
+const listBundledSkills = vi.hoisted(() => vi.fn(() => ["argent-device-interact"]));
+
+vi.mock("../src/utils.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../src/utils.js")>();
+  // buildArgentSkillsSource and SKILLS_DIR stay REAL so the argument
+  // assertions below mean something.
+  return { ...original, isOnline, isSkillsCliAvailable, listBundledSkills };
+});
+
+const track = vi.hoisted(() => vi.fn());
+vi.mock("@argent/telemetry", () => ({ track }));
+
+const log = vi.hoisted(() => ({
+  step: vi.fn(),
+  message: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+const note = vi.hoisted(() => vi.fn());
+vi.mock("@clack/prompts", () => ({
+  log,
+  note,
+  spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
+  select: vi.fn(async () => "default"),
+  confirm: vi.fn(async () => true),
+  isCancel: () => false,
+}));
+
+import { runSkillsStep } from "../src/init-skills.js";
+import { SKILLS_DIR, buildArgentSkillsSource } from "../src/utils.js";
+
+const PINNED = buildArgentSkillsSource("0.18.1");
+
+function step(overrides: Record<string, unknown> = {}) {
+  return runSkillsStep({
+    scope: "local",
+    version: "0.18.1",
+    fromTar: null,
+    yes: true,
+    ...overrides,
+  } as never);
+}
+
+/** The source argument of the Nth `npx skills add` attempt. */
+function sourceOfAttempt(n: number): string {
+  const args = runNpxSkills.mock.calls[n]![0];
+  return args[args.indexOf("add") + 1]!;
+}
+
+const REPORTED_FAILURE = `npm WARN using --force Recommended protections disabled.
+■  Failed to clone repository
+│  fatal: Remote branch v0.18.1 not found in upstream origin`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runNpxSkills.mockResolvedValue(undefined);
+  isOnline.mockResolvedValue(true);
+  isSkillsCliAvailable.mockReturnValue(true);
+  listBundledSkills.mockReturnValue(["argent-device-interact"]);
+});
+
+describe("skills install falls back to the copy that ships with the package", () => {
+  it("uses the pinned source when it works, and does not touch the bundled copy", async () => {
+    const result = await step();
+
+    expect(runNpxSkills).toHaveBeenCalledTimes(1);
+    expect(sourceOfAttempt(0)).toBe(PINNED);
+    expect(result).toMatchObject({ outcome: "success", source: "pinned", usedFallback: false });
+  });
+
+  it("installs the bundled copy when the pinned ref does not exist (issue #614)", async () => {
+    runNpxSkills.mockRejectedValueOnce(new Error(REPORTED_FAILURE));
+
+    const result = await step();
+
+    expect(runNpxSkills).toHaveBeenCalledTimes(2);
+    expect(sourceOfAttempt(0)).toBe(PINNED);
+    expect(sourceOfAttempt(1)).toBe(SKILLS_DIR);
+    expect(result).toMatchObject({ outcome: "success", source: "bundled", usedFallback: true });
+    // The user is told, because their lock entry is now machine-local.
+    expect(log.warn).toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith(
+      "installation:skill_install",
+      expect.objectContaining({ used_fallback: true, fallback_reason: "ref_missing" })
+    );
+  });
+
+  it("falls back on any failure, not only one whose text it recognises", async () => {
+    // The decision is structural: the interactive path captures no output to
+    // match on, and git's wording is translated, so a text rule would silently
+    // stop working outside an English toolchain.
+    runNpxSkills.mockRejectedValueOnce(new Error("npx skills exited with code 1"));
+
+    const result = await step();
+
+    expect(result).toMatchObject({ outcome: "success", usedFallback: true });
+    expect(track).toHaveBeenCalledWith(
+      "installation:skill_install",
+      expect.objectContaining({ fallback_reason: "unclassified" })
+    );
+  });
+
+  it("does not retry a source that is already the bundled copy", async () => {
+    // Offline, `--from <tgz>` and an unknown version all resolve to the bundled
+    // copy up front — retrying it against itself would just fail twice.
+    runNpxSkills.mockRejectedValue(new Error("boom"));
+
+    const result = await step({ fromTar: "/tmp/argent.tgz" });
+
+    expect(runNpxSkills).toHaveBeenCalledTimes(1);
+    expect(sourceOfAttempt(0)).toBe(SKILLS_DIR);
+    expect(result).toMatchObject({ outcome: "failure", usedFallback: false });
+  });
+
+  it("does not retry when the bundled copy is unreadable", async () => {
+    // Retrying against an empty directory installs nothing and buries the real
+    // problem behind a second, identical failure.
+    listBundledSkills.mockReturnValue([]);
+    runNpxSkills.mockRejectedValue(new Error(REPORTED_FAILURE));
+
+    const result = await step();
+
+    expect(runNpxSkills).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ outcome: "failure" });
+  });
+
+  it("reports failure — and a command that could work — when both attempts fail", async () => {
+    runNpxSkills.mockRejectedValue(new Error(REPORTED_FAILURE));
+
+    const result = await step();
+
+    expect(runNpxSkills).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ outcome: "failure", usedFallback: false });
+    // Printing the failing command back as the remedy is what made the original
+    // report so confusing.
+    const hint = log.info.mock.calls
+      .map((c) => String(c[0]))
+      .find((line) => line.includes("manually"))!;
+    expect(hint).toContain(SKILLS_DIR);
+    expect(hint).not.toContain(PINNED);
+  });
+
+  it("keeps the scope flag when it retries", async () => {
+    runNpxSkills.mockRejectedValueOnce(new Error(REPORTED_FAILURE));
+
+    await step({ scope: "global" });
+
+    expect(runNpxSkills.mock.calls[1]![0]).toContain("-g");
+  });
+});

--- a/packages/telemetry/src/events.ts
+++ b/packages/telemetry/src/events.ts
@@ -85,6 +85,12 @@ export interface InstallationSkillInstallProps {
   is_online: boolean;
   has_offline_cache: boolean;
   outcome: "success" | "failure" | "skipped";
+  /** Which source the skills came from: the pinned ref or the bundled copy. */
+  source?: "pinned" | "bundled" | null;
+  /** True when the pinned source failed and the bundled copy rescued the install. */
+  used_fallback?: boolean;
+  /** Why the pinned source lost, when it did. */
+  fallback_reason?: "ref_missing" | "unclassified";
 }
 
 export interface InstallationSkillRefreshResultProps extends FailureTelemetryProps {

--- a/packages/telemetry/src/sanitize.ts
+++ b/packages/telemetry/src/sanitize.ts
@@ -177,6 +177,9 @@ export const ALLOWED: ValidatorMap = {
     warned_count: COUNT,
   },
   "installation:skill_install": {
+    source: oneOf(["pinned", "bundled"]),
+    used_fallback: bool,
+    fallback_reason: oneOf(["ref_missing", "unclassified"]),
     method: oneOf(["default", "interactive", "manual"] as const),
     is_online: bool,
     has_offline_cache: bool,


### PR DESCRIPTION
Fixes #614.

## Reproduced on a published build

`0.18.1` never reached npm, but the **canaries did** — and canaries get no tag either, so this is live for every prerelease user right now, not only for the tarball in the report.

```
$ npm i -g @swmansion/argent@0.18.1-next.7        (clean VM)
$ argent init -y

Running: npx skills add …/packages/skills/skills#v0.18.1-next.7 --skill * -y
◇  Skills installation failed.
│  fatal: Remote branch v0.18.1-next.7 not found in upstream origin

◇  Summary ──────────────╮
│  Skills installed      │   ← after a visible failure
╰────────────────────────╯
EXIT: 0        skills on disk: 0
```

## The fix

**The package already ships every skill.** `SKILLS_DIR` resolves *inside* the installed package, so the bundled copy is that version's skills by construction — the pinned ref buys canonical provenance, not fresher content. `argent init --local --from <tgz>` installed all fifteen while plain `argent init` from the same package installed none. Only the decision was missing, and the comment above the source choice already claimed it existed.

A failed install now retries against that bundled copy. **The same fallback already exists on the update path** (`skills.ts:108-124`), so this brings init in line rather than inventing a mechanism.

**The retry decision is structural, not textual.** The interactive path captures no output to match on, and git's missing-ref wording is a translated string — so a text rule would silently stop working outside an English toolchain. It retries when the source wasn't already the bundled copy *and* the bundled copy is readable; everything else fails as before, cheaply.

**The summary keys on the outcome**, and a fallback says so out loud. That's not just honesty: the lockfile then records a machine-local path instead of a shared source, which the user should know. A bundled source chosen *deliberately* — offline, `--from`, unknown version — stays an ordinary success, so the e2e path doesn't start crying wolf.

**Two smaller lies went with it.** The "install manually" hint printed the *identical failing command*; it now names the source that could work. And the reported cause was whichever line came out first — usually `npm WARN using --force` rather than the clone failure.

**Telemetry** gains `source`, `used_fallback` and `fallback_reason`. Without it, a release whose tag was never pushed looks perfectly healthy: every install quietly rescued, nobody filing anything.

## Verified live

Same canary, same VM, fix grafted in:

```
▲  Could not install skills from …#v0.18.1-next.7: Failed to clone repository
│  Falling back to the copy bundled with this package.
◇  Skills installed from the bundled copy.
◇  Skills installed locally ─── (lock now records a local path; a later
                                 argent update on a tagged release restores it)

skills on disk: 15
```

## Deliberately not in this PR

- **The exit code.** I had planned to exit 1 on total failure and dropped it: skills failing doesn't stop MCP config, rules and agents from landing; the e2e already downgrades a missing skills-lock to `skip`, so exiting 1 would convert a tolerated state into a hard CI failure; and the one rule that mentions `init` tells the agent to *hand the command to a human*, not run it — so "an agent reads the exit code" doesn't hold. Worth its own change once telemetry shows how often skills genuinely fail.
- **A confirm before falling back in interactive mode.** `runNpxSkills` uses `stdio: "inherit"` and there's no SIGINT handler, so Ctrl-C kills argent along with the TUI — the confirm would be unreachable for the case that justified it.
- **The release-process half.** A publish-time tag check would prevent the whole class, but it belongs in CI. Note it can't be scoped to canaries: the publish workflow creates no tag for *any* channel, which is why the reported case was a stable version.

## Corrections to my own analysis, for the record

- I claimed the fallback's cost was that teammates inherit a machine-local lock. **Wrong** — `.gitignore` excludes `skills-lock.json` and says why in as many words: it *"bakes in machine-specific absolute skill paths, so it must never be committed."* The cost is local refresh semantics, not team contamination, and it doesn't argue for making the fallback opt-in.
- I described this as "canaries are never tagged". More accurately, publishing and tagging are decoupled for **every** channel — which is exactly why the reported failure was a stable `0.18.1`.

## Tests

7 new cases: pinned success touches nothing else; the #614 case falls back and is disclosed; a *generic* failure also falls back (proving the decision isn't regex-gated); no self-retry when the source is already bundled; no retry when the bundled copy is unreadable; both-failed names a usable command and not the failing one; and the scope flag survives the retry.

`runNpxSkills` moved to a leaf module so a test can assert **which source each attempt used** — the precise regression this is about.

Mutation-verified: disabling the fallback fails 4. Installer suite 542 green, telemetry 282 green.


## Update (2026-09-17): merged with main at 0.25.1

- Merged `origin/main` (no rebase). The only conflict was `init-skills.ts`, where main had moved `runNpxSkills` inline and reworded comments. The fallback logic stays, `runNpxSkills` stays in `npx-skills.ts`, and main's comment wording is kept. The unused `runNpxSkills` re-export and the `formatSkillsSummaryLine` export are gone, so knip passes.
- Fix: the manual command printed after both attempts fail dropped the scope. A global install was told to run a project-scope `npx skills add`. It now keeps `-g`, and for a custom root it runs from that root. Added a test for this. The test helper also passed `yes` instead of `nonInteractive`, and that is fixed too.
- Docs: none needed. The installation page already says init copies skills, and this PR only makes that true when the pinned tag is missing.

Live A/B test, run in a sandbox (temp HOME, npm prefix and cache). I installed the npm 0.25.1 tarball as a devDependency and ran `argent init --local -y`. The control is the stock `installer.mjs`. The branch run swaps in this branch's `installer.mjs`.

| version in package.json | main | branch |
|---|---|---|
| `0.25.1-revive692` (no tag) | `fatal: Remote branch … not found`, summary "Skills installed", exit 0, **0 skills** | warns and falls back, summary "installed from the bundled copy", exit 0, **18 skills** |
| `0.25.1` (tag exists) | 18 skills, lock source `software-mansion/argent` | same output, same lock source |

Checks: installer vitest 582, telemetry vitest 347, `typecheck:tests` for both packages, eslint, knip, prettier and build all pass.
