### PR TITLE
test(tool-server): stop ARGENT_* overrides from failing the suite

### DIFF
--- a/packages/tool-server/test/setup/clear-ambient-argent-env.ts
+++ b/packages/tool-server/test/setup/clear-ambient-argent-env.ts
@@ -1,0 +1,16 @@
+// `ARGENT_*` variables are user-facing overrides: the tools read them ahead of
+// their own defaults, so any assertion about a default measures the developer's
+// shell unless the variable is cleared first. The machines most likely to
+// export one are exactly the machines whose work these tests cover — the
+// documented fix for a host whose GL stack or window server misbehaves is
+// `ARGENT_EMULATOR_GPU_MODE` / `ARGENT_EMULATOR_NO_WINDOW`, and setting either
+// turned this package permanently red.
+//
+// Cleared suite-wide for the same reason the status-bar stub is: no unit test
+// wants the real environment, and per-file guards had already been written
+// three separate times without covering it. A test that exercises an override
+// sets the variable itself, which still works — this only removes what leaked
+// in from outside.
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("ARGENT_")) delete process.env[key];
+}

--- a/packages/tool-server/vitest.config.ts
+++ b/packages/tool-server/vitest.config.ts
@@ -5,9 +5,10 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     globals: true,
-    // Suite-wide guard against unit tests incidentally shelling out to real
-    // `xcrun simctl` / adb (see the setup file's comment).
-    setupFiles: ["test/setup/stub-status-bar.ts"],
+    // Suite-wide guards, each explained in its own file: keep unit tests from
+    // shelling out to real `xcrun simctl` / adb, and from reading the
+    // developer's `ARGENT_*` overrides instead of the defaults they assert.
+    setupFiles: ["test/setup/stub-status-bar.ts", "test/setup/clear-ambient-argent-env.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
These are the six `boot-device-hotboot` failures I kept measuring as "pre-existing" while reviewing #610. They are not pre-existing breakage - they are this box's `ARGENT_EMULATOR_GPU_MODE=host`, which is the documented workaround for a host whose default renderer misbehaves.

## The defect

`selectGpuMode` and its siblings read `ARGENT_*` ahead of their platform defaults - correctly; that is what an override is for. The tests assert the defaults without clearing the variable, so they assert against the developer's shell.

Per variable on `main`, running only the affected files:

| ambient variable | result |
|---|---|
| `ARGENT_EMULATOR_GPU_MODE=host` | **6 failed** - `boot-device-hotboot.test.ts` |
| `ARGENT_EMULATOR_NO_WINDOW=1` | **4 failed** - `boot-device-hotboot.test.ts` |
| `ARGENT_SIMULATOR_NO_WINDOW=1` | **1 failed** - `boot-device.test.ts` |
| nothing set | 57 passed |

The failure is silent in the worst way: CI is green because CI sets none of them, so the red only appears on the machines that needed the workaround - and eleven permanently-red tests train everyone there to stop reading the suite output.

No user impact. The shipped behaviour is right in both directions; this is purely test isolation.

## Why in the suite setup rather than per file

`boot-device.test.ts` already saves and restores `ARGENT_SIMULATOR_NO_WINDOW` - inside the one test that exercises the override, while a different test in the same file asserts the default and fails. `http-auth.test.ts`, `http-upload.test.ts`, `chromium-discovery.test.ts` and `native-profiler-ios-capture-strategy-shell-safety.test.ts` each hand-clear a different variable. The pattern had been written five times without covering the three that break the build, which is the case for doing it once.

It goes beside `test/setup/stub-status-bar.ts`, whose comment already makes this exact argument for the real-`simctl`/adb problem: *"No unit test wants the real side effect, so stub the module suite-wide here instead of copy-pasting the mock into every flow test file."* A test that exercises an override still sets it itself - the guard only removes what leaked in from outside.

## Verification

| | result |
|---|---|
| affected files, guard, each of the three variables set | 57 passed (each) |
| full suite, guard, all three set | 3090 passed / 1 skipped, 297 files |
| full suite, guard, nothing set | 3090 passed / 1 skipped - identical to the control |

Isolation of the mechanism, before the fix: `env -u ARGENT_EMULATOR_GPU_MODE` turns the same file from `6 failed | 19 passed` into `25 passed`.

The sweep covered `ARGENT_EMULATOR_GPU_MODE`, `ARGENT_EMULATOR_NO_WINDOW`, `ARGENT_SIMULATOR_NO_WINDOW`, `ARGENT_SCREENSHOT_SCALE`, `ARGENT_CHROMIUM_PORTS`, `ARGENT_IDLE_TIMEOUT_MINUTES`, `ARGENT_EVENT_LOG`, `ARGENT_PROJECT_ROOT`, `ANDROID_HOME`, `ANDROID_SDK_ROOT` and `ANDROID_AVD_HOME`, one full-suite run each. Only the three above flip a result; the `ANDROID_*` ones are clean, which is why the guard stays scoped to argent's own namespace.

## One thing the sweep turned up that this PR does not fix

`test/vega-cli-timeout.test.ts` failed in two full-suite runs and then passed in isolation 3/3 with the same variable set, and passes in a repeat full-suite run. It spawns **real** subprocesses against a 400ms timeout and a 3s sentinel, so it is load-sensitive, not env-sensitive - I initially mis-attributed it to `ARGENT_PROJECT_ROOT`, which is read only by `update-argent.ts` and never on that path. Recording it as a flake to look at separately rather than folding a guess into this PR.