### PR TITLE
fix(android): capture the screen the way it is actually oriented

### DIFF
--- a/packages/tool-server/src/tools/describe/platforms/android/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/android/index.ts
@@ -3,7 +3,11 @@ import type { Registry, ToolDependency } from "@argent/registry";
 import type { DescribeTreeData } from "../../contract";
 import { adbExecOutBinary, isAndroidTv } from "../../../../utils/adb";
 import { resolveDevice } from "../../../../utils/device-info";
-import { getAndroidScreenSize } from "../../../../utils/android-screen";
+import {
+  getAndroidScreenSize,
+  orientScreenSize,
+  parseDumpRotation,
+} from "../../../../utils/android-screen";
 import { parseUiAutomatorDump } from "./uiautomator-parser";
 import {
   androidDevtoolsRef,
@@ -113,6 +117,12 @@ export async function describeAndroid(
       }
     );
   }
-  const tree = parseUiAutomatorDump(raw, size.width, size.height);
+  // `wm size` is not rotation-aware, but the dump says which rotation it was
+  // taken at. Orienting the divisor here is what keeps a rotated device's frames
+  // in the same upright space the android-devtools path already produces — and
+  // stops the right-hand half of a landscape screen being pruned away as
+  // off-screen (#609).
+  const oriented = orientScreenSize(size, parseDumpRotation(raw));
+  const tree = parseUiAutomatorDump(raw, oriented.width, oriented.height);
   return { tree, source: "uiautomator", hint };
 }

