### PR TITLE
fix(flow): raise the flow tree's depth cap and say why targeting failed

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -147,9 +147,12 @@ function retargetRemedy(idKind: string, condition: WaitCondition): string {
  * readers each show a different projection, so naming one of them would point
  * the author at the wrong tree.
  *
- * On iOS the near miss is also SHALLOWER: `native-full-hierarchy` defaults to
- * `maxDepth: 8` where the runner's read asks for 100, so absent from it does
- * not mean absent from the runner's tree until the depth is raised.
+ * On an iOS SIMULATOR the near miss is also SHALLOWER: `native-full-hierarchy`
+ * defaults to `maxDepth: 8` where the runner's read asks for 100, so absent
+ * from it does not mean absent from the runner's tree until the depth is
+ * raised. A physical device is not covered: `platformOf` reports `ios` for one
+ * too, but its runner reads the XCUITest snapshot, which takes no depth at all,
+ * and `native-full-hierarchy` is simulator-only.
  */
 function runnerSideReadClause(udid: unknown, condition: WaitCondition): string {
   const platform = platformOf(udid);

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -146,6 +146,10 @@ function retargetRemedy(idKind: string, condition: WaitCondition): string {
  * Chromium, that no read-only tool reports it. `describe` and the native
  * readers each show a different projection, so naming one of them would point
  * the author at the wrong tree.
+ *
+ * On iOS the near miss is also SHALLOWER: `native-full-hierarchy` defaults to
+ * `maxDepth: 8` where the runner's read asks for 100, so absent from it does
+ * not mean absent from the runner's tree until the depth is raised.
  */
 function runnerSideReadClause(udid: unknown, condition: WaitCondition): string {
   const platform = platformOf(udid);
@@ -376,19 +380,17 @@ function unmetWaitWarningFor(cause: UnmetUiWaitCause): string {
   return UNMET_WAIT_WARNING;
 }
 
-// The indeterminate reason is quoted verbatim, and on iOS it can end "provide
-// bundleId explicitly" — advice written for the native tools. Correct it rather
-// than honour it.
+// The indeterminate reason is quoted verbatim, and it carries whatever recovery
+// fits: on iOS `queryFullHierarchyTree` writes one per failure branch, having
+// dropped the shared native-target error's "provide bundleId explicitly" line
+// that a flow selector step cannot act on. So name no remedy here — a second one
+// would contradict it. Add only what the reason cannot see: this step.
 function indeterminateReasonCaveat(udid: unknown): string {
   if (platformOf(udid) !== "ios") return "";
   return (
-    ". That reason may tell you to pass `bundleId` — it is quoted from the shared native-target " +
-    "error, and it does not apply here: the probe predicts an `await:`/`assert:` directive, and " +
-    "no directive takes a bundleId, so neither this probe nor the runner accepts one (the " +
-    "`bundleId` on this step reached the live wait only). What the runner's iOS tree needs is an " +
-    "app with argent's instrumentation loaded — relaunch it with `launch-app` or a flow `launch:` " +
-    "step. An app that cannot load it at all, such as a `com.apple.*` system app, can never be " +
-    "probed or converted: keep the check as a raw `tool:` step"
+    ". One thing that reason cannot see is this step: the probe predicts an `await:`/`assert:` " +
+    "directive, and no directive takes a bundleId, so neither this probe nor the runner accepts " +
+    "one (the `bundleId` on this step reached the live wait only)"
   );
 }
 
@@ -578,6 +580,27 @@ async function probeAgainstRunnerTree(
 }
 
 /**
+ * `deriveSelector`'s last resort: the tapped node has no identifier and no
+ * visible text, so the step replays on role alone. It holds only while that
+ * element keeps winning `selectorToFrame`'s ranking. The re-resolve guard below
+ * proves that for the recording screen, never for the screen replay meets, so
+ * the warning says so instead of leaving it silent.
+ *
+ * The raised iOS depth cap makes this more common. An unlabeled icon that the
+ * device used to truncate away, which left `nodeAtPoint` to pick its `testID`
+ * container, is now present and is the smaller frame under the tap.
+ */
+function roleOnlySelectorWarning(selector: Selector): string | undefined {
+  if (selector.role === undefined || selector.identifier !== undefined) return undefined;
+  if (selector.text !== undefined || selector.textMatches !== undefined) return undefined;
+  return (
+    `selector ${describeSelector(selector)} matches by role alone (the tapped element has no id ` +
+    `or visible text) — replay takes whichever element of that role ranks first, so re-record ` +
+    `against a labelled element if that is not reliably this one`
+  );
+}
+
+/**
  * For a recorded `gesture-tap`, look up the element under the tapped point and
  * record a portable `tap: { selector }` step instead of raw coordinates.
  * Returns the selector (possibly with a caveat warning), or a warning
@@ -635,7 +658,11 @@ async function captureTapSelector(
         warning: `selector ${describeSelector(selector)} resolves to a different element on this screen; kept coordinates (brittle)`,
       };
     }
-    return { selector, warning: fallbackSourceWarning(source, device.platform) };
+    const warnings = [
+      roleOnlySelectorWarning(selector),
+      fallbackSourceWarning(source, device.platform),
+    ].filter((w) => w !== undefined);
+    return { selector, ...(warnings.length > 0 ? { warning: warnings.join("; ") } : {}) };
   } catch (err) {
     return {
       warning: `selector capture failed (${err instanceof Error ? err.message : String(err)}); kept coordinates`,

--- a/packages/tool-server/src/tools/flows/flow-ios-tree.ts
+++ b/packages/tool-server/src/tools/flows/flow-ios-tree.ts
@@ -8,6 +8,7 @@ import {
   type NativeDevtoolsApi,
 } from "../../blueprints/native-devtools";
 import { chooseFrontmostConnectedApp, resolveNativeTargetApp } from "../../utils/native-target-app";
+import { deviceSetForUdid, simctlPrefix } from "../../utils/ios-device-sets";
 import { nodeText } from "../../utils/ui-tree-match";
 import { describeIosDevice } from "../describe/platforms/ios-device";
 import type { FlowTreeTarget } from "./flow-actions";
@@ -248,6 +249,15 @@ function adaptFullHierarchy(raw: unknown): {
     : { tree };
 }
 
+/**
+ * Depth ceiling for the flow selector tree, counting raw UIView nesting. React
+ * Native wrappers alone run 40 to 60 levels deep, so the old cap of 40 silently
+ * truncated a production app's visible elements and left `id:` and `text:`
+ * selectors unresolvable. Headroom past a tree's real depth is free: the
+ * payload is field-limited (see {@link FULL_HIERARCHY_FIELDS}).
+ */
+const FLOW_TREE_MAX_DEPTH = 100;
+
 /** Fields requested from getFullHierarchy — the minimum to flatten + match. */
 const FULL_HIERARCHY_FIELDS = [
   "className",
@@ -336,9 +346,9 @@ export async function queryFullHierarchyTree(
     const ndRef = nativeDevtoolsRef(device);
     nativeApi = await registry.resolveService<NativeDevtoolsApi>(ndRef.urn, ndRef.options);
   } catch (err) {
-    throw new Error(
+    throw wrapPreservingFailure(
       `native devtools is unavailable (${errMsg(err)}) — flows resolve selectors against the full view hierarchy it serves`,
-      { cause: err }
+      err
     );
   }
 
@@ -456,7 +466,7 @@ export async function queryFullHierarchyTree(
     } catch (err) {
       const timedOut =
         getFailureSignal(err)?.error_code === FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT;
-      if (!timedOut || !target) throw err;
+      if (!timedOut || !target) throw await explainTargetingFailure(err, nativeApi, device);
       // Checked before the connections list to keep the refusal terminal
       // either way.
       if (!isInjectableBundleId(target.bundleId)) {
@@ -471,7 +481,9 @@ export async function queryFullHierarchyTree(
           err instanceof Error ? { cause: err } : undefined
         );
       }
-      if (!nativeApi.listConnectedBundleIds().includes(target.bundleId)) throw err;
+      if (!nativeApi.listConnectedBundleIds().includes(target.bundleId)) {
+        throw await explainTargetingFailure(err, nativeApi, device);
+      }
       // The timed-out fan-out proved nothing about what is on screen, so the
       // hint must vouch for itself before taking the read. A probe it cannot
       // answer is nothing to vouch for: the fan-out's own timeout stands.
@@ -480,7 +492,7 @@ export async function queryFullHierarchyTree(
         hintState = await nativeApi.getAppState(target.bundleId);
       } catch (probeErr) {
         if (getFailureSignal(probeErr)?.error_code === FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT) {
-          throw err;
+          throw await explainTargetingFailure(err, nativeApi, device);
         }
         throw probeErr;
       }
@@ -501,6 +513,19 @@ export async function queryFullHierarchyTree(
       resolved = { bundleId: target.bundleId };
     }
     bundleId = resolved.bundleId;
+    // Only a disconnect race reaches this. `resolveNativeTargetApp(api,
+    // undefined)` returns ids from `listConnectedBundleIds()`, so an id missing
+    // from that same live map means the socket dropped after the resolve. The
+    // app was instrumented, so the "launched before argent's instrumentation
+    // loaded" diagnosis of an explicitly-named bundle is wrong here.
+    if (!nativeApi.listConnectedBundleIds().includes(bundleId)) {
+      throw new Error(
+        `${bundleId} answered the target probe and then dropped its native-devtools ` +
+          `connection before the view hierarchy could be read. It was instrumented, so a retry may ` +
+          `ride this out; if the connection does not come back, relaunch with restart-app (or a ` +
+          `flow \`launch\` step) — launch-app would only foreground the process that just lost it.`
+      );
+    }
   }
 
   const rawResult = (await nativeApi.queryViewHierarchy(
@@ -508,7 +533,7 @@ export async function queryFullHierarchyTree(
     "ViewHierarchy.getFullHierarchy",
     {
       fields: FULL_HIERARCHY_FIELDS,
-      maxDepth: 40,
+      maxDepth: FLOW_TREE_MAX_DEPTH,
     }
   )) as { windows?: unknown[]; error?: string };
 
@@ -537,6 +562,216 @@ export async function queryFullHierarchyTree(
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Why auto-targeting could not pick an app to read, in terms a flow can act on.
+ *
+ * `resolveNativeTargetApp` asks the caller to provide a bundleId, which a flow
+ * selector step cannot do: the unpinned read hardcodes auto-targeting. Each
+ * branch replaces that advice with a remedy for its own failure. If apps are
+ * connected but none is uniquely frontmost, the remedy is to foreground the
+ * intended one, not to relaunch instrumentation it already has. Only "no
+ * connected app" means the target started outside Argent (Metro/Expo, Xcode, or
+ * its home-screen icon) and needs an Argent relaunch.
+ *
+ * Returns the error to throw rather than throwing, so each call site reads as
+ * the `throw` it is.
+ */
+async function explainTargetingFailure(
+  err: unknown,
+  nativeApi: NativeDevtoolsApi,
+  device: DeviceInfo
+): Promise<Error> {
+  const failureCode = getFailureSignal(err)?.error_code;
+  if (failureCode === FAILURE_CODES.NATIVE_TARGET_MULTIPLE_APPS_AMBIGUOUS) {
+    const terminate = await terminateCommand(device);
+    // The reason does not offer to background the other apps. They stay
+    // connected, so the set stays ambiguous, and iOS then suspends one until it
+    // no longer answers the state probe. That turns this failure into the
+    // harder indeterminate one below.
+    return wrapPreservingFailure(
+      // Short header: the embedded diagnostic already says the set is
+      // ambiguous, and the per-app entries need those 90 characters.
+      `could not target an app to read the view hierarchy from:\n` +
+        `${cappedAppDiagnostic(withoutExplicitBundleIdAdvice(errMsg(err)))}\n` +
+        `Flow selectors auto-target and cannot name a bundleId. Foreground the intended app with ` +
+        `launch-app (it does not terminate), then retry; clear the others with ` +
+        `\`${terminate}\` (argent has no terminate tool, and ` +
+        `restart-app would just bring that app back to the front).`,
+      err
+    );
+  }
+  if (failureCode === FAILURE_CODES.NATIVE_TARGET_SINGLE_APP_NOT_FOREGROUND) {
+    // The one connected app answered the state probe, so it is instrumented and
+    // not suspended. It is either just backgrounded, or it keeps running in the
+    // background (audio, location, VoIP). A permission dialog does not land
+    // here: the app keeps a foreground-inactive scene and resolves normally.
+    // Foregrounding fixes the read, so the relaunch advice below would
+    // misdiagnose this state. Keep resolveNativeTargetApp's per-app
+    // applicationState diagnostic.
+    return wrapPreservingFailure(
+      `the only native-devtools-connected app is not foreground, so it cannot be auto-targeted:\n` +
+        `${withoutExplicitBundleIdAdvice(errMsg(err))}\n` +
+        `Flow selector steps auto-target and cannot provide a bundleId. Bring that app to the ` +
+        `foreground with launch-app (it does not terminate — the app is already instrumented, ` +
+        `just not frontmost), then retry.`,
+      err
+    );
+  }
+  // No verdict at all: resolveNativeTargetApp probes applicationState for every
+  // connected app in one Promise.all, so one stale connection rejects the whole
+  // read. iOS suspends a backgrounded app after about a second, and a suspended
+  // app stops answering. The connections are still live, so the relaunch advice
+  // below does not apply: a relaunch discards the state the flow built up, and
+  // cannot help when another app is the stale one.
+  const stillConnected = nativeApi.listConnectedBundleIds();
+  if (stillConnected.length > 0) {
+    // Say this only when another connection exists to clear, and name a command
+    // that exists: argent has no terminate tool, and restart-app would bring the
+    // other app to the front.
+    const clearOthers =
+      stillConnected.length > 1
+        ? ` To clear the others use \`${await terminateCommand(device)}\` — argent ` +
+          `exposes no terminate tool, and restart-app would bring that app to the front instead.`
+        : ``;
+    return wrapPreservingFailure(
+      `could not read the state of the native-devtools-connected apps, so none could be ` +
+        `auto-targeted (${firstClause(err)}). Connected: ${cappedList(stillConnected)}. ` +
+        `They are instrumented — do not relaunch. A suspended app stops answering: foreground ` +
+        `the app the flow drives with launch-app (it does not terminate), then retry.` +
+        clearOthers,
+      err
+    );
+  }
+  // Kept short: every failed selector read repeats this reason verbatim, and the
+  // recorder repeats it once per captured tap.
+  return wrapPreservingFailure(
+    `no app is connected to native devtools, so flow selectors have no instrumented process to ` +
+      `read the view hierarchy from (${firstClause(err)}). Relaunch with restart-app (or a flow ` +
+      `\`launch\` step): launch-app does not terminate, so on an app already running from ` +
+      `Metro/Expo, Xcode, or its icon it only foregrounds that uninstrumented process. ` +
+      // "feature tools", not "the native-* tools": only the six that run the
+      // throwing 3-arg precheck refuse a com.apple.* bundle.
+      // native-devtools-status runs the 2-arg form and reports injectable:false,
+      // and the native-profiler-* tools do not precheck. The broader claim would
+      // hide the one tool that confirms this state.
+      `Argent treats an Apple system app (com.apple.*) as non-injectable — the native-devtools ` +
+      `feature tools refuse it too — so if one never connects, drive it with raw point taps ` +
+      `and tool: await-ui-element steps.`,
+    err
+  );
+}
+
+/**
+ * The `xcrun simctl terminate` command an agent can run against this device. Two
+ * targeting reasons offer it to clear a competing connected app, because argent
+ * has no terminate tool.
+ *
+ * simctl scopes each operation to one device set, so a UDID from a configured
+ * `ios.additionalDeviceSets` set (Radon IDE's, for example) needs `--set` to
+ * resolve. See `simctlArgsForUdid`, which argent's own call sites use. Only the
+ * prefix is resolved. The udid and bundleId stay placeholders, because the agent
+ * knows its device and picks the app to clear. A default-set device gets the
+ * plain command, so its reason keeps the same size budget (see
+ * {@link MAX_TARGETING_REASON_CHARS}).
+ *
+ * Call this only from a branch that interpolates the result. With additional
+ * sets configured, a default-set UDID matches none of them, so `deviceSetForUdid`
+ * caches nothing and re-runs the whole `simctl list devices` sweep on every
+ * call - seconds, and a failing `await:` rebuilds its reason once per poll.
+ */
+async function terminateCommand(device: DeviceInfo): Promise<string> {
+  const prefix = simctlPrefix(await deviceSetForUdid(device.id));
+  return `xcrun ${prefix.join(" ")} terminate <udid> <bundleId>`;
+}
+
+// The first sentence of a diagnostic's first line: what went wrong, without the
+// remedy each source appends for its own callers. A sentence ends at a period
+// plus whitespace or the end of the line. Messages that reach here carry dotted
+// identifiers (`Application.getState`), which a bare period cuts in half. A line
+// with no sentence break is already the clause.
+function firstClause(err: unknown): string {
+  const firstLine = errMsg(err).split("\n", 1)[0];
+  const sentenceEnd = /\.(?=\s|$)/.exec(firstLine);
+  return sentenceEnd === null ? firstLine : firstLine.slice(0, sentenceEnd.index + 1);
+}
+
+/**
+ * How many connected apps a targeting reason may list.
+ *
+ * The ambiguous and indeterminate branches both embed a per-app list, so without
+ * a cap the reason grows with the connected-app count: 778 characters for 2
+ * apps, 1000 for 4 and 1444 for 8. That cost is paid per step, because
+ * `captureTapSelector` embeds the reason in the warning of every recorded tap
+ * and a failing `await:` repeats it once per poll. Two entries are enough to act
+ * on: the remedy is to foreground the app you want and clear the rest. The
+ * dropped count is still reported.
+ */
+export const MAX_LISTED_APPS = 2;
+
+/**
+ * Ceiling every reason thrown from {@link queryFullHierarchyTree}'s auto-target
+ * path must fit, enforced by `keeps every targeting reason short enough to
+ * repeat per step`.
+ *
+ * Measured on the raw message, before the prefix a caller adds, and without the
+ * `--set <dir>` that an `ios.additionalDeviceSets` device adds to its terminate
+ * command (see {@link terminateCommand}).
+ *
+ * The guard covers {@link unreadableHierarchyReason} too, which the recorder
+ * repeats once per captured tap and which sets the ceiling: 775 characters for
+ * `unregistered` against a 37-character bundle id, in wording shared with
+ * `native-devtools-status` and iOS `describe`. The ambiguous branch is next at
+ * 702, because it carries the two per-app `applicationState` diagnostics an
+ * agent needs to pick the app to clear. Neither figure grows with the
+ * connected-app count; see {@link MAX_LISTED_APPS}.
+ */
+export const MAX_TARGETING_REASON_CHARS = 800;
+
+/** Keep the first {@link MAX_LISTED_APPS} entries, and say how many were not shown. */
+function cappedList(bundleIds: readonly string[]): string {
+  if (bundleIds.length <= MAX_LISTED_APPS) return bundleIds.join(", ");
+  const dropped = bundleIds.length - MAX_LISTED_APPS;
+  return `${bundleIds.slice(0, MAX_LISTED_APPS).join(", ")} (+${dropped} more)`;
+}
+
+/**
+ * Cap the per-app lines of an embedded `resolveNativeTargetApp` diagnostic and
+ * keep its leading summary line. The entries are its `- <bundleId>
+ * (applicationState=…)` lines. Every other line passes through, so a reworded
+ * source loses the cap instead of getting a mangled message.
+ */
+function cappedAppDiagnostic(message: string): string {
+  const lines = message.split("\n");
+  const isEntry = (line: string): boolean => line.startsWith("- ");
+  const firstEntry = lines.findIndex(isEntry);
+  if (firstEntry === -1) return message;
+  const entries = lines.filter(isEntry);
+  if (entries.length <= MAX_LISTED_APPS) return message;
+  const kept = entries.slice(0, MAX_LISTED_APPS);
+  const dropped = entries.length - MAX_LISTED_APPS;
+  return [
+    ...lines.slice(0, firstEntry),
+    ...kept,
+    `- (+${dropped} more connected app${dropped === 1 ? "" : "s"})`,
+    ...lines.slice(firstEntry + entries.length).filter((line) => !isEntry(line)),
+  ].join("\n");
+}
+
+// Strip resolveNativeTargetApp's trailing "Provide bundleId explicitly…" line: a
+// flow selector step hardcodes auto-targeting and cannot act on it. Match the
+// whole line, not the bare sentence, because the ambiguous and single-app cases
+// end that line differently.
+function withoutExplicitBundleIdAdvice(message: string): string {
+  return message.replace(/\nProvide bundleId explicitly[^\n]*$/, "");
+}
+
+/** Add actionable flow-specific context without stripping FailureError data. */
+function wrapPreservingFailure(message: string, err: unknown): Error {
+  const cause = err instanceof Error ? err : new Error(String(err));
+  const signal = getFailureSignal(err);
+  return signal ? new FailureError(message, signal, { cause }) : new Error(message, { cause });
 }
 
 /**

--- a/packages/tool-server/src/tools/flows/flow-ios-tree.ts
+++ b/packages/tool-server/src/tools/flows/flow-ios-tree.ts
@@ -8,7 +8,7 @@ import {
   type NativeDevtoolsApi,
 } from "../../blueprints/native-devtools";
 import { chooseFrontmostConnectedApp, resolveNativeTargetApp } from "../../utils/native-target-app";
-import { deviceSetForUdid, simctlPrefix } from "../../utils/ios-device-sets";
+import { simctlTargetForUdid } from "../../utils/ios-device-sets";
 import { nodeText } from "../../utils/ui-tree-match";
 import { describeIosDevice } from "../describe/platforms/ios-device";
 import type { FlowTreeTarget } from "./flow-actions";
@@ -332,9 +332,10 @@ function systemAppFlowTargetRefusal(bundleId: string): string {
  * fan-out — and re-deciding against the pinned app alone what that fan-out
  * would otherwise have decided.
  *
- * An UNPINNED target is only a hint: auto-resolve decides and its own errors
- * propagate unwrapped, and the hint takes the read solely when that fan-out
- * times out and the hint vouches for itself with a probe of its own.
+ * An UNPINNED target is only a hint: auto-resolve decides, and its errors are
+ * restated by {@link explainTargetingFailure} with a remedy a flow can act on.
+ * The hint takes the read solely when that fan-out times out and the hint
+ * vouches for itself with a probe of its own.
  */
 export async function queryFullHierarchyTree(
   registry: Registry,
@@ -451,8 +452,9 @@ export async function queryFullHierarchyTree(
       throw new Error(await unreadableHierarchyReason(nativeApi, target.bundleId));
     }
     // resolveNativeTargetApp's own errors (no connected app / ambiguous
-    // frontmost) already carry the actionable next step, so they propagate
-    // unwrapped - with one exception. Its `Application.getState` fan-out probes
+    // frontmost) become this read's failure, restated by
+    // `explainTargetingFailure` with the remedy a flow selector step actually
+    // has - with one exception. Its `Application.getState` fan-out probes
     // every connection at once, so one process whose main thread is pinned
     // times the whole resolution out and leaves the read no target at all. ONLY
     // then, and only while the target names an injectable app whose connection
@@ -466,7 +468,7 @@ export async function queryFullHierarchyTree(
     } catch (err) {
       const timedOut =
         getFailureSignal(err)?.error_code === FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT;
-      if (!timedOut || !target) throw await explainTargetingFailure(err, nativeApi, device);
+      if (!timedOut || !target) throw await explainTargetingFailure(err, nativeApi, device, target);
       // Checked before the connections list to keep the refusal terminal
       // either way.
       if (!isInjectableBundleId(target.bundleId)) {
@@ -482,7 +484,7 @@ export async function queryFullHierarchyTree(
         );
       }
       if (!nativeApi.listConnectedBundleIds().includes(target.bundleId)) {
-        throw await explainTargetingFailure(err, nativeApi, device);
+        throw await explainTargetingFailure(err, nativeApi, device, target);
       }
       // The timed-out fan-out proved nothing about what is on screen, so the
       // hint must vouch for itself before taking the read. A probe it cannot
@@ -492,7 +494,7 @@ export async function queryFullHierarchyTree(
         hintState = await nativeApi.getAppState(target.bundleId);
       } catch (probeErr) {
         if (getFailureSignal(probeErr)?.error_code === FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT) {
-          throw await explainTargetingFailure(err, nativeApi, device);
+          throw await explainTargetingFailure(err, nativeApi, device, target);
         }
         throw probeErr;
       }
@@ -575,17 +577,28 @@ function errMsg(err: unknown): string {
  * connected app" means the target started outside Argent (Metro/Expo, Xcode, or
  * its home-screen icon) and needs an Argent relaunch.
  *
+ * `launched` is the run's launch hint, when it has one. It is what separates
+ * "an app the flow does not drive went stale" from "the app the flow drives is
+ * gone": the second needs the relaunch the first must not be given.
+ *
  * Returns the error to throw rather than throwing, so each call site reads as
  * the `throw` it is.
  */
 async function explainTargetingFailure(
   err: unknown,
   nativeApi: NativeDevtoolsApi,
-  device: DeviceInfo
+  device: DeviceInfo,
+  launched?: FlowTreeTarget
 ): Promise<Error> {
   const failureCode = getFailureSignal(err)?.error_code;
   if (failureCode === FAILURE_CODES.NATIVE_TARGET_MULTIPLE_APPS_AMBIGUOUS) {
     const terminate = await terminateCommand(device);
+    // Dropped whole when the command may not be offered (see
+    // {@link terminateCommand}); the foreground remedy stands on its own.
+    const clearOthers = terminate
+      ? `; clear the others with \`${terminate}\` (argent has no terminate tool, and restart-app ` +
+        `would just bring that app back to the front).`
+      : `.`;
     // The reason does not offer to background the other apps. They stay
     // connected, so the set stays ambiguous, and iOS then suspends one until it
     // no longer answers the state probe. That turns this failure into the
@@ -596,9 +609,7 @@ async function explainTargetingFailure(
       `could not target an app to read the view hierarchy from:\n` +
         `${cappedAppDiagnostic(withoutExplicitBundleIdAdvice(errMsg(err)))}\n` +
         `Flow selectors auto-target and cannot name a bundleId. Foreground the intended app with ` +
-        `launch-app (it does not terminate), then retry; clear the others with ` +
-        `\`${terminate}\` (argent has no terminate tool, and ` +
-        `restart-app would just bring that app back to the front).`,
+        `launch-app (it does not terminate), then retry${clearOthers}`,
       err
     );
   }
@@ -622,24 +633,39 @@ async function explainTargetingFailure(
   // No verdict at all: resolveNativeTargetApp probes applicationState for every
   // connected app in one Promise.all, so one stale connection rejects the whole
   // read. iOS suspends a backgrounded app after about a second, and a suspended
-  // app stops answering. The connections are still live, so the relaunch advice
-  // below does not apply: a relaunch discards the state the flow built up, and
-  // cannot help when another app is the stale one.
+  // app stops answering. A connection that is still live needs no relaunch - it
+  // discards the state the flow built up, and cannot help when another app is
+  // the stale one - so the relaunch advice is held back for the two states that
+  // earn it: the launched app missing from that live map, and nothing connected
+  // at all.
   const stillConnected = nativeApi.listConnectedBundleIds();
   if (stillConnected.length > 0) {
-    // Say this only when another connection exists to clear, and name a command
-    // that exists: argent has no terminate tool, and restart-app would bring the
-    // other app to the front.
-    const clearOthers =
-      stillConnected.length > 1
-        ? ` To clear the others use \`${await terminateCommand(device)}\` — argent ` +
-          `exposes no terminate tool, and restart-app would bring that app to the front instead.`
-        : ``;
+    // Which app is missing decides the remedy, so the two are not merged. The
+    // launched app absent from a live connections map is the one state a
+    // relaunch fixes; every other app in that map is instrumented, and
+    // relaunching one discards the state the flow built up.
+    const launchedGone = launched !== undefined && !stillConnected.includes(launched.bundleId);
+    // Say this only when a connection the flow does not drive exists to clear -
+    // which is every connection once the launched app is gone from the map, and
+    // all but one while it is still there. Name a command that exists: argent
+    // has no terminate tool, and restart-app would foreground what it restarts.
+    // Dropped whole when the command may not be offered (see
+    // {@link terminateCommand}).
+    const terminate =
+      stillConnected.length > (launchedGone ? 0 : 1) ? await terminateCommand(device) : undefined;
+    const clearOthers = terminate
+      ? ` To clear the others use \`${terminate}\` — argent exposes no terminate tool, and ` +
+        `restart-app would bring the app you cleared back to the front instead.`
+      : ``;
     return wrapPreservingFailure(
       `could not read the state of the native-devtools-connected apps, so none could be ` +
         `auto-targeted (${firstClause(err)}). Connected: ${cappedList(stillConnected)}. ` +
-        `They are instrumented — do not relaunch. A suspended app stops answering: foreground ` +
-        `the app the flow drives with launch-app (it does not terminate), then retry.` +
+        (launchedGone
+          ? `${launched.bundleId} — the app this flow launched — is NOT among them, so relaunch ` +
+            `it with restart-app (or a flow \`launch\` step); launch-app does not terminate, so ` +
+            `it would only foreground the same uninstrumented process.`
+          : `They are instrumented — do not relaunch. A suspended app stops answering: foreground ` +
+            `the app the flow drives with launch-app (it does not terminate), then retry.`) +
         clearOthers,
       err
     );
@@ -664,26 +690,36 @@ async function explainTargetingFailure(
 }
 
 /**
- * The `xcrun simctl terminate` command an agent can run against this device. Two
- * targeting reasons offer it to clear a competing connected app, because argent
- * has no terminate tool.
+ * The `xcrun simctl terminate` command an agent can run against this device, or
+ * undefined when it must not be offered. Two targeting reasons quote it to clear
+ * a competing connected app, because argent has no terminate tool.
  *
  * simctl scopes each operation to one device set, so a UDID from a configured
  * `ios.additionalDeviceSets` set (Radon IDE's, for example) needs `--set` to
- * resolve. See `simctlArgsForUdid`, which argent's own call sites use. Only the
- * prefix is resolved. The udid and bundleId stay placeholders, because the agent
- * knows its device and picks the app to clear. A default-set device gets the
- * plain command, so its reason keeps the same size budget (see
+ * resolve. Only the prefix is taken. The udid and bundleId stay placeholders,
+ * because the agent knows its device and picks the app to clear. A default-set
+ * device gets the plain command, so its reason keeps the same size budget (see
  * {@link MAX_TARGETING_REASON_CHARS}).
  *
- * Call this only from a branch that interpolates the result. With additional
- * sets configured, a default-set UDID matches none of them, so `deviceSetForUdid`
- * caches nothing and re-runs the whole `simctl list devices` sweep on every
- * call - seconds, and a failing `await:` rebuilds its reason once per poll.
+ * Resolved through `simctlTargetForUdid` rather than `deviceSetForUdid` +
+ * `simctlPrefix` so the advice passes the same entitlement gate as an actual
+ * spawn: a provider that withholds the `simctl` grant for its device must not be
+ * handed a command argent itself would refuse, nor have its device-set path
+ * quoted back. The refusal is a thrown capability error, so it is caught and the
+ * clause dropped - a reason is not the place to report it.
+ *
+ * Call this only from a branch that quotes the result. `deviceSetForUdid` skips
+ * simctl entirely when no additional sets are configured and memoizes the
+ * verdict otherwise, but a UDID in no set at all re-probes on every call, and a
+ * failing `await:` rebuilds its reason once per poll.
  */
-async function terminateCommand(device: DeviceInfo): Promise<string> {
-  const prefix = simctlPrefix(await deviceSetForUdid(device.id));
-  return `xcrun ${prefix.join(" ")} terminate <udid> <bundleId>`;
+async function terminateCommand(device: DeviceInfo): Promise<string | undefined> {
+  try {
+    const { prefix } = await simctlTargetForUdid(device.id);
+    return `xcrun ${prefix.join(" ")} terminate <udid> <bundleId>`;
+  } catch {
+    return undefined;
+  }
 }
 
 // The first sentence of a diagnostic's first line: what went wrong, without the
@@ -701,10 +737,11 @@ function firstClause(err: unknown): string {
  * How many connected apps a targeting reason may list.
  *
  * The ambiguous and indeterminate branches both embed a per-app list, so without
- * a cap the reason grows with the connected-app count: 778 characters for 2
- * apps, 1000 for 4 and 1444 for 8. That cost is paid per step, because
- * `captureTapSelector` embeds the reason in the warning of every recorded tap
- * and a failing `await:` repeats it once per poll. Two entries are enough to act
+ * a cap the reason grows by one ~125-character entry per connected app: the
+ * ambiguous branch measures 702 characters at 2 apps, where the cap is still
+ * inert, and would reach about 950 at 4 and 1450 at 8. That cost is paid per
+ * step, because `captureTapSelector` embeds the reason in the warning of every
+ * recorded tap and a failing `await:` repeats it once per poll. Two entries are enough to act
  * on: the remedy is to foreground the app you want and clear the rest. The
  * dropped count is still reported.
  */
@@ -722,10 +759,14 @@ export const MAX_LISTED_APPS = 2;
  * The guard covers {@link unreadableHierarchyReason} too, which the recorder
  * repeats once per captured tap and which sets the ceiling: 775 characters for
  * `unregistered` against a 37-character bundle id, in wording shared with
- * `native-devtools-status` and iOS `describe`. The ambiguous branch is next at
- * 702, because it carries the two per-app `applicationState` diagnostics an
- * agent needs to pick the app to clear. Neither figure grows with the
- * connected-app count; see {@link MAX_LISTED_APPS}.
+ * `native-devtools-status` and iOS `describe`. That figure is 738 plus the
+ * bundle id, so the ceiling holds for the ids seen in practice and not for every
+ * one: an id of 63 characters or more puts this branch over it, and only 37 is
+ * exercised. The ambiguous branch is next at 702, because it carries the two
+ * per-app `applicationState` diagnostics an agent needs to pick the app to
+ * clear. Neither figure grows with the connected-app count beyond the digits of
+ * the `(+N more)` count - ambiguous measures 702 at 2 apps and 730 at 16; see
+ * {@link MAX_LISTED_APPS}.
  */
 export const MAX_TARGETING_REASON_CHARS = 800;
 

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -516,9 +516,12 @@ async function androidDevtoolsReady(registry: Registry, device: DeviceInfo): Pro
  * successful launch pins later tree reads to this bundle
  * ({@link FlowTreeTarget}), so the read no longer has to agree with
  * auto-targeting about which app is frontmost — but the pin only names the app,
- * it does not prove the app can serve a hierarchy. This wait is what proves
- * that, so a launch that skips it hands the next selector step a pin to a
- * process whose tree source is not up yet.
+ * it does not prove the app can serve a hierarchy. This wait is the closest
+ * evidence the gate has, so a launch that skips it hands the next selector step
+ * a pin to a process whose tree source is not up yet. It is not a guarantee:
+ * the wait ends on `isConnected`, which simulator-wide injection lets a
+ * `com.apple.*` process satisfy, and the first selector read refuses that pin
+ * anyway (see `queryFullHierarchyTree`).
  */
 async function treeSourceGate(
   registry: Registry,

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -511,6 +511,14 @@ async function androidDevtoolsReady(registry: Registry, device: DeviceInfo): Pro
  * aborted, and for an iOS app the native tools refuse to target (see
  * {@link waitForNativeDevtools}) — there the launch is not what failed.
  * Otherwise the reason to report.
+ *
+ * The iOS wait is per bundle, and it does more than confirm readiness. A
+ * successful launch pins later tree reads to this bundle
+ * ({@link FlowTreeTarget}), so the read no longer has to agree with
+ * auto-targeting about which app is frontmost — but the pin only names the app,
+ * it does not prove the app can serve a hierarchy. This wait is what proves
+ * that, so a launch that skips it hands the next selector step a pin to a
+ * process whose tree source is not up yet.
  */
 async function treeSourceGate(
   registry: Registry,

--- a/packages/tool-server/test/flows/flow-composition.test.ts
+++ b/packages/tool-server/test/flows/flow-composition.test.ts
@@ -2373,14 +2373,15 @@ describe("flow composition (run:)", () => {
     // must fail rather than let selectors silently fall back to the AX tree.
     // (An unresolvable service fails fast; a resolvable-but-never-connected
     // one hits the same guard after the connect timeout.)
+    const resolveService = vi.fn(async () => {
+      throw new Error("native-devtools unavailable");
+    });
     const registry = {
       invokeTool: vi.fn(async (id: string) =>
         id === "list-devices" ? { devices: [] } : { ok: true }
       ),
       getTool: vi.fn(() => undefined),
-      resolveService: vi.fn(async () => {
-        throw new Error("native-devtools unavailable");
-      }),
+      resolveService,
     } as unknown as Registry;
 
     const result = asRun(
@@ -2401,6 +2402,122 @@ describe("flow composition (run:)", () => {
     // and the step's reason is the only place any of them surfaces.
     expect(result.steps[0].reason).toContain("native-devtools unavailable");
     expect(result.ok).toBe(false);
+    expect(resolveService).toHaveBeenCalled();
+  });
+
+  it("waits out the gate for a com.apple.* launch, then withholds the verdict", async () => {
+    // The gate ties the launched bundle to the app a later selector step
+    // auto-targets, so the wait runs for every bundle (see `treeSourceGate`).
+    // Only the verdict is withheld for `com.apple.*`: the first selector read
+    // reports the missing hierarchy instead.
+    await writeFlow("main", {
+      executionPrerequisite: "",
+      steps: [
+        // The bundle prefix match is case-insensitive.
+        { kind: "launch", app: "com.APPLE.Preferences" },
+        { kind: "echo", message: "should never run" },
+      ],
+    });
+    const resolveService = vi.fn(async () => ({ isConnected: () => false }));
+    const registry = {
+      invokeTool: vi.fn(async (id: string) =>
+        id === "list-devices" ? { devices: [] } : { ok: true }
+      ),
+      getTool: vi.fn(() => undefined),
+      resolveService,
+    } as unknown as Registry;
+
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "main", project_root: tmpDir, device: DEVICE }
+      )
+    );
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["launch:pass", "echo:pass"]);
+    expect(result.ok).toBe(true);
+    // The wait ran: a per-bundle skip would never touch the service.
+    expect(resolveService).toHaveBeenCalled();
+    // The pass is clean: no connection failure for a hierarchy the gate cannot
+    // wait for.
+    expect(result.steps[0].reason ?? "").not.toMatch(/could not connect to native devtools/i);
+    expect(result.steps[0].reason ?? "").not.toMatch(/stale or duplicate argent server/i);
+    // The launch spends the post-launch settle plus the full 15s
+    // NATIVE_DEVTOOLS_CONNECT_BUDGET_MS, so the 30s budget covers both on a
+    // loaded host.
+  }, 30000);
+
+  it("runs a coordinate-only flow green against an app that never connects", async () => {
+    // A raw `tool: restart-app` step dispatches through the registry, not
+    // `runLaunch`, so it never reaches `treeSourceGate`. Point taps and `tool:`
+    // steps resolve no selectors.
+    await writeFlow("main", {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "tool", name: "restart-app", args: { bundleId: "com.apple.Preferences" } },
+        {
+          kind: "tool",
+          name: "await-ui-element",
+          args: { condition: "visible", selector: { text: "General" } },
+        },
+        { kind: "tap", x: 0.5, y: 0.35 },
+      ],
+    });
+    const resolveService = vi.fn(async () => ({ isConnected: () => false }));
+    const registry = {
+      invokeTool: vi.fn(async (id: string) =>
+        id === "list-devices" ? { devices: [] } : { ok: true }
+      ),
+      getTool: vi.fn(() => undefined),
+      resolveService,
+    } as unknown as Registry;
+
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "main", project_root: tmpDir, device: DEVICE }
+      )
+    );
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual([
+      "tool:pass",
+      "tool:pass",
+      "tap:pass",
+    ]);
+    expect(result.ok).toBe(true);
+    // No step gates on the connection this flow never gets. A gesture without a
+    // selector still settles the screen first, so the tap goes out unsettled and
+    // warns.
+    expect(result.steps[2].warning).toContain("without settling the screen");
+  });
+
+  it("passes the gate for a com.apple.* app that does connect", async () => {
+    // Argent treats `com.apple.*` as non-injectable, but simulator system apps
+    // do connect after a restart-app (measured on iOS 18.3 and 26.5).
+    await writeFlow("main", {
+      executionPrerequisite: "",
+      steps: [
+        { kind: "launch", app: "com.apple.Preferences" },
+        { kind: "echo", message: "runs once the system app has connected" },
+      ],
+    });
+    const registry = {
+      invokeTool: vi.fn(async (id: string) =>
+        id === "list-devices" ? { devices: [] } : { ok: true }
+      ),
+      getTool: vi.fn(() => undefined),
+      resolveService: vi.fn(async () => ({ isConnected: () => true })),
+    } as unknown as Registry;
+
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "main", project_root: tmpDir, device: DEVICE }
+      )
+    );
+
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["launch:pass", "echo:pass"]);
+    expect(result.ok).toBe(true);
   });
 
   // Argent refuses an Apple system app a flow tree, so its hierarchy never
@@ -2718,8 +2835,12 @@ describe("flow composition (run:)", () => {
       );
 
       const reason = result.steps[2].reason ?? "";
-      expect(reason).toMatch(/Apple system app/);
-      expect(reason).not.toMatch(/Launch or restart the app first/);
+      // Both reasons say "Apple system app", so that phrase no longer separates
+      // the two paths. Only the launched-id diagnosis NAMES the bundle: it is
+      // handed the id the tool step preserved. Drop that id and the read falls
+      // through to auto-targeting, whose no-connection text names no app.
+      expect(reason).toMatch(/com\.apple\.Preferences is an Apple system app/);
+      expect(reason).not.toMatch(/no app is connected to native devtools/);
     }
   );
 
@@ -2743,7 +2864,12 @@ describe("flow composition (run:)", () => {
       )
     );
 
-    expect(result.steps[2].reason ?? "").toMatch(/Launch or restart the app first/);
+    // A flow selector step cannot name a bundleId, so `resolveNativeTargetApp`'s
+    // own "Launch or restart the app first" advice is dropped. The auto-target
+    // reason that replaces it names no bundle and reports nothing is connected.
+    const reason = result.steps[2].reason ?? "";
+    expect(reason).toMatch(/no app is connected to native devtools/);
+    expect(reason).not.toMatch(/platform binary with library validation/);
   });
 
   // The measured half says what is wrong with the app; without this half a flow

--- a/packages/tool-server/test/flows/flow-ios-tree.test.ts
+++ b/packages/tool-server/test/flows/flow-ios-tree.test.ts
@@ -1,0 +1,755 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FAILURE_CODES,
+  FailureError,
+  getFailureSignal,
+  type DeviceInfo,
+  type Registry,
+} from "@argent/registry";
+import type { NativeDevtoolsApi } from "../../src/blueprints/native-devtools";
+import type { DescribeNode } from "../../src/tools/describe/contract";
+import {
+  MAX_LISTED_APPS,
+  MAX_TARGETING_REASON_CHARS,
+  queryFullHierarchyTree,
+} from "../../src/tools/flows/flow-ios-tree";
+import { evaluateCondition, selectorToFrame } from "../../src/utils/ui-tree-match";
+import { resolveNativeTargetApp } from "../../src/utils/native-target-app";
+import {
+  __resetDeviceSetCacheForTesting,
+  deviceSetForUdid,
+  rememberDeviceSet,
+} from "../../src/utils/ios-device-sets";
+
+// A pass-through spy, so the case below can count which reasons pay for the
+// device-set lookup while every other case keeps the real memo.
+vi.mock("../../src/utils/ios-device-sets", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/utils/ios-device-sets")>();
+  return { ...actual, deviceSetForUdid: vi.fn(actual.deviceSetForUdid) };
+});
+
+const DEVICE = {
+  id: "00000000-0000-0000-0000-0000000000ab",
+  platform: "ios",
+  kind: "simulator",
+} as DeviceInfo;
+
+function registryFor(api: Partial<NativeDevtoolsApi>): Registry {
+  return {
+    resolveService: vi.fn(async () => api),
+  } as unknown as Registry;
+}
+
+// The udid to device-set memo is module state. Without this reset, a seeded
+// `--set` prefix leaks into the next case.
+afterEach(() => {
+  __resetDeviceSetCacheForTesting();
+});
+
+describe("flow iOS full-hierarchy source", () => {
+  it("requests enough hierarchy depth for deeply nested app content", async () => {
+    // A real window, not `windows: []`: an empty list is a hard read failure,
+    // indistinguishable from an uninjectable app.
+    const queryViewHierarchy = vi.fn(async () => ({
+      windows: [
+        {
+          className: "UIWindow",
+          frame: { x: 0, y: 0, width: 400, height: 800 },
+          windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+          children: [
+            {
+              className: "UIView",
+              windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+              children: [],
+            },
+          ],
+        },
+      ],
+    }));
+    const api = {
+      listConnectedBundleIds: () => ["com.example.app"],
+      getAppState: vi.fn(async (bundleId: string) => ({
+        bundleId,
+        applicationState: "active",
+        foregroundActiveSceneCount: 1,
+        foregroundInactiveSceneCount: 0,
+        backgroundSceneCount: 0,
+        unattachedSceneCount: 0,
+        isFrontmostCandidate: true,
+      })),
+      queryViewHierarchy,
+    } as unknown as NativeDevtoolsApi;
+
+    await queryFullHierarchyTree(registryFor(api), DEVICE);
+
+    expect(queryViewHierarchy).toHaveBeenCalledWith(
+      "com.example.app",
+      "ViewHierarchy.getFullHierarchy",
+      expect.objectContaining({ maxDepth: 100 })
+    );
+  });
+
+  it("adapts and resolves a view buried deeper than the old 40-level cap", async () => {
+    // A maxDepth of 100 proves nothing on its own: the device cap truncates.
+    const DEEP = 45;
+    const buildRaw = (maxDepth: number) => {
+      // Innermost first, then wrap outward, so the leaf sits at depth `DEEP`.
+      let node: Record<string, unknown> = {
+        className: "UIButton",
+        identifier: "deep-button",
+        label: "Buy now",
+        frame: { x: 100, y: 400, width: 200, height: 40 },
+        windowFrame: { x: 100, y: 400, width: 200, height: 40 },
+        children: [],
+      };
+      for (let depth = DEEP - 1; depth >= 1; depth--) {
+        node = {
+          className: "RNSScreenView",
+          frame: { x: 0, y: 0, width: 400, height: 800 },
+          windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+          // The device drops everything past the requested depth.
+          children: depth < maxDepth ? [node] : [],
+        };
+      }
+      return {
+        windows: [
+          {
+            className: "UIWindow",
+            frame: { x: 0, y: 0, width: 400, height: 800 },
+            windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+            children: [node],
+          },
+        ],
+      };
+    };
+
+    const apiWithCap = (deviceCap: number) =>
+      ({
+        listConnectedBundleIds: () => ["com.example.app"],
+        getAppState: vi.fn(async (bundleId: string) => ({
+          bundleId,
+          applicationState: "active",
+          foregroundActiveSceneCount: 1,
+          foregroundInactiveSceneCount: 0,
+          backgroundSceneCount: 0,
+          unattachedSceneCount: 0,
+          isFrontmostCandidate: true,
+        })),
+        queryViewHierarchy: vi.fn(async (_bundleId, _method, params) =>
+          buildRaw(Math.min((params as { maxDepth: number }).maxDepth, deviceCap))
+        ),
+      }) as unknown as NativeDevtoolsApi;
+
+    const { tree } = await queryFullHierarchyTree(registryFor(apiWithCap(DEEP)), DEVICE);
+    expect(selectorToFrame(tree, { identifier: "deep-button" })).toBeDefined();
+
+    // Sensitivity check: under the old cap the same fixture loses the view.
+    const { tree: truncated } = await queryFullHierarchyTree(registryFor(apiWithCap(40)), DEVICE);
+    expect(selectorToFrame(truncated, { identifier: "deep-button" })).toBeUndefined();
+  });
+
+  // A `card` container under RN wrappers, over labels at four depths, two of them
+  // past the old cap of 40. Hoisting stops at the next identified node, so
+  // everything below lands in the card's `subtreeText`.
+  const hoistCardUnder = async (deviceCap: number): Promise<DescribeNode> => {
+    const LABEL_AT = [20, 30, 41, 55];
+    const buildRaw = (maxDepth: number) => {
+      let node: Record<string, unknown> | null = null;
+      for (let depth = 60; depth >= 1; depth--) {
+        const children: Record<string, unknown>[] = [];
+        if (node && depth < maxDepth) children.push(node);
+        if (LABEL_AT.includes(depth) && depth < maxDepth) {
+          children.push({
+            className: "UILabel",
+            label: `row-${depth}-content`,
+            frame: { x: 0, y: 0, width: 400, height: 20 },
+            windowFrame: { x: 0, y: 0, width: 400, height: 20 },
+            children: [],
+          });
+        }
+        node = {
+          className: "RNSScreenView",
+          ...(depth === 2 ? { identifier: "card" } : {}),
+          frame: { x: 0, y: 0, width: 400, height: 800 },
+          windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+          children,
+        };
+      }
+      return {
+        windows: [
+          {
+            className: "UIWindow",
+            frame: { x: 0, y: 0, width: 400, height: 800 },
+            windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+            children: [node as Record<string, unknown>],
+          },
+        ],
+      };
+    };
+    const api = {
+      listConnectedBundleIds: () => ["com.example.app"],
+      getAppState: vi.fn(async (bundleId: string) => ({
+        bundleId,
+        applicationState: "active",
+        foregroundActiveSceneCount: 1,
+        foregroundInactiveSceneCount: 0,
+        backgroundSceneCount: 0,
+        unattachedSceneCount: 0,
+        isFrontmostCandidate: true,
+      })),
+      queryViewHierarchy: vi.fn(async (_bundleId, _method, params) =>
+        buildRaw(Math.min((params as { maxDepth: number }).maxDepth, deviceCap))
+      ),
+    } as unknown as NativeDevtoolsApi;
+
+    const { tree } = await queryFullHierarchyTree(registryFor(api), DEVICE);
+    const find = (node: DescribeNode): DescribeNode | undefined => {
+      if (node.identifier === "card") return node;
+      for (const child of node.children ?? []) {
+        const inner = find(child);
+        if (inner) return inner;
+      }
+      return undefined;
+    };
+    return find(tree)!;
+  };
+
+  it("hoists more text into an identified container as the cap admits more of it", async () => {
+    // The cost of the raised cap, claimed by the `FLOW_TREE_MAX_DEPTH` docblock.
+    // `assertReason`'s `text` arm quotes the hoisted subtreeText verbatim into a
+    // failing reason, and nothing truncates it later.
+    const shallow = (await hoistCardUnder(40)).subtreeText ?? "";
+    const deep = (await hoistCardUnder(100)).subtreeText ?? "";
+
+    expect(shallow).toContain("row-20-content");
+    expect(shallow).not.toContain("row-41-content");
+    expect(deep).toContain("row-41-content");
+    expect(deep).toContain("row-55-content");
+    expect(deep.length).toBeGreaterThan(shallow.length);
+  });
+
+  it("moves an `equals` text verdict against a container as the cap admits more of it", async () => {
+    // `assert: { text: { in: { id: card }, equals: <hoist> } }` reads the
+    // container's subtreeText, which now carries the deeper rows.
+    // `evaluateCondition` also tries the node's own label and value, but a
+    // testID'd wrapper has neither.
+    const shallow = await hoistCardUnder(40);
+    const deep = await hoistCardUnder(100);
+    const asRecordedAt40 = shallow.subtreeText ?? "";
+
+    expect(asRecordedAt40).toBe("row-30-content row-20-content");
+    expect(deep.subtreeText).toBe("row-55-content row-41-content row-30-content row-20-content");
+
+    // `contains` is the docblock's remedy for this, along with retargeting at the
+    // leaf.
+    expect(evaluateCondition("text", asRecordedAt40, [shallow], "equals")).toBe(true);
+    expect(evaluateCondition("text", asRecordedAt40, [deep], "equals")).toBe(false);
+    expect(evaluateCondition("text", asRecordedAt40, [deep], "contains")).toBe(true);
+  });
+
+  it("keeps native-target FailureError metadata while replacing impossible advice", async () => {
+    const api = {
+      listConnectedBundleIds: () => [] as string[],
+      getAppState: vi.fn(),
+    } as unknown as NativeDevtoolsApi;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error).toBeInstanceOf(FailureError);
+    expect(getFailureSignal(error)).toMatchObject({
+      error_code: FAILURE_CODES.NATIVE_TARGET_NO_CONNECTED_APPS,
+      failure_stage: "native_target_auto_resolve",
+    });
+    expect(error.message).not.toContain("provide bundleId explicitly");
+    expect(error.message).toContain("restart-app");
+    expect(error.message).toContain("com.apple.*");
+    expect(error.message).toContain("raw point taps");
+    // An injectable app launched outside Argent also reaches this branch, and the
+    // native-* tools still work for it: the precheck throws only for com.apple.*,
+    // and returns restart_required otherwise.
+    expect(error.message).not.toContain("native-describe-screen");
+    expect(error.message).not.toContain("Do not fall back to the native-devtools feature tools");
+    // The wording covers the six tools that run the throwing 3-arg precheck.
+    // "The native-* tools" would also cover native-devtools-status, which reports
+    // injectable:false from the 2-arg form, and native-profiler-*, which never
+    // prechecks.
+    expect(error.message).toContain("the native-devtools feature tools refuse it too");
+    expect(error.message).not.toContain("the native-* tools");
+    // Trimming at the sentence break keeps the source's second sentence out of the
+    // flow reason.
+    expect(error.message).toContain(
+      "(No native-devtools-connected apps are available for auto-targeting.)"
+    );
+  });
+
+  it("preserves app diagnostics and gives relevant advice when auto-targeting is ambiguous", async () => {
+    const api = {
+      listConnectedBundleIds: () => ["com.example.second", "com.example.first"],
+      getAppState: vi.fn(async (bundleId: string) => ({
+        bundleId,
+        applicationState: "background",
+        foregroundActiveSceneCount: 0,
+        foregroundInactiveSceneCount: 0,
+        backgroundSceneCount: 1,
+        unattachedSceneCount: 0,
+        isFrontmostCandidate: false,
+      })),
+    } as unknown as NativeDevtoolsApi;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error).toBeInstanceOf(FailureError);
+    expect(getFailureSignal(error)).toMatchObject({
+      error_code: FAILURE_CODES.NATIVE_TARGET_MULTIPLE_APPS_AMBIGUOUS,
+      failure_stage: "native_target_auto_resolve",
+    });
+    expect(error.message).toContain("com.example.first (applicationState=background");
+    expect(error.message).toContain("com.example.second (applicationState=background");
+    // Only the trailing advice line is dropped. The strip is anchored at the end
+    // of the message, not per line.
+    const source = await resolveNativeTargetApp(api, undefined).catch((err) => err);
+    expect(error.message).toContain(source.message.split("\n").slice(0, -1).join("\n"));
+    expect(error.message).toContain("Flow selectors auto-target and cannot name a bundleId");
+    expect(error.message).toContain("Foreground the intended app with launch-app");
+    // argent has no terminate tool, and restart-app would bring the cleared app
+    // back to the front.
+    expect(error.message).toContain("xcrun simctl terminate <udid> <bundleId>");
+    expect(error.message).toContain("argent has no terminate tool");
+    // Backgrounding does not help: the apps stay connected and, once suspended,
+    // cannot answer the state probe.
+    expect(error.message).not.toContain("background or terminate");
+    expect(error.message).not.toContain("Provide bundleId explicitly");
+    expect(error.message).not.toContain("guarantees instrumentation");
+  });
+
+  it("tells a lone backgrounded app to foreground (not relaunch) and keeps its diagnostic", async () => {
+    const api = {
+      listConnectedBundleIds: () => ["com.example.solo"],
+      getAppState: vi.fn(async (bundleId: string) => ({
+        bundleId,
+        applicationState: "background",
+        foregroundActiveSceneCount: 0,
+        foregroundInactiveSceneCount: 0,
+        backgroundSceneCount: 1,
+        unattachedSceneCount: 0,
+        isFrontmostCandidate: false,
+      })),
+    } as unknown as NativeDevtoolsApi;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error).toBeInstanceOf(FailureError);
+    expect(getFailureSignal(error)).toMatchObject({
+      error_code: FAILURE_CODES.NATIVE_TARGET_SINGLE_APP_NOT_FOREGROUND,
+      failure_stage: "native_target_auto_resolve",
+    });
+    // Preserves the per-app applicationState diagnostic from resolveNativeTargetApp.
+    expect(error.message).toContain("com.example.solo (applicationState=background");
+    // launch-app foregrounds without terminating, so existing instrumentation
+    // survives.
+    expect(error.message).toContain("Bring that app to the foreground with launch-app");
+    expect(error.message).toContain("already instrumented");
+    // Not the impossible advice, and not the no-connected-app relaunch text.
+    expect(error.message).not.toContain("Provide bundleId explicitly");
+    expect(error.message).not.toContain("guarantees instrumentation");
+  });
+
+  it("does not call a suspended-but-connected app uninstrumented", async () => {
+    // iOS suspends a backgrounded app within about 1s. The devtools socket stays
+    // open, but Application.getState stops answering and the RPC times out.
+    const api = {
+      listConnectedBundleIds: () => ["com.example.solo"],
+      getAppState: vi.fn(async () => {
+        throw new FailureError("ViewInspector RPC timed out: Application.getState", {
+          error_code: FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT,
+          failure_stage: "native_devtools_rpc_request",
+          failure_area: "tool_server",
+          error_kind: "timeout",
+        });
+      }),
+    } as unknown as NativeDevtoolsApi;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(getFailureSignal(error)).toMatchObject({
+      error_code: FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT,
+    });
+    // The dotted identifier names the RPC that hung. Keying on a bare period used
+    // to cut it off.
+    expect(error.message).toContain("(ViewInspector RPC timed out: Application.getState)");
+    expect(error.message).toContain("com.example.solo");
+    // The app is instrumented, so relaunching it discards the flow's state.
+    expect(error.message).toContain("do not relaunch");
+    expect(error.message).toContain("launch-app");
+    expect(error.message).not.toContain("guarantees instrumentation");
+    expect(error.message).not.toContain("restart-app");
+  });
+
+  it("blames the unreadable connection, not the healthy frontmost app", async () => {
+    // A second instrumented app, left suspended, fails the whole state probe even
+    // though the flow's own app is frontmost and readable.
+    const api = {
+      listConnectedBundleIds: () => ["com.example.driven", "com.example.stale"],
+      getAppState: vi.fn(async (bundleId: string) => {
+        if (bundleId === "com.example.stale") {
+          throw new FailureError("ViewInspector RPC timed out: Application.getState", {
+            error_code: FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT,
+            failure_stage: "native_devtools_rpc_request",
+            failure_area: "tool_server",
+            error_kind: "timeout",
+          });
+        }
+        return {
+          bundleId,
+          applicationState: "active",
+          foregroundActiveSceneCount: 1,
+          foregroundInactiveSceneCount: 0,
+          backgroundSceneCount: 0,
+          unattachedSceneCount: 0,
+          isFrontmostCandidate: true,
+        };
+      }),
+    } as unknown as NativeDevtoolsApi;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error.message).toContain("com.example.driven, com.example.stale");
+    expect(error.message).toContain("xcrun simctl terminate <udid> <bundleId>");
+    // These apps are instrumented, so relaunching one discards state and does not
+    // fix the read.
+    expect(error.message).not.toMatch(/Relaunch with restart-app/i);
+    expect(error.message).toContain("do not relaunch");
+  });
+
+  it("addresses the terminate command to the device set the simulator lives in", async () => {
+    // simctl scopes every operation to a single device set, so the bare command
+    // cannot resolve a udid from a configured `ios.additionalDeviceSets` set, such
+    // as a Radon IDE simulator.
+    const RADON = "/Users/dev/Library/Caches/com.swmansion.radon-ide/Devices/iOS";
+    rememberDeviceSet(DEVICE.id, RADON);
+    const api = {
+      listConnectedBundleIds: () => ["com.example.driven", "com.example.stale"],
+      getAppState: vi.fn(rpcTimeout),
+    } as unknown as NativeDevtoolsApi;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error.message).toContain(`xcrun simctl --set ${RADON} terminate <udid> <bundleId>`);
+
+    // The ambiguous branch offers the same command.
+    const ambiguous = {
+      listConnectedBundleIds: () => ["com.example.driven", "com.example.stale"],
+      getAppState: vi.fn(async (bundleId: string) =>
+        appState(bundleId, {
+          applicationState: "background",
+          isFrontmostCandidate: false,
+          foregroundActiveSceneCount: 0,
+          backgroundSceneCount: 1,
+        })
+      ),
+    } as unknown as NativeDevtoolsApi;
+
+    const ambiguousError = await queryFullHierarchyTree(registryFor(ambiguous), DEVICE).catch(
+      (err) => err
+    );
+
+    expect(ambiguousError.message).toContain(
+      `xcrun simctl --set ${RADON} terminate <udid> <bundleId>`
+    );
+  });
+
+  // One entry per failure branch of `queryFullHierarchyTree`, iterated by the
+  // length guard below. The bundle ids are long on purpose, so the measured
+  // budget holds for real ones.
+  //
+  // `launched` covers the branch auto-targeting never reaches: a flow that ran a
+  // `launch:` step passes that id down, and with nothing connected the read fails
+  // through `unreadableHierarchyReason`. Those entries hold the longest reason
+  // (`unregistered`, 775 chars) and the branch the recorder takes, since
+  // `captureTapSelector` passes a launched id on every captured tap.
+  const LONG_ID = "com.example.enterprise.mobile.client";
+  const rpcTimeout = (): never => {
+    throw new FailureError("ViewInspector RPC timed out: Application.getState", {
+      error_code: FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT,
+      failure_stage: "native_devtools_rpc_request",
+      failure_area: "tool_server",
+      error_kind: "timeout",
+    });
+  };
+  const appState = (bundleId: string, over: Record<string, unknown> = {}) => ({
+    bundleId,
+    applicationState: "active",
+    foregroundActiveSceneCount: 1,
+    foregroundInactiveSceneCount: 0,
+    backgroundSceneCount: 0,
+    unattachedSceneCount: 0,
+    isFrontmostCandidate: true,
+    ...over,
+  });
+  const notFrontmost = { applicationState: "background", isFrontmostCandidate: false } as const;
+
+  const targetingFailures = (
+    appCount: number
+  ): { branch: string; api: NativeDevtoolsApi; launched?: string }[] => {
+    const ids = Array.from({ length: appCount }, (_, i) => `${LONG_ID}${i}`);
+    // Nothing connected plus a launched id is the only shape that reaches
+    // `unreadableHierarchyReason`. One entry per state it diagnoses.
+    const launchGone = (
+      state: string,
+      bundleId = ids[0],
+      label = state
+    ): { branch: string; api: NativeDevtoolsApi; launched?: string } => ({
+      branch: `launched app not connected: ${label}`,
+      api: {
+        listConnectedBundleIds: () => [] as string[],
+        appConnectionState: vi.fn(async () => state),
+        getAppState: vi.fn(),
+      } as unknown as NativeDevtoolsApi,
+      launched: bundleId,
+    });
+    return [
+      {
+        branch: "ambiguous connected set",
+        api: {
+          listConnectedBundleIds: () => ids,
+          getAppState: vi.fn(async (b: string) =>
+            appState(b, { ...notFrontmost, foregroundActiveSceneCount: 0, backgroundSceneCount: 1 })
+          ),
+        } as unknown as NativeDevtoolsApi,
+      },
+      {
+        branch: "single app not foreground",
+        api: {
+          listConnectedBundleIds: () => [ids[0]],
+          getAppState: vi.fn(async (b: string) =>
+            appState(b, { ...notFrontmost, foregroundActiveSceneCount: 0, backgroundSceneCount: 1 })
+          ),
+        } as unknown as NativeDevtoolsApi,
+      },
+      {
+        branch: "state probe failed, connections live",
+        api: {
+          listConnectedBundleIds: () => ids,
+          getAppState: vi.fn(rpcTimeout),
+        } as unknown as NativeDevtoolsApi,
+      },
+      {
+        branch: "no connected app",
+        api: {
+          listConnectedBundleIds: () => [] as string[],
+          getAppState: vi.fn(),
+        } as unknown as NativeDevtoolsApi,
+      },
+      {
+        branch: "target dropped its connection",
+        api: (() => {
+          let connected = [ids[0]];
+          return {
+            listConnectedBundleIds: () => {
+              const now = connected;
+              connected = [];
+              return now;
+            },
+            getAppState: vi.fn(async (b: string) => appState(b)),
+          } as unknown as NativeDevtoolsApi;
+        })(),
+      },
+      {
+        branch: "no windows",
+        api: {
+          listConnectedBundleIds: () => [ids[0]],
+          getAppState: vi.fn(async (b: string) => appState(b)),
+          queryViewHierarchy: vi.fn(async () => ({ windows: [] })),
+        } as unknown as NativeDevtoolsApi,
+      },
+      {
+        branch: "getFullHierarchy errored",
+        api: {
+          listConnectedBundleIds: () => [ids[0]],
+          getAppState: vi.fn(async (b: string) => appState(b)),
+          queryViewHierarchy: vi.fn(async () => ({ error: "serializer busy" })),
+        } as unknown as NativeDevtoolsApi,
+      },
+      ...["not_running", "stale_process", "connecting", "indeterminate", "unregistered"].map(
+        (state) => launchGone(state)
+      ),
+      // Two branches answer before the state switch: a connection that arrived
+      // mid-read, and a bundle the dylib may not load into.
+      launchGone("connected"),
+      launchGone("not_running", "com.apple.Preferences", "non-injectable bundle"),
+    ];
+  };
+
+  it("keeps every targeting reason short enough to repeat per step", async () => {
+    // The recorder embeds this reason in the warning for each captured tap, and a
+    // failing `await` repeats it once per poll. At about 900 characters, one
+    // stuck screen made the recorder the largest context consumer of a session.
+    for (const { branch, api, launched } of targetingFailures(2)) {
+      // Unpinned: these branches are auto-targeting's, and a launched id is only
+      // the hint auto-resolve falls back to.
+      const error = await queryFullHierarchyTree(
+        registryFor(api),
+        DEVICE,
+        launched ? { bundleId: launched, pinned: false, probeAnswered: false } : undefined
+      ).catch((err) => err);
+      expect(`${branch}: ${error.message.length}`).toBe(
+        `${branch}: ${Math.min(error.message.length, MAX_TARGETING_REASON_CHARS)}`
+      );
+    }
+    // The service-unresolvable wrap never reaches an api, so it is built here.
+    const unresolvable = await queryFullHierarchyTree(
+      {
+        resolveService: vi.fn(async () => {
+          throw new Error("no simulator-server for 0000…00ab");
+        }),
+      } as unknown as Registry,
+      DEVICE
+    ).catch((err) => err);
+    expect(unresolvable.message.length).toBeLessThanOrEqual(MAX_TARGETING_REASON_CHARS);
+  });
+
+  it("resolves the device set only for a reason that offers the terminate command", async () => {
+    // With additional sets configured, a default-set udid matches none of them,
+    // so `deviceSetForUdid` caches no verdict and re-runs the whole
+    // `simctl list devices` sweep on every call. Building the command up front
+    // charged that to every branch, including the four that never quote it - and
+    // a failing `await:` rebuilds its reason once per poll.
+    const lookups = vi.mocked(deviceSetForUdid);
+    // One connection covers the sub-case with nothing to clear: the probe-failure
+    // branch offers the command only when a second app is connected.
+    for (const appCount of [1, 2]) {
+      for (const { branch, api, launched } of targetingFailures(appCount)) {
+        lookups.mockClear();
+        const error = await queryFullHierarchyTree(
+          registryFor(api),
+          DEVICE,
+          launched ? { bundleId: launched, pinned: false, probeAnswered: false } : undefined
+        ).catch((err) => err);
+        const quotesCommand = error.message.includes("xcrun simctl");
+        expect(`${branch} x${appCount}: ${lookups.mock.calls.length}`).toBe(
+          `${branch} x${appCount}: ${quotesCommand ? 1 : 0}`
+        );
+      }
+    }
+  });
+
+  it("keeps the reason the same size as connections pile up", async () => {
+    // The device must not be able to spend the budget. Both list-bearing branches
+    // used to grow per app: the ambiguous one measured 778, 1000 and 1444 chars at
+    // 2, 4 and 8 apps.
+    for (const branch of ["ambiguous connected set", "state probe failed, connections live"]) {
+      const lengths = await Promise.all(
+        [2, 4, 16].map(async (appCount) => {
+          const { api } = targetingFailures(appCount).find((f) => f.branch === branch)!;
+          const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+          return error.message.length as number;
+        })
+      );
+      // Not byte-identical: the "(+N more)" count gains a digit. Four more
+      // connections cost one digit, not four lines of about 110 characters.
+      expect(`${branch}: ${lengths[2] - lengths[1] < 5}`).toBe(`${branch}: true`);
+      expect(lengths[2]).toBeLessThanOrEqual(MAX_TARGETING_REASON_CHARS);
+    }
+  });
+
+  it("reports nothing withheld when the connected set is exactly at the cap", async () => {
+    // The boundary both cap helpers turn on. Away from it, `<=` and `<` behave the
+    // same. With `<`, a list that dropped nothing still gets "(+0 more)".
+    for (const { branch, api } of targetingFailures(MAX_LISTED_APPS)) {
+      if (branch !== "ambiguous connected set" && branch !== "state probe failed, connections live")
+        continue;
+      const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+      for (let i = 0; i < MAX_LISTED_APPS; i++) {
+        expect(`${branch}: ${error.message.includes(`${LONG_ID}${i}`)}`).toBe(`${branch}: true`);
+      }
+      expect(`${branch}: ${/\(\+\d+ more/.test(error.message)}`).toBe(`${branch}: false`);
+    }
+  });
+
+  it("says how many connected apps a capped reason left out", async () => {
+    const { api } = targetingFailures(5).find((f) => f.branch === "ambiguous connected set")!;
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error.message).toContain(`${LONG_ID}0 (applicationState=background`);
+    expect(error.message).toContain(`${LONG_ID}1 (applicationState=background`);
+    expect(error.message).not.toContain(`${LONG_ID}2 (`);
+    expect(error.message).toContain("(+3 more connected apps)");
+
+    const probe = targetingFailures(5).find(
+      (f) => f.branch === "state probe failed, connections live"
+    )!;
+    const probeError = await queryFullHierarchyTree(registryFor(probe.api), DEVICE).catch(
+      (err) => err
+    );
+    expect(probeError.message).toContain(`Connected: ${LONG_ID}0, ${LONG_ID}1 (+3 more).`);
+  });
+
+  it("reports an unresolvable native-devtools service and keeps the original error", async () => {
+    const cause = new Error("no simulator-server for 0000…00ab");
+    const registry = {
+      resolveService: vi.fn(async () => {
+        throw cause;
+      }),
+    } as unknown as Registry;
+
+    const error = await queryFullHierarchyTree(registry, DEVICE).catch((err) => err);
+
+    expect(error.message).toContain("native devtools is unavailable");
+    expect(error.message).toContain("no simulator-server for 0000…00ab");
+    // A plain Error carries no failure signal, so the wrapper stays a plain Error
+    // rather than inventing one.
+    expect(error).not.toBeInstanceOf(FailureError);
+    expect(error.cause).toBe(cause);
+  });
+
+  it("keeps the original error as the cause of a wrapped targeting failure", async () => {
+    const api = {
+      listConnectedBundleIds: () => [] as string[],
+      getAppState: vi.fn(),
+    } as unknown as NativeDevtoolsApi;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error.cause).toBeInstanceOf(FailureError);
+    // The rendered message keeps only the source's first sentence. The cause keeps
+    // the full text.
+    expect((error.cause as Error).message).toContain("provide bundleId explicitly");
+    expect(error.message).not.toContain("provide bundleId explicitly");
+  });
+
+  it("reports a dropped connection, not a pre-instrumentation launch, when the target needs a restart", async () => {
+    // Auto-resolution only yields ids from `listConnectedBundleIds()`, so a target
+    // missing from that map later means the socket dropped between the resolve and
+    // the read. The mock is connected for the resolve and gone by the re-read.
+    let connected = ["com.example.app"];
+    const api = {
+      listConnectedBundleIds: () => {
+        const now = connected;
+        connected = [];
+        return now;
+      },
+      getAppState: vi.fn(async (bundleId: string) => ({
+        bundleId,
+        applicationState: "active",
+        foregroundActiveSceneCount: 1,
+        foregroundInactiveSceneCount: 0,
+        backgroundSceneCount: 0,
+        unattachedSceneCount: 0,
+        isFrontmostCandidate: true,
+      })),
+    } as unknown as NativeDevtoolsApi;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("com.example.app answered the target probe and then dropped");
+    // The app was instrumented, so the message names the retry before the
+    // relaunch.
+    expect(error.message).toContain("It was instrumented");
+    expect(error.message).toContain("a retry may ride this out");
+    expect(error.message).not.toContain("launched before argent's instrumentation loaded");
+    expect(error.message).toContain("relaunch with restart-app");
+    expect(error.message).not.toContain("launch-app, or a flow");
+  });
+});

