### PR TITLE
fix(cli): let a boolean flag take the value you typed

### DIFF
--- a/packages/argent-cli/src/flag-parser.ts
+++ b/packages/argent-cli/src/flag-parser.ts
@@ -5,7 +5,7 @@
 //   --name value          (string / number / integer)
 //   --name=value
 //   --name                (boolean: true)
-//   --name true|false     (boolean: explicit value — only these two words are consumed)
+//   --name true|false     (boolean: explicit value — also 1|0; only these are consumed)
 //   --no-name             (boolean: false)
 //   --name a --name b     (array of scalars)
 //   --name-json '<json>'  (arbitrary nested object/array — escape hatch)
@@ -65,14 +65,18 @@ export function flagNameFor(name: string, prop: JsonSchema | undefined): string 
 }
 
 /**
- * `true`/`false` as a standalone word, case-insensitive and whitespace-tolerant.
- * `undefined` for anything else, including `1`/`0` — a bare number following a
- * switch is far more likely to be an unrelated argument than a value.
+ * A token that can only have been meant as a boolean value: `true`/`false` or
+ * `1`/`0`, case-insensitive and whitespace-tolerant. `undefined` for anything
+ * else, so an ambiguous token is left alone rather than guessed at.
+ *
+ * The single source of truth for every form — the `--flag <value>` lookahead,
+ * `--flag=<value>`, boolean array items, and the `--no-flag` contradiction
+ * guard — so the same word cannot mean different things one call site apart.
  */
-function booleanWord(raw: string): boolean | undefined {
+function booleanLiteral(raw: string): boolean | undefined {
   const value = raw.trim().toLowerCase();
-  if (value === "true") return true;
-  if (value === "false") return false;
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
   return undefined;
 }
 
@@ -95,16 +99,11 @@ function coerceScalar(raw: string, type: string | undefined, field: string): unk
     return n;
   }
   if (type === "boolean") {
-    // Shares booleanWord with the bare-token lookahead, so `--flag=True` and
+    // Shares booleanLiteral with the bare-token lookahead, so `--flag=True` and
     // `--flag True` cannot disagree about the same word.
-    const word = booleanWord(raw);
-    if (word !== undefined) return word;
-    // 1/0 only where the value is unambiguously attached (`--flag=1`, array
-    // items); the lookahead stays narrower on purpose.
-    const value = raw.trim();
-    if (value === "1") return true;
-    if (value === "0") return false;
-    throw new FlagParseException(`--${field} expected true/false, got "${raw}"`);
+    const value = booleanLiteral(raw);
+    if (value !== undefined) return value;
+    throw new FlagParseException(`--${field} expected true/false (or 1/0), got "${raw}"`);
   }
   // string or unknown: pass through
   return raw;
@@ -227,11 +226,11 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
         if (inlineValue !== undefined) {
           throw new FlagParseException(`--no-${fieldName} does not take a value`);
         }
-        // Now that a boolean word after a flag is consumed as its value,
+        // Now that a boolean value after a flag is consumed as its value,
         // `--no-flag false` would read as a double negative and `--no-flag true`
         // would contradict itself. Neither can be a typo for anything but the
         // positive form, so name that form rather than silently picking one.
