### PR TITLE
feat(tools): add screen-fingerprint, a stable answer to "which screen is this"

### DIFF
--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -84,6 +84,7 @@ Decision order:
   If the user started Metro separately, ask whether to call `stop-metro` (specify the port if not 8081).
 - If tools provided by mcp-server are not sufficient and action can be done using `xcrun`, `adb`, or other commands, use the command. Examples: changing device options, performing a device action such as lock, shake, etc.
 - When waiting for an action, do not call `screenshot` repeatedly without a proper wait mechanism. Use the `await-ui-element` tool to block until the UI settles (e.g. wait for an element to become `visible`/`hidden`, or to contain expected `text`) instead of polling.
+- To confirm which screen a React Native app is on, use `screen-fingerprint` — it reads the app's focused navigation route. It answers only "which screen": it does not see a modal or system alert on top, and the route commits before the transition finishes animating.
   </general_rules>
 
 <react_native_detection>

--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -56,25 +56,27 @@ Common schemes: `messages://`, `settings://`, `maps://?q=<query>`, `tel://<numbe
 
 ## 4. Choosing the Right Tool
 
-| Action            | Tool               | Notes                                                            |
-| ----------------- | ------------------ | ---------------------------------------------------------------- |
-| Multiple actions  | `run-sequence`     | Batch steps in one call (no intermediate screenshots)            |
-| Open an app       | `launch-app`       | **Always — never tap home-screen icons**                         |
-| Restart an app    | `restart-app`      | Terminate and relaunch by bundle ID                              |
-| Open URL/scheme   | `open-url`         | Web pages, deep links, URL schemes                               |
-| Single tap        | `gesture-tap`      | Buttons, links, checkboxes                                       |
-| Scroll/swipe      | `gesture-swipe`    | Straight-line scroll or swipe                                    |
-| Scroll (Chromium) | `gesture-scroll`   | Wheel-based; deltas are window fractions, positive deltaY = down |
-| Drag (Chromium)   | `gesture-drag`     | Sliders, drag-and-drop, text selection                           |
-| Long press        | `gesture-custom`   | Context menus, drag start                                        |
-| Drag & drop       | `gesture-custom`   | Complex drag interactions                                        |
-| Pinch/zoom        | `gesture-pinch`    | Two-finger pinch with auto-interpolation                         |
-| Rotation          | `gesture-rotate`   | Two-finger rotation with auto-interpolation                      |
-| Custom gesture    | `gesture-custom`   | Arbitrary touch sequences, optional interpolation                |
-| Hardware key      | `button`           | Home, back, power, volume, appSwitch, actionButton               |
-| Type text         | `keyboard`         | iOS+Android. Supports Enter, Escape, arrows                      |
-| Rotate device     | `rotate`           | Orientation changes                                              |
-| Wait for UI       | `await-ui-element` | Block until an element is visible/hidden/exists/contains text    |
+| Action            | Tool                 | Notes                                                            |
+| ----------------- | -------------------- | ---------------------------------------------------------------- |
+| Multiple actions  | `run-sequence`       | Batch steps in one call (no intermediate screenshots)            |
+| Open an app       | `launch-app`         | **Always — never tap home-screen icons**                         |
+| Restart an app    | `restart-app`        | Terminate and relaunch by bundle ID                              |
+| Open URL/scheme   | `open-url`           | Web pages, deep links, URL schemes                               |
+| Single tap        | `gesture-tap`        | Buttons, links, checkboxes                                       |
+| Scroll/swipe      | `gesture-swipe`      | Straight-line scroll or swipe                                    |
+| Scroll (Chromium) | `gesture-scroll`     | Wheel-based; deltas are window fractions, positive deltaY = down |
+| Drag (Chromium)   | `gesture-drag`       | Sliders, drag-and-drop, text selection                           |
+| Long press        | `gesture-custom`     | Context menus, drag start                                        |
+| Drag & drop       | `gesture-custom`     | Complex drag interactions                                        |
+| Pinch/zoom        | `gesture-pinch`      | Two-finger pinch with auto-interpolation                         |
+| Rotation          | `gesture-rotate`     | Two-finger rotation with auto-interpolation                      |
+| Custom gesture    | `gesture-custom`     | Arbitrary touch sequences, optional interpolation                |
+| Hardware key      | `button`             | Home, back, power, volume, appSwitch, actionButton               |
+| Type text         | `keyboard`           | Every platform. Supports Enter, Escape, arrows (not on TV)       |
+| Rotate device     | `rotate`             | Orientation changes                                              |
+| Wait for UI       | `await-ui-element`   | Block until an element is visible/hidden/exists/contains text    |
+| Wait for idle     | `await-screen-idle`  | Block until a non-empty screen tree stops changing               |
+| Identify a screen | `screen-fingerprint` | Read which screen a React Native app is on, as its route path    |
 
 ## 5. Finding Tap Targets
 
@@ -203,10 +205,24 @@ Instead of polling `screenshot`/`describe` in a loop, use `await-ui-element` to 
 - `selector`: `{ text?, identifier?, role? }` — every provided field must match. `text` matches the element's label or value and `role` its element role (e.g. `AXButton`, `button`, `TextView`, `StaticText`), both as case-insensitive substrings; `identifier` matches its accessibility id / resource-id / testID **exactly** (case-insensitive), also accepting the unqualified Android resource-id name (`submit` matches `com.example.app:id/submit`). The synthetic `ROOT` container `describe` prints is never matched, so a `role` like `AXGroup`/`html` won't trivially "match the screen".
 - Prefer a **specific** selector. A loose substring can match several elements, and the tool may then key off one you didn't mean: `text` reads the first **visible** match in **reading order** (top-to-bottom, left-to-right — the same order `describe` lists them, so it's the one you saw first; when no match is visible, the first match overall), while `visible`/`exists` are satisfied by **any** match. Disambiguate with a longer or more exact string, an `identifier`, or a `role` (e.g. pin to a text role like `StaticText` to skip a same-named button). On a `text` timeout the `note` quotes the matched element's text, so you can see which one it landed on.
 - `text` condition also needs `expectedText` (substring the matched element must contain).
-- `hidden` treats a selector that matches **nothing** as already-hidden, so a typo'd selector returns an instant (false) success. Double-check the selector for `hidden` waits — the result `note` flags when the selector never matched any element. (On iOS, if the accessibility backend is down the tree comes back empty; the tool will **not** report `hidden` success off such a degraded read and the `note` surfaces the boot hint instead.)
+- `hidden` treats a selector that matches **nothing** as already-hidden, so a typo'd selector returns an instant (false) success. The result `note` flags when the selector never matched any element; treat that note as a failed check, not a pass, and find the real selector before continuing. `flow-add-step` refuses to record such a wait, because a gate that cannot fail proves nothing on replay. (On iOS, if the accessibility backend is down the tree comes back empty; the tool will **not** report `hidden` success off such a degraded read and the `note` surfaces the boot hint instead.)
 - Optional `timeoutMs` (default 5000) and `pollIntervalMs` (default 400).
 
 Returns `{ success, elapsed }`; on a timeout `success` is `false` and a `note` explains what was seen.
+
+### screen-fingerprint — Which screen is the app on
+
+For a React Native app served by Metro, this reads the focused React Navigation route path and returns it as `"HomeTab>Profile"`:
+
+```json
+{ "app_id": "com.acme.notes" }
+```
+
+It answers "which screen" and nothing else — pair it with `await-screen-idle` for readiness, and an element check for an overlay above the screen.
+
+- `available: false` — this app has no reader (release build, fully native app, Chromium, Metro down). Recognize the screen by a destination-only element instead.
+- `route: null` with `available: true` — no focused route at this instant: a native screen, or a transition still in flight. Let it settle and probe again.
+- Optional `platform`, `device`, and `metro_port` (default 8081).
 
 ---
 

--- a/packages/tool-server/src/tools/screen-fingerprint/index.ts
+++ b/packages/tool-server/src/tools/screen-fingerprint/index.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import type { Registry, ToolContext, ToolDefinition } from "@argent/registry";
+import { resolveFlowDevice } from "../flows/flow-device";
+import { connectRouteReader, probeRoute, routeFingerprint } from "../../utils/route-identity";
+import { metroServerRunning } from "../../utils/debugger/discovery";
+
+/**
+ * Whether a Metro dev server is answering on `port` at all. Never throws.
+ *
+ * Asks only whether the SERVER is up — see {@link metroServerRunning}. Target
+ * discovery cannot answer it: a Metro serving one app reports an empty target
+ * list for the several seconds after that app relaunches, which is exactly
+ * when this tool is called, and reading that as "Metro is down" produced the
+ * one message the branch below exists to avoid.
+ */
+async function metroReachable(port: number): Promise<boolean> {
+  return metroServerRunning(port);
+}
+
+/**
+ * Read the current screen's route fingerprint from the running app — the
+ * recorder's source for a flow's `await: { screen: … }` gate. A thin,
+ * device-only probe: nothing is tapped and no file is touched.
+ */
+
+export const SCREEN_FINGERPRINT_TOOL_ID = "screen-fingerprint";
+
+// chromium is deliberately absent: an Electron app has no React Navigation
+// state to read, so there is nothing this tool could return for it.
+const FINGERPRINT_PLATFORMS = ["ios", "android", "vega"] as const;
+
+const zodSchema = z.object({
+  app_id: z
+    .string()
+    .min(1)
+    .describe(
+      "Bundle id / package name of the app under test — guards against reading a foreign " +
+        "app's Metro on the same port."
+    ),
+  platform: z
+    .enum(FINGERPRINT_PLATFORMS)
+    .optional()
+    .describe(
+      "Platform of the device under test. Only needed to disambiguate when several platforms " +
+        "have a booted device."
+    ),
+  device: z
+    .string()
+    .optional()
+    .describe(
+      "Device id to probe (iOS UDID, Android/Vega serial). Auto-detected from the single " +
+        "booted device when omitted."
+    ),
+  metro_port: z
+    .number()
+    .int()
+    .min(1)
+    .max(65535)
+    .optional()
+    .describe("Metro dev-server port the app was launched from (default 8081)."),
+});
+
+type Params = z.infer<typeof zodSchema>;
+
+export interface ScreenFingerprintResult {
+  /** false = no reader for this app (not a Metro-served debuggable RN app). */
+  available: boolean;
+  /** The fingerprint to gate on, or null when none could be read. */
+  route: string | null;
+  /** Focused route names outermost→innermost (what `route` joins). */
+  path?: string[];
+  /**
+   * The leaf route's params — evidence the screen is parameterized (one route
+   * serves every instance). Data about the screen, never its identity.
+   */
+  params?: Record<string, unknown> | null;
+  reason?: string;
+  hint?: string;
+}
+
+export function createScreenFingerprintTool(
+  registry: Registry
+): ToolDefinition<Params, ScreenFingerprintResult> {
+  return {
+    id: SCREEN_FINGERPRINT_TOOL_ID,
+    interaction: {
+      startedMsg: ({ params }) => `Reading screen identity of ${params.app_id}`,
+      // A read that returns no route still succeeds, so the message has to say
+      // which of the two happened — "read the screen" would imply a fingerprint
+      // that the caller may not have got.
+      completedMsg: ({ params, result }) =>
+        result.route === null
+          ? `Read no focused route for ${params.app_id}`
+          : `Read screen ${result.route}`,
+      failedMsg: ({ params, failureSignal }) =>
+        `Failed to read screen identity of ${params.app_id}: ${failureSignal.error_code}`,
+    },
+    description: `Read which screen the app is on, as its focused React Navigation route path ("HomeTab>Profile"), via the RN debugger over Metro.
+This is screen IDENTITY, and it is stronger than any element check: it comes from the app's own navigation state, so it does not depend on which tree source rendered \`describe\`, on content, on count, or on locale, and every instance of a parameterized screen (one profile vs another) shares one route. Gate a flow on it with \`await: { screen: "HomeTab>Profile" }\`, or record that step by passing this command to \`flow-add-step\`.
+It answers "which screen" and nothing else. It does NOT prove the screen finished animating (navigation state commits before the transition ends) and it does NOT see a native overlay above the screen (a permission alert, a share sheet, an RN <Modal> leave the route unchanged) — pair it with \`await: { idle: true }\` for readiness and an element check for the overlay.
+Only Metro-served debuggable RN apps have routes: \`available: false\` means this app has no reader (release build, fully native, chromium) — gate on elements instead. \`route: null\` with \`available: true\` means no focused route right now (a native screen, or a transition mid-flight) — let the screen settle and probe again.`,
+    searchHint:
+      "screen identity fingerprint which screen route react navigation current screen prove navigation",
+    zodSchema,
+    services: () => ({}),
+    async execute(_services, params, ctx?: ToolContext) {
+      const device = await resolveFlowDevice(registry, ctx, {
+        ...(params.device !== undefined ? { device: params.device } : {}),
+        ...(params.platform !== undefined ? { platform: params.platform } : {}),
+      });
+      const metroPort = params.metro_port ?? 8081;
+      if (device.platform === "chromium") {
+        return {
+          available: false,
+          route: null,
+          reason:
+            "chromium apps have no React Navigation route identity — gate on a destination-only " +
+            "element instead.",
+        };
+      }
+      // "ios-remote" is an iOS simulator over a remote bridge — same runtime.
+      const platform = device.platform === "ios-remote" ? "ios" : device.platform;
+      const reader = await connectRouteReader(registry, ctx, {
+        udid: device.id,
+        bundleId: params.app_id,
+        metroPort,
+        platform,
+      });
+      if (reader === undefined) {
+        // Which cause holds is checkable, so check it. Asserting "Metro is
+        // down" while Metro is demonstrably up — the routine case, because an
+        // app re-registers a few seconds AFTER it relaunches and the recorder
+        // probes immediately — sent authors to repair a working dev server,
+        // and the conclusion the old wording drew for them ("screens of this
+        // app can only be recognized by element checks") deleted the identity
+        // proof for the whole flow on the strength of a transient miss.
+        const metroUp = await metroReachable(metroPort);
+        return {
+          available: false,
+          route: null,
+          reason: metroUp
+            ? `Metro is running on port ${metroPort}, but no debuggable target for ` +
+              `${params.app_id} is registered there. If the app was just launched or restarted, ` +
+              `it re-registers a few seconds later — wait for the screen to settle and probe ` +
+              `again. If it stays this way, the app is not a debuggable RN build, or this port ` +
+              `serves a different app.`
+            : `No Metro dev server is answering on port ${metroPort}, so ${params.app_id} has ` +
+              `no route reader. Start Metro (or pass the right \`metro_port\`); if this app is ` +
+              `not a debuggable RN build at all, its screens can only be recognized by element ` +
+              `checks.`,
+        };
+      }
+      const route = await probeRoute(reader, {
+        ...(ctx?.signal !== undefined ? { signal: ctx.signal } : {}),
+      });
+      if (route === null) {
+        return {
+          available: true,
+          route: null,
+          reason:
+            "The app exposes no focused React Navigation route right now — a fully native " +
+            "screen, or a transition mid-flight. Let the screen settle and probe again; if it " +
+            "stays null, this screen has no route identity (gate on an element instead).",
+        };
+      }
+      const fingerprint = routeFingerprint(route);
+      return {
+        available: true,
+        route: fingerprint,
+        path: route.path,
+        params: route.params,
+        hint:
+          `Gate on it with: - await: { screen: "${fingerprint}" }, PAIRED with a readiness ` +
+          `check — navigation state commits before the screen renders, so this route is already ` +
+          `reported while the app is still blank. If the screen you just navigated FROM reports ` +
+          `this same route, the two are one route and gating on it would prove nothing: use a ` +
+          `destination-only element instead. ` +
+          `Non-null params mean the screen is parameterized — the route still identifies it, ` +
+          `but do not also gate on the specific instance's content.`,
+      };
+    },
+  };
+}