--- a/packages/tool-server/test/flows/flow-ios-tree.test.ts
+++ b/packages/tool-server/test/flows/flow-ios-tree.test.ts
@@ -17,15 +17,15 @@ import { evaluateCondition, selectorToFrame } from "../../src/utils/ui-tree-matc
 import { resolveNativeTargetApp } from "../../src/utils/native-target-app";
 import {
   __resetDeviceSetCacheForTesting,
-  deviceSetForUdid,
   rememberDeviceSet,
+  simctlTargetForUdid,
 } from "../../src/utils/ios-device-sets";
 
 // A pass-through spy, so the case below can count which reasons pay for the
 // device-set lookup while every other case keeps the real memo.
 vi.mock("../../src/utils/ios-device-sets", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/utils/ios-device-sets")>();
-  return { ...actual, deviceSetForUdid: vi.fn(actual.deviceSetForUdid) };
+  return { ...actual, simctlTargetForUdid: vi.fn(actual.simctlTargetForUdid) };
 });
 
 const DEVICE = {
@@ -541,6 +541,17 @@ describe("flow iOS full-hierarchy source", () => {
         } as unknown as NativeDevtoolsApi,
       },
       {
+        // The launched app is gone while a sibling still answers the map. The
+        // fan-out still times out, so this is the probe-failure branch with the
+        // one app a relaunch is right for missing from it.
+        branch: "state probe failed, launched app not connected",
+        api: {
+          listConnectedBundleIds: () => ids,
+          getAppState: vi.fn(rpcTimeout),
+        } as unknown as NativeDevtoolsApi,
+        launched: "com.example.under.test",
+      },
+      {
         branch: "target dropped its connection",
         api: (() => {
           let connected = [ids[0]];
@@ -609,12 +620,12 @@ describe("flow iOS full-hierarchy source", () => {
   });
 
   it("resolves the device set only for a reason that offers the terminate command", async () => {
-    // With additional sets configured, a default-set udid matches none of them,
-    // so `deviceSetForUdid` caches no verdict and re-runs the whole
-    // `simctl list devices` sweep on every call. Building the command up front
-    // charged that to every branch, including the four that never quote it - and
-    // a failing `await:` rebuilds its reason once per poll.
-    const lookups = vi.mocked(deviceSetForUdid);
+    // The resolve is not free: an unknown udid re-probes `simctl list devices`
+    // on every call, and it is also where the external-provider `simctl` grant
+    // is checked. Building the command up front charged both to every branch,
+    // including the ones that never quote it - and a failing `await:` rebuilds
+    // its reason once per poll.
+    const lookups = vi.mocked(simctlTargetForUdid);
     // One connection covers the sub-case with nothing to clear: the probe-failure
     // branch offers the command only when a second app is connected.
     for (const appCount of [1, 2]) {
@@ -635,8 +646,9 @@ describe("flow iOS full-hierarchy source", () => {
 
   it("keeps the reason the same size as connections pile up", async () => {
     // The device must not be able to spend the budget. Both list-bearing branches
-    // used to grow per app: the ambiguous one measured 778, 1000 and 1444 chars at
-    // 2, 4 and 8 apps.
+    // used to grow by one ~125-char entry per app: the ambiguous one measures 702
+    // chars at 2 apps, where the cap is inert, and would reach about 950 at 4 and
+    // 1450 at 8.
     for (const branch of ["ambiguous connected set", "state probe failed, connections live"]) {
       const lengths = await Promise.all(
         [2, 4, 16].map(async (appCount) => {
@@ -683,6 +695,57 @@ describe("flow iOS full-hierarchy source", () => {
       (err) => err
     );
     expect(probeError.message).toContain(`Connected: ${LONG_ID}0, ${LONG_ID}1 (+3 more).`);
+  });
+
+  it("drops the terminate advice when the device's provider withholds the simctl grant", async () => {
+    // `simctlTargetForUdid` is that gate: an external provider can grant
+    // native-devtools (so flows read the tree) while withholding `simctl`. A
+    // command argent itself would refuse must not be quoted back, nor the
+    // provider's device-set path with it.
+    vi.mocked(simctlTargetForUdid).mockRejectedValueOnce(
+      new Error("ext:provider:0001 does not grant simctl")
+    );
+    const { api } = targetingFailures(3).find((f) => f.branch === "ambiguous connected set")!;
+
+    const error = await queryFullHierarchyTree(registryFor(api), DEVICE).catch((err) => err);
+
+    expect(error.message).not.toContain("xcrun");
+    expect(error.message).not.toContain("clear the others");
+    // The remedy that needs no simctl still stands, and the sentence still ends.
+    expect(error.message).toContain("Foreground the intended app with launch-app");
+    expect(error.message).toContain("then retry.");
+  });
+
+  it("sends the launched app to restart-app when it is the connection that is missing", async () => {
+    // The advice this PR exists to remove: launch-app does not terminate, so it
+    // cannot instrument an app that is no longer connected. It stays the remedy
+    // only while the launched app IS one of the connected, merely-suspended ones.
+    const gone = targetingFailures(2).find(
+      (f) => f.branch === "state probe failed, launched app not connected"
+    )!;
+    const goneError = await queryFullHierarchyTree(registryFor(gone.api), DEVICE, {
+      bundleId: gone.launched!,
+      pinned: false,
+      probeAnswered: false,
+    }).catch((err) => err);
+
+    expect(goneError.message).toContain(`${gone.launched} — the app this flow launched — is NOT`);
+    expect(goneError.message).toContain("relaunch it with restart-app");
+    expect(goneError.message).not.toContain("foreground the app the flow drives with launch-app");
+
+    // Same branch, launched app present among the connected: the app is only
+    // suspended, so foregrounding it is still the remedy and a relaunch is not.
+    const live = targetingFailures(2).find(
+      (f) => f.branch === "state probe failed, connections live"
+    )!;
+    const liveError = await queryFullHierarchyTree(registryFor(live.api), DEVICE, {
+      bundleId: `${LONG_ID}0`,
+      pinned: false,
+      probeAnswered: false,
+    }).catch((err) => err);
+
+    expect(liveError.message).toContain("foreground the app the flow drives with launch-app");
+    expect(liveError.message).not.toContain("relaunch it with restart-app");
   });
 
   it("reports an unresolvable native-devtools service and keeps the original error", async () => {

--- a/packages/tool-server/test/flows/flow-record-cross-tree.test.ts
+++ b/packages/tool-server/test/flows/flow-record-cross-tree.test.ts
@@ -5,6 +5,11 @@ import * as path from "node:path";
 import type { Registry } from "@argent/registry";
 import { ToolNotFoundError, ToolExecutionError } from "@argent/registry";
 import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
+import type { NativeDevtoolsApi } from "../../src/blueprints/native-devtools";
+import {
+  __resetDeviceSetCacheForTesting,
+  rememberDeviceSet,
+} from "../../src/utils/ios-device-sets";
 
 // `await-ui-element` reads the agent-facing describe tree; the `await:`/`assert:`
 // directive polish converts the step into reads `fetchFlowTree`'s. Neither tree
@@ -38,7 +43,10 @@ import { createAwaitUiElementTool, evaluateMatches } from "../../src/tools/await
 import { assertSupported } from "../../src/utils/capability";
 import { resolveDevice } from "../../src/utils/device-info";
 import { findAll, type Selector } from "../../src/utils/ui-tree-match";
-import { adaptFullHierarchyToDescribeResult } from "../../src/tools/flows/flow-ios-tree";
+import {
+  adaptFullHierarchyToDescribeResult,
+  queryFullHierarchyTree,
+} from "../../src/tools/flows/flow-ios-tree";
 import { adaptFullAndroidHierarchyToDescribeResult } from "../../src/tools/flows/flow-android-tree";
 import { parseUiAutomatorDump } from "../../src/tools/describe/platforms/android/uiautomator-parser";
 import { adaptChromiumTreeForFlows } from "../../src/tools/flows/flow-chromium-tree";
@@ -277,6 +285,9 @@ beforeEach(async () => {
 
 afterEach(async () => {
   __resetRecordingsForTesting();
+  // The udid to device-set memo is module state; a seeded entry would outlive
+  // the case that seeded it.
+  __resetDeviceSetCacheForTesting();
   await fs.rm(tmpDir, { recursive: true, force: true });
   vi.clearAllMocks();
 });
@@ -1194,14 +1205,31 @@ describe("a recorded wait is re-probed against the runner's tree", () => {
     expect(warning).not.toContain("no directive takes a bundleId");
   });
 
-  // The quoted reason ends "provide bundleId explicitly", but no directive takes one.
-  it("iOS: says the bundleId its quoted reason recommends cannot reach the probe", async () => {
+  /**
+   * The iOS caveat rides on a reason the RUNNER's own tree source writes, so
+   * build that reason with the real function. A hand-copied one is what let the
+   * caveat go on describing a message production had stopped emitting.
+   */
+  async function realIosTargetingFailure(): Promise<Error> {
+    // Seed the device set so `terminateCommand` answers from the memo instead of
+    // probing simctl.
+    rememberDeviceSet(IOS, null);
+    const api = {
+      listConnectedBundleIds: () => [] as string[],
+      getAppState: vi.fn(),
+    } as unknown as NativeDevtoolsApi;
+    const registry = { resolveService: vi.fn(async () => api) } as unknown as Registry;
+    return (await queryFullHierarchyTree(registry, resolveDevice(IOS)).catch(
+      (err: unknown) => err
+    )) as Error;
+  }
+
+  // That reason carries its own remedy, so the caveat must not answer it with a
+  // second one.
+  it("iOS: adds no remedy of its own to the reason the runner's source wrote", async () => {
+    const failure = await realIosTargetingFailure();
     fetchRunnerTree = async () => {
-      throw new Error(
-        "No native-devtools-connected apps are available for auto-targeting. " +
-          "Launch or restart the app first, provide bundleId explicitly, or use screenshot " +
-          "to inspect visible Home/system UI."
-      );
+      throw failure;
     };
     await startRecording("iosblind");
 
@@ -1211,16 +1239,27 @@ describe("a recorded wait is re-probed against the runner's tree", () => {
     });
     const warning = warningOf(result, "iosblind");
 
-    // The quoted reason still arrives whole — its tail is the recovery.
-    expect(warning).toContain("provide bundleId explicitly");
+    // The reason arrives whole, its own recovery included.
+    expect(warning).toContain(failure.message);
+    expect(warning).toContain("Relaunch with restart-app");
+    // launch-app does not terminate, so it cannot instrument a process that is
+    // already running — the opposite move to the one just quoted.
+    expect(warning).not.toContain("relaunch it with `launch-app`");
+    // And no advice attributed to the reason that it does not carry.
+    expect(warning).not.toContain("provide bundleId explicitly");
+    expect(warning).not.toContain("quoted from the shared native-target");
+    // The reason is not always the iOS tree source's: a blind-but-not-throwing
+    // read is described by the poll loop instead, and names no recovery at all.
+    // So the caveat asserts nothing about where the reason came from.
+    expect(warning).not.toContain("tree source writes it");
+    // What the reason cannot see — this step — is still said.
     expect(warning).toContain("no directive takes a bundleId");
-    expect(warning).toContain("`launch-app`");
-    expect(warning).toContain("keep the check as a raw `tool:` step");
   });
 
   it("iOS: the caveat holds when the step DID carry a bundleId", async () => {
+    const failure = await realIosTargetingFailure();
     fetchRunnerTree = async () => {
-      throw new Error("no connected app; provide bundleId explicitly");
+      throw failure;
     };
     await startRecording("iosblindbundle");
 

--- a/packages/tool-server/test/flows/flow-record-tap.test.ts
+++ b/packages/tool-server/test/flows/flow-record-tap.test.ts
@@ -264,6 +264,48 @@ describe("flow-add-step tap selector capture", () => {
     expect(await recordedSteps()).toEqual([{ kind: "tap", x: 0.2, y: 0.52 }]);
   });
 
+  it("flags a role-only selector rather than recording the downgrade silently", async () => {
+    // The raised iOS flow tree depth cap now keeps unlabeled icons. One is the
+    // smallest frame under the tap, so `nodeAtPoint` picks it and
+    // `deriveSelector` falls back to its role. Replay then depends on that icon
+    // ranking first for the role.
+    setTree([
+      n({
+        identifier: "product-card",
+        frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+        children: [n({ role: "AXImage", frame: { x: 0.48, y: 0.48, width: 0.04, height: 0.04 } })],
+      }),
+    ]);
+
+    const result = await recordTap({ x: 0.5, y: 0.5 });
+
+    expect(result.message).toContain("matches by role alone");
+    expect(await recordedSteps()).toEqual([{ kind: "tap", selector: { role: "AXImage" } }]);
+  });
+
+  // `roleOnlySelectorWarning` withholds the warning under separate guards for an
+  // identifier and for visible text, so both need a case. Each node also carries
+  // a role, so the withholding follows from the stable field, not a missing role.
+  it.each([
+    {
+      carries: "an id",
+      node: { identifier: "add-to-cart" },
+      selector: { identifier: "add-to-cart" },
+    },
+    { carries: "text", node: { label: "Add to cart" }, selector: { text: "Add to cart" } },
+  ])("does not flag a selector that carries $carries", async ({ node, selector }) => {
+    setTree([
+      n({ ...node, role: "AXButton", frame: { x: 0.3, y: 0.5, width: 0.4, height: 0.06 } }),
+    ]);
+
+    const result = await recordTap({ x: 0.5, y: 0.52 });
+
+    // Assert the step too. A coordinate fallback also carries no role-only
+    // warning, so the negative check alone proves nothing.
+    expect(await recordedSteps()).toEqual([{ kind: "tap", selector }]);
+    expect(result.message).not.toContain("matches by role alone");
+  });
+
   it("records the selector with a caveat when captured from the fallback tree source", async () => {
     setTree(
       [n({ label: "Settings", frame: { x: 0.3, y: 0.5, width: 0.4, height: 0.06 } })],
@@ -274,6 +316,30 @@ describe("flow-add-step tap selector capture", () => {
 
     expect(result.message).toContain("fallback ax-service tree");
     expect(await recordedSteps()).toEqual([{ kind: "tap", selector: { text: "Settings" } }]);
+  });
+
+  it("reports both caveats when a role-only selector comes off the fallback tree", async () => {
+    // The two warnings are independent and can fire on one capture. A
+    // fallback-source read is the most likely to return an unlabeled node. Other
+    // tests cover each warning alone, so only this test holds the pair.
+    setTree(
+      [
+        n({
+          identifier: "product-card",
+          frame: { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+          children: [
+            n({ role: "AXImage", frame: { x: 0.48, y: 0.48, width: 0.04, height: 0.04 } }),
+          ],
+        }),
+      ],
+      "ax-service"
+    );
+
+    const result = await recordTap({ x: 0.5, y: 0.5 });
+
+    expect(result.message).toContain("matches by role alone");
+    expect(result.message).toContain("fallback ax-service tree");
+    expect(await recordedSteps()).toEqual([{ kind: "tap", selector: { role: "AXImage" } }]);
   });
 
   it("keeps coordinates with a warning when the tree fetch fails", async () => {


### PR DESCRIPTION
Rebased onto `main` (was stacked on #720), with a single hunk dropped — see
**Restack notes** at the bottom. Two commits: `a71c0f0` is exactly this PR's own
delta from the stacked version, `54fe761` is a review pass over it on the
post-rebase base. Squash on merge.

## Depth cap: 40 → 100

The flow selector tree capped raw `UIView` nesting at **40**. That does not clear the invisible wrapper layers React Native stacks on every screen — nested navigators (`RNSScreenStackView` → `RNSScreenView`, often two deep) plus a drawer/root wrapper routinely bury on-screen content **40–60 levels down** before the first tappable view.

In a deeply nested production app, plainly visible interactive elements sat at depths **41–62**. So `id:` and `text:` selectors silently failed to resolve, and only coordinate taps worked — which is the origin of coordinate-heavy flows on those apps.

The overflow is **silent**: nothing reports "truncated", selectors just stop matching. So the new cap carries generous headroom rather than hugging the deepest observed measurement.

**What it costs.** The tree itself is internal to selector resolution — consumed by `selectorToFrame`/`evaluateCondition`, never returned — so no tool result carries it. Text derived from it does reach the agent, though: `assertReason`'s `text` arm quotes the matched node's hoisted `subtreeText` verbatim into a failing `assert`/`await` reason, and nothing truncates it downstream. Descendants a depth-40 read dropped now hoist, so that quoted string grows with the cap. That is the trade — under the old cap those selectors did not resolve at all. Otherwise the cap only grows the `getFullHierarchy` payload over the native-devtools socket, which is already field-limited: ~11KB at depth 40, ~15KB at 48, and nothing at all past the tree's real depth.

## Targeting errors that could not be acted on

**`Provide bundleId explicitly`** — `resolveNativeTargetApp`'s own errors close with that advice. A flow selector step cannot follow it: the call hardcodes auto-targeting. Each failure now carries the remedy that actually exists:

- **ambiguous connected set** — foreground the intended app with `launch-app` (which does not terminate, so the instrumentation it already has survives), and clear the others with `xcrun simctl terminate` (argent exposes no terminate tool, and `restart-app` would just bring that app back to the front). The command is resolved through `simctlTargetForUdid`, so it carries the device's own CoreSimulator `--set` — a simulator from a configured `ios.additionalDeviceSets` resolves — and passes the same entitlement gate an actual spawn does. An external provider (#735) that grants `native-devtools` but withholds `simctl` gets the clause dropped whole, rather than a command argent itself would refuse and its device-set path quoted back.
- **a lone connected app that is not foreground** — same foreground remedy; it is already instrumented, so a relaunch would only discard state.
- **the state probe failed while connections are live** — which app is missing decides the remedy. While the app the flow launched is still in the live connections map it is merely suspended: foreground it, do not relaunch, since a relaunch discards the state the flow built up and cannot help when another app is the stale one. When it is *absent* from that map it is the one thing a relaunch fixes, so the reason names it and sends it to `restart-app` — `launch-app` cannot instrument a process that is already gone.
- **no connected app** — this is the one state a relaunch fixes, through `restart-app` or a flow `launch` step.

**`launch-app, or a flow launch step`** — this was wrong in a way that wastes a cycle. `launch-app` does **not** terminate first, so against an app already running from Metro/Expo, Xcode, or its home-screen icon it only foregrounds that same uninstrumented process, and the next read fails identically. Only `restart-app` (terminate + relaunch) guarantees an instrumented launch whatever was already running.

These reasons are repeated per step — the recorder embeds one in the warning for every captured tap, and a failing `await:` repeats it per poll — so the two that enumerate connected apps are capped at two entries plus a count of what was left out, and the whole set is held under a documented ceiling by a test that iterates every branch. That ceiling is 800 characters. It is set by the `unregistered` reason, which measures 738 plus the bundle id, so it holds for the ids seen in practice and not for every one: a 63-character id clears it. Every figure quoted at `MAX_LISTED_APPS` and `MAX_TARGETING_REASON_CHARS` was re-measured against the current code.

`FailureError` data is preserved when these messages wrap an underlying error, so the failure code still reaches callers that switch on it.

## Recorder: role-only selectors

A tapped node with no identifier and no visible text replays on role alone, which holds only while that element keeps winning `selectorToFrame`'s ranking. The raised depth cap makes this more common — an unlabeled icon the old cap truncated away, which left `nodeAtPoint` to pick its `testID` container, is now present and is the smaller frame under the tap. The recorder now warns instead of recording that silently.

## Launch gate: why the wait is per bundle

`treeSourceGate` already waits for every bundle, `com.apple.*` included, and withholds only the *verdict* for a non-injectable one. This PR documents why that wait is load-bearing rather than a readiness formality: it is what ties the launched bundle to the app a later selector step auto-targets, since `resolveNativeTargetApp(api, undefined)` never compares the two. Skipping it per bundle could hand the next step a different app's hierarchy and still report the run green.

The matching fallback advice lands in the no-connected-app reason: for a `com.apple.*` bundle that never connects, drive the app with raw point taps and `tool: await-ui-element` steps, which read the AX tree instead of selectors.

## Restack notes

- `a71c0f0` keeps the stacked version's per-file insert/delete counts unchanged. `54fe761` is the review pass on top: the entitlement gate above, the launched-app-gone remedy, four comments this branch left stale or overstated, and the re-measured figures.
- No docs update needed — nothing in `packages/docs` documents the depth cap, the targeting reasons or the recorder warning.
- Conflict resolved in `flow-ios-tree.ts`: #944 (physical iOS support) landed new device-tree functions in the same region. Both blocks kept — the targeting helpers sit next to `queryFullHierarchyTree`, which they serve; the device block follows.
- **One hunk dropped:** a 35-line test in `flow-hidden-blank-reads.test.ts` asserting that an `exists` miss does not quote hoisted `subtreeText`. It is written against `compatibilityMissNote` / "typographic variant", which #720 introduces and `main` does not have. Worth re-adding to that PR, or here once #720 lands.
- Verified on this base: `tsc --build` and `typecheck:tests` clean; 254 tests across the 4 touched test files pass; full tool-server suite 433 files / 6190 passed / 1 skipped (one run showed a single unrelated load flake, green on a clean re-run); eslint, prettier and both knip passes clean. All 8 CI checks green on `54fe761`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dA4nMpWrzECNhV6if4YXZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - iOS hierarchy inspection now supports substantially deeper views, improving selector and condition handling for deeply nested content.
  - iOS targeting failures provide clearer, actionable recovery guidance, including relevant app and device-state details.
  - System-app flows can continue successfully when apps do not establish a connection, including coordinate-based actions.

- **Bug Fixes**
  - Captured tap steps now warn when selectors rely only on an element’s role.
  - Related selector warnings are combined into a single concise warning.
  - iOS failure messages no longer include misleading recovery advice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