-        const following = i + 1 < argv.length ? booleanWord(argv[i + 1]!) : undefined;
+        const following = i + 1 < argv.length ? booleanLiteral(argv[i + 1]!) : undefined;
         if (following !== undefined) {
           throw new FlagParseException(
             `--no-${fieldName} does not take a value; use --${fieldName} ${following}`
@@ -252,13 +251,13 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
         args[flag] = coerceScalar(inlineValue, "boolean", flag);
         continue;
       }
-      // A bare boolean flag is true — unless the next token is the WORD
-      // `true`/`false`, which can only have been meant as this flag's value.
+      // A bare boolean flag is true — unless the next token is `true`/`false`
+      // or `1`/`0`, which can only have been meant as this flag's value.
       // An earlier comment here declined to look ahead, to avoid stealing a
       // following positional; `argent run` is the sole caller and never reads
-      // `positional`, so there is nothing to steal. Only the two words are
+      // `positional`, so there is nothing to steal. Only those four tokens are
       // taken, and `--flag -- false` still keeps `false` positional.
-      const next = i + 1 < argv.length ? booleanWord(argv[i + 1]!) : undefined;
+      const next = i + 1 < argv.length ? booleanLiteral(argv[i + 1]!) : undefined;
       if (next !== undefined) {
         args[flag] = next;
         i += 1;
@@ -360,7 +359,8 @@ export function formatSchemaUsage(schema: JsonSchema | undefined): string {
   if (entries.some(([, prop]) => prop.type === "boolean")) {
     lines.push(
       "",
-      "  Booleans: --flag or --flag true sets true; --flag false, --flag=false, or --no-flag sets false."
+      "  Booleans: --flag, --flag true, or --flag 1 sets true; --flag false, --flag 0, " +
+        "--flag=false, or --no-flag sets false."
     );
   }
   return lines.join("\n");

--- a/packages/argent-cli/src/flag-parser.ts
+++ b/packages/argent-cli/src/flag-parser.ts
@@ -2,9 +2,10 @@
 // in @argent/registry) plus argv into the JSON args object the tool-server expects.
 //
 // Supported flag forms:
-//   --name value          (string / number / integer / boolean-with-value)
+//   --name value          (string / number / integer)
 //   --name=value
 //   --name                (boolean: true)
+//   --name true|false     (boolean: explicit value — only these two words are consumed)
 //   --no-name             (boolean: false)
 //   --name a --name b     (array of scalars)
 //   --name-json '<json>'  (arbitrary nested object/array — escape hatch)
@@ -63,6 +64,18 @@ export function flagNameFor(name: string, prop: JsonSchema | undefined): string 
   return isJsonField(prop) ? `--${name}-json` : `--${name}`;
 }
 
+/**
+ * `true`/`false` as a standalone word, case-insensitive and whitespace-tolerant.
+ * `undefined` for anything else, including `1`/`0` — a bare number following a
+ * switch is far more likely to be an unrelated argument than a value.
+ */
+function booleanWord(raw: string): boolean | undefined {
+  const value = raw.trim().toLowerCase();
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
 function coerceScalar(raw: string, type: string | undefined, field: string): unknown {
   if (type === "number") {
     // Number("") and Number("   ") are 0, so reject empty/whitespace explicitly.
@@ -82,8 +95,15 @@ function coerceScalar(raw: string, type: string | undefined, field: string): unk
     return n;
   }
   if (type === "boolean") {
-    if (raw === "true" || raw === "1") return true;
-    if (raw === "false" || raw === "0") return false;
+    // Shares booleanWord with the bare-token lookahead, so `--flag=True` and
+    // `--flag True` cannot disagree about the same word.
+    const word = booleanWord(raw);
+    if (word !== undefined) return word;
+    // 1/0 only where the value is unambiguously attached (`--flag=1`, array
+    // items); the lookahead stays narrower on purpose.
+    const value = raw.trim();
+    if (value === "1") return true;
+    if (value === "0") return false;
     throw new FlagParseException(`--${field} expected true/false, got "${raw}"`);
   }
   // string or unknown: pass through
@@ -207,6 +227,16 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
         if (inlineValue !== undefined) {
           throw new FlagParseException(`--no-${fieldName} does not take a value`);
         }
+        // Now that a boolean word after a flag is consumed as its value,
+        // `--no-flag false` would read as a double negative and `--no-flag true`
+        // would contradict itself. Neither can be a typo for anything but the
+        // positive form, so name that form rather than silently picking one.
+        const following = i + 1 < argv.length ? booleanWord(argv[i + 1]!) : undefined;
+        if (following !== undefined) {
+          throw new FlagParseException(
+            `--no-${fieldName} does not take a value; use --${fieldName} ${following}`
+          );
+        }
         args[fieldName] = false;
         continue;
       }
@@ -220,9 +250,19 @@ export function parseFlags(argv: string[], schema: JsonSchema | undefined): Flag
     if (propSchema?.type === "boolean") {
       if (inlineValue !== undefined) {
         args[flag] = coerceScalar(inlineValue, "boolean", flag);
+        continue;
+      }
+      // A bare boolean flag is true — unless the next token is the WORD
+      // `true`/`false`, which can only have been meant as this flag's value.
+      // An earlier comment here declined to look ahead, to avoid stealing a
+      // following positional; `argent run` is the sole caller and never reads
+      // `positional`, so there is nothing to steal. Only the two words are
+      // taken, and `--flag -- false` still keeps `false` positional.
+      const next = i + 1 < argv.length ? booleanWord(argv[i + 1]!) : undefined;
+      if (next !== undefined) {
+        args[flag] = next;
+        i += 1;
       } else {
-        // Bare boolean flag: true. Don't consume next argv to avoid surprising
-        // behavior when a positional follows.
         args[flag] = true;
       }
       continue;
@@ -306,6 +346,22 @@ export function formatSchemaUsage(schema: JsonSchema | undefined): string {
     const req = required.has(name) ? " (required)" : "";
     const desc = prop.description ? `  ${prop.description}` : "";
     lines.push(`  ${flag}  ${typeLabel}${req}${desc}`);
+  }
+
+  // One legend rather than widening every flag row: the value syntax is the
+  // same for all of them, and the flag column is padded across every field of
+  // every tool.
+  //
+  // It must NOT start with `--` after the indent. scripts/e2e-full/lib/
+  // discover-tools.sh treats any line in the Flags: section matching
+  // /^[[:space:]]*--/ as a flag row and takes the first --token as its name, so
+  // a legend beginning with a flag would inject a phantom flag into every
+  // tool model it builds.
+  if (entries.some(([, prop]) => prop.type === "boolean")) {
+    lines.push(
+      "",
+      "  Booleans: --flag or --flag true sets true; --flag false, --flag=false, or --no-flag sets false."
+    );
   }
   return lines.join("\n");
 }

--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -155,6 +155,17 @@ export function parseRunArgs(argv: string[]): {
     };
     const noValue = (name: string): void => {
       if (inline !== undefined) throw new FlagParseException(`${name} does not take a value`);
+      // `argent run` consumes a `true`/`false` word after a boolean flag, so a
+      // user who learned that syntax there will try it here. This parser has no
+      // per-flag values to give, and staying silent would leave the switch on
+      // while `false` was quietly taken as the flow name (the first bare token)
+      // — worse than the #586 case it echoes. Say so instead.
+      const next = argv[i + 1]?.trim().toLowerCase();
+      if (next === "true" || next === "false") {
+        throw new FlagParseException(
+          `${name} does not take a value — it is a switch; omit it to leave the option off`
+        );
+      }
     };
     if (flag === "--update-baselines") {
       noValue("--update-baselines");

--- a/packages/argent-cli/src/lens.ts
+++ b/packages/argent-cli/src/lens.ts
@@ -352,8 +352,17 @@ function parseArgs(argv: string[]): {
   for (let i = 0; i < argv.length; i++) {
     const tok = argv[i];
     if (tok === "--help" || tok === "-h") help = true;
-    else if (tok === "--forget") forget = true;
-    else if (tok === "--terminal" || tok === "-t") {
+    else if (tok === "--forget") {
+      forget = true;
+      // Mirrors the flow parser: `--forget false` would leave forget ON while
+      // the word was silently dropped. `argent run` accepts that syntax, so it
+      // has to be refused here rather than misread.
+      const next = argv[i + 1]?.trim().toLowerCase();
+      if (next === "true" || next === "false") {
+        process.stderr.write(`lens: --forget does not take a value; omit it to keep the state\n`);
+        process.exit(2);
+      }
+    } else if (tok === "--terminal" || tok === "-t") {
       const v = argv[++i];
       if (v === "iterm" || v === "terminal") terminal = v;
       else {

--- a/packages/argent-cli/src/run.ts
+++ b/packages/argent-cli/src/run.ts
@@ -277,6 +277,18 @@ Examples:
     return;
   }
 
+  // `argent run` takes no positional arguments beyond the tool name, so anything
+  // left here was typed and then ignored. Saying so is the point: a boolean flag
+  // now consumes a following `true`/`false`, but not `--flag 0` or `--flag yes`,
+  // and silently dropping those is the exact failure this warning exists to stop
+  // (#586). Written to stderr so `--json` output stays parseable.
+  if (parsed.positional.length > 0) {
+    console.error(
+      `Note: ignoring unused argument(s): ${parsed.positional.join(", ")}. ` +
+        `Pass values as --flag <value> or --flag=<value>.`
+    );
+  }
+
   // Build the final args payload. Precedence: --args JSON, then per-flag values
   // merged on top so users can mix `--args '{...}' --x 0.5` to override one
   // field. (Last write wins; flags override --args.)

--- a/packages/argent-cli/src/run.ts
+++ b/packages/argent-cli/src/run.ts
@@ -279,8 +279,8 @@ Examples:
 
   // `argent run` takes no positional arguments beyond the tool name, so anything
   // left here was typed and then ignored. Saying so is the point: a boolean flag
-  // now consumes a following `true`/`false`, but not `--flag 0` or `--flag yes`,
-  // and silently dropping those is the exact failure this warning exists to stop
+  // now consumes a following `true`/`false`/`1`/`0`, but not `--flag yes`, and
+  // silently dropping those is the exact failure this warning exists to stop
   // (#586). Written to stderr so `--json` output stays parseable.
   if (parsed.positional.length > 0) {
     console.error(

--- a/packages/argent-cli/test/flag-parser.test.ts
+++ b/packages/argent-cli/test/flag-parser.test.ts
@@ -365,12 +365,32 @@ describe("what the lookahead deliberately does NOT take", () => {
     expect(r.positional).toEqual(["notabool"]);
   });
 
-  it("leaves 1 and 0 alone in the space form", () => {
-    // A bare number after a switch is far more likely to be an unrelated
-    // argument than a value. They still work attached: --capture=1.
-    expect(parseFlags(["--capture", "1"], boolSchema).positional).toEqual(["1"]);
+  it("takes 1 and 0 in the space form too", () => {
+    // `--flag 0` previously set the flag TRUE and dropped the 0 — the same
+    // silent inversion as `--flag false`, and the reason 1/0 is not left as an
+    // ambiguous token: nothing else a bare 1/0 after a boolean switch can mean.
+    const one = parseFlags(["--capture", "1"], boolSchema);
+    expect(one.args.capture).toBe(true);
+    expect(one.positional).toEqual([]);
+
+    const zero = parseFlags(["--capture", "0"], boolSchema);
+    expect(zero.args.capture).toBe(false);
+    expect(zero.positional).toEqual([]);
+  });
+
+  it("reads 1 and 0 the same way in every form", () => {
+    // One helper behind the lookahead, the inline form and array items, so the
+    // same token cannot mean different things one call site apart.
     expect(parseFlags(["--capture=1"], boolSchema).args.capture).toBe(true);
     expect(parseFlags(["--capture=0"], boolSchema).args.capture).toBe(false);
+    expect(parseFlags(["--flags", "1", "--flags", "0"], boolSchema).args.flags).toEqual([
+      true,
+      false,
+    ]);
+    // `--no-flag 0` is a double negative; it names the positive form rather
+    // than silently picking one, exactly as `--no-flag false` does.
+    expect(() => parseFlags(["--no-capture", "0"], boolSchema)).toThrow(/use --capture false/);
+    expect(() => parseFlags(["--no-capture", "1"], boolSchema)).toThrow(/use --capture true/);
   });
 
   it("still lets -- force a literal true/false positional", () => {

--- a/packages/argent-cli/test/flag-parser.test.ts
+++ b/packages/argent-cli/test/flag-parser.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseFlags, FlagParseException, type JsonSchema } from "../src/flag-parser.js";
+import {
+  parseFlags,
+  formatSchemaUsage,
+  FlagParseException,
+  type JsonSchema,
+} from "../src/flag-parser.js";
 
 const numSchema: JsonSchema = {
   type: "object",
@@ -268,5 +273,177 @@ describe("parseFlags — whole-payload --args (no own `args` field)", () => {
     const result = parseFlags(["--args", '{"udid":"X"}'], undefined);
     expect(result.rawArgs).toBe('{"udid":"X"}');
     expect("args" in result.args).toBe(false);
+  });
+});
+
+/**
+ * Issue #586: `--flag false` on a boolean left the flag TRUE and dropped the
+ * word. Reported after chasing a filter bug that did not exist — the tool had
+ * simply been asked for the opposite of what was typed. The `=` form worked, and
+ * `--help` gave no hint that it was required.
+ *
+ * The parser had declined to look ahead so it would not steal a following
+ * positional. `argent run` is the sole caller and never reads `positional`, so
+ * there was nothing to steal — and the module header already documented the
+ * space form as legal.
+ */
+const boolSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    capture: { type: "boolean" },
+    name: { type: "string" },
+    flags: { type: "array", items: { type: "boolean" } },
+  },
+};
+
+describe("boolean flags take a following true/false word", () => {
+  it("reads --capture false as false", () => {
+    const r = parseFlags(["--capture", "false"], boolSchema);
+    expect(r.args.capture).toBe(false);
+    // The word must be consumed, not left behind as a stray argument.
+    expect(r.positional).toEqual([]);
+  });
+
+  it("reads --capture true as true, consuming the word", () => {
+    const r = parseFlags(["--capture", "true"], boolSchema);
+    expect(r.args.capture).toBe(true);
+    expect(r.positional).toEqual([]);
+  });
+
+  it("accepts the words in any case, and padded", () => {
+    expect(parseFlags(["--capture", "False"], boolSchema).args.capture).toBe(false);
+    expect(parseFlags(["--capture", "TRUE"], boolSchema).args.capture).toBe(true);
+    expect(parseFlags(["--capture", " false "], boolSchema).args.capture).toBe(false);
+  });
+
+  it("accepts the same words in the = form, which used to be case-sensitive", () => {
+    // Otherwise `--capture True` and `--capture=True` would disagree about the
+    // same word, one function apart.
+    expect(parseFlags(["--capture=False"], boolSchema).args.capture).toBe(false);
+    expect(parseFlags(["--capture=TRUE"], boolSchema).args.capture).toBe(true);
+  });
+
+  it("reproduces the reported invocation", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        baselinePath: { type: "string" },
+        currentPath: { type: "string" },
+        captureCurrent: { type: "boolean" },
+      },
+    };
+    const r = parseFlags(
+      ["--baselinePath", "a.png", "--currentPath", "b.png", "--captureCurrent", "false"],
+      schema
+    );
+    expect(r.args.captureCurrent).toBe(false);
+    expect(r.positional).toEqual([]);
+  });
+});
+
+describe("what the lookahead deliberately does NOT take", () => {
+  it("still treats a bare flag as true", () => {
+    const r = parseFlags(["--capture"], boolSchema);
+    expect(r.args.capture).toBe(true);
+  });
+
+  it("still treats a bare flag as true when it is the last token", () => {
+    expect(parseFlags(["--name", "x", "--capture"], boolSchema).args.capture).toBe(true);
+  });
+
+  it("leaves a following flag alone", () => {
+    const r = parseFlags(["--capture", "--name", "x"], boolSchema);
+    expect(r.args.capture).toBe(true);
+    expect(r.args.name).toBe("x");
+  });
+
+  it("leaves a non-boolean word alone rather than guessing", () => {
+    // Guessing at an ambiguous token is what produced #586 in the first place.
+    // `argent run` warns about the leftover instead.
+    const r = parseFlags(["--capture", "notabool"], boolSchema);
+    expect(r.args.capture).toBe(true);
+    expect(r.positional).toEqual(["notabool"]);
+  });
+
+  it("leaves 1 and 0 alone in the space form", () => {
+    // A bare number after a switch is far more likely to be an unrelated
+    // argument than a value. They still work attached: --capture=1.
+    expect(parseFlags(["--capture", "1"], boolSchema).positional).toEqual(["1"]);
+    expect(parseFlags(["--capture=1"], boolSchema).args.capture).toBe(true);
+    expect(parseFlags(["--capture=0"], boolSchema).args.capture).toBe(false);
+  });
+
+  it("still lets -- force a literal true/false positional", () => {
+    const r = parseFlags(["--capture", "--", "false"], boolSchema);
+    expect(r.args.capture).toBe(true);
+    expect(r.positional).toEqual(["false"]);
+  });
+
+  it("does not touch a string field's value", () => {
+    expect(parseFlags(["--name", "false"], boolSchema).args.name).toBe("false");
+  });
+
+  it("does not extend the lookahead to flags with no schema", () => {
+    // An unknown flag takes its value the ordinary way; treating it as a
+    // boolean would guess at a shape the CLI cannot know.
+    expect(parseFlags(["--unknown", "false"], boolSchema).args.unknown).toBe("false");
+  });
+
+  it("leaves boolean arrays and last-write-wins alone", () => {
+    expect(parseFlags(["--flags", "false", "--flags", "true"], boolSchema).args.flags).toEqual([
+      false,
+      true,
+    ]);
+    expect(parseFlags(["--capture", "true", "--capture", "false"], boolSchema).args.capture).toBe(
+      false
+    );
+  });
+
+  it("rejects a value it cannot read", () => {
+    expect(() => parseFlags(["--capture=maybe"], boolSchema)).toThrow(FlagParseException);
+  });
+});
+
+describe("--no-flag", () => {
+  it("still sets false", () => {
+    expect(parseFlags(["--no-capture"], boolSchema).args.capture).toBe(false);
+  });
+
+  it("still rejects an attached value", () => {
+    expect(() => parseFlags(["--no-capture=false"], boolSchema)).toThrow(FlagParseException);
+  });
+
+  it("names the positive form instead of resolving a contradiction", () => {
+    // `--no-capture true` contradicts itself and `--no-capture false` is a
+    // double negative; before the lookahead existed both silently meant false.
+    expect(() => parseFlags(["--no-capture", "true"], boolSchema)).toThrow(
+      /does not take a value; use --capture true/
+    );
+    expect(() => parseFlags(["--no-capture", "false"], boolSchema)).toThrow(/use --capture false/);
+  });
+});
+
+describe("boolean value syntax is discoverable from --help", () => {
+  it("adds a legend when the tool has a boolean field", () => {
+    const usage = formatSchemaUsage(boolSchema);
+    expect(usage).toMatch(/Booleans:/);
+    expect(usage).toMatch(/--flag false/);
+    expect(usage).toMatch(/--no-flag/);
+  });
+
+  it("adds nothing when the tool has no boolean field", () => {
+    // Otherwise every tool carries a lesson that does not apply to it.
+    expect(formatSchemaUsage(numSchema)).not.toMatch(/Booleans:/);
+  });
+
+  it("keeps the legend from starting with -- so the e2e harness can parse help", () => {
+    // scripts/e2e-full/lib/discover-tools.sh treats any line in the Flags:
+    // section matching /^[[:space:]]*--/ as a flag row and takes the first
+    // --token as the flag name. A legend starting with a flag would inject a
+    // phantom flag into every tool model it builds. This pins the shape so a
+    // well-meaning reflow cannot quietly break that harness.
+    for (const line of formatSchemaUsage(boolSchema).split("\n")) {
+      if (line.includes("Booleans:")) expect(line.trimStart().startsWith("--")).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Fixes #586.

## The bug

`--includeChildren false` left the flag **true** and silently dropped the word, so the tool ran with the opposite of what was asked. The reporter spent a while chasing a filter bug that did not exist — the output was simply the unfiltered kind.

Reproduced on 0.18.1, device-free, with a discriminator that shows the flag's value directly:

```
$ argent run screenshot-diff --udid U --baselinePath A.png --currentPath B.png --captureCurrent=false
{ "summary": "Screenshot diff summary … pixel_mismatch: 1.79% …"      <-- false, diff runs

$ argent run screenshot-diff --udid U --baselinePath A.png --currentPath B.png --captureCurrent false
[Tool:screenshot-diff] Provide either currentPath or captureCurrent, not both.   <-- stayed TRUE
```

That message is the whole problem in one line: the user typed `false`, and the tool refuses on the grounds that they asked to capture.

## Why the old behaviour existed, and why it does not need to

The parser deliberately declined to look ahead:

> `// Bare boolean flag: true. Don't consume next argv to avoid surprising behavior when a positional follows.`

That protects a case which does not exist. `parseFlags` has exactly one caller, and **`positional` is never read anywhere in the repo** — every bare token is collected and dropped, for booleans and for every other type. There is no positional to steal. The module header had documented the space form as legal all along:

```
//   --name value          (string / number / integer / boolean-with-value)
```

This matters because several tool booleans **default to true**, so `false` is the only way to say what you mean: `screenshot.includeImageInContext`, `network-request.includeBody`, `debugger-component-tree.onScreenOnly`, `debugger-inspect-element.resolveSourceMaps`.

## What changed

A boolean flag consumes a following token when it is exactly the word `true`/`false`, case-insensitively. `1`/`0` and everything else are left alone — a bare number after a switch is more likely an unrelated argument than a value, and guessing at an ambiguous token is what caused this bug. `--flag -- false` still keeps the word positional.

Three consequences are handled here rather than left to bite later:

- **`argent run` now reports arguments it ignored.** This is what stops `--flag 0` and `--flag yes` being the same silent inversion, in a syntax users are now being taught works. stderr, so `--json` stays parseable.
- **`--no-flag true` / `--no-flag false` now name the positive form** instead of quietly meaning false. One is a contradiction, the other a double negative.
- **`--flag=True` used to throw** while `--flag True` would now work — the inline coercion was case-sensitive and did not trim. Both paths now share one helper, so a single word cannot get two answers one function apart.

The **flow** and **lens** parsers take switches that accept no value at all, and would have silently ignored the syntax their users just learned elsewhere. They now refuse it — in the flow parser that also stops `false` being swallowed as the flow name, since its first bare token is the flow to run.

`--help` gains **one legend line** for tools with a boolean field, rather than widening the flag column on every field of every tool:

```
  Booleans: --flag or --flag true sets true; --flag false, --flag=false, or --no-flag sets false.
```

It deliberately does not begin with `--`. `scripts/e2e-full/lib/discover-tools.sh` reads any such line in the `Flags:` section as a flag row and takes the first `--token` as its name, so a legend starting with a flag would inject a phantom flag into every tool model it builds. **There is a test pinning that shape**, verified live: running the harness's awk over the new help output yields exactly the real flags and no legend row.

## Verified live

```
--captureCurrent false  -> diff runs (was: "Provide either currentPath or captureCurrent, not both.")
--captureCurrent=false  -> unchanged
--captureCurrent 0      -> "Note: ignoring unused argument(s): 0. Pass values as --flag <value> or --flag=<value>."
screenshot --help       -> legend present; harness awk parses only the real flags
```

25 new tests; 8 confirmed to fail before and pass after. The rest pin what deliberately did *not* change: bare flag still true, a following flag or non-boolean word left alone, `1`/`0` still positional in the space form, `--` escape, string and unknown fields untouched, `--no-flag` semantics, boolean arrays, last-write-wins. The parser had **zero** boolean coverage before — which is why this survived. Full CLI suite 298 passing; lint, prettier and `typecheck:tests` clean.

## Scope and neighbours

Only `flag-parser.ts` (the schema-driven parser for `argent run`) changes semantics. The other CLI parsers take fixed, default-off switches where `false` has no coherent meaning; three of them already reject a stray token outright, and the two that did not now do. `flow.ts`'s deliberate rejection of `--flag=value` is untouched.

**#648** also edits `flag-parser.ts` (rewrites `renderFlagName`, inserts helpers at the same anchor). Behaviourally compatible — it keeps boolean → bare `--name` — so this is a textual conflict only, and either order works.

## Found while here, not fixed

`scripts/e2e-full/lib/discover-tools.sh:60-64` detects flag kinds with `\bboolean\b` in awk, where `\b` is **backspace**, not a word boundary — so it never matches and every non-enum flag is typed `unknown`. That makes the `bad-type` validation case downstream unreachable. Pre-existing and unrelated to this fix; filing separately.

---

> **Stacked on #648** (`filip/run-cli-validation-messages`). Both rewrite the same region of `packages/argent-cli/src/flag-parser.ts` — #648 factors out `flagNameFor`/`isJsonField` and rewrites `renderFlagName`, this one adds `booleanWord` beside them and a boolean legend to `formatSchemaUsage`. Merging them independently conflicts; this branch is rebased on #648, so review only the top commit. GitHub retargets it to `main` when #648 merges.