--- a/packages/tool-server/src/utils/debugger/discovery.ts
+++ b/packages/tool-server/src/utils/debugger/discovery.ts
@@ -6,6 +6,8 @@ export interface CDPTarget {
   description: string;
   webSocketDebuggerUrl: string;
   deviceName?: string;
+  /** Bundle id / package name of the app that registered the target (modern RN). */
+  appId?: string;
   /** Legacy inspector-proxy only. Its synthetic reload page reports "don't use". */
   vm?: string;
   reactNative?: {
@@ -33,6 +35,28 @@ export interface MetroInfo {
  * reports no pages) correctly reads as "no targets" instead of connecting to it.
  */
 const DECOY_VM = "don't use";
+
+/**
+ * Is a Metro dev server LISTENING on `port` — regardless of whether any app is
+ * currently attached to it? Probes `/status` only. Never throws.
+ *
+ * Deliberately not `discoverMetro`, which also requires at least one CDP
+ * target and throws `DEBUGGER_METRO_NO_TARGETS` otherwise. That distinction is
+ * the whole point here: a Metro serving ONE app has an empty target list for
+ * several seconds after that app is relaunched, so "no targets" is the normal
+ * post-launch state, not a down server. Callers that used discovery for this
+ * question therefore concluded "Metro is down" exactly when an app was coming
+ * back up — telling the author to start a server that was already running, and
+ * skipping the extended connect budget that window exists to cover.
+ */
+export async function metroServerRunning(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://localhost:${port}/status`);
+    return (await res.text()).includes("packager-status:running");
+  } catch {
+    return false;
+  }
+}
 
 export async function discoverMetro(port: number): Promise<MetroInfo> {
   let statusRes: Response;

--- a/packages/tool-server/src/utils/route-identity.ts
+++ b/packages/tool-server/src/utils/route-identity.ts
@@ -1,0 +1,448 @@
+import type { Registry, ToolContext } from "@argent/registry";
+import { invokeSubTool } from "./sub-invoke";
+import { sleepOrAbort } from "./timing";
+import { discoverMetro, type CDPTarget, type MetroInfo } from "./debugger/discovery";
+import { listIosSimulators } from "./ios-devices";
+import { adbShell } from "./adb";
+
+/**
+ * React Native route identity — a stable answer to "which screen is this?".
+ *
+ * Every other screen check argent has proxies identity through one element of
+ * the UI tree, and an element is a weak proxy: a shared header matches on two
+ * screens, a positional id encodes how many siblings exist, and during a push
+ * or modal presentation source and destination are in the tree together, so a
+ * destination landmark matches while the destination is still animating in.
+ * Worse, the vocabulary of the tree is source-dependent — iOS `describe`
+ * prefers the ax-service and falls back to native-devtools when the AX read
+ * comes back empty, flipping labels to testIDs mid-session.
+ *
+ * The focused React Navigation route path has none of that. It is read from
+ * the app's own navigation state, so it is independent of the tree source, of
+ * content (`/user/alice` and `/user/bob` share a route), and of locale. One
+ * route names one screen.
+ *
+ * We read it the black-box way argent already uses for the RN component tree:
+ * walk the fiber tree via `__REACT_DEVTOOLS_GLOBAL_HOOK__` and collect the
+ * focused `route`/`navigation` prop pairs. No app cooperation is needed — the
+ * app does not have to export its `navigationRef`. Only debuggable RN apps
+ * served by Metro qualify; a release build, a fully native app, or a chromium
+ * app has no reader, and callers fall back to element checks.
+ *
+ * Two limits, both accepted and both load-bearing for callers:
+ *
+ * 1. A native overlay ABOVE an RN screen (a system permission alert, a share
+ *    sheet, an RN `<Modal>`) does not change the focused route, so the probe
+ *    reports the screen beneath it. Route identity answers "which screen",
+ *    never "is anything covering it".
+ * 2. Navigation state commits when the navigator commits, which is BEFORE the
+ *    transition finishes animating. Route identity is therefore not a
+ *    readiness signal either — pair it with one.
+ */
+
+/** The focused navigation route path of the current screen, read at runtime. */
+export interface RouteContext {
+  /** Focused route names outermost→innermost, e.g. ["HomeTab", "Profile"]. */
+  path: string[];
+  /** The innermost (leaf) focused route name — the screen the user is looking at. */
+  name: string;
+  /** The leaf route's params (dynamic-segment values), or null. Data, not identity. */
+  params: Record<string, unknown> | null;
+}
+
+/**
+ * JS evaluated in the app's Hermes runtime (via debugger-evaluate). Walks the
+ * React fiber tree, gathers every fiber carrying a `route.name` +
+ * `navigation.isFocused()` prop pair (React Navigation's screen wrappers), keeps
+ * the focused ones, and returns them ordered outermost→innermost by fiber
+ * depth. Self-contained (no closures over TS scope), defensive (never throws
+ * out), and bounded (fiber-count cap) so it can't hang navigation. Returns a
+ * JSON string — debugger-evaluate serializes by value, and a plain string is
+ * always safe (RN route/navigation objects are cyclic and would fail to
+ * serialize).
+ */
+export const ROUTE_PROBE_EXPRESSION = `(() => {
+  try {
+    var g = typeof globalThis !== "undefined" ? globalThis : global;
+    var hook = g.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    if (!hook || typeof hook.getFiberRoots !== "function") {
+      return JSON.stringify({ ok: false, reason: "no-devtools-hook" });
+    }
+    var rendererIds = [];
+    try {
+      if (hook.renderers && typeof hook.renderers.keys === "function") {
+        var it = hook.renderers.keys();
+        for (var step = it.next(); !step.done; step = it.next()) rendererIds.push(step.value);
+      }
+    } catch (e) {}
+    if (rendererIds.length === 0) rendererIds = [1];
+    var roots = [];
+    for (var i = 0; i < rendererIds.length; i++) {
+      try {
+        hook.getFiberRoots(rendererIds[i]).forEach(function (r) { roots.push(r); });
+      } catch (e) {}
+    }
+    if (roots.length === 0) return JSON.stringify({ ok: false, reason: "no-fiber-roots" });
+    var byKey = {};
+    var stack = [];
+    for (var j = 0; j < roots.length; j++) {
+      if (roots[j] && roots[j].current) stack.push({ f: roots[j].current, d: 0 });
+    }
+    var visited = 0;
+    while (stack.length) {
+      var top = stack.pop();
+      var fiber = top.f;
+      var depth = top.d;
+      visited++;
+      if (visited > 300000) break;
+      var props = fiber.memoizedProps;
+      if (
+        props && props.route && typeof props.route.name === "string" &&
+        props.navigation && typeof props.navigation.isFocused === "function"
+      ) {
+        var key = props.route.key || props.route.name;
+        var entry = byKey[key];
+        if (!entry) {
+          var focused = false;
+          try { focused = props.navigation.isFocused(); } catch (e) {}
+          var params = null;
+          try {
+            var raw = props.route.params;
+            if (raw && typeof raw === "object") {
+              params = {};
+              var ks = Object.keys(raw);
+              for (var k = 0; k < ks.length && k < 20; k++) {
+                var v = raw[ks[k]];
+                var t = typeof v;
+                params[ks[k]] =
+                  t === "string" || t === "number" || t === "boolean" || v === null
+                    ? v : "<" + t + ">";
+              }
+            }
+          } catch (e) {}
+          byKey[key] = { name: props.route.name, depth: depth, params: params, focused: focused };
+        } else if (depth < entry.depth) {
+          entry.depth = depth;
+        }
+      }
+      if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
+      if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
+    }
+    var focused = [];
+    for (var key2 in byKey) { if (byKey[key2].focused) focused.push(byKey[key2]); }
+    focused.sort(function (a, b) { return a.depth - b.depth; });
+    if (focused.length === 0) return JSON.stringify({ ok: false, reason: "no-focused-route" });
+    var leaf = focused[focused.length - 1];
+    return JSON.stringify({
+      ok: true,
+      path: focused.map(function (r) { return r.name; }),
+      name: leaf.name,
+      params: leaf.params,
+    });
+  } catch (e) {
+    return JSON.stringify({ ok: false, reason: String((e && e.message) || e) });
+  }
+})()`;
+
+/** A route reader: one probe of the currently focused route, null on any failure. */
+export type RouteReader = () => Promise<RouteContext | null>;
+
+// Android's RN inspector registers devices with Metro as
+// "<Build.MODEL> - <release> - API <sdk>"; iOS registers a bare device name.
+// The suffix is the only platform signal the target list carries — the names
+// themselves are runtime-reported and need not match simctl/adb labels.
+const ANDROID_DEVICE_NAME_PATTERN = / - API \d+$/;
+
+/**
+ * The name OUR device would register with Metro under: an iOS simulator
+ * registers as its simctl device name ("iPhone 16 Pro"); Android registers
+ * "<Build.MODEL> - …" (prefix-matched by the caller). Best-effort — undefined
+ * (no strict pinning possible) when the lookup fails or the platform has no
+ * stable convention (vega).
+ */
+async function metroDeviceName(
+  udid: string,
+  platform: "ios" | "android" | "vega"
+): Promise<string | undefined> {
+  try {
+    if (platform === "ios") {
+      const sims = await listIosSimulators();
+      return sims.find((sim) => sim.udid === udid)?.name;
+    }
+    if (platform === "android") {
+      const model = (await adbShell(udid, "getprop ro.product.model")).trim();
+      return model === "" ? undefined : model;
+    }
+  } catch {
+    // Lookup tooling unavailable — the caller falls back to the platform
+    // heuristic below.
+  }
+  return undefined;
+}
+
+function targetNameMatches(
+  target: CDPTarget,
+  platform: "ios" | "android" | "vega",
+  deviceName: string
+): boolean {
+  const name = target.deviceName ?? "";
+  if (platform === "android") return name === deviceName || name.startsWith(`${deviceName} - `);
+  return name === deviceName;
+}
+
+/**
+ * The Metro logicalDeviceId of OUR device running `bundleId`, from a
+ * /json/list target dump — or undefined when no target can be pinned to the
+ * device (never guess: reading a foreign runtime's route would fingerprint
+ * every screen of the app under test with another device's state — a physical
+ * phone on the LAN sharing the dev Metro is a routine setup).
+ *
+ * Needed because debugger-connect matches targets by logicalDeviceId, which a
+ * sim udid / adb serial never equals. When `deviceName` is known the match is
+ * strict: only a target registered under that name counts, and zero matches
+ * means OUR device has no target (an unloaded dev-client, a foreign device's
+ * target sitting on the list). Only when the name is unknown does the
+ * platform-shaped-name heuristic run, and only a unique candidate wins.
+ * Legacy-inspector targets (no logicalDeviceId) are always skipped — they
+ * cannot be singled out of a shared Metro.
+ */
+export function pickLogicalDeviceId(
+  targets: CDPTarget[],
+  bundleId: string,
+  platform: "ios" | "android" | "vega",
+  deviceName?: string
+): string | undefined {
+  const wanted = bundleId.toLowerCase();
+  const ids = new Set<string>();
+  for (const target of targets) {
+    const logicalId = target.reactNative?.logicalDeviceId;
+    if (!logicalId) continue;
+    const appId = target.appId?.toLowerCase() ?? "";
+    // Older RN omits appId; its titles read "<bundleId> (<device>)".
+    const ownsApp = appId !== "" ? appId === wanted : target.title.toLowerCase().includes(wanted);
+    if (!ownsApp) continue;
+    if (deviceName !== undefined) {
+      if (!targetNameMatches(target, platform, deviceName)) continue;
+    } else {
+      const androidName = ANDROID_DEVICE_NAME_PATTERN.test(target.deviceName ?? "");
+      if ((platform === "android") !== androidName) continue;
+    }
+    ids.add(logicalId);
+  }
+  if (ids.size !== 1) return undefined;
+  return ids.values().next().value;
+}
+
+/**
+ * Attach a JS-runtime debugger to a Metro-served RN app and return a route
+ * reader ({@link RouteReader}). A failure to connect (Metro down, not an RN
+ * app, a release build with no inspector) is expected and non-fatal: return
+ * undefined so the caller falls back to landmarks. Best-effort — never throws.
+ *
+ * `discover` is injectable for tests; production always reads the real Metro.
+ */
+export async function connectRouteReader(
+  registry: Registry,
+  ctx: ToolContext | undefined,
+  opts: {
+    udid: string;
+    bundleId: string;
+    metroPort: number;
+    platform: "ios" | "android" | "vega";
+    /** Metro registration name of the device; resolved from udid when omitted. */
+    deviceName?: string;
+  },
+  discover: (port: number) => Promise<MetroInfo> = discoverMetro
+): Promise<RouteReader | undefined> {
+  // Resolve the target ourselves when possible (see pickLogicalDeviceId).
+  let connectId = opts.udid;
+  let matchedByAppId = false;
+  try {
+    const metro = await discover(opts.metroPort);
+    // Name lookup only once the app is known to be served here — it shells
+    // simctl/adb, which is wasted on the (common) no-Metro / foreign-Metro
+    // paths.
+    const served = metro.targets.some(
+      (t) =>
+        t.reactNative?.logicalDeviceId !== undefined &&
+        ((t.appId ?? "").toLowerCase() === opts.bundleId.toLowerCase() ||
+          ((t.appId ?? "") === "" && t.title.toLowerCase().includes(opts.bundleId.toLowerCase())))
+    );
+    if (served) {
+      const deviceName = opts.deviceName ?? (await metroDeviceName(opts.udid, opts.platform));
+      const logicalId = pickLogicalDeviceId(
+        metro.targets,
+        opts.bundleId,
+        opts.platform,
+        deviceName
+      );
+      if (logicalId !== undefined) {
+        connectId = logicalId;
+        matchedByAppId = true;
+      } else if (deviceName !== undefined) {
+        // The app is served on this Metro but no target is pinned to OUR
+        // device (its dev-client hasn't loaded the app, or only foreign
+        // devices are attached). The udid fallback below would land on a
+        // foreign device's runtime — refuse instead.
+        return undefined;
+      }
+    }
+  } catch {
+    // Metro unreachable or unparseable — let the connect below be the judge.
+  }
+  let deviceId: string;
+  try {
+    const res = await invokeSubTool<{
+      logicalDeviceId?: string;
+      connected?: boolean;
+      appName?: string;
+    }>(registry, ctx, "debugger-connect", { port: opts.metroPort, device_id: connectId });
+    if (!res.connected) return undefined;
+    // Guard the udid-fallback path against binding to a FOREIGN app's Metro:
+    // an unmatched udid makes debugger-connect fall back to whichever single
+    // app Metro serves on this port. If that is a different app (another
+    // project's dev server on 8081), its route would fingerprint EVERY screen
+    // of the app under test — strictly worse than landmarks. The RN inspector
+    // titles a target "<bundleId> (<device>)", so require the connected app to
+    // name our bundle; when the title is unrecognizable (empty), proceed
+    // rather than over-reject. A target resolved by appId already proved
+    // ownership.
+    const appName = res.appName ?? "";
+    if (
+      !matchedByAppId &&
+      appName &&
+      !appName.toLowerCase().includes(opts.bundleId.toLowerCase())
+    ) {
+      return undefined;
+    }
+    // Subsequent debugger-* calls must be pinned to the session's logical id.
+    deviceId = res.logicalDeviceId ?? connectId;
+  } catch {
+    return undefined;
+  }
+  return async () => {
+    try {
+      const res = await invokeSubTool<{ result: unknown }>(registry, ctx, "debugger-evaluate", {
+        port: opts.metroPort,
+        device_id: deviceId,
+        expression: ROUTE_PROBE_EXPRESSION,
+      });
+      return parseRouteResult(res.result);
+    } catch {
+      // A transient eval failure (runtime busy, reload in flight) must not fail
+      // the observation — the caller falls back to landmarks for this read.
+      return null;
+    }
+  };
+}
+
+/** Parse the probe's JSON-string result into a RouteContext, or null on any failure. */
+export function parseRouteResult(raw: unknown): RouteContext | null {
+  let obj: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const rec = obj as Record<string, unknown>;
+  if (rec.ok !== true) return null;
+  const path = rec.path;
+  const name = rec.name;
+  if (!Array.isArray(path) || path.length === 0 || typeof name !== "string" || name.length === 0) {
+    return null;
+  }
+  const cleanPath = path.filter((p): p is string => typeof p === "string" && p.length > 0);
+  if (cleanPath.length === 0) return null;
+  const params =
+    rec.params && typeof rec.params === "object" && !Array.isArray(rec.params)
+      ? (rec.params as Record<string, unknown>)
+      : null;
+  return { path: cleanPath, name, params };
+}
+
+/**
+ * The fingerprint string a screen records: the focused route PATH joined with
+ * ">" ("HomeTab>Profile"). Params are deliberately excluded so every instance
+ * of a parameterized screen shares one fingerprint.
+ */
+export function routeFingerprint(route: RouteContext): string {
+  return route.path.join(">");
+}
+
+// The route state lags the visual transition by a beat; a single null read
+// right after a tap does not mean "no route".
+const ROUTE_PROBE_ATTEMPTS = 3;
+const ROUTE_PROBE_RETRY_MS = 250;
+
+/**
+ * Probe the focused route, retrying a null read (mid-transition, runtime busy)
+ * a few times before conceding. Returns null when every attempt failed or the
+ * signal aborted — callers re-check the signal themselves.
+ */
+export async function probeRoute(
+  reader: RouteReader,
+  opts?: { attempts?: number; retryMs?: number; signal?: AbortSignal }
+): Promise<RouteContext | null> {
+  const attempts = opts?.attempts ?? ROUTE_PROBE_ATTEMPTS;
+  const retryMs = opts?.retryMs ?? ROUTE_PROBE_RETRY_MS;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (opts?.signal?.aborted) return null;
+    const route = await reader();
+    if (route !== null) return route;
+    if (attempt < attempts - 1 && !(await sleepOrAbort(retryMs, opts?.signal))) return null;
+  }
+  return null;
+}
+
+/** Verdict of {@link verifyRouteFingerprint}. */
+export interface RouteVerifyOutcome {
+  /** True only when a probe read the expected fingerprint before the deadline. */
+  ok: boolean;
+  /** The run was cancelled mid-poll — not a verdict about the app. */
+  aborted?: boolean;
+  /**
+   * Fingerprint of the last SUCCESSFUL probe. Absent means every probe came
+   * back null (the reader died, the screen is native, or the transition never
+   * settled) — the caller must not report the app as being on a screen it
+   * never actually read.
+   */
+  observedRoute?: string;
+}
+
+/**
+ * Poll the route reader until the focused route's fingerprint equals
+ * `expected` or the deadline passes. `timeoutMs: 0` probes exactly once — the
+ * immediate "am I where I claim to be" check.
+ *
+ * A null probe (transition mid-flight, runtime busy, reader lost) keeps
+ * polling rather than deciding: the distinction between "read a different
+ * screen" and "read nothing" is the whole diagnostic value here, so it is
+ * carried out in {@link RouteVerifyOutcome.observedRoute} rather than
+ * collapsed into a boolean.
+ */
+export async function verifyRouteFingerprint(
+  readRoute: RouteReader,
+  expected: string,
+  timeoutMs: number,
+  pollMs: number,
+  signal?: AbortSignal
+): Promise<RouteVerifyOutcome> {
+  const deadline = Date.now() + timeoutMs;
+  let observedRoute: string | undefined;
+  for (;;) {
+    if (signal?.aborted) return { ok: false, aborted: true };
+    const route = await readRoute();
+    if (route !== null) {
+      observedRoute = routeFingerprint(route);
+      if (observedRoute === expected) return { ok: true, observedRoute };
+    }
+    if (signal?.aborted) return { ok: false, aborted: true };
+    if (Date.now() >= deadline) {
+      return { ok: false, ...(observedRoute !== undefined ? { observedRoute } : {}) };
+    }
+    if (!(await sleepOrAbort(pollMs, signal))) return { ok: false, aborted: true };
+  }
+}

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -50,6 +50,7 @@ import { networkRequestTool } from "../tools/network/network-request";
 import { createDescribeTool } from "../tools/describe";
 import { createAwaitUiElementTool } from "../tools/await-ui-element";
 import { createAwaitScreenIdleTool } from "../tools/await-screen-idle";
+import { createScreenFingerprintTool } from "../tools/screen-fingerprint";
 import { createReactProfilerStartTool } from "../tools/profiler/react/react-profiler-start";
 import { createReactProfilerStopTool } from "../tools/profiler/react/react-profiler-stop";
 import { createReactProfilerStatusTool } from "../tools/profiler/react/react-profiler-status";
@@ -148,6 +149,7 @@ export function createRegistry(): Registry {
   registry.registerTool(createDescribeTool(registry));
   registry.registerTool(createAwaitUiElementTool(registry));
   registry.registerTool(createAwaitScreenIdleTool(registry));
+  registry.registerTool(createScreenFingerprintTool(registry));
   registry.registerTool(createReactProfilerStartTool(registry));
   registry.registerTool(createReactProfilerStopTool(registry));
   registry.registerTool(createReactProfilerStatusTool(registry));

--- a/packages/tool-server/test/debugger/metro-server-running.test.ts
+++ b/packages/tool-server/test/debugger/metro-server-running.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as http from "node:http";
+import { discoverMetro, metroServerRunning } from "../../src/utils/debugger/discovery";
+
+/**
+ * `metroServerRunning` answers "is the dev server up", NOT "is an app attached
+ * to it". The distinction is load-bearing for every `screen` gate: a Metro
+ * serving one app has an EMPTY target list for the seconds after that app is
+ * relaunched, which is exactly when the post-launch identity gate runs.
+ *
+ * These tests drive a real socket rather than a stub, because the defect they
+ * pin was introduced by a stub: a test double answered "reachable" for a
+ * zero-target list while the real `discoverMetro` throws on one, so the
+ * post-launch connect budget silently lost its extension and the failure told
+ * the author to start a server that was already running.
+ */
+
+let server: http.Server | undefined;
+
+async function startMetro(targets: unknown[], status = "packager-status:running"): Promise<number> {
+  server = http.createServer((req, res) => {
+    if (req.url?.startsWith("/status")) {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(status);
+      return;
+    }
+    if (req.url?.startsWith("/json/list")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(targets));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+  return (server!.address() as { port: number }).port;
+}
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = undefined;
+});
+
+describe("metroServerRunning", () => {
+  it("is true for a running server with NO attached targets — the post-launch window", async () => {
+    const port = await startMetro([]);
+
+    // The state this exists for: the server is plainly up ...
+    await expect(metroServerRunning(port)).resolves.toBe(true);
+    // ... while discovery, which additionally demands a target, rejects it.
+    // Answering "is Metro up" with discovery is what read a relaunching app as
+    // a down dev server.
+    await expect(discoverMetro(port)).rejects.toThrow(/no CDP targets/);
+  });
+
+  it("is true for a running server that does have targets", async () => {
+    const port = await startMetro([
+      { id: "1", title: "app (Device)", description: "", webSocketDebuggerUrl: "ws://x" },
+    ]);
+    await expect(metroServerRunning(port)).resolves.toBe(true);
+  });
+
+  it("is false when nothing is listening on the port", async () => {
+    const port = await startMetro([]);
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = undefined;
+    await expect(metroServerRunning(port)).resolves.toBe(false);
+  });
+
+  it("is false when the port answers but is not Metro", async () => {
+    const port = await startMetro([], "<!doctype html><html>some other server</html>");
+    await expect(metroServerRunning(port)).resolves.toBe(false);
+  });
+});

--- a/packages/tool-server/test/interaction-messages.test.ts
+++ b/packages/tool-server/test/interaction-messages.test.ts
@@ -38,7 +38,7 @@ function definitionsById(registry: Registry): Map<string, ToolDefinition<any, an
 describe("tool interaction messages", () => {
   it("defines all three formatters for every tool", () => {
     const definitions = definitionsById(createRegistry());
-    expect(definitions.size).toBe(77);
+    expect(definitions.size).toBe(78);
 
     for (const [id, definition] of definitions) {
       expect(definition.interaction?.startedMsg, `${id}.startedMsg`).toBeTypeOf("function");

--- a/packages/tool-server/test/route-identity.test.ts
+++ b/packages/tool-server/test/route-identity.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from "vitest";
+import type { Registry } from "@argent/registry";
+import type { CDPTarget, MetroInfo } from "../src/utils/debugger/discovery";
+import {
+  connectRouteReader,
+  parseRouteResult,
+  pickLogicalDeviceId,
+  probeRoute,
+  routeFingerprint,
+  verifyRouteFingerprint,
+  type RouteContext,
+  type RouteReader,
+} from "../src/utils/route-identity";
+
+const route = (path: string[], params: Record<string, unknown> | null = null): RouteContext => ({
+  path,
+  name: path[path.length - 1]!,
+  params,
+});
+
+describe("routeFingerprint", () => {
+  it("keys identity on the route PATH, ignoring params (the dynamic-screen collapse)", () => {
+    const alice = route(["HomeTab", "Profile"], { name: "alice" });
+    const bob = route(["HomeTab", "Profile"], { name: "bob" });
+    expect(routeFingerprint(alice)).toBe("HomeTab>Profile");
+    expect(routeFingerprint(alice)).toBe(routeFingerprint(bob));
+  });
+
+  it("distinguishes different route paths", () => {
+    expect(routeFingerprint(route(["HomeTab", "Profile"]))).not.toBe(
+      routeFingerprint(route(["SearchTab", "Profile"]))
+    );
+    expect(routeFingerprint(route(["HomeTab", "Feed"]))).not.toBe(
+      routeFingerprint(route(["HomeTab", "Profile"]))
+    );
+  });
+});
+
+describe("parseRouteResult", () => {
+  it("parses a successful probe payload (string or object)", () => {
+    const payload = { ok: true, path: ["HomeTab", "Profile"], name: "Profile", params: { id: 7 } };
+    const expected = { path: ["HomeTab", "Profile"], name: "Profile", params: { id: 7 } };
+    expect(parseRouteResult(JSON.stringify(payload))).toEqual(expected);
+    expect(parseRouteResult(payload)).toEqual(expected);
+  });
+
+  it("returns null for every failure shape", () => {
+    expect(parseRouteResult(JSON.stringify({ ok: false, reason: "no-devtools-hook" }))).toBeNull();
+    expect(parseRouteResult(JSON.stringify({ ok: true, path: [], name: "X" }))).toBeNull();
+    expect(parseRouteResult(JSON.stringify({ ok: true, path: ["A"], name: "" }))).toBeNull();
+    expect(parseRouteResult("not json")).toBeNull();
+    expect(parseRouteResult(undefined)).toBeNull();
+    expect(parseRouteResult(42)).toBeNull();
+  });
+
+  it("normalizes a non-object params to null and drops empty path segments", () => {
+    expect(parseRouteResult({ ok: true, path: ["A", "", "B"], name: "B", params: "x" })).toEqual({
+      path: ["A", "B"],
+      name: "B",
+      params: null,
+    });
+  });
+});
+
+/** Metro /json/list target shorthand. */
+function target(opts: {
+  logicalId?: string;
+  appId?: string;
+  title?: string;
+  deviceName?: string;
+}): CDPTarget {
+  return {
+    id: "t",
+    title: opts.title ?? `${opts.appId ?? "app"} (${opts.deviceName ?? "device"})`,
+    description: "React Native Bridge [C++ connection]",
+    webSocketDebuggerUrl: "ws://localhost:8081/debugger",
+    ...(opts.deviceName !== undefined ? { deviceName: opts.deviceName } : {}),
+    ...(opts.appId !== undefined ? { appId: opts.appId } : {}),
+    ...(opts.logicalId !== undefined ? { reactNative: { logicalDeviceId: opts.logicalId } } : {}),
+  };
+}
+
+describe("pickLogicalDeviceId", () => {
+  const APP = "com.example.app";
+  // The routine RN-dev shape: one Metro serving the same app on an iOS sim
+  // AND an Android emulator (plus per-device Reanimated runtime targets).
+  const shared = [
+    target({ logicalId: "android1", appId: APP, deviceName: "sdk_gphone64_arm64 - 14 - API 34" }),
+    target({ logicalId: "android1", appId: APP, deviceName: "sdk_gphone64_arm64 - 14 - API 34" }),
+    target({ logicalId: "ios1", appId: APP, deviceName: "iPhone 17 Pro" }),
+    target({ logicalId: "ios1", appId: APP, deviceName: "iPhone 17 Pro" }),
+  ];
+
+  it("singles out the right platform's device on a Metro shared across platforms", () => {
+    expect(pickLogicalDeviceId(shared, APP, "ios")).toBe("ios1");
+    expect(pickLogicalDeviceId(shared, APP, "android")).toBe("android1");
+  });
+
+  it("ignores foreign apps and matches by title when appId is absent (older RN)", () => {
+    const targets = [
+      target({ logicalId: "other", appId: "com.other.app", deviceName: "iPhone 15" }),
+      target({ logicalId: "ios1", title: `${APP} (iPhone 17 Pro)`, deviceName: "iPhone 17 Pro" }),
+    ];
+    expect(pickLogicalDeviceId(targets, APP, "ios")).toBe("ios1");
+  });
+
+  it("refuses to guess between two same-platform devices running the app", () => {
+    const twoSims = [
+      target({ logicalId: "ios1", appId: APP, deviceName: "iPhone 17 Pro" }),
+      target({ logicalId: "ios2", appId: APP, deviceName: "iPhone 16e" }),
+    ];
+    expect(pickLogicalDeviceId(twoSims, APP, "ios")).toBeUndefined();
+  });
+
+  it("pins strictly by device name when known — a foreign phone on the LAN never matches", () => {
+    // The live incident shape: our sim ("iPhone 16 Pro") has no target yet
+    // (dev-client launcher up), while a physical iPhone 17 Pro on the LAN
+    // serves the same app from the same Metro. The heuristic would pick the
+    // phone; the name pin must refuse.
+    const foreignOnly = [target({ logicalId: "phone1", appId: APP, deviceName: "iPhone 17 Pro" })];
+    expect(pickLogicalDeviceId(foreignOnly, APP, "ios", "iPhone 16 Pro")).toBeUndefined();
+    expect(pickLogicalDeviceId(foreignOnly, APP, "ios", "iPhone 17 Pro")).toBe("phone1");
+  });
+
+  it("matches Android names by model prefix (Metro appends release and API level)", () => {
+    const emulator = [
+      target({
+        logicalId: "android1",
+        appId: APP,
+        deviceName: "sdk_gphone64_arm64 - 14 - API 34",
+      }),
+    ];
+    expect(pickLogicalDeviceId(emulator, APP, "android", "sdk_gphone64_arm64")).toBe("android1");
+    expect(pickLogicalDeviceId(emulator, APP, "android", "Pixel 7")).toBeUndefined();
+  });
+
+  it("skips legacy-inspector targets (no logicalDeviceId) and empty lists", () => {
+    expect(pickLogicalDeviceId([target({ appId: APP })], APP, "ios")).toBeUndefined();
+    expect(pickLogicalDeviceId([], APP, "ios")).toBeUndefined();
+  });
+});
+
+describe("connectRouteReader", () => {
+  // Fake registry answering the two debugger tools connectRouteReader calls.
+  function reg(
+    opts: { connect: Record<string, unknown> | Error; evalResult?: unknown },
+    calls: { tool: string; args: Record<string, unknown> }[] = []
+  ): Registry {
+    return {
+      invokeTool: async (id: string, args: Record<string, unknown>) => {
+        calls.push({ tool: id, args });
+        if (id === "debugger-connect") {
+          if (opts.connect instanceof Error) throw opts.connect;
+          return opts.connect;
+        }
+        if (id === "debugger-evaluate") return { result: opts.evalResult };
+        return {};
+      },
+    } as unknown as Registry;
+  }
+
+  const args = {
+    udid: "SIM",
+    bundleId: "com.example.app",
+    metroPort: 8081,
+    platform: "ios" as const,
+  };
+  /** No Metro reachable — forces the udid-fallback connect path. */
+  const noMetro = async (): Promise<MetroInfo> => {
+    throw new Error("Metro at port 8081 is not running");
+  };
+
+  const sharedMetro = async (): Promise<MetroInfo> => ({
+    port: 8081,
+    projectRoot: "",
+    targets: [
+      target({
+        logicalId: "android1",
+        appId: args.bundleId,
+        deviceName: "sdk_gphone64_arm64 - 14 - API 34",
+      }),
+      target({ logicalId: "ios1", appId: args.bundleId, deviceName: "iPhone 17 Pro" }),
+    ],
+  });
+
+  it("resolves the logicalDeviceId from Metro's target list and connects with it", async () => {
+    const calls: { tool: string; args: Record<string, unknown> }[] = [];
+    const registry = reg(
+      {
+        // The connected app's own title — matchedByAppId skips the name guard.
+        connect: { connected: true, logicalDeviceId: "ios1", appName: "whatever" },
+        evalResult: JSON.stringify({ ok: true, path: ["Root"], name: "Root", params: null }),
+      },
+      calls
+    );
+
+    const reader = await connectRouteReader(
+      registry,
+      undefined,
+      { ...args, deviceName: "iPhone 17 Pro" },
+      sharedMetro
+    );
+
+    expect(reader).toBeDefined();
+    expect(calls.find((c) => c.tool === "debugger-connect")?.args).toMatchObject({
+      device_id: "ios1",
+    });
+    expect(await reader!()).toEqual({ path: ["Root"], name: "Root", params: null });
+  });
+
+  it("refuses (no udid fallback) when the app is served here but OUR device has no target", async () => {
+    const calls: { tool: string; args: Record<string, unknown> }[] = [];
+    const registry = reg(
+      { connect: { connected: true, logicalDeviceId: "phone1", appName: args.bundleId } },
+      calls
+    );
+
+    const reader = await connectRouteReader(
+      registry,
+      undefined,
+      { ...args, deviceName: "iPhone 16 Pro" },
+      sharedMetro
+    );
+
+    expect(reader).toBeUndefined();
+    // Falling through to a udid connect would bind a foreign device's runtime.
+    expect(calls.filter((c) => c.tool === "debugger-connect")).toEqual([]);
+  });
+
+  it("returns a working reader when the connected app names our bundle", async () => {
+    const registry = reg({
+      connect: {
+        connected: true,
+        logicalDeviceId: "dev1",
+        appName: "com.example.app (iPhone 17 Pro)",
+      },
+      evalResult: JSON.stringify({
+        ok: true,
+        path: ["HomeTab", "Home"],
+        name: "Home",
+        params: null,
+      }),
+    });
+    const reader = await connectRouteReader(registry, undefined, args, noMetro);
+    expect(reader).toBeDefined();
+    expect(await reader!()).toEqual({ path: ["HomeTab", "Home"], name: "Home", params: null });
+  });
+
+  it("refuses (→ landmark fallback) when Metro serves a DIFFERENT app", async () => {
+    // A foreign RN project's dev server on 8081: its title names another bundle.
+    const registry = reg({
+      connect: {
+        connected: true,
+        logicalDeviceId: "dev1",
+        appName: "com.other.app (iPhone 17 Pro)",
+      },
+    });
+    expect(await connectRouteReader(registry, undefined, args, noMetro)).toBeUndefined();
+  });
+
+  it("returns undefined when not connected or connect throws (non-RN app)", async () => {
+    expect(
+      await connectRouteReader(reg({ connect: { connected: false } }), undefined, args, noMetro)
+    ).toBeUndefined();
+    expect(
+      await connectRouteReader(reg({ connect: new Error("Metro down") }), undefined, args, noMetro)
+    ).toBeUndefined();
+  });
+
+  it("proceeds when the target title is unknown (no over-rejection)", async () => {
+    const registry = reg({
+      connect: { connected: true, logicalDeviceId: "dev1", appName: "" },
+      evalResult: JSON.stringify({ ok: true, path: ["Root"], name: "Root", params: null }),
+    });
+    const reader = await connectRouteReader(registry, undefined, args, noMetro);
+    expect(reader).toBeDefined();
+    expect(await reader!()).toEqual({ path: ["Root"], name: "Root", params: null });
+  });
+});
+
+describe("probeRoute", () => {
+  it("retries a null read (mid-transition) and returns the route once it appears", async () => {
+    let reads = 0;
+    const reader = async (): Promise<RouteContext | null> =>
+      ++reads < 3 ? null : route(["HomeTab", "Feed"]);
+
+    const result = await probeRoute(reader, { retryMs: 1 });
+
+    expect(result).toEqual(route(["HomeTab", "Feed"]));
+    expect(reads).toBe(3);
+  });
+
+  it("concedes null after the attempts are exhausted", async () => {
+    let reads = 0;
+    const reader = async (): Promise<RouteContext | null> => {
+      reads++;
+      return null;
+    };
+
+    expect(await probeRoute(reader, { attempts: 2, retryMs: 1 })).toBeNull();
+    expect(reads).toBe(2);
+  });
+
+  it("returns null immediately on an aborted signal without reading", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let reads = 0;
+    const reader = async (): Promise<RouteContext | null> => {
+      reads++;
+      return route(["A"]);
+    };
+
+    expect(await probeRoute(reader, { signal: controller.signal })).toBeNull();
+    expect(reads).toBe(0);
+  });
+});
+
+// The verification primitive the flow `screen` gate is built on. Its whole
+// value is keeping "read a different screen" and "read nothing" apart: the
+// first is a verdict about the app, the second is a broken probe, and
+// collapsing them is how a green run comes to prove nothing.
+describe("verifyRouteFingerprint", () => {
+  const reads = (...values: Array<RouteContext | null>): RouteReader => {
+    const queue = [...values];
+    return async () => queue.shift() ?? null;
+  };
+
+  it("passes on the first probe when the route already matches", async () => {
+    const outcome = await verifyRouteFingerprint(
+      reads(route(["HomeTab", "Profile"])),
+      "HomeTab>Profile",
+      0,
+      1
+    );
+    expect(outcome).toEqual({ ok: true, observedRoute: "HomeTab>Profile" });
+  });
+
+  it("keeps polling through the transition until the route commits", async () => {
+    const outcome = await verifyRouteFingerprint(
+      reads(null, route(["HomeTab", "Feed"]), route(["HomeTab", "Profile"])),
+      "HomeTab>Profile",
+      2000,
+      1
+    );
+    expect(outcome.ok).toBe(true);
+  });
+
+  it("reports the screen it actually observed when the route is wrong", async () => {
+    const outcome = await verifyRouteFingerprint(
+      reads(route(["HomeTab", "Feed"])),
+      "HomeTab>Profile",
+      0,
+      1
+    );
+    expect(outcome).toEqual({ ok: false, observedRoute: "HomeTab>Feed" });
+  });
+
+  it("reports NO observed route when every probe came back null", async () => {
+    // Absent observedRoute is the caller's signal that identity is unknown
+    // rather than wrong — it must not be dressed up as arrival or as failure.
+    const outcome = await verifyRouteFingerprint(reads(null), "Home", 0, 1);
+    expect(outcome).toEqual({ ok: false });
+  });
+
+  it("reports an abort distinctly from a failed match", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const outcome = await verifyRouteFingerprint(
+      reads(route(["A"])),
+      "B",
+      500,
+      1,
+      controller.signal
+    );
+    expect(outcome).toEqual({ ok: false, aborted: true });
+  });
+});


### PR DESCRIPTION
> Stacked on #726.

## Why an element is a weak proxy for a screen

Every screen check argent had went through one element of the UI tree, and that is unreliable in four separate ways:

- a shared header matches on two different screens;
- a positional id encodes how many siblings exist, not what the thing is;
- during a push or a modal presentation, source and destination are in the tree **together**, so a destination landmark matches while the destination is still animating in;
- the vocabulary of the tree is **source-dependent** — iOS `describe` prefers the ax-service and falls back to native-devtools when the AX read comes back empty, flipping labels to testIDs mid-session.

## What this adds

`screen-fingerprint` reads the app's **focused React Navigation route path** and returns it as `"HomeTab>Profile"`.

Because it comes from the app's own navigation state it is independent of the tree source, of content (`/user/alice` and `/user/bob` share a route), and of locale. One route names one screen.

It is read the same black-box way argent already reads the RN component tree: walk the fiber tree via `__REACT_DEVTOOLS_GLOBAL_HOOK__` and collect the focused `route`/`navigation` prop pairs. **No app cooperation is required** — the app does not have to export its `navigationRef`. The probe is self-contained, defensive, and fiber-count bounded so it cannot hang navigation.

A read-only, device-only probe: nothing is tapped, no file is touched.

## Two limits, stated rather than papered over

Both are load-bearing for callers, so they are documented in the API and in the skill:

1. **A native overlay above an RN screen** — a system permission alert, a share sheet, an RN `<Modal>` — does not change the focused route, so the probe reports the screen beneath it. Route identity answers "which screen", never "is anything covering it".
2. **Navigation state commits when the navigator commits**, which is *before* the transition finishes animating. It is not a readiness signal either.

## Answers that mean different things

- `available: false` — this build can never have a reader (release build, fully native app, Chromium, Metro down). Recognize the screen by a destination-only element instead.
- `route: null` with `available: true` — no focused route *at this instant*: a native screen, or a transition still in flight. Let it settle and probe again.

`app_id` is required, and guards against reading a foreign app's Metro on the same port.

## `metroServerRunning`

Added alongside, and deliberately **not** `discoverMetro` — which also requires at least one CDP target and throws otherwise. That distinction is the whole point: a Metro serving one app reports an **empty target list for several seconds after that app relaunches**, so "no targets" is the normal post-launch state, not a down server. Answering the up/down question with target discovery told authors to start a server that was already running.

## Skill/docs

`argent-device-interact` gains the tool and its two limits; the routing rules gain a line pointing at it for "which screen is the app on". The `await-screen-idle` row joins the same table — it documents a tool that already exists and belongs beside this one.