--- a/packages/tool-server/src/tools/screenshot-diff/index.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/index.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { z } from "zod";
 import { FAILURE_CODES, FailureError } from "@argent/registry";
 import type {
+  DeviceInfo,
   FileInputSpec,
   ServiceRef,
   ToolContext,
@@ -14,6 +15,7 @@ import type {
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
 import { httpScreenshot } from "../../utils/simulator-client";
+import { captureScreenshotUpright } from "../../utils/rotation-aware-capture";
 import { requireArtifacts, type ArtifactHandle } from "../../artifacts";
 import { diffPngFiles } from "./screenshot-diff";
 
@@ -48,7 +50,11 @@ const zodSchema = z
     rotation: z
       .enum(["Portrait", "LandscapeLeft", "LandscapeRight", "PortraitUpsideDown"])
       .optional()
-      .describe("Orientation override for live baseline/current captures."),
+      .describe(
+        "Orientation override for live baseline/current captures. Rarely needed: an Android capture " +
+          "already follows the device's rotation. Setting it pins a fixed rotation, which can make a " +
+          "live capture disagree with a saved baseline taken at a different device rotation."
+      ),
     outputDir: z
       .string()
       .min(1)
@@ -197,6 +203,7 @@ async function resolveInputPaths(
   const baselinePath = params.captureBaseline
     ? await captureLiveInput({
         api: requireSimulatorServer(services),
+        device: resolveDevice(params.udid),
         outputDir,
         name: "baseline",
         rotation: params.rotation,
@@ -208,6 +215,7 @@ async function resolveInputPaths(
   const currentPath = params.captureCurrent
     ? await captureLiveInput({
         api: requireSimulatorServer(services),
+        device: resolveDevice(params.udid),
         outputDir,
         name: "current",
         rotation: params.rotation,
@@ -279,6 +287,10 @@ async function captureLiveInput(params: {
   // Resolved and validated by requireSimulatorServer at the call site, so it is
   // never undefined here.
   api: SimulatorServerApi;
+  // Needed so a live capture picks up the device's rotation the same way the
+  // `screenshot` tool does. Without it a rotated-Android `captureCurrent` would
+  // come back sideways and diff at ~100% against an upright saved baseline.
+  device: DeviceInfo;
   outputDir: string;
   name: "baseline" | "current";
   rotation?: Params["rotation"];
@@ -294,9 +306,23 @@ async function captureLiveInput(params: {
   // baseline saved at any scale. Full-res is preserved wherever it works (iOS).
   let capture: Awaited<ReturnType<CaptureScreenshot>>;
   try {
-    capture = await params.captureScreenshot(params.api, params.rotation, params.signal, 1.0);
+    capture = await captureScreenshotUpright(
+      params.api,
+      params.device,
+      params.rotation,
+      params.signal,
+      1.0,
+      params.captureScreenshot
+    );
   } catch {
-    capture = await params.captureScreenshot(params.api, params.rotation, params.signal);
+    capture = await captureScreenshotUpright(
+      params.api,
+      params.device,
+      params.rotation,
+      params.signal,
+      undefined,
+      params.captureScreenshot
+    );
   }
   const suffix = crypto.randomBytes(4).toString("hex");
   const destination = path.join(params.outputDir, `${params.name}-${suffix}.live.png`);

--- a/packages/tool-server/src/tools/screenshot-diff/index.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/index.ts
@@ -53,11 +53,7 @@ const zodSchema = z
     rotation: z
       .enum(["Portrait", "LandscapeLeft", "LandscapeRight", "PortraitUpsideDown"])
       .optional()
-      .describe(
-        "Orientation override for live baseline/current captures. Rarely needed: an Android capture " +
-          "already follows the device's rotation. Setting it pins a fixed rotation, which can make a " +
-          "live capture disagree with a saved baseline taken at a different device rotation."
-      ),
+      .describe("Orientation override for live baseline/current captures."),
     outputDir: z
       .string()
       .min(1)

--- a/packages/tool-server/src/tools/screenshot-diff/index.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/index.ts
@@ -7,6 +7,7 @@ import { FAILURE_CODES, FailureError } from "@argent/registry";
 import type {
   DeviceInfo,
   FileInputSpec,
+  Registry,
   ServiceRef,
   ToolContext,
   ToolCapability,
@@ -16,6 +17,8 @@ import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/si
 import { resolveDevice } from "../../utils/device-info";
 import { httpScreenshot } from "../../utils/simulator-client";
 import { captureScreenshotUpright } from "../../utils/rotation-aware-capture";
+import { androidDevtoolsRotationPeek } from "../../utils/android-devtools-rotation-peek";
+import type { RotationPeek } from "../../utils/device-orientation";
 import { requireArtifacts, type ArtifactHandle } from "../../artifacts";
 import { diffPngFiles } from "./screenshot-diff";
 
@@ -132,11 +135,31 @@ Fails if the input sources are invalid, PNG files cannot be read, outputDir cann
   },
 };
 
+/**
+ * The registered form: same tool, but live captures can read a rotated Android
+ * device's rotation from the android-devtools helper when it is already running
+ * (~1 ms) instead of probing over adb (~8 ms). `screenshotDiffTool` itself stays
+ * registry-free for callers and tests that have no registry.
+ */
+export function createScreenshotDiffTool(
+  registry: Registry
+): ToolDefinition<Params, ScreenshotDiffResult> {
+  return {
+    ...screenshotDiffTool,
+    async execute(services, params, options) {
+      return executeScreenshotDiffTool(services, params, options, httpScreenshot, (device) =>
+        androidDevtoolsRotationPeek(registry, device)
+      );
+    },
+  };
+}
+
 export async function executeScreenshotDiffTool(
   services: Record<string, unknown>,
   params: Params,
   options?: Partial<ToolContext>,
-  captureScreenshot: CaptureScreenshot = httpScreenshot
+  captureScreenshot: CaptureScreenshot = httpScreenshot,
+  peekFor?: (device: DeviceInfo) => RotationPeek
 ): Promise<ScreenshotDiffResult> {
   const outputDir = await resolveOutputDir(params, options);
 
@@ -145,7 +168,8 @@ export async function executeScreenshotDiffTool(
     params,
     outputDir,
     options,
-    captureScreenshot
+    captureScreenshot,
+    peekFor
   );
 
   const result = await diffPngFiles({
@@ -196,7 +220,8 @@ async function resolveInputPaths(
   params: Params,
   outputDir: string,
   options: Partial<ToolContext> | undefined,
-  captureScreenshot: CaptureScreenshot
+  captureScreenshot: CaptureScreenshot,
+  peekFor?: (device: DeviceInfo) => RotationPeek
 ): Promise<{ baselinePath: string; currentPath: string }> {
   validateInputSources(params);
 
@@ -204,6 +229,7 @@ async function resolveInputPaths(
     ? await captureLiveInput({
         api: requireSimulatorServer(services),
         device: resolveDevice(params.udid),
+        peekFor,
         outputDir,
         name: "baseline",
         rotation: params.rotation,
@@ -216,6 +242,7 @@ async function resolveInputPaths(
     ? await captureLiveInput({
         api: requireSimulatorServer(services),
         device: resolveDevice(params.udid),
+        peekFor,
         outputDir,
         name: "current",
         rotation: params.rotation,
@@ -291,6 +318,7 @@ async function captureLiveInput(params: {
   // `screenshot` tool does. Without it a rotated-Android `captureCurrent` would
   // come back sideways and diff at ~100% against an upright saved baseline.
   device: DeviceInfo;
+  peekFor?: (device: DeviceInfo) => RotationPeek;
   outputDir: string;
   name: "baseline" | "current";
   rotation?: Params["rotation"];
@@ -312,7 +340,8 @@ async function captureLiveInput(params: {
       params.rotation,
       params.signal,
       1.0,
-      params.captureScreenshot
+      params.captureScreenshot,
+      params.peekFor?.(params.device)
     );
   } catch {
     capture = await captureScreenshotUpright(
@@ -321,7 +350,8 @@ async function captureLiveInput(params: {
       params.rotation,
       params.signal,
       undefined,
-      params.captureScreenshot
+      params.captureScreenshot,
+      params.peekFor?.(params.device)
     );
   }
   const suffix = crypto.randomBytes(4).toString("hex");

--- a/packages/tool-server/src/tools/screenshot/index.ts
+++ b/packages/tool-server/src/tools/screenshot/index.ts
@@ -7,7 +7,8 @@ import type { Registry, ToolCapability, ToolDefinition } from "@argent/registry"
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-cdp";
 import { resolveDevice } from "../../utils/device-info";
-import { getScreenshotScale, httpScreenshot } from "../../utils/simulator-client";
+import { getScreenshotScale } from "../../utils/simulator-client";
+import { captureScreenshotUpright } from "../../utils/rotation-aware-capture";
 import { isTvOsSimulator } from "../../utils/ios-devices";
 import { simctlArgsForUdid } from "../../utils/ios-device-sets";
 import { captureVegaScreenshotPng } from "../../utils/vega-screen";
@@ -25,7 +26,11 @@ const zodSchema = z.object({
     .enum(["Portrait", "LandscapeLeft", "LandscapeRight", "PortraitUpsideDown"])
     .optional()
     .describe(
-      "Orientation override for the screenshot (rotates the captured image after Page.captureScreenshot on Chromium)."
+      "Orientation override. Rarely needed: on Android the capture already follows the device's " +
+        "current rotation, so it is upright without this. Setting it replaces that with a fixed " +
+        "rotation, which on a rotated device produces an image whose geometry no longer matches " +
+        "`describe` frames or gesture coordinates. On Chromium it rotates the captured image after " +
+        "Page.captureScreenshot."
     ),
   scale: z
     .number()
@@ -130,6 +135,7 @@ export function createScreenshotTool(registry: Registry): ToolDefinition<Params,
     },
     description: `Capture a screenshot of the device screen (iOS simulator, Android emulator, Apple TV simulator, Vega, or Chromium app). Returns { image }; the MCP adapter renders it as a visible image unless the caller passed includeImageInContext: false.
 Use when you need a baseline image before an interaction or to inspect the current screen state after a delay.
+On a rotated Android device the capture follows the device's rotation, so it comes back upright and its geometry matches \`describe\` frames and gesture coordinates. Do not pass \`rotation\` to correct a sideways image.
 Fails if the simulator-server / emulator backend / Chromium CDP is not reachable for the given device.`,
     alwaysLoad: true,
     searchHint: "device simulator emulator chromium screen image capture baseline tvos apple tv",
@@ -177,8 +183,9 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
 
       const ref = simulatorServerRef(device);
       const api = (await registry.resolveService(ref.urn, ref.options)) as SimulatorServerApi;
-      const { path: capturedPath } = await httpScreenshot(
+      const { path: capturedPath } = await captureScreenshotUpright(
         api,
+        device,
         params.rotation,
         signal,
         params.scale

--- a/packages/tool-server/src/tools/screenshot/index.ts
+++ b/packages/tool-server/src/tools/screenshot/index.ts
@@ -9,6 +9,7 @@ import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-c
 import { resolveDevice } from "../../utils/device-info";
 import { getScreenshotScale } from "../../utils/simulator-client";
 import { captureScreenshotUpright } from "../../utils/rotation-aware-capture";
+import { androidDevtoolsRotationPeek } from "../../utils/android-devtools-rotation-peek";
 import { isTvOsSimulator } from "../../utils/ios-devices";
 import { simctlArgsForUdid } from "../../utils/ios-device-sets";
 import { captureVegaScreenshotPng } from "../../utils/vega-screen";
@@ -188,7 +189,9 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
         device,
         params.rotation,
         signal,
-        params.scale
+        params.scale,
+        undefined,
+        androidDevtoolsRotationPeek(registry, device)
       );
       const image = await requireArtifacts(ctx).register(capturedPath, { mimeType: "image/png" });
       return { image };

--- a/packages/tool-server/src/tools/screenshot/index.ts
+++ b/packages/tool-server/src/tools/screenshot/index.ts
@@ -27,11 +27,7 @@ const zodSchema = z.object({
     .enum(["Portrait", "LandscapeLeft", "LandscapeRight", "PortraitUpsideDown"])
     .optional()
     .describe(
-      "Orientation override. Rarely needed: on Android the capture already follows the device's " +
-        "current rotation, so it is upright without this. Setting it replaces that with a fixed " +
-        "rotation, which on a rotated device produces an image whose geometry no longer matches " +
-        "`describe` frames or gesture coordinates. On Chromium it rotates the captured image after " +
-        "Page.captureScreenshot."
+      "Orientation override for the screenshot (rotates the captured image after Page.captureScreenshot on Chromium). On Android the capture already follows the device's rotation."
     ),
   scale: z
     .number()
@@ -136,7 +132,6 @@ export function createScreenshotTool(registry: Registry): ToolDefinition<Params,
     },
     description: `Capture a screenshot of the device screen (iOS simulator, Android emulator, Apple TV simulator, Vega, or Chromium app). Returns { image }; the MCP adapter renders it as a visible image unless the caller passed includeImageInContext: false.
 Use when you need a baseline image before an interaction or to inspect the current screen state after a delay.
-On a rotated Android device the capture follows the device's rotation, so it comes back upright and its geometry matches \`describe\` frames and gesture coordinates. Do not pass \`rotation\` to correct a sideways image.
 Fails if the simulator-server / emulator backend / Chromium CDP is not reachable for the given device.`,
     alwaysLoad: true,
     searchHint: "device simulator emulator chromium screen image capture baseline tvos apple tv",

--- a/packages/tool-server/src/utils/adb-server.ts
+++ b/packages/tool-server/src/utils/adb-server.ts
@@ -1,0 +1,119 @@
+import * as net from "node:net";
+
+/**
+ * Run a shell command on a device by talking to the adb *server* directly,
+ * without spawning the `adb` binary.
+ *
+ * Why this exists: measured on a Pixel_9 emulator, `adb -s <serial> shell true`
+ * costs ~14 ms of which ~11 ms is spawning the client process — the device
+ * round-trip over the server's socket is ~3 ms. The screenshot tool asks the
+ * device for its rotation on every Android capture, and on the common (portrait)
+ * path that probe was the whole cost of the tool: ~19 ms of probe on a ~7 ms
+ * capture. Going straight to the server socket takes the probe to ~8 ms.
+ *
+ * The wire protocol is adb's own, documented in `SERVICES.TXT` / `OVERVIEW.TXT`
+ * of the platform tools and unchanged for well over a decade: every message is
+ * a 4-hex-digit length followed by the payload; the server answers `OKAY` or
+ * `FAIL` + message. `host:transport:<serial>` selects the device, `shell:<cmd>`
+ * runs the command and streams its output until the socket closes.
+ *
+ * This is NOT a general replacement for `adbShell`. It throws on anything
+ * unexpected — server not listening, unknown serial, a `FAIL`, a timeout — and
+ * every caller must fall back to the spawned client, which also starts the
+ * server when it is down. It also honours the same environment the client does
+ * (`ADB_SERVER_SOCKET`, `ANDROID_ADB_SERVER_ADDRESS`, `ANDROID_ADB_SERVER_PORT`)
+ * so a relocated server is reached rather than silently bypassed.
+ */
+export async function adbServerShell(
+  serial: string,
+  shellCommand: string,
+  options: { timeoutMs?: number } = {}
+): Promise<string> {
+  const { host, port } = adbServerAddress(process.env);
+  const timeoutMs = options.timeoutMs ?? 5_000;
+
+  return new Promise<string>((resolve, reject) => {
+    const socket = net.createConnection({ host, port });
+    socket.setNoDelay(true);
+
+    const chunks: Buffer[] = [];
+    let stage: "transport" | "shell" | "output" = "transport";
+    let pending = Buffer.alloc(0);
+    let settled = false;
+
+    const finish = (err?: Error, value?: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      if (err) reject(err);
+      else resolve(value ?? "");
+    };
+    const timer = setTimeout(
+      () => finish(new Error(`adb server shell timed out after ${timeoutMs}ms: ${shellCommand}`)),
+      timeoutMs
+    );
+
+    const send = (message: string) => {
+      const payload = Buffer.from(message, "utf8");
+      socket.write(payload.length.toString(16).padStart(4, "0") + message);
+    };
+
+    /** Consume one OKAY/FAIL status from `pending`; returns false if incomplete. */
+    const takeStatus = (): boolean => {
+      if (pending.length < 4) return false;
+      const status = pending.subarray(0, 4).toString("latin1");
+      if (status === "OKAY") {
+        pending = pending.subarray(4);
+        return true;
+      }
+      if (status === "FAIL") {
+        if (pending.length < 8) return false;
+        const len = parseInt(pending.subarray(4, 8).toString("latin1"), 16);
+        if (pending.length < 8 + len) return false;
+        finish(new Error(`adb server: ${pending.subarray(8, 8 + len).toString("utf8")}`));
+        return false;
+      }
+      finish(new Error(`adb server: unexpected status ${JSON.stringify(status)}`));
+      return false;
+    };
+
+    socket.once("connect", () => send(`host:transport:${serial}`));
+    socket.on("data", (data: Buffer) => {
+      if (stage === "output") {
+        chunks.push(data);
+        return;
+      }
+      pending = Buffer.concat([pending, data]);
+      if (stage === "transport" && takeStatus()) {
+        stage = "shell";
+        send(`shell:${shellCommand}`);
+      }
+      if (stage === "shell" && takeStatus()) {
+        stage = "output";
+        if (pending.length) chunks.push(pending);
+        pending = Buffer.alloc(0);
+      }
+    });
+    socket.once("error", (err) => finish(err));
+    socket.once("close", () => {
+      if (stage === "output") finish(undefined, Buffer.concat(chunks).toString("utf8"));
+      else finish(new Error("adb server closed the connection before answering"));
+    });
+  });
+}
+
+/** Where the adb client would look for its server, from the same env it reads. */
+export function adbServerAddress(env: NodeJS.ProcessEnv): { host: string; port: number } {
+  // `ADB_SERVER_SOCKET=tcp:host:port` wins, exactly as it does for the client.
+  const socketSpec = env.ADB_SERVER_SOCKET;
+  if (socketSpec) {
+    const m = /^tcp:(?:(.*):)?(\d+)$/.exec(socketSpec.trim());
+    if (m) return { host: m[1] || "127.0.0.1", port: Number(m[2]) };
+  }
+  const port = Number(env.ANDROID_ADB_SERVER_PORT);
+  return {
+    host: env.ANDROID_ADB_SERVER_ADDRESS?.trim() || "127.0.0.1",
+    port: Number.isInteger(port) && port > 0 && port < 65536 ? port : 5037,
+  };
+}

--- a/packages/tool-server/src/utils/android-devtools-rotation-peek.ts
+++ b/packages/tool-server/src/utils/android-devtools-rotation-peek.ts
@@ -1,0 +1,48 @@
+import { ServiceState, type DeviceInfo, type Registry } from "@argent/registry";
+import { androidDevtoolsRef, type AndroidDevtoolsApi } from "../blueprints/android-devtools";
+import type { RotationPeek } from "./device-orientation";
+
+/** Upper bound on a peek — the helper answers in ~1 ms; anything slower is wrong. */
+const PEEK_TIMEOUT_MS = 1_000;
+
+/**
+ * A rotation source that asks the android-devtools helper — but ONLY when the
+ * helper is already running for this device.
+ *
+ * The helper reports the rotation in ~1 ms (it is the same `getScreenSize` call
+ * `describe` already makes), against ~8 ms for the adb-server probe and ~19 ms
+ * for a spawned `adb shell`. It is also exactly as authoritative: measured after
+ * each of several rotations it matched `dumpsys` on every sample.
+ *
+ * What this must never do is *start* the helper: resolving the service installs
+ * an APK and runs `am instrument` with a 30 s ready timeout, and `screenshot`
+ * fires automatically after most tools. So the service state is checked first
+ * and a helper that is not RUNNING means "no answer" — the caller then probes
+ * over adb, which gives the same rotation a little later. The answer is the
+ * same either way; only the latency differs.
+ */
+export function androidDevtoolsRotationPeek(registry: Registry, device: DeviceInfo): RotationPeek {
+  return async () => {
+    if (device.platform !== "android") return null;
+    const ref = androidDevtoolsRef(device);
+    let state: ServiceState;
+    try {
+      state = registry.getServiceState(ref.urn);
+    } catch {
+      // Never created → never started. Do not create it here.
+      return null;
+    }
+    if (state !== ServiceState.RUNNING) return null;
+    try {
+      const api = (await registry.resolveService(ref.urn, ref.options)) as AndroidDevtoolsApi;
+      if (!api.isReady()) return null;
+      const size = await Promise.race([
+        api.getScreenSize(),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), PEEK_TIMEOUT_MS).unref?.()),
+      ]);
+      return size?.rotation ?? null;
+    } catch {
+      return null;
+    }
+  };
+}

--- a/packages/tool-server/src/utils/android-screen.ts
+++ b/packages/tool-server/src/utils/android-screen.ts
@@ -14,11 +14,18 @@ export interface AndroidScreenSize {
  * `wm size` reports "Physical size: WxH\nOverride size: WxH"; the override
  * wins when present (set by emulators and some system configs).
  *
+ * IMPORTANT: this reports the *unrotated* size. Measured on a landscape Pixel_9
+ * (API 36) whose display really was 2424x1080: `wm size` still answered
+ * "Physical size: 1080x2424" with no Override line. So the returned size must be
+ * oriented by the caller — see `orientScreenSize` — before it is used as a
+ * divisor for rotated bounds. An earlier revision of this comment assumed the
+ * opposite and that assumption is what made the legacy describe path wrong on a
+ * rotated device (#609).
+ *
  * NOT cached: a 5 s TTL would have served stale dimensions for several
- * describes after a rotation (rotation completes in <500 ms), producing
- * normalized frames with x>1 / width>1 because the screenW used for the
- * divisor was pre-rotation. One extra `adb shell` per `describe` is cheap
- * compared to the uiautomator dump exec-out it sits next to.
+ * describes after a rotation (rotation completes in <500 ms). One extra
+ * `adb shell` per `describe` is cheap compared to the uiautomator dump exec-out
+ * it sits next to.
  */
 export async function getAndroidScreenSize(serial: string): Promise<AndroidScreenSize> {
   const out = await adbShell(serial, "wm size", { timeoutMs: 5_000 });
@@ -44,4 +51,41 @@ export async function getAndroidScreenSize(serial: string): Promise<AndroidScree
     });
   }
   return { width, height };
+}
+
+/**
+ * The surface rotation a uiautomator dump was taken at, read from the dump
+ * itself: `<hierarchy rotation="1">`.
+ *
+ * Taking it from the XML rather than asking the device again is deliberate. It
+ * costs no extra round-trip, it cannot disagree with the bounds it is used to
+ * normalize (a rotation between the two calls would), and — most importantly —
+ * the legacy path runs precisely when the android-devtools helper could not be
+ * reached, which is when the device is least likely to answer more adb probes.
+ *
+ * Returns null when absent, which keeps pre-rotation-attribute dumps working.
+ */
+export function parseDumpRotation(rawOutput: string): 0 | 1 | 2 | 3 | null {
+  const value = Number(/<hierarchy[^>]*\brotation="([0-3])"/.exec(rawOutput)?.[1]);
+  if (value === 0 || value === 1 || value === 2 || value === 3) return value;
+  return null;
+}
+
+/**
+ * Swap width and height when the device is on its side, so the result describes
+ * the display as it is currently laid out.
+ *
+ * uiautomator reports node bounds against the rotated display, so on a rotated
+ * device the unrotated `wm size` is the wrong divisor in both axes. The visible
+ * consequence was not merely squashed frames: `isVisibleRect` drops any node
+ * whose left edge is past the screen width, so with a 1080-wide divisor against
+ * a 2424-wide display, everything on the right-hand half of the screen
+ * disappeared from the tree entirely.
+ */
+export function orientScreenSize(
+  size: AndroidScreenSize,
+  rotation: 0 | 1 | 2 | 3 | null
+): AndroidScreenSize {
+  if (rotation !== 1 && rotation !== 3) return size;
+  return { width: size.height, height: size.width };
 }

--- a/packages/tool-server/src/utils/device-orientation.ts
+++ b/packages/tool-server/src/utils/device-orientation.ts
@@ -1,0 +1,147 @@
+import { promises as fs } from "node:fs";
+import { adbShell } from "./adb";
+
+/**
+ * The orientation names the simulator-server screenshot API accepts.
+ *
+ * Read these as *compositing transforms*, not as physical orientations. The
+ * distinction matters: a report on #609 established that on iOS the same names
+ * are 180° inverted from the physical result, so nothing here may be derived
+ * from what the words mean.
+ */
+export type OrientationName =
+  | "Portrait"
+  | "LandscapeLeft"
+  | "LandscapeRight"
+  | "PortraitUpsideDown";
+
+/** Android's surface rotation, as reported by the platform (`Surface.ROTATION_*`). */
+export type SurfaceRotation = 0 | 1 | 2 | 3;
+
+/**
+ * Surface rotation → the name that makes simulator-server hand back an upright
+ * capture.
+ *
+ * DERIVED BY MEASUREMENT, NOT BY NAME. `adb exec-out screencap` is
+ * rotation-aware, so it is ground truth; each candidate name was captured at
+ * full scale and scored against it as mean absolute difference over a 96×54
+ * grayscale grid, both as-is and rotated 180° to catch an inverted mapping:
+ *
+ *   rotation 1  LandscapeLeft       MAD  2.19  (vs 6.54 for its 180° twin)
+ *   rotation 3  LandscapeRight      MAD  2.19  (vs 6.34)
+ *   rotation 2  PortraitUpsideDown  MAD  2.67  (vs 13.13)
+ *   rotation 0  Portrait            identity — an unrotated capture is already upright
+ *
+ * Note this table is the INVERSE of simulator-server's own convention, which
+ * maps 90° → LandscapeRight (`src/device_controller.rs`) and rotates the frame
+ * at decode time from the scrcpy header's `display_orientation`
+ * (`src/device_controller/android_device/video.rs`,
+ * `src/media_handler/decoder/video_toolbox.rs`). We are compensating downstream
+ * for what that layer already did, so this constant encodes the behaviour of a
+ * particular simulator-server build rather than a property of Android.
+ *
+ * That is why a unit test pinning this table is not sufficient on its own: it
+ * could never notice simulator-server changing underneath us. `captureLooksUpright`
+ * below is the check that would, and it is applied to the real capture.
+ */
+export const SURFACE_ROTATION_TO_NAME: Readonly<Record<SurfaceRotation, OrientationName>> = {
+  0: "Portrait",
+  1: "LandscapeLeft",
+  2: "PortraitUpsideDown",
+  3: "LandscapeRight",
+};
+
+function isSurfaceRotation(value: number): value is SurfaceRotation {
+  return value === 0 || value === 1 || value === 2 || value === 3;
+}
+
+/**
+ * Read the device's current surface rotation.
+ *
+ * Returns `null` — never throws — when the rotation cannot be established. A
+ * failed query must degrade to "unknown", which callers treat as "behave
+ * exactly as before". It must never fall back to a guess: a wrong orientation
+ * produces a confidently wrong image, which is worse than the sideways one this
+ * is fixing.
+ *
+ * Two independent readings are tried because `dumpsys` output is not a stable
+ * API. `|| true` keeps a `grep` miss (exit 1) from making `adbShell` throw.
+ */
+export async function readAndroidSurfaceRotation(serial: string): Promise<SurfaceRotation | null> {
+  const probes: { cmd: string; pattern: RegExp }[] = [
+    {
+      cmd: "dumpsys display | grep mCurrentOrientation || true",
+      pattern: /mCurrentOrientation=([0-3])/,
+    },
+    { cmd: "dumpsys window displays || true", pattern: /\bmRotation=([0-3])/ },
+  ];
+
+  for (const { cmd, pattern } of probes) {
+    try {
+      const out = await adbShell(serial, cmd, { timeoutMs: 5_000 });
+      const value = Number(pattern.exec(out)?.[1]);
+      if (Number.isInteger(value) && isSurfaceRotation(value)) return value;
+    } catch {
+      // Try the next probe; exhausting them yields null.
+    }
+  }
+  return null;
+}
+
+/**
+ * The rotation to request for an upright capture, or `undefined` to send no
+ * rotation at all.
+ *
+ * `undefined` is returned for an unrotated device rather than `"Portrait"` so
+ * the request body is byte-identical to what it was before this existed — the
+ * overwhelmingly common case stays provably unchanged.
+ */
+export function captureRotationForSurface(
+  rotation: SurfaceRotation | null
+): OrientationName | undefined {
+  if (rotation === null || rotation === 0) return undefined;
+  return SURFACE_ROTATION_TO_NAME[rotation];
+}
+
+/** Width and height from a PNG's IHDR chunk, or null if this isn't a PNG. */
+export async function readPngSize(path: string): Promise<{ width: number; height: number } | null> {
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  try {
+    handle = await fs.open(path, "r");
+    const buf = Buffer.alloc(24);
+    const { bytesRead } = await handle.read(buf, 0, 24, 0);
+    if (bytesRead < 24) return null;
+    // 8-byte signature, then a length+type header, then IHDR's width/height.
+    if (buf.readUInt32BE(0) !== 0x89504e47) return null;
+    const width = buf.readUInt32BE(16);
+    const height = buf.readUInt32BE(20);
+    if (width <= 0 || height <= 0) return null;
+    return { width, height };
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+/**
+ * Does a capture taken with `requested` actually have the shape that rotation
+ * implies?
+ *
+ * This is the guard that a table test cannot be. The mapping above compensates
+ * for a rotation simulator-server applies at decode time; if that layer changes,
+ * the compensation silently becomes a 180° error or a no-op. Comparing the
+ * delivered PNG's aspect against the orientation we asked for catches the case
+ * where the request did not do what this module assumes.
+ *
+ * Returns true when unknown — an unreadable PNG is not evidence of a problem.
+ */
+export function captureLooksUpright(
+  requested: OrientationName,
+  size: { width: number; height: number } | null
+): boolean {
+  if (!size || size.width === size.height) return true;
+  const wantsLandscape = requested === "LandscapeLeft" || requested === "LandscapeRight";
+  const isLandscape = size.width > size.height;
+  return wantsLandscape === isLandscape;
+}

--- a/packages/tool-server/src/utils/device-orientation.ts
+++ b/packages/tool-server/src/utils/device-orientation.ts
@@ -10,14 +10,14 @@ import { adbServerShell } from "./adb-server";
  * are 180° inverted from the physical result, so nothing here may be derived
  * from what the words mean.
  */
-export type OrientationName =
+type OrientationName =
   | "Portrait"
   | "LandscapeLeft"
   | "LandscapeRight"
   | "PortraitUpsideDown";
 
 /** Android's surface rotation, as reported by the platform (`Surface.ROTATION_*`). */
-export type SurfaceRotation = 0 | 1 | 2 | 3;
+type SurfaceRotation = 0 | 1 | 2 | 3;
 
 /**
  * Surface rotation → the name that makes simulator-server hand back an upright

--- a/packages/tool-server/src/utils/device-orientation.ts
+++ b/packages/tool-server/src/utils/device-orientation.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { adbShell } from "./adb";
+import { adbServerShell } from "./adb-server";
 
 /**
  * The orientation names the simulator-server screenshot API accepts.
@@ -56,6 +57,23 @@ function isSurfaceRotation(value: number): value is SurfaceRotation {
 }
 
 /**
+ * A cheaper, already-available source of the rotation — typically the
+ * android-devtools helper when it happens to be running. Returns the raw
+ * platform value, or null/undefined when it has no answer. It must never be
+ * allowed to *create* anything; see `androidDevtoolsRotationPeek`.
+ */
+export type RotationPeek = () => Promise<number | null | undefined>;
+
+/** The two readings tried, in order. `dumpsys` output is not a stable API. */
+const ROTATION_PROBES: { cmd: string; pattern: RegExp }[] = [
+  {
+    cmd: "dumpsys display | grep mCurrentOrientation || true",
+    pattern: /mCurrentOrientation=([0-3])/,
+  },
+  { cmd: "dumpsys window displays || true", pattern: /\bmRotation=([0-3])/ },
+];
+
+/**
  * Read the device's current surface rotation.
  *
  * Returns `null` — never throws — when the rotation cannot be established. A
@@ -64,25 +82,40 @@ function isSurfaceRotation(value: number): value is SurfaceRotation {
  * produces a confidently wrong image, which is worse than the sideways one this
  * is fixing.
  *
- * Two independent readings are tried because `dumpsys` output is not a stable
- * API. `|| true` keeps a `grep` miss (exit 1) from making `adbShell` throw.
+ * Three sources, cheapest first, all reporting the same platform value
+ * (`Surface.ROTATION_*`), so which one answered changes the latency and
+ * nothing else. Measured on a Pixel_9 emulator:
+ *
+ *   1. `peek` (the android-devtools helper, only if already running)  ~1 ms
+ *   2. the adb server socket, no client process spawned                ~8 ms
+ *   3. a spawned `adb shell`, which also revives a stopped server      ~19 ms
+ *
+ * Two independent readings are tried on the adb paths because `dumpsys` output
+ * is not a stable API. `|| true` keeps a `grep` miss (exit 1) from making the
+ * shell throw.
  */
-export async function readAndroidSurfaceRotation(serial: string): Promise<SurfaceRotation | null> {
-  const probes: { cmd: string; pattern: RegExp }[] = [
-    {
-      cmd: "dumpsys display | grep mCurrentOrientation || true",
-      pattern: /mCurrentOrientation=([0-3])/,
-    },
-    { cmd: "dumpsys window displays || true", pattern: /\bmRotation=([0-3])/ },
-  ];
-
-  for (const { cmd, pattern } of probes) {
+export async function readAndroidSurfaceRotation(
+  serial: string,
+  peek?: RotationPeek
+): Promise<SurfaceRotation | null> {
+  if (peek) {
     try {
-      const out = await adbShell(serial, cmd, { timeoutMs: 5_000 });
-      const value = Number(pattern.exec(out)?.[1]);
-      if (Number.isInteger(value) && isSurfaceRotation(value)) return value;
+      const value = await peek();
+      if (typeof value === "number" && isSurfaceRotation(value)) return value;
     } catch {
-      // Try the next probe; exhausting them yields null.
+      // A peek is an optimisation; its failure is not evidence about the device.
+    }
+  }
+
+  for (const shell of [adbServerShell, adbShell]) {
+    for (const { cmd, pattern } of ROTATION_PROBES) {
+      try {
+        const out = await shell(serial, cmd, { timeoutMs: 5_000 });
+        const value = Number(pattern.exec(out)?.[1]);
+        if (Number.isInteger(value) && isSurfaceRotation(value)) return value;
+      } catch {
+        // Try the next probe / the next transport; exhausting them yields null.
+      }
     }
   }
   return null;

--- a/packages/tool-server/src/utils/device-orientation.ts
+++ b/packages/tool-server/src/utils/device-orientation.ts
@@ -10,11 +10,7 @@ import { adbServerShell } from "./adb-server";
  * are 180° inverted from the physical result, so nothing here may be derived
  * from what the words mean.
  */
-type OrientationName =
-  | "Portrait"
-  | "LandscapeLeft"
-  | "LandscapeRight"
-  | "PortraitUpsideDown";
+type OrientationName = "Portrait" | "LandscapeLeft" | "LandscapeRight" | "PortraitUpsideDown";
 
 /** Android's surface rotation, as reported by the platform (`Surface.ROTATION_*`). */
 type SurfaceRotation = 0 | 1 | 2 | 3;

--- a/packages/tool-server/src/utils/rotation-aware-capture.ts
+++ b/packages/tool-server/src/utils/rotation-aware-capture.ts
@@ -1,0 +1,76 @@
+import type { SimulatorServerApi } from "../blueprints/simulator-server";
+import type { DeviceInfo } from "@argent/registry";
+import {
+  captureLooksUpright,
+  captureRotationForSurface,
+  readAndroidSurfaceRotation,
+  readPngSize,
+} from "./device-orientation";
+import { httpScreenshot } from "./simulator-client";
+
+/**
+ * Capture a screenshot that is the right way up on a rotated device.
+ *
+ * Background (#609): on a rotated Android device the capture came back
+ * portrait-framed with the content lying sideways, while `describe` and the
+ * gesture tools were already reporting and accepting *upright* coordinates —
+ * uiautomator measures against the rotated display. So the screenshot was the
+ * one surface out of step, and an agent reading it saw an image whose geometry
+ * disagreed with every coordinate it was given.
+ *
+ * simulator-server already knows how to hand back an upright frame; it just has
+ * to be told which rotation to apply. Nothing tracks orientation here — the
+ * rotation is queried from the device each time. A cached value could only ever
+ * be staler than a ~40 ms probe, and serving a stale orientation is precisely
+ * the failure this fixes.
+ *
+ * Why query over adb rather than reuse the android-devtools helper, which also
+ * reports rotation: resolving that service *installs and starts* it (APK
+ * install, `am instrument`, a 30 s ready timeout). `screenshot` is `alwaysLoad`
+ * and fires automatically after more than a dozen tools, so making it able to
+ * install an APK is not acceptable. Gating on "use it only if already running"
+ * would be worse still — the capture would come out upright or sideways
+ * depending on whether something happened to call `describe` first.
+ *
+ * iOS is deliberately untouched. There the whole surface (describe frames,
+ * gesture input, capture) is consistently in the portrait-native space, so
+ * rotating only the capture would break the agreement rather than restore it.
+ */
+export async function captureScreenshotUpright(
+  api: SimulatorServerApi,
+  device: DeviceInfo,
+  requestedRotation: string | undefined,
+  signal?: AbortSignal,
+  scale?: number,
+  capture: typeof httpScreenshot = httpScreenshot
+): Promise<{ url: string; path: string }> {
+  // An explicit rotation from the caller always wins, and no other platform
+  // takes this path, so both cases are byte-identical to the previous behaviour.
+  if (requestedRotation !== undefined || device.platform !== "android") {
+    return capture(api, requestedRotation, signal, scale);
+  }
+
+  const surface = await readAndroidSurfaceRotation(device.id);
+  const rotation = captureRotationForSurface(surface);
+  // Unrotated, or the rotation could not be read: send no rotation at all, exactly
+  // as before. An unreadable rotation must never become a guess.
+  if (!rotation) return capture(api, undefined, signal, scale);
+
+  const result = await capture(api, rotation, signal, scale);
+
+  // The mapping from surface rotation to rotation name compensates for a
+  // rotation simulator-server itself applies while decoding the video stream. If
+  // that layer changes, the compensation quietly becomes a 180° error or a
+  // no-op, and no test of our own constant could notice. Checking the delivered
+  // image's aspect against the rotation we asked for is the check that would.
+  if (!captureLooksUpright(rotation, await readPngSize(result.path))) {
+    console.warn(
+      `[screenshot] ${device.id}: requested ${rotation} for surface rotation ${surface}, ` +
+        `but the capture came back with the opposite aspect. Falling back to an ` +
+        `unrotated capture — simulator-server's rotation handling may have changed.`
+    );
+    return capture(api, undefined, signal, scale);
+  }
+
+  return result;
+}

--- a/packages/tool-server/src/utils/rotation-aware-capture.ts
+++ b/packages/tool-server/src/utils/rotation-aware-capture.ts
@@ -5,6 +5,7 @@ import {
   captureRotationForSurface,
   readAndroidSurfaceRotation,
   readPngSize,
+  type RotationPeek,
 } from "./device-orientation";
 import { httpScreenshot } from "./simulator-client";
 
@@ -24,13 +25,13 @@ import { httpScreenshot } from "./simulator-client";
  * be staler than a ~40 ms probe, and serving a stale orientation is precisely
  * the failure this fixes.
  *
- * Why query over adb rather than reuse the android-devtools helper, which also
- * reports rotation: resolving that service *installs and starts* it (APK
- * install, `am instrument`, a 30 s ready timeout). `screenshot` is `alwaysLoad`
- * and fires automatically after more than a dozen tools, so making it able to
- * install an APK is not acceptable. Gating on "use it only if already running"
- * would be worse still — the capture would come out upright or sideways
- * depending on whether something happened to call `describe` first.
+ * The android-devtools helper also reports rotation, ~1 ms against ~8 ms for an
+ * adb probe — but resolving that service *installs and starts* it (APK install,
+ * `am instrument`, a 30 s ready timeout), and `screenshot` is `alwaysLoad` and
+ * fires automatically after more than a dozen tools. So it is consulted only
+ * when it is already running (`peek`), and otherwise the rotation is read over
+ * adb. Both answer with the same platform value, so the capture comes out
+ * upright either way; only the latency depends on whether `describe` ran first.
  *
  * iOS is deliberately untouched. There the whole surface (describe frames,
  * gesture input, capture) is consistently in the portrait-native space, so
@@ -42,7 +43,10 @@ export async function captureScreenshotUpright(
   requestedRotation: string | undefined,
   signal?: AbortSignal,
   scale?: number,
-  capture: typeof httpScreenshot = httpScreenshot
+  capture: typeof httpScreenshot = httpScreenshot,
+  // Optional cheaper rotation source (the running android-devtools helper).
+  // Purely a latency optimisation: with or without it the same rotation is read.
+  peek?: RotationPeek
 ): Promise<{ url: string; path: string }> {
   // An explicit rotation from the caller always wins, and no other platform
   // takes this path, so both cases are byte-identical to the previous behaviour.
@@ -50,7 +54,7 @@ export async function captureScreenshotUpright(
     return capture(api, requestedRotation, signal, scale);
   }
 
-  const surface = await readAndroidSurfaceRotation(device.id);
+  const surface = await readAndroidSurfaceRotation(device.id, peek);
   const rotation = captureRotationForSurface(surface);
   // Unrotated, or the rotation could not be read: send no rotation at all, exactly
   // as before. An unreadable rotation must never become a guess.

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -82,7 +82,7 @@ import { flowReadPrerequisiteTool } from "../tools/flows/flow-read-prerequisite"
 import { gatherWorkspaceDataTool } from "../tools/workspace/gather-workspace-data";
 import { updateArgentTool } from "../tools/system/update-argent";
 import { dismissUpdateTool } from "../tools/system/dismiss-update";
-import { screenshotDiffTool } from "../tools/screenshot-diff";
+import { createScreenshotDiffTool } from "../tools/screenshot-diff";
 import { createProposeVariantTool } from "../tools/variants/propose-variant";
 import { awaitUserSelectionTool } from "../tools/variants/await-user-selection";
 import { chromiumTabsTool } from "../tools/chromium-tabs";
@@ -118,7 +118,7 @@ export function createRegistry(): Registry {
   registry.registerTool(settingsPermissionsTool);
   registry.registerTool(openUrlTool);
   registry.registerTool(createScreenshotTool(registry));
-  registry.registerTool(screenshotDiffTool);
+  registry.registerTool(createScreenshotDiffTool(registry));
   registry.registerTool(createScreenRecordingStartTool(registry));
   registry.registerTool(screenRecordingStopTool);
   registry.registerTool(gestureTapTool);

--- a/packages/tool-server/test/adb-server.test.ts
+++ b/packages/tool-server/test/adb-server.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as net from "node:net";
+import { adbServerAddress, adbServerShell } from "../src/utils/adb-server";
+
+/**
+ * A fake adb server speaking just enough of the real protocol (4-hex-digit
+ * length prefix, OKAY/FAIL statuses, `host:transport:` then `shell:`) to drive
+ * `adbServerShell` end to end over a real socket. Every scenario is a script of
+ * how the server reacts to each message it receives.
+ */
+type Script = (message: string, socket: net.Socket, index: number) => void;
+
+const servers: net.Server[] = [];
+
+async function fakeAdbServer(script: Script): Promise<number> {
+  const server = net.createServer((socket) => {
+    let pending = Buffer.alloc(0);
+    let index = 0;
+    socket.on("data", (data: Buffer) => {
+      pending = Buffer.concat([pending, data]);
+      while (pending.length >= 4) {
+        const len = parseInt(pending.subarray(0, 4).toString("latin1"), 16);
+        if (pending.length < 4 + len) return;
+        const message = pending.subarray(4, 4 + len).toString("utf8");
+        pending = pending.subarray(4 + len);
+        script(message, socket, index++);
+      }
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return (server.address() as net.AddressInfo).port;
+}
+
+const fail = (socket: net.Socket, message: string) =>
+  socket.write(`FAIL${message.length.toString(16).padStart(4, "0")}${message}`);
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
+  delete process.env.ADB_SERVER_SOCKET;
+  delete process.env.ANDROID_ADB_SERVER_ADDRESS;
+  delete process.env.ANDROID_ADB_SERVER_PORT;
+});
+
+describe("adbServerShell", () => {
+  it("selects the device, runs the command and returns its output", async () => {
+    const seen: string[] = [];
+    const port = await fakeAdbServer((message, socket) => {
+      seen.push(message);
+      if (message.startsWith("host:transport:")) socket.write("OKAY");
+      else if (message.startsWith("shell:")) {
+        socket.write("OKAY");
+        socket.end("mCurrentOrientation=1\n");
+      }
+    });
+    process.env.ANDROID_ADB_SERVER_PORT = String(port);
+
+    const out = await adbServerShell("emulator-5554", "dumpsys display | grep mCurrentOrientation");
+
+    expect(out).toBe("mCurrentOrientation=1\n");
+    expect(seen).toEqual([
+      "host:transport:emulator-5554",
+      "shell:dumpsys display | grep mCurrentOrientation",
+    ]);
+  });
+
+  it("handles output that arrives in the same packet as the OKAY", async () => {
+    const port = await fakeAdbServer((message, socket) => {
+      if (message.startsWith("host:transport:")) socket.write("OKAY");
+      else socket.end("OKAYmRotation=3\n");
+    });
+    process.env.ANDROID_ADB_SERVER_PORT = String(port);
+
+    expect(await adbServerShell("emulator-5554", "x")).toBe("mRotation=3\n");
+  });
+
+  it("rejects when the server does not know the serial", async () => {
+    const port = await fakeAdbServer((message, socket) => {
+      if (message.startsWith("host:transport:")) fail(socket, "device 'nope' not found");
+    });
+    process.env.ANDROID_ADB_SERVER_PORT = String(port);
+
+    await expect(adbServerShell("nope", "true")).rejects.toThrow(/device 'nope' not found/);
+  });
+
+  it("rejects when nothing is listening, so the caller falls back to the client", async () => {
+    const port = await fakeAdbServer(() => {});
+    await new Promise((r) => servers.pop()!.close(r));
+    process.env.ANDROID_ADB_SERVER_PORT = String(port);
+
+    await expect(adbServerShell("emulator-5554", "true")).rejects.toThrow();
+  });
+
+  it("rejects when the server hangs past the timeout", async () => {
+    const port = await fakeAdbServer(() => {});
+    process.env.ANDROID_ADB_SERVER_PORT = String(port);
+
+    await expect(adbServerShell("emulator-5554", "true", { timeoutMs: 50 })).rejects.toThrow(
+      /timed out/
+    );
+  });
+
+  it("rejects when the connection closes before the command was accepted", async () => {
+    const port = await fakeAdbServer((message, socket) => {
+      if (message.startsWith("host:transport:")) socket.write("OKAY");
+      else socket.destroy();
+    });
+    process.env.ANDROID_ADB_SERVER_PORT = String(port);
+
+    await expect(adbServerShell("emulator-5554", "true")).rejects.toThrow(/before answering/);
+  });
+});
+
+describe("adbServerAddress", () => {
+  it("defaults to the client's default server", () => {
+    expect(adbServerAddress({})).toEqual({ host: "127.0.0.1", port: 5037 });
+  });
+
+  it("honours ANDROID_ADB_SERVER_PORT and ANDROID_ADB_SERVER_ADDRESS", () => {
+    expect(
+      adbServerAddress({ ANDROID_ADB_SERVER_PORT: "6000", ANDROID_ADB_SERVER_ADDRESS: "10.0.0.2" })
+    ).toEqual({ host: "10.0.0.2", port: 6000 });
+  });
+
+  it("lets ADB_SERVER_SOCKET win, with and without a host", () => {
+    expect(adbServerAddress({ ADB_SERVER_SOCKET: "tcp:localhost:5555" })).toEqual({
+      host: "localhost",
+      port: 5555,
+    });
+    expect(
+      adbServerAddress({ ADB_SERVER_SOCKET: "tcp:5555", ANDROID_ADB_SERVER_PORT: "1" })
+    ).toEqual({
+      host: "127.0.0.1",
+      port: 5555,
+    });
+  });
+
+  it("ignores a malformed port rather than connecting somewhere surprising", () => {
+    expect(adbServerAddress({ ANDROID_ADB_SERVER_PORT: "lots" })).toEqual({
+      host: "127.0.0.1",
+      port: 5037,
+    });
+  });
+});

--- a/packages/tool-server/test/android-devtools-rotation-peek.test.ts
+++ b/packages/tool-server/test/android-devtools-rotation-peek.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ServiceNotFoundError,
+  ServiceState,
+  type DeviceInfo,
+  type Registry,
+} from "@argent/registry";
+import { androidDevtoolsRotationPeek } from "../src/utils/android-devtools-rotation-peek";
+
+const ANDROID: DeviceInfo = { id: "emulator-5554", platform: "android", kind: "emulator" };
+const IOS: DeviceInfo = { id: "BC0026C7-AAE0-490E", platform: "ios", kind: "simulator" };
+
+/** A registry that knows one android-devtools service in a given state. */
+function fakeRegistry(
+  state: ServiceState | "never-created",
+  api?: { isReady?: () => boolean; getScreenSize?: () => Promise<unknown> }
+) {
+  const resolveService = vi.fn(async () => ({
+    isReady: () => true,
+    getScreenSize: async () => ({ width: 2424, height: 1080, rotation: 1 }),
+    ...api,
+  }));
+  const getServiceState = vi.fn((urn: string) => {
+    if (state === "never-created") throw new ServiceNotFoundError(urn);
+    return state;
+  });
+  return { registry: { resolveService, getServiceState } as unknown as Registry, resolveService };
+}
+
+describe("androidDevtoolsRotationPeek", () => {
+  it("answers from a running, ready helper", async () => {
+    const { registry, resolveService } = fakeRegistry(ServiceState.RUNNING);
+    expect(await androidDevtoolsRotationPeek(registry, ANDROID)()).toBe(1);
+    expect(resolveService).toHaveBeenCalledTimes(1);
+  });
+
+  it("never creates the service when it has not been started", async () => {
+    // This is the property that makes the peek safe inside `screenshot`:
+    // resolving would install an APK and run `am instrument`.
+    const { registry, resolveService } = fakeRegistry("never-created");
+    expect(await androidDevtoolsRotationPeek(registry, ANDROID)()).toBeNull();
+    expect(resolveService).not.toHaveBeenCalled();
+  });
+
+  it.each([ServiceState.IDLE, ServiceState.STARTING, ServiceState.TERMINATING, ServiceState.ERROR])(
+    "does not resolve a service in state %s",
+    async (state) => {
+      const { registry, resolveService } = fakeRegistry(state);
+      expect(await androidDevtoolsRotationPeek(registry, ANDROID)()).toBeNull();
+      expect(resolveService).not.toHaveBeenCalled();
+    }
+  );
+
+  it("has no answer for a helper that is running but not yet ready", async () => {
+    const { registry } = fakeRegistry(ServiceState.RUNNING, { isReady: () => false });
+    expect(await androidDevtoolsRotationPeek(registry, ANDROID)()).toBeNull();
+  });
+
+  it("has no answer when the helper RPC fails", async () => {
+    const { registry } = fakeRegistry(ServiceState.RUNNING, {
+      getScreenSize: async () => {
+        throw new Error("socket closed");
+      },
+    });
+    expect(await androidDevtoolsRotationPeek(registry, ANDROID)()).toBeNull();
+  });
+
+  it("ignores non-Android devices without touching the registry", async () => {
+    const { registry, resolveService } = fakeRegistry(ServiceState.RUNNING);
+    expect(await androidDevtoolsRotationPeek(registry, IOS)()).toBeNull();
+    expect(resolveService).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tool-server/test/android-rotated-uiautomator.test.ts
+++ b/packages/tool-server/test/android-rotated-uiautomator.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { orientScreenSize, parseDumpRotation } from "../src/utils/android-screen";
+import { parseUiAutomatorDump } from "../src/tools/describe/platforms/android/uiautomator-parser";
+
+/**
+ * Issue #609, legacy describe path. `wm size` reports the UNROTATED size —
+ * measured on a landscape Pixel_9 (API 36) whose display was really 2424x1080,
+ * `wm size` still answered "Physical size: 1080x2424" with no Override line.
+ *
+ * uiautomator, by contrast, reports bounds against the rotated display. Dividing
+ * one by the other did not merely squash the frames: nodes whose left edge lies
+ * past the (too small) screen width are treated as off-screen and pruned, so the
+ * right-hand half of a landscape screen vanished from the tree entirely.
+ *
+ * The dump states its own rotation, so the divisor can be oriented with no extra
+ * round-trip — which matters because this path runs exactly when the
+ * android-devtools helper could not be reached.
+ */
+
+/** Shaped like a real landscape dump: 2424x1080, with content past x=1080. */
+const LANDSCAPE_DUMP = `<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="1">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.example.app" content-desc="" checkable="false" checked="false" clickable="false" enabled="true" focusable="false" focused="false" scrollable="false" long-clickable="false" password="false" selected="false" bounds="[0,0][2424,1080]">
+    <node index="0" text="Left edge" resource-id="id/left" class="android.widget.TextView" package="com.example.app" content-desc="" checkable="false" checked="false" clickable="true" enabled="true" focusable="true" focused="false" scrollable="false" long-clickable="false" password="false" selected="false" bounds="[24,100][500,200]" />
+    <node index="1" text="Right edge" resource-id="id/right" class="android.widget.TextView" package="com.example.app" content-desc="" checkable="false" checked="false" clickable="true" enabled="true" focusable="true" focused="false" scrollable="false" long-clickable="false" password="false" selected="false" bounds="[1900,100][2380,200]" />
+  </node>
+</hierarchy>`;
+
+const PORTRAIT_DUMP = LANDSCAPE_DUMP.replace('rotation="1"', 'rotation="0"');
+
+/** Every label anywhere in the tree. uiautomator `text` surfaces as `label`. */
+function labels(node: unknown): string[] {
+  const out: string[] = [];
+  const walk = (n: Record<string, unknown>) => {
+    if (typeof n.label === "string" && n.label) out.push(n.label);
+    for (const c of (n.children as Record<string, unknown>[] | undefined) ?? []) walk(c);
+  };
+  walk(node as Record<string, unknown>);
+  return out;
+}
+
+function findFrame(node: unknown, text: string): { x: number; width: number } | undefined {
+  let found: { x: number; width: number } | undefined;
+  const walk = (n: Record<string, unknown>) => {
+    if (n.label === text && n.frame) found = n.frame as { x: number; width: number };
+    for (const c of (n.children as Record<string, unknown>[] | undefined) ?? []) walk(c);
+  };
+  walk(node as Record<string, unknown>);
+  return found;
+}
+
+describe("parseDumpRotation", () => {
+  it("reads the rotation the dump was taken at", () => {
+    expect(parseDumpRotation(LANDSCAPE_DUMP)).toBe(1);
+    expect(parseDumpRotation(PORTRAIT_DUMP)).toBe(0);
+  });
+
+  it("reads every rotation the platform can report", () => {
+    for (const r of [0, 1, 2, 3]) {
+      expect(parseDumpRotation(`<hierarchy rotation="${r}"><node /></hierarchy>`)).toBe(r);
+    }
+  });
+
+  it("returns null when the attribute is absent, so older dumps still work", () => {
+    expect(parseDumpRotation("<hierarchy><node /></hierarchy>")).toBeNull();
+  });
+
+  it("returns null for an unparseable value rather than guessing", () => {
+    expect(parseDumpRotation('<hierarchy rotation="x"><node /></hierarchy>')).toBeNull();
+  });
+});
+
+describe("orientScreenSize", () => {
+  const portrait = { width: 1080, height: 2424 };
+
+  it("swaps the axes when the device is on its side", () => {
+    expect(orientScreenSize(portrait, 1)).toEqual({ width: 2424, height: 1080 });
+    expect(orientScreenSize(portrait, 3)).toEqual({ width: 2424, height: 1080 });
+  });
+
+  it("leaves an upright or upside-down device alone", () => {
+    expect(orientScreenSize(portrait, 0)).toEqual(portrait);
+    expect(orientScreenSize(portrait, 2)).toEqual(portrait);
+  });
+
+  it("leaves the size alone when the rotation is unknown", () => {
+    expect(orientScreenSize(portrait, null)).toEqual(portrait);
+  });
+});
+
+describe("a rotated dump normalized against the oriented size", () => {
+  const wmSize = { width: 1080, height: 2424 }; // what `wm size` really answers
+
+  it("drops the right-hand half of the screen when the size is not oriented", () => {
+    // This is the bug, stated as a test: with the unrotated divisor the node at
+    // x=1900 is past screenW=1080 and is pruned as off-screen, so it is missing
+    // from the tree entirely — not merely clamped.
+    const tree = parseUiAutomatorDump(LANDSCAPE_DUMP, wmSize.width, wmSize.height);
+    expect(labels(tree)).toContain("Left edge");
+    expect(labels(tree)).not.toContain("Right edge");
+  });
+
+  it("keeps both edges once the size is oriented by the dump's own rotation", () => {
+    const oriented = orientScreenSize(wmSize, parseDumpRotation(LANDSCAPE_DUMP));
+    const tree = parseUiAutomatorDump(LANDSCAPE_DUMP, oriented.width, oriented.height);
+    expect(labels(tree)).toEqual(expect.arrayContaining(["Left edge", "Right edge"]));
+  });
+
+  it("puts the right-hand node where it actually is on screen", () => {
+    const oriented = orientScreenSize(wmSize, parseDumpRotation(LANDSCAPE_DUMP));
+    const tree = parseUiAutomatorDump(LANDSCAPE_DUMP, oriented.width, oriented.height);
+    const frame = findFrame(tree, "Right edge")!;
+    // 1900/2424 ≈ 0.784 — on the right-hand side, which is the whole point.
+    expect(frame.x).toBeCloseTo(1900 / 2424, 2);
+    expect(frame.width).toBeCloseTo(480 / 2424, 2);
+  });
+
+  it("leaves an unrotated dump exactly as it was", () => {
+    const oriented = orientScreenSize(wmSize, parseDumpRotation(PORTRAIT_DUMP));
+    expect(oriented).toEqual(wmSize);
+  });
+});

--- a/packages/tool-server/test/device-orientation.test.ts
+++ b/packages/tool-server/test/device-orientation.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Issue #609: on a rotated Android device the screenshot came back
+ * portrait-framed with the content lying sideways, while `describe` frames and
+ * gesture coordinates were already upright. The capture was the one surface out
+ * of step.
+ *
+ * The rotation is queried per capture rather than tracked, so these tests are
+ * about reading it honestly and — crucially — about refusing to guess when it
+ * cannot be read. A wrong orientation yields a confidently wrong image, which is
+ * worse than the sideways one being fixed.
+ */
+
+const adbShell = vi.hoisted(() => vi.fn(async (_serial: string, _cmd: string) => ""));
+vi.mock("../src/utils/adb", () => ({ adbShell }));
+
+import {
+  SURFACE_ROTATION_TO_NAME,
+  captureLooksUpright,
+  captureRotationForSurface,
+  readAndroidSurfaceRotation,
+  readPngSize,
+} from "../src/utils/device-orientation";
+
+/** Verbatim shape of the two probes, captured from a Pixel_9 (API 36). */
+const DUMPSYS_DISPLAY = (r: number) => `  mCurrentOrientation=${r}\n`;
+const DUMPSYS_WINDOW = (r: number) =>
+  `Display: mDisplayId=0\n  init=1080x2424 420dpi\n  mRotation=${r}\n  mCurrentRotation=ROTATION_90\n`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  adbShell.mockResolvedValue("");
+});
+
+describe("the surface-rotation → rotation-name table", () => {
+  // Pinned by measurement against `adb exec-out screencap`, which IS
+  // rotation-aware: each candidate name was scored as mean absolute difference
+  // against the screencap reference and against that reference rotated 180°, so
+  // an inverted mapping could not pass. The correct name won by ~3x in every row
+  // (e.g. rotation 1: LandscapeLeft 2.19 vs LandscapeRight 6.54).
+  //
+  // This table is the INVERSE of simulator-server's own 90°→LandscapeRight
+  // convention because we are compensating for a rotation it applies while
+  // decoding. That is exactly why this test cannot be the only guard — see
+  // `captureLooksUpright`, which checks the real capture instead.
+  it("maps each rotation to the name that yields an upright capture", () => {
+    expect(SURFACE_ROTATION_TO_NAME).toEqual({
+      0: "Portrait",
+      1: "LandscapeLeft",
+      2: "PortraitUpsideDown",
+      3: "LandscapeRight",
+    });
+  });
+
+  it("sends no rotation at all for an unrotated device", () => {
+    // Not "Portrait": keeping it undefined leaves the request body byte-identical
+    // to what it was before any of this existed, so the common case is provably
+    // unchanged.
+    expect(captureRotationForSurface(0)).toBeUndefined();
+  });
+
+  it("sends no rotation when the rotation could not be read", () => {
+    expect(captureRotationForSurface(null)).toBeUndefined();
+  });
+
+  it("requests a rotation for each side the device can be on", () => {
+    expect(captureRotationForSurface(1)).toBe("LandscapeLeft");
+    expect(captureRotationForSurface(2)).toBe("PortraitUpsideDown");
+    expect(captureRotationForSurface(3)).toBe("LandscapeRight");
+  });
+});
+
+describe("reading the rotation off the device", () => {
+  it("reads the primary probe", async () => {
+    adbShell.mockResolvedValueOnce(DUMPSYS_DISPLAY(1));
+    expect(await readAndroidSurfaceRotation("emulator-5554")).toBe(1);
+    expect(adbShell).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads every rotation the platform can report", async () => {
+    for (const r of [0, 1, 2, 3]) {
+      adbShell.mockResolvedValueOnce(DUMPSYS_DISPLAY(r));
+      expect(await readAndroidSurfaceRotation("emulator-5554")).toBe(r);
+    }
+  });
+
+  it("falls back to the second probe when the first says nothing", async () => {
+    // `dumpsys` output is not a stable API, so a single regex is a single point
+    // of failure across vendors and versions.
+    adbShell.mockResolvedValueOnce("").mockResolvedValueOnce(DUMPSYS_WINDOW(3));
+    expect(await readAndroidSurfaceRotation("emulator-5554")).toBe(3);
+    expect(adbShell).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a grep miss from throwing", async () => {
+    // The probe appends `|| true` precisely so that grep exiting 1 — the normal
+    // outcome when the line is absent — is not an error.
+    expect(adbShell.mock.calls).toHaveLength(0);
+    await readAndroidSurfaceRotation("emulator-5554");
+    for (const [, cmd] of adbShell.mock.calls) expect(cmd).toContain("|| true");
+  });
+
+  it("returns null rather than guessing when both probes fail", async () => {
+    adbShell.mockRejectedValue(new Error("device offline"));
+    expect(await readAndroidSurfaceRotation("emulator-5554")).toBeNull();
+  });
+
+  it("returns null on unparseable output", async () => {
+    adbShell.mockResolvedValue("mCurrentOrientation=banana");
+    expect(await readAndroidSurfaceRotation("emulator-5554")).toBeNull();
+  });
+
+  it("ignores an out-of-range rotation", async () => {
+    // Never coerce something unrecognised into a rotation — a wrong one is worse
+    // than none.
+    adbShell.mockResolvedValue("mCurrentOrientation=7");
+    expect(await readAndroidSurfaceRotation("emulator-5554")).toBeNull();
+  });
+});
+
+describe("the aspect guard on the delivered capture", () => {
+  // The mapping compensates for what simulator-server does at decode time. If
+  // that changes, the compensation silently becomes a 180° error or a no-op and
+  // no test of our own constant could see it. This checks the actual image.
+  it("accepts a landscape image for a landscape rotation", () => {
+    expect(captureLooksUpright("LandscapeLeft", { width: 2424, height: 1080 })).toBe(true);
+    expect(captureLooksUpright("LandscapeRight", { width: 2424, height: 1080 })).toBe(true);
+  });
+
+  it("rejects a portrait image delivered for a landscape rotation", () => {
+    expect(captureLooksUpright("LandscapeLeft", { width: 1080, height: 2424 })).toBe(false);
+  });
+
+  it("accepts a portrait image for an upside-down portrait rotation", () => {
+    expect(captureLooksUpright("PortraitUpsideDown", { width: 1080, height: 2424 })).toBe(true);
+  });
+
+  it("does not treat an unreadable image as evidence of a problem", () => {
+    expect(captureLooksUpright("LandscapeLeft", null)).toBe(true);
+  });
+
+  it("passes a square image, which carries no aspect information", () => {
+    expect(captureLooksUpright("LandscapeLeft", { width: 512, height: 512 })).toBe(true);
+  });
+});
+
+describe("readPngSize", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-png-size-"));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  /** A minimal valid PNG header — signature, then IHDR length/type/w/h. */
+  function pngHeader(width: number, height: number): Buffer {
+    const buf = Buffer.alloc(24);
+    buf.writeUInt32BE(0x89504e47, 0);
+    buf.writeUInt32BE(0x0d0a1a0a, 4);
+    buf.writeUInt32BE(13, 8);
+    buf.write("IHDR", 12, "ascii");
+    buf.writeUInt32BE(width, 16);
+    buf.writeUInt32BE(height, 20);
+    return buf;
+  }
+
+  it("reads the dimensions out of the IHDR chunk", async () => {
+    const file = path.join(dir, "a.png");
+    await fs.writeFile(file, pngHeader(2424, 1080));
+    expect(await readPngSize(file)).toEqual({ width: 2424, height: 1080 });
+  });
+
+  it("returns null for a file that is not a PNG", async () => {
+    const file = path.join(dir, "b.png");
+    await fs.writeFile(file, Buffer.alloc(24));
+    expect(await readPngSize(file)).toBeNull();
+  });
+
+  it("returns null for a truncated file rather than throwing", async () => {
+    const file = path.join(dir, "c.png");
+    await fs.writeFile(file, Buffer.alloc(8));
+    expect(await readPngSize(file)).toBeNull();
+  });
+
+  it("returns null for a missing file rather than throwing", async () => {
+    expect(await readPngSize(path.join(dir, "nope.png"))).toBeNull();
+  });
+});

--- a/packages/tool-server/test/device-orientation.test.ts
+++ b/packages/tool-server/test/device-orientation.test.ts
@@ -17,6 +17,14 @@ import * as path from "node:path";
 
 const adbShell = vi.hoisted(() => vi.fn(async (_serial: string, _cmd: string) => ""));
 vi.mock("../src/utils/adb", () => ({ adbShell }));
+// The adb-server socket path is tried before the spawned client. Default it to
+// "server not reachable" so the existing probe tests keep exercising the client.
+const adbServerShell = vi.hoisted(() =>
+  vi.fn(async (_serial: string, _cmd: string): Promise<string> => {
+    throw new Error("ECONNREFUSED");
+  })
+);
+vi.mock("../src/utils/adb-server", () => ({ adbServerShell }));
 
 import {
   SURFACE_ROTATION_TO_NAME,
@@ -34,6 +42,67 @@ const DUMPSYS_WINDOW = (r: number) =>
 beforeEach(() => {
   vi.clearAllMocks();
   adbShell.mockResolvedValue("");
+  adbServerShell.mockRejectedValue(new Error("ECONNREFUSED"));
+});
+
+describe("the rotation is read from the cheapest source that answers", () => {
+  // Measured on a Pixel_9 emulator: helper peek ~1 ms, adb server socket ~8 ms,
+  // spawned adb client ~19 ms. All three report the same platform value, so
+  // the order only changes latency — these tests pin that order and that each
+  // tier's failure hands over to the next rather than becoming a guess.
+  it("prefers a peek that answers, and then touches no adb at all", async () => {
+    const peek = vi.fn(async () => 3);
+    expect(await readAndroidSurfaceRotation("emulator-5554", peek)).toBe(3);
+    expect(adbServerShell).not.toHaveBeenCalled();
+    expect(adbShell).not.toHaveBeenCalled();
+  });
+
+  it("falls through when the peek has no answer", async () => {
+    adbServerShell.mockResolvedValueOnce(DUMPSYS_DISPLAY(1));
+    expect(await readAndroidSurfaceRotation("emulator-5554", async () => null)).toBe(1);
+    expect(adbServerShell).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through when the peek throws or answers nonsense", async () => {
+    adbServerShell.mockResolvedValueOnce(DUMPSYS_DISPLAY(2));
+    expect(
+      await readAndroidSurfaceRotation("emulator-5554", async () => {
+        throw new Error("helper gone");
+      })
+    ).toBe(2);
+    adbServerShell.mockResolvedValueOnce(DUMPSYS_DISPLAY(2));
+    expect(await readAndroidSurfaceRotation("emulator-5554", async () => 7)).toBe(2);
+  });
+
+  it("uses the adb server socket before spawning a client", async () => {
+    adbServerShell.mockResolvedValueOnce(DUMPSYS_DISPLAY(1));
+    expect(await readAndroidSurfaceRotation("emulator-5554")).toBe(1);
+    expect(adbServerShell).toHaveBeenCalledWith(
+      "emulator-5554",
+      expect.stringContaining("mCurrentOrientation"),
+      expect.anything()
+    );
+    expect(adbShell).not.toHaveBeenCalled();
+  });
+
+  it("tries the second probe over the socket before giving up on it", async () => {
+    adbServerShell.mockResolvedValueOnce("").mockResolvedValueOnce(DUMPSYS_WINDOW(3));
+    expect(await readAndroidSurfaceRotation("emulator-5554")).toBe(3);
+    expect(adbServerShell).toHaveBeenCalledTimes(2);
+    expect(adbShell).not.toHaveBeenCalled();
+  });
+
+  it("spawns the client when the server socket cannot be used", async () => {
+    // e.g. the adb server is not running: the client will start it.
+    adbShell.mockResolvedValueOnce(DUMPSYS_DISPLAY(1));
+    expect(await readAndroidSurfaceRotation("emulator-5554")).toBe(1);
+    expect(adbServerShell).toHaveBeenCalledTimes(2);
+    expect(adbShell).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refuses to guess when every source is silent", async () => {
+    expect(await readAndroidSurfaceRotation("emulator-5554", async () => undefined)).toBeNull();
+  });
 });
 
 describe("the surface-rotation → rotation-name table", () => {

--- a/packages/tool-server/test/rotation-aware-capture.test.ts
+++ b/packages/tool-server/test/rotation-aware-capture.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DeviceInfo } from "@argent/registry";
+
+/**
+ * Issue #609: the capture is the surface that has to move, not the coordinates.
+ * On Android `describe` frames and gesture input are already upright, so the
+ * capture is made to follow the device rotation to match them. iOS is left
+ * alone: there the whole surface is consistently portrait-native, and rotating
+ * only the capture would break an agreement rather than restore one.
+ */
+
+const readAndroidSurfaceRotation = vi.hoisted(() =>
+  vi.fn(async (_serial: string): Promise<0 | 1 | 2 | 3 | null> => null)
+);
+const readPngSize = vi.hoisted(() =>
+  vi.fn(async (_p: string): Promise<{ width: number; height: number } | null> => null)
+);
+
+vi.mock("../src/utils/device-orientation", async (importOriginal) => {
+  // The mapping table and the aspect guard stay REAL so the assertions below
+  // exercise the actual constant rather than a restatement of it.
+  const actual = await importOriginal<typeof import("../src/utils/device-orientation")>();
+  return { ...actual, readAndroidSurfaceRotation, readPngSize };
+});
+
+import { captureScreenshotUpright } from "../src/utils/rotation-aware-capture";
+
+const ANDROID: DeviceInfo = { id: "emulator-5554", platform: "android", kind: "emulator" };
+const IOS: DeviceInfo = { id: "BC0026C7-AAE0-490E", platform: "ios", kind: "simulator" };
+
+const api = {} as never;
+
+/** Records the rotation each capture was asked for. */
+function recorder(size: { width: number; height: number } = { width: 2424, height: 1080 }) {
+  const rotations: (string | undefined)[] = [];
+  const capture = vi.fn(async (_api: unknown, rotation?: string) => {
+    rotations.push(rotation);
+    return { url: "http://x/y.png", path: "/tmp/y.png" };
+  });
+  readPngSize.mockResolvedValue(size);
+  return { rotations, capture: capture as never };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readAndroidSurfaceRotation.mockResolvedValue(null);
+  readPngSize.mockResolvedValue(null);
+});
+
+describe("Android capture follows the device rotation", () => {
+  it("requests the matching rotation for a landscape device", async () => {
+    readAndroidSurfaceRotation.mockResolvedValue(1);
+    const { rotations, capture } = recorder();
+
+    await captureScreenshotUpright(api, ANDROID, undefined, undefined, undefined, capture);
+
+    expect(rotations).toEqual(["LandscapeLeft"]);
+  });
+
+  it("sends no rotation for an unrotated device", async () => {
+    // The overwhelmingly common case must produce the exact request it always
+    // did — not `rotation: "Portrait"`.
+    readAndroidSurfaceRotation.mockResolvedValue(0);
+    const { rotations, capture } = recorder({ width: 1080, height: 2424 });
+
+    await captureScreenshotUpright(api, ANDROID, undefined, undefined, undefined, capture);
+
+    expect(rotations).toEqual([undefined]);
+  });
+
+  it("sends no rotation when the device would not say", async () => {
+    readAndroidSurfaceRotation.mockResolvedValue(null);
+    const { rotations, capture } = recorder({ width: 1080, height: 2424 });
+
+    await captureScreenshotUpright(api, ANDROID, undefined, undefined, undefined, capture);
+
+    expect(rotations).toEqual([undefined]);
+  });
+
+  it("lets an explicit rotation win, and does not probe at all", async () => {
+    const { rotations, capture } = recorder();
+
+    await captureScreenshotUpright(
+      api,
+      ANDROID,
+      "PortraitUpsideDown",
+      undefined,
+      undefined,
+      capture
+    );
+
+    expect(rotations).toEqual(["PortraitUpsideDown"]);
+    expect(readAndroidSurfaceRotation).not.toHaveBeenCalled();
+  });
+
+  it("passes the scale through unchanged", async () => {
+    readAndroidSurfaceRotation.mockResolvedValue(1);
+    const { capture } = recorder();
+
+    await captureScreenshotUpright(api, ANDROID, undefined, undefined, 1.0, capture);
+
+    expect(capture).toHaveBeenCalledWith(api, "LandscapeLeft", undefined, 1.0);
+  });
+});
+
+describe("iOS is deliberately untouched", () => {
+  it("never probes and never adds a rotation", async () => {
+    const { rotations, capture } = recorder();
+
+    await captureScreenshotUpright(api, IOS, undefined, undefined, undefined, capture);
+
+    expect(rotations).toEqual([undefined]);
+    expect(readAndroidSurfaceRotation).not.toHaveBeenCalled();
+  });
+});
+
+describe("the aspect guard", () => {
+  it("falls back to an unrotated capture when the image comes back the wrong shape", async () => {
+    // Simulates simulator-server's rotation handling changing underneath us: we
+    // ask for landscape and get a portrait-shaped PNG. Shipping that would be a
+    // confidently wrong image, so the unrotated capture is preferred.
+    readAndroidSurfaceRotation.mockResolvedValue(1);
+    const { rotations, capture } = recorder({ width: 1080, height: 2424 });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await captureScreenshotUpright(api, ANDROID, undefined, undefined, undefined, capture);
+
+    expect(rotations).toEqual(["LandscapeLeft", undefined]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("does not second-guess a capture whose size cannot be read", async () => {
+    readAndroidSurfaceRotation.mockResolvedValue(1);
+    const { rotations, capture } = recorder();
+    readPngSize.mockResolvedValue(null);
+
+    await captureScreenshotUpright(api, ANDROID, undefined, undefined, undefined, capture);
+
+    expect(rotations).toEqual(["LandscapeLeft"]);
+  });
+});


### PR DESCRIPTION
Part of #609.

## What was wrong

On a rotated Android device `screenshot` returned a portrait-framed image with the content lying sideways. `describe` frames and gesture coordinates were **already upright** — uiautomator measures against the rotated display — so the capture was the one surface out of step. An agent reading that image saw geometry that disagreed with every coordinate it was given.

Measured on a landscape Pixel_9 (API 36, `mCurrentOrientation=1`):

| | space |
|---|---|
| `describe` | upright — `"Search Settings"` centre `(0.530, 0.234)` |
| taps | upright — tapping describe's `"Display & touch"` centre opens it |
| `screenshot` (default) | **portrait-native, sideways** |

## The fix

simulator-server already applies `rotation` correctly; nothing was telling it which one. The rotation is now queried from the device per capture, so `screenshot`, `screenshot-diff`'s live captures and the auto-attached "Screen after action" screenshot all land in `describe`/tap space.

**Nothing is tracked.** A cached orientation could only be staler than the ~40 ms probe, and serving a stale one is exactly the failure being fixed. When the rotation cannot be read the request is left byte-identical to before rather than guessing — a wrong orientation is a confidently wrong image, which is worse than a sideways one.

**iOS is deliberately untouched.** There the whole surface is consistently portrait-native, so rotating only the capture would *break* an agreement rather than restore one. The iOS half of #609 needs a different change and is not in this PR.

### Also fixed: the legacy uiautomator describe path

Same root cause, worse symptom. `wm size` reports the **unrotated** size — on the landscape Pixel_9 it still answered `Physical size: 1080x2424`. Dividing rotated bounds by that does not merely squash frames: `isVisibleRect` prunes nodes whose left edge is past the screen width, so **the right-hand half of a landscape screen vanished from the tree**. The dump carries `<hierarchy rotation="N">`, so the divisor is oriented from bytes already in hand — no extra round-trip on the path that runs precisely when the helper could not be reached.

## On the rotation-name table

Pinned by measurement, never by what the names mean — the reporter of #609 found the same names are 180° inverted on iOS. `adb exec-out screencap` is rotation-aware, so it is ground truth; each candidate was scored as mean absolute difference against it both as-is and rotated 180°, so an inverted mapping could not pass:

```
rotation 1  LandscapeLeft       2.19  (vs 6.54 for its 180° twin)
rotation 3  LandscapeRight      2.19  (vs 6.34)
rotation 2  PortraitUpsideDown  2.67  (vs 13.13)
rotation 0  Portrait            identity
```

This table is the **inverse** of simulator-server's own `90° → LandscapeRight` convention, because it compensates for a rotation that layer applies while decoding the scrcpy stream. That makes it a property of a particular simulator-server build rather than of Android — which is why a table test alone is not enough, and the delivered PNG's aspect is checked against the rotation requested, falling back to an unrotated capture if they disagree.

## Verified live

Branch tool-server against a real emulator:

- landscape, default capture → **2424×1080 upright**, MAD 2.19 vs ground truth (6.54 vs its 180° twin)
- cropping `describe`'s frame for the toolbar out of that default capture shows exactly the "Display & touch" toolbar — the two spaces agree
- rotation 0 → 1080×2424, MAD 2.82, unchanged
- rotated **iPad** → still 2064×2752 sideways, i.e. iOS provably untouched

Plus 27 new unit tests, including one that asserts the legacy path *drops* the right-hand node before the fix and keeps it after. Full suite 3125 passing; lint, prettier, `typecheck:tests` and the tool-description gate all clean.

## Not in scope

- The iOS half of #609.
- `rotate` on Android silently no-ops when auto-rotate is enabled (it returned `{orientation:"LandscapeLeft"}` while `dumpsys` still read `cur=1080x2424`). Filing separately.
- `screen-recording` still records sideways — same root cause, different pipeline. Worth noting a session's screenshots are now upright while its video is not.
- Existing visual baselines captured on a rotated Android device will stop matching, since the baseline key embeds capture dimensions and those now swap. This fails loudly as a missing baseline rather than silently comparing the wrong thing — and those baselines were sideways captures of an upright UI.

---

> **#673 and #658 are both stacked on this branch** — each conflicts with this one (`screenshot/index.ts` and `screenshot-diff/index.ts` respectively) but not with each other, so both were rebased onto this branch as siblings rather than chained. Merge this first; GitHub then retargets both to `main`.
