### PR TITLE
feat(flow): record the screen identity gate from a fingerprint read

### DIFF
--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -84,6 +84,7 @@ Decision order:
   If the user started Metro separately, ask whether to call `stop-metro` (specify the port if not 8081).
 - If tools provided by mcp-server are not sufficient and action can be done using `xcrun`, `adb`, or other commands, use the command. Examples: changing device options, performing a device action such as lock, shake, etc.
 - When waiting for an action, do not call `screenshot` repeatedly without a proper wait mechanism. Use the `await-ui-element` tool to block until the UI settles (e.g. wait for an element to become `visible`/`hidden`, or to contain expected `text`) instead of polling.
+- To confirm which screen a React Native app is on, use `screen-fingerprint` — it reads the app's focused navigation route. It answers only "which screen": it does not see a modal or system alert on top, and the route commits before the transition finishes animating.
   </general_rules>
 
 <react_native_detection>

--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -210,6 +210,18 @@ Instead of polling `screenshot`/`describe` in a loop, use `await-ui-element` to 
 
 Returns `{ success, elapsed }`; on a timeout `success` is `false` and a `note` explains what was seen.
 
+### await-screen-idle — Block until the screen tree settles
+
+Use this after launch/navigation and before a raw tap when an early-painted element may still be moving or non-interactive:
+
+```json
+{ "udid": "<UDID>", "timeoutMs": 3000, "minStableMs": 250 }
+```
+
+The tool supports local iOS, Android, and Chromium. It polls the same accessibility/DOM tree as `describe` until a non-empty tree remains unchanged. Continue only when it returns `settled: true`; `settled: false` is a soft timeout result, not a thrown error. Pair it with `await-ui-element` for a destination-specific landmark because an idle wrong screen is still wrong, and verify the action's outcome because tree stability does not directly test hit-testing. Call it directly for live diagnosis: do not add it with `flow-add-step` or persist it as a raw flow `tool:` step, where a soft `settled: false` result would not hard-fail replay. Do not place it inside `run-sequence` (it is not an allowed nested tool). Flow selector actions already resolve their target from a settled flow tree during replay.
+
+Within a flow, the persistable equivalent is `await: { idle: true }`, which hard-fails on timeout.
+
 ### screen-fingerprint — Which screen is the app on
 
 For a React Native app served by Metro, this reads the focused React Navigation route path and returns it as `"HomeTab>Profile"`:

--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -56,25 +56,27 @@ Common schemes: `messages://`, `settings://`, `maps://?q=<query>`, `tel://<numbe
 
 ## 4. Choosing the Right Tool
 
-| Action            | Tool               | Notes                                                            |
-| ----------------- | ------------------ | ---------------------------------------------------------------- |
-| Multiple actions  | `run-sequence`     | Batch steps in one call (no intermediate screenshots)            |
-| Open an app       | `launch-app`       | **Always — never tap home-screen icons**                         |
-| Restart an app    | `restart-app`      | Terminate and relaunch by bundle ID                              |
-| Open URL/scheme   | `open-url`         | Web pages, deep links, URL schemes                               |
-| Single tap        | `gesture-tap`      | Buttons, links, checkboxes                                       |
-| Scroll/swipe      | `gesture-swipe`    | Straight-line scroll or swipe                                    |
-| Scroll (Chromium) | `gesture-scroll`   | Wheel-based; deltas are window fractions, positive deltaY = down |
-| Drag (Chromium)   | `gesture-drag`     | Sliders, drag-and-drop, text selection                           |
-| Long press        | `gesture-custom`   | Context menus, drag start                                        |
-| Drag & drop       | `gesture-custom`   | Complex drag interactions                                        |
-| Pinch/zoom        | `gesture-pinch`    | Two-finger pinch with auto-interpolation                         |
-| Rotation          | `gesture-rotate`   | Two-finger rotation with auto-interpolation                      |
-| Custom gesture    | `gesture-custom`   | Arbitrary touch sequences, optional interpolation                |
-| Hardware key      | `button`           | Home, back, power, volume, appSwitch, actionButton               |
-| Type text         | `keyboard`         | iOS+Android. Supports Enter, Escape, arrows                      |
-| Rotate device     | `rotate`           | Orientation changes                                              |
-| Wait for UI       | `await-ui-element` | Block until an element is visible/hidden/exists/contains text    |
+| Action            | Tool                 | Notes                                                            |
+| ----------------- | -------------------- | ---------------------------------------------------------------- |
+| Multiple actions  | `run-sequence`       | Batch steps in one call (no intermediate screenshots)            |
+| Open an app       | `launch-app`         | **Always — never tap home-screen icons**                         |
+| Restart an app    | `restart-app`        | Terminate and relaunch by bundle ID                              |
+| Open URL/scheme   | `open-url`           | Web pages, deep links, URL schemes                               |
+| Single tap        | `gesture-tap`        | Buttons, links, checkboxes                                       |
+| Scroll/swipe      | `gesture-swipe`      | Straight-line scroll or swipe                                    |
+| Scroll (Chromium) | `gesture-scroll`     | Wheel-based; deltas are window fractions, positive deltaY = down |
+| Drag (Chromium)   | `gesture-drag`       | Sliders, drag-and-drop, text selection                           |
+| Long press        | `gesture-custom`     | Context menus, drag start                                        |
+| Drag & drop       | `gesture-custom`     | Complex drag interactions                                        |
+| Pinch/zoom        | `gesture-pinch`      | Two-finger pinch with auto-interpolation                         |
+| Rotation          | `gesture-rotate`     | Two-finger rotation with auto-interpolation                      |
+| Custom gesture    | `gesture-custom`     | Arbitrary touch sequences, optional interpolation                |
+| Hardware key      | `button`             | Home, back, power, volume, appSwitch, actionButton               |
+| Type text         | `keyboard`           | Every platform. Supports Enter, Escape, arrows (not on TV)       |
+| Rotate device     | `rotate`             | Orientation changes                                              |
+| Wait for UI       | `await-ui-element`   | Block until an element is visible/hidden/exists/contains text    |
+| Wait for idle     | `await-screen-idle`  | Block until a non-empty screen tree stops changing               |
+| Identify a screen | `screen-fingerprint` | Read which screen a React Native app is on, as its route path    |
 
 ## 5. Finding Tap Targets
 
@@ -203,10 +205,24 @@ Instead of polling `screenshot`/`describe` in a loop, use `await-ui-element` to 
 - `selector`: `{ text?, identifier?, role? }` — every provided field must match. `text` matches the element's label or value and `role` its element role (e.g. `AXButton`, `button`, `TextView`, `StaticText`), both as case-insensitive substrings; `identifier` matches its accessibility id / resource-id / testID **exactly** (case-insensitive), also accepting the unqualified Android resource-id name (`submit` matches `com.example.app:id/submit`). The synthetic `ROOT` container `describe` prints is never matched, so a `role` like `AXGroup`/`html` won't trivially "match the screen".
 - Prefer a **specific** selector. A loose substring can match several elements, and the tool may then key off one you didn't mean: `text` reads the first **visible** match in **reading order** (top-to-bottom, left-to-right — the same order `describe` lists them, so it's the one you saw first; when no match is visible, the first match overall), while `visible`/`exists` are satisfied by **any** match. Disambiguate with a longer or more exact string, an `identifier`, or a `role` (e.g. pin to a text role like `StaticText` to skip a same-named button). On a `text` timeout the `note` quotes the matched element's text, so you can see which one it landed on.
 - `text` condition also needs `expectedText` (substring the matched element must contain).
-- `hidden` treats a selector that matches **nothing** as already-hidden, so a typo'd selector returns an instant (false) success. Double-check the selector for `hidden` waits — the result `note` flags when the selector never matched any element. (On iOS, if the accessibility backend is down the tree comes back empty; the tool will **not** report `hidden` success off such a degraded read and the `note` surfaces the boot hint instead.)
+- `hidden` treats a selector that matches **nothing** as already-hidden, so a typo'd selector returns an instant (false) success. The result `note` flags when the selector never matched any element; treat that note as a failed check, not a pass, and find the real selector before continuing. `flow-add-step` refuses to record such a wait, because a gate that cannot fail proves nothing on replay. (On iOS, if the accessibility backend is down the tree comes back empty; the tool will **not** report `hidden` success off such a degraded read and the `note` surfaces the boot hint instead.)
 - Optional `timeoutMs` (default 5000) and `pollIntervalMs` (default 400).
 
 Returns `{ success, elapsed }`; on a timeout `success` is `false` and a `note` explains what was seen.
+
+### screen-fingerprint — Which screen is the app on
+
+For a React Native app served by Metro, this reads the focused React Navigation route path and returns it as `"HomeTab>Profile"`:
+
+```json
+{ "app_id": "com.acme.notes" }
+```
+
+It answers "which screen" and nothing else — pair it with `await-screen-idle` for readiness, and an element check for an overlay above the screen.
+
+- `available: false` — this app has no reader (release build, fully native app, Chromium, Metro down). Recognize the screen by a destination-only element instead.
+- `route: null` with `available: true` — no focused route at this instant: a native screen, or a transition still in flight. Let it settle and probe again.
+- Optional `platform`, `device`, and `metro_port` (default 8081).
 
 ---
 

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -24,6 +24,12 @@ import {
 } from "../../utils/ui-tree-match";
 import { sleepOrAbort } from "../../utils/timing";
 import { invokeSubTool } from "../../utils/sub-invoke";
+import {
+  connectRouteReader,
+  verifyRouteFingerprint,
+  type RouteReader,
+} from "../../utils/route-identity";
+import { metroServerRunning } from "../../utils/debugger/discovery";
 import { selectorIdentityTerms } from "./flow-selector-evidence";
 import { bindDeviceArgs } from "./flow-device";
 import { fetchFlowTree } from "./flow-tree";
@@ -50,12 +56,69 @@ import {
   type ScrollDirection,
 } from "./flow-utils";
 
+/**
+ * Per-run scratch for `await: { screen: … }` gates. Connecting the RN debugger
+ * costs a Metro discovery plus a CDP attach, so the reader is established once
+ * and reused for every gate in the run. A failed connect is memoized as `null`
+ * (not retried), because "this app has no route reader" is a property of the
+ * build, not a transient.
+ */
+export interface ScreenIdentityState {
+  /** App id of the last executed `launch` step — the default a gate reads. */
+  launchedAppId?: string;
+  /**
+   * Memoized readers keyed `<appId>@<metroPort>`. SUCCESSES ONLY — a failed
+   * connect is never stored, because the debugger session comes and goes with
+   * the app: a `launch` invalidates it, and the first gate after one routinely
+   * connects too early. Caching that failure made every later gate on the run
+   * fail instantly with no wait, which no per-step `timeout:` could rescue.
+   */
+  readers: Map<string, RouteReader>;
+  /**
+   * Keys whose platform can never have a route reader (chromium has no React
+   * Navigation). Permanent for the run — unlike a failed connect, retrying
+   * cannot change the answer.
+   */
+  unsupported: Set<string>;
+  /**
+   * Keys whose connect exhausted its whole retry budget since the last
+   * `launch`. NOT the cache R2 forbids: this one is scoped to the launch
+   * epoch and cleared by every launch, so the case that poisoned runs — a
+   * gate that connected into the post-launch gap and condemned the rest of
+   * the run — cannot recur.
+   *
+   * It is a backstop, not a load-bearing optimization, and the difference is
+   * worth stating because the obvious reading ("it saves the flow's LATER
+   * gates from paying the budget again") does not hold: an exhausted connect
+   * makes the step `indeterminate`, the runner scores that `error`, and an
+   * errored step stops the run — so no later step gets to consult this set.
+   * What it does cover is a second `routeReaderFor` inside ONE step, and the
+   * only such caller (the reconnect after an all-null poll) deliberately
+   * clears the key first. Keep it as the guard that bounds any future caller;
+   * do not credit it with saving time on today's paths.
+   */
+  connectExhausted: Set<string>;
+  /**
+   * True while the app is in the window right after a `launch` (and at the
+   * start of a run, whose first step is a launch for an e2e flow). The first
+   * connect of such an epoch is allowed a much larger budget, because the app
+   * is not slow to answer — it is not registered with Metro yet at all.
+   * Cleared by the first successful connect.
+   */
+  coldSinceLaunch: boolean;
+}
+
 /** Everything a directive needs to act on the run's device. */
 export interface ActionEnv {
   registry: Registry;
   ctx?: ToolContext;
   device: DeviceInfo;
   signal?: AbortSignal;
+  /**
+   * Present for a flow run; absent for one-off directive callers. A `screen`
+   * gate without it fails with authoring guidance rather than silently passing.
+   */
+  screenIdentity?: ScreenIdentityState;
   /**
    * Selector identity terms (`id:…`/`text:…`) the run has positively
    * established so far — populated by the runner as each step passes. Absent
@@ -107,10 +170,22 @@ export const ABORTED_OUTCOME: DirectiveOutcome = {
   reason: "run aborted",
 };
 
-/** The selector-acting steps {@link runDirective} handles. */
+/** The condition/action steps {@link runDirective} handles. */
 export type DirectiveStep = Extract<
   FlowStep,
-  { kind: "tap" | "long-press" | "type" | "await" | "assert" | "scroll-to" | "pinch" | "rotate" }
+  {
+    kind:
+      | "tap"
+      | "long-press"
+      | "type"
+      | "await"
+      | "assert"
+      | "screen"
+      | "idle"
+      | "scroll-to"
+      | "pinch"
+      | "rotate";
+  }
 >;
 
 /** Dispatch a tool with the run's resolved device id bound into its args. */
@@ -492,16 +567,26 @@ function collectFocused(node: DescribeNode, acc: DescribeNode[]): DescribeNode[]
 }
 
 /**
- * Poll until an element reporting `focused` overlaps the typed-into element.
- * Overlap, not identity: the selector often matches a testID container while
- * focus is reported by the input inside it. The target's frame is re-resolved
- * each round — the keyboard sliding up routinely scrolls the field away from
- * where it was tapped (keyboard avoidance), and the focused element must be
- * compared against where the field is NOW; `tappedFrame` covers rounds where
- * the selector momentarily doesn't resolve. Best-effort by design — a source
- * that can't report focus returns immediately, and an unconfirmed poll falls
- * through to typing after the timeout rather than failing the step, since "no
- * focus seen" can also mean the focused view didn't make it into the tree.
+ * Poll until an element reporting `focused` nests with the typed-into element,
+ * per {@link framesNest} — containment, not identity and not bare overlap. The
+ * selector often matches a testID container while focus is reported by the
+ * input inside it, which is why identity is too strict; an element that merely
+ * clips a corner of the target is evidence of nothing, which is why overlap is
+ * too loose. The target's frame is re-resolved each round — the keyboard
+ * sliding up routinely scrolls the field away from where it was tapped
+ * (keyboard avoidance), and the focused element must be compared against where
+ * the field is NOW; `tappedFrame` covers rounds where the selector momentarily
+ * doesn't resolve.
+ *
+ * The verdict is returned rather than swallowed, and the three ways of not
+ * saying "confirmed" are kept apart, because they warrant opposite responses:
+ *
+ * - `unreported` — the source cannot surface focus at all (Vega). Nothing to
+ *   wait for and nothing to conclude; typing proceeds as it always has.
+ * - `unreadable` — the source can, but every read of the window threw. That is
+ *   an environment problem, not evidence about where focus went.
+ * - `unconfirmed` — reads succeeded and no focused element overlapped the
+ *   field. This is real evidence the keys would land somewhere else.
  */
 type FocusVerdict = "confirmed" | "unconfirmed" | "unreported" | "unreadable" | "aborted";
 
@@ -727,6 +812,10 @@ export async function runDirective(env: ActionEnv, step: DirectiveStep): Promise
       return waitForCondition(env, step, step.timeout ?? DEFAULT_ACTION_TIMEOUT_MS);
     case "assert":
       return waitForCondition(env, step, DEFAULT_ASSERT_TIMEOUT_MS);
+    case "screen":
+      return waitForScreen(env, step);
+    case "idle":
+      return waitForIdle(env, step);
     case "scroll-to": {
       const r = await scrollToVisible(env, step.target, step.direction, step.within);
       if (r.aborted) return ABORTED_OUTCOME;
@@ -987,13 +1076,6 @@ async function runRotate(
 }
 
 /**
- * Resolve `into` → tap to focus → wait for focus to land → type text via the
- * keyboard tool. Unless `submit` is explicitly `false`, a trailing Enter is
- * pressed to commit the value and dismiss the keyboard, so it can't obscure
- * later steps (chained form fields that end in an explicit submit `tap` should
- * pass `submit: false`).
- */
-/**
  * Tap a field's centre and wait for focus to land there, re-resolving the
  * field's frame first (the keyboard sliding up can scroll it).
  */
@@ -1004,11 +1086,25 @@ async function tapForFocus(
 ): Promise<FocusVerdict> {
   await invokeOnDevice(env, "gesture-tap", getDescribeTapPoint(frame));
   // Keys are injected at the HID level and go to whatever holds focus, so the
-  // tap-to-type gap must cover the app's focus round-trip (see the constants).
+  // tap→type gap must cover the app's focus round-trip (see the constants).
   if (!(await sleepOrAbort(TYPE_FOCUS_SETTLE_MS, env.signal))) return "aborted";
   return waitForFocus(env, into, frame);
 }
 
+/**
+ * Resolve `into` → tap to focus → wait for focus to land → type text via the
+ * keyboard tool. Unless `submit` is explicitly `false`, a trailing Enter is
+ * pressed to commit the value and dismiss the keyboard, so it can't obscure
+ * later steps (chained form fields that end in an explicit submit `tap` should
+ * pass `submit: false`).
+ *
+ * Typing is refused when focus was NOT confirmed on a source that reports it.
+ * Keys go to the HID layer, not to the element — unfocused, they land wherever
+ * the app last put the caret, and the damage shows up much later: the observed
+ * case was a dropped leading character that iOS autocorrect then completed into
+ * a different word, which the app saved. One retry first, because losing the
+ * focus race is far more common than the field being untappable.
+ */
 async function runType(
   env: ActionEnv,
   step: { into: FlowSelector; text: string; submit?: boolean }
@@ -1068,23 +1164,6 @@ async function runType(
 const NEEDS_SECOND_READ: ReadonlySet<WaitCondition> = new Set(["exists", "visible", "text"]);
 
 /**
- * Identity of the set of nodes a selector matched, for comparing one read
- * against the next. Frames are included: an element still sliding into place
- * has not settled, and a `tap` resolved against a moving frame lands where the
- * element no longer is.
- */
-function matchFingerprint(matches: DescribeNode[]): string {
-  return matches
-    .map(
-      (n) =>
-        `${n.role}|${Math.round(n.frame.x * 1000)},${Math.round(n.frame.y * 1000)},` +
-        `${Math.round(n.frame.width * 1000)},${Math.round(n.frame.height * 1000)}` +
-        `|${n.label ?? ""}|${n.value ?? ""}|${n.identifier ?? ""}|${n.subtreeText ?? ""}`
-    )
-    .join("\n");
-}
-
-/**
  * Whether a `hidden` check that never saw its selector can still fail — i.e.
  * whether an earlier step of the run positively established that selector.
  * With no evidence set at all (a one-off directive caller outside a flow run)
@@ -1126,6 +1205,23 @@ export function vacuousHiddenReason(selector: FlowSelector): string {
 }
 
 /**
+ * Identity of the set of nodes a selector matched, for comparing one read
+ * against the next. Frames are included: an element still sliding into place
+ * has not settled, and a `tap` resolved against a moving frame lands where the
+ * element no longer is.
+ */
+function matchFingerprint(matches: DescribeNode[]): string {
+  return matches
+    .map(
+      (n) =>
+        `${n.role}|${Math.round(n.frame.x * 1000)},${Math.round(n.frame.y * 1000)},` +
+        `${Math.round(n.frame.width * 1000)},${Math.round(n.frame.height * 1000)}` +
+        `|${n.label ?? ""}|${n.value ?? ""}|${n.identifier ?? ""}|${n.subtreeText ?? ""}`
+    )
+    .join("\n");
+}
+
+/**
  * Poll a condition against the flow tree until it holds or `timeoutMs` passes.
  * One engine behind both conditional directives — they differ only in budget
  * and intent:
@@ -1146,6 +1242,10 @@ export function vacuousHiddenReason(selector: FlowSelector): string {
  * satisfies) when the adapter flagged the read as degraded or the selector had
  * matched on an earlier poll — a transient blank frame mid-navigation must not
  * confirm the element left.
+ *
+ * A POSITIVE verdict additionally has to survive a second read (see
+ * {@link matchFingerprint}). A silently-wrong green is worse than a flake: the
+ * test has stopped testing, and nothing downstream will ever flag it.
  */
 async function waitForCondition(
   env: ActionEnv,
@@ -1197,13 +1297,14 @@ async function waitForCondition(
         !blind &&
         evaluateCondition(step.condition, step.expectedText, lastMatches, step.textMatch)
       ) {
-        // `hidden` satisfied without the selector ever matching, by a flow
-        // that never showed it present, is a gate that cannot fail — a typo,
-        // a renamed id and the wrong screen all pass it. The recorder refuses
-        // to WRITE one; refuse to score one as clean, or a hand-written (or
-        // hand-edited) flow keeps the permanently-green check the recorder
-        // exists to prevent.
         if (!NEEDS_SECOND_READ.has(step.condition)) {
+          // `hidden` satisfied without the selector ever matching, by a flow
+          // that never showed it present, is a gate that cannot fail — a typo,
+          // a renamed id and the wrong screen all pass it. The recorder refuses
+          // to WRITE one; refuse to score one, or a hand-written (or
+          // hand-edited) flow keeps the permanently-green check the recorder
+          // exists to prevent. Indeterminate, not failed: nothing was learned
+          // about the app, and reporting a regression here would be a lie.
           if (
             step.condition === "hidden" &&
             !everMatched &&
@@ -1376,6 +1477,380 @@ function compatibilityMissNote(
         `(a rendered "…" is ONE character, not three dots; likewise ligatures and fullwidth ` +
         `forms). Those are not folded together, because doing so would also equate a styled ` +
         `display name with the plain one it imitates. Copy the characters the app actually renders.`;
+}
+
+// ── Screen identity and readiness ────────────────────────────────────
+//
+// Two checks a selector condition cannot express, and which the flows that
+// prompted them were substituting fixed `wait:` steps for:
+//
+//   screen  — WHICH screen, from the app's own navigation state
+//   idle    — has it stopped moving
+//
+// They are deliberately separate. A dropped tap leaves the source screen
+// perfectly idle, so readiness cannot prove identity; navigation state commits
+// before the transition animates, so identity cannot prove readiness.
+
+/** Route-fingerprint poll cadence. `assert` uses timeout 0 — one probe. */
+const SCREEN_POLL_MS = 250;
+const SCREEN_DEFAULT_TIMEOUT_MS = 7500;
+const DEFAULT_METRO_PORT = 8081;
+
+/** `idle` poll cadence, matching `await-screen-idle`'s defaults. */
+const IDLE_POLL_MS = 200;
+const IDLE_DEFAULT_TIMEOUT_MS = 7500;
+const IDLE_DEFAULT_MIN_STABLE_MS = 250;
+
+/**
+ * How long a route-reader connect may keep retrying. Floored so an `assert`
+ * (budget 0) still rides out a connect that is merely early, and otherwise the
+ * step's own `timeout:` — connecting is setup, so it is NOT charged against the
+ * route-polling budget (see {@link waitForScreen}); a `timeout:` therefore buys
+ * time for both phases rather than being silently spent on one.
+ */
+const CONNECT_RETRY_FLOOR_MS = 2500;
+const CONNECT_RETRY_INTERVAL_MS = 400;
+
+/**
+ * The floor for the FIRST connect after a `launch`, which is a cold one: the
+ * app has just been terminated and relaunched, and it re-registers with Metro
+ * on its own schedule — measured at ~12.5s for a React Native app on a loaded
+ * simulator host. The previous 5s cap made the gate in the position both flow
+ * skills mandate (`launch:` then identity) unreachable: the connect gave up
+ * before the app came back, no `timeout:` could raise the cap, and the step
+ * reported an environment failure naming three causes that were all false.
+ *
+ * Spent only while Metro is actually REACHABLE on the port (see
+ * {@link metroReachable}). An app with no Metro at all — a release build, a
+ * fully native app — still fails fast on the floor above rather than making
+ * every run wait out this window to be told what it could learn immediately.
+ */
+const POST_LAUNCH_CONNECT_FLOOR_MS = 20_000;
+
+function connectBudgetMs(stepTimeoutMs: number): number {
+  return Math.max(CONNECT_RETRY_FLOOR_MS, stepTimeoutMs);
+}
+
+/**
+ * The run's route reader for `appId`, connecting on first use and retrying
+ * within `budgetMs` until one lands.
+ *
+ * Only a SUCCESSFUL connect is memoized. The debugger session is tied to the
+ * app process, so a `launch` invalidates it and the gate that follows connects
+ * into the gap while the app re-registers with Metro; remembering that failure
+ * poisoned every later gate on the run. Retrying inside the step's budget is
+ * also what makes `flow-execute` own connection setup end to end — recycling
+ * the simulator services before a run no longer needs an external ordering
+ * ritual to be survivable.
+ */
+async function routeReaderFor(
+  env: ActionEnv,
+  appId: string,
+  metroPort: number,
+  budgetMs: number
+): Promise<RouteReader | null> {
+  const state = env.screenIdentity;
+  if (state === undefined) return null;
+  const key = `${appId}@${metroPort}`;
+  const cached = state.readers.get(key);
+  if (cached !== undefined) return cached;
+  if (state.unsupported.has(key) || state.connectExhausted.has(key)) return null;
+  // chromium has no React Navigation; ios-remote is an iOS simulator over a
+  // remote bridge and reads exactly like a local one.
+  const platform = env.device.platform === "ios-remote" ? "ios" : env.device.platform;
+  if (platform === "chromium") {
+    state.unsupported.add(key);
+    return null;
+  }
+  let deadline = Date.now() + budgetMs;
+  // A cold epoch is the window after a `launch`, where the app is not merely
+  // slow to answer but absent from Metro entirely while it boots. Extending the
+  // budget there is only justified while Metro itself is up: that is what
+  // distinguishes "the app has not re-registered YET" from "this build has no
+  // reader at all", and only the first is worth waiting out.
+  if (state.coldSinceLaunch && budgetMs < POST_LAUNCH_CONNECT_FLOOR_MS) {
+    if (await metroReachable(metroPort)) {
+      deadline = Math.max(deadline, Date.now() + POST_LAUNCH_CONNECT_FLOOR_MS);
+    }
+  }
+  for (;;) {
+    if (env.signal?.aborted) return null;
+    const reader = await connectRouteReader(env.registry, env.ctx, {
+      udid: env.device.id,
+      bundleId: appId,
+      metroPort,
+      platform,
+    });
+    if (reader) {
+      state.readers.set(key, reader);
+      // The app is registered and attached; a later connect in this run is a
+      // reconnect, not a cold boot, and must not buy the launch window again.
+      state.coldSinceLaunch = false;
+      return reader;
+    }
+    if (Date.now() >= deadline) {
+      state.connectExhausted.add(key);
+      return null;
+    }
+    const sleepMs = Math.min(CONNECT_RETRY_INTERVAL_MS, Math.max(0, deadline - Date.now()));
+    if (!(await sleepOrAbort(sleepMs, env.signal))) return null;
+  }
+}
+
+/**
+ * Whether a Metro dev server is answering on `port` at all. Never throws.
+ *
+ * Asks only whether the SERVER is up, not whether an app is attached to it —
+ * see {@link metroServerRunning}. Both callers below are in the window right
+ * after a `launch`, where the app under test has deregistered and a Metro
+ * serving only that app reports an empty target list. Answering this question
+ * with target discovery made both of them read that normal window as "Metro is
+ * down": the connect budget lost its post-launch extension, and the failure
+ * told the author to start a server that was already running.
+ */
+async function metroReachable(port: number): Promise<boolean> {
+  return metroServerRunning(port);
+}
+
+/**
+ * Drop a memoized reader whose debugger session has gone dead (the app
+ * reloaded, the services were recycled) so the next gate reconnects instead of
+ * reusing a handle that can only ever return null.
+ */
+function evictRouteReader(env: ActionEnv, appId: string, metroPort: number): boolean {
+  const key = `${appId}@${metroPort}`;
+  // Re-arm the budget alongside the eviction: this path exists precisely to
+  // spend one more connect, so an exhaustion recorded earlier in the epoch
+  // must not short-circuit it.
+  env.screenIdentity?.connectExhausted.delete(key);
+  return env.screenIdentity?.readers.delete(key) ?? false;
+}
+
+/**
+ * Forget every route reader, and re-arm the retry budget — called by `launch`,
+ * which terminates the app and with it the JS runtime each reader is attached
+ * to. Without this a post-launch gate would probe a handle onto a process that
+ * no longer exists, and a connect that failed before the relaunch would keep
+ * standing in for one that has every reason to succeed now.
+ */
+export function resetRouteReaders(state: ScreenIdentityState | undefined): void {
+  state?.readers.clear();
+  state?.connectExhausted.clear();
+  // The app is coming back from a cold start; the next connect must be allowed
+  // to wait out its Metro re-registration (see POST_LAUNCH_CONNECT_FLOOR_MS).
+  if (state) state.coldSinceLaunch = true;
+}
+
+/**
+ * Prove the app is on the screen the step names, by exact route match.
+ *
+ * Every failure mode is distinct in the reason, because they call for opposite
+ * responses: a DIFFERENT route means the app is genuinely elsewhere (a dropped
+ * tap, or a real regression — the thing the flow exists to catch); NO route
+ * means the check itself could not run, which is never allowed to read as a
+ * pass.
+ */
+async function waitForScreen(
+  env: ActionEnv,
+  step: Extract<FlowStep, { kind: "screen" }>
+): Promise<DirectiveOutcome> {
+  const appId = step.app ?? env.screenIdentity?.launchedAppId;
+  if (appId === undefined) {
+    return {
+      ok: false,
+      indeterminate: true,
+      reason:
+        "no app to read the route from — add `app:` to the screen check, or a `launch` step " +
+        "before it so the flow declares which app it drives",
+    };
+  }
+  const metroPort = step.metroPort ?? DEFAULT_METRO_PORT;
+  const timeoutMs = step.mode === "assert" ? 0 : (step.timeout ?? SCREEN_DEFAULT_TIMEOUT_MS);
+
+  const reader = await routeReaderFor(env, appId, metroPort, connectBudgetMs(timeoutMs));
+  // Deliberately anchored AFTER the connect. `timeout:` is the author's answer
+  // to "how long may this screen take to arrive", and attaching the debugger is
+  // not the screen arriving: charging setup to the same budget made a generous
+  // timeout buy nothing on exactly the gate that needed it (the one after a
+  // `launch`), and made "waited 7500ms" describe a window that was mostly spent
+  // connecting.
+  const deadline = Date.now() + timeoutMs;
+  if (env.signal?.aborted) return ABORTED_OUTCOME;
+  if (reader === null) {
+    // A platform that can never have a route reader is a different answer from
+    // a connect that did not land, and it deserves to be said: telling a
+    // Chromium author that "Metro is down" and to "fix the connection" sends
+    // them after something that does not exist and cannot be repaired — and
+    // since an indeterminate step reports as `errored`, the QA contract's
+    // "fix the environment and rerun" would loop forever on it.
+    const unsupported = env.screenIdentity?.unsupported.has(`${appId}@${metroPort}`) === true;
+    if (unsupported) {
+      return {
+        ok: false,
+        indeterminate: true,
+        reason:
+          `\`screen\` reads the focused React Navigation route over the Metro debugger, and ` +
+          `${env.device.platform} has neither — no retry or environment change will make this ` +
+          `work. Gate this navigation on a destination-only element instead.`,
+      };
+    }
+    // Which of the causes actually holds is checkable, so check it rather than
+    // listing all of them: naming "Metro is down" while Metro is demonstrably
+    // up sends the author to repair something that is not broken, and the
+    // conclusion they draw — that this app can only be gated on elements —
+    // deletes the identity proof for the rest of the flow.
+    const metroUp = await metroReachable(metroPort);
+    return {
+      ok: false,
+      indeterminate: true,
+      reason: metroUp
+        ? `Metro is running on port ${metroPort}, but no debuggable target for "${appId}" ` +
+          `registered there in time. The app re-registers a few seconds AFTER it relaunches, so ` +
+          `a gate this close to a \`launch\` can outrun it. The fix is the readiness gate the ` +
+          `launch itself is supposed to have: an \`await\` on the real first screen, recorded ` +
+          `directly after \`launch:\`, which holds until the app is actually up and leaves this ` +
+          `route readable. (That is the launch's own gate — it does NOT reorder identity and ` +
+          `readiness within a navigation, where identity still comes first.) Failing that, ` +
+          `raise this step's \`timeout:\`. Otherwise this build is not a debuggable RN build, ` +
+          `or the port serves a different app. Screen identity is unknown, not wrong.`
+        : `no Metro dev server is answering on port ${metroPort}, so the route cannot be read ` +
+          `for "${appId}". This is an environment failure, not a verdict about the app: start ` +
+          `Metro (or point the step at the right \`metroPort:\`), or gate on a destination-only ` +
+          `element instead of \`screen\`.`,
+    };
+  }
+  // The polling budget is the step's whole `timeout:`, because `deadline` was
+  // anchored after the connect (above) — the connect is setup and is NOT
+  // charged here. A function rather than a constant because the reconnect path
+  // below re-enters this with time already spent, and an `assert` (budget 0)
+  // still gets its single probe, the same floor it runs on everywhere.
+  const pollMs = () => Math.max(0, deadline - Date.now());
+  let outcome = await verifyRouteFingerprint(
+    reader,
+    step.route,
+    pollMs(),
+    SCREEN_POLL_MS,
+    env.signal
+  );
+  // Every probe came back null: either the screen genuinely has no route, or
+  // the memoized reader is attached to a runtime that has since gone away (a
+  // Fast Refresh reload, recycled services). The two are indistinguishable
+  // from here, so spend one reconnect finding out rather than reporting an
+  // environment problem the run could have repaired itself.
+  if (!outcome.ok && !outcome.aborted && outcome.observedRoute === undefined) {
+    if (env.signal?.aborted) return ABORTED_OUTCOME;
+    if (evictRouteReader(env, appId, metroPort)) {
+      const fresh = await routeReaderFor(env, appId, metroPort, connectBudgetMs(timeoutMs));
+      if (env.signal?.aborted) return ABORTED_OUTCOME;
+      if (fresh) {
+        outcome = await verifyRouteFingerprint(
+          fresh,
+          step.route,
+          pollMs(),
+          SCREEN_POLL_MS,
+          env.signal
+        );
+      }
+    }
+  }
+  if (outcome.aborted) return ABORTED_OUTCOME;
+  if (outcome.ok) return { ok: true };
+  if (outcome.observedRoute !== undefined) {
+    return {
+      ok: false,
+      reason:
+        `the app is on "${outcome.observedRoute}", not "${step.route}"` +
+        (timeoutMs > 0 ? ` (waited ${timeoutMs}ms)` : "") +
+        " — the navigation did not land where this step expects",
+    };
+  }
+  return {
+    ok: false,
+    indeterminate: true,
+    reason:
+      `no focused route could be read within ${timeoutMs}ms — the screen is native, the app ` +
+      `reloaded, or the transition never settled. Screen identity is unknown, not wrong.`,
+  };
+}
+
+/**
+ * Wait until the UI tree has content and holds it identical for `minStableMs`.
+ *
+ * This is `await-screen-idle`'s question asked against the tree the directives
+ * actually resolve against, and — unlike that tool — it FAILS when the screen
+ * never settles, which is what makes it safe to persist in a flow. It says
+ * nothing about which screen settled: pair it with a `screen` or element check.
+ */
+async function waitForIdle(
+  env: ActionEnv,
+  step: Extract<FlowStep, { kind: "idle" }>
+): Promise<DirectiveOutcome> {
+  const timeoutMs = step.timeout ?? IDLE_DEFAULT_TIMEOUT_MS;
+  const minStableMs = step.minStableMs ?? IDLE_DEFAULT_MIN_STABLE_MS;
+  const deadline = Date.now() + timeoutMs;
+  let stableSignature: string | undefined;
+  let stableSince = 0;
+  let sawContent = false;
+  let fetchError: string | undefined;
+
+  for (;;) {
+    if (env.signal?.aborted) return ABORTED_OUTCOME;
+    try {
+      const { tree } = await fetchFlowTree(env.registry, env.device);
+      fetchError = undefined;
+      if (tree.children.length === 0) {
+        // Blank or still loading — never "settled", and it resets the hold.
+        stableSignature = undefined;
+        stableSince = 0;
+      } else {
+        sawContent = true;
+        const signature = treeFingerprint(tree);
+        const now = Date.now();
+        if (signature === stableSignature) {
+          if (now - stableSince >= minStableMs) return { ok: true };
+        } else {
+          stableSignature = signature;
+          stableSince = now;
+          if (minStableMs === 0) return { ok: true };
+        }
+      }
+    } catch (err) {
+      // A tree-source blip mid-animation is expected; keep polling. Only its
+      // persistence to the deadline is reportable.
+      fetchError = err instanceof Error ? err.message : String(err);
+      stableSignature = undefined;
+      stableSince = 0;
+    }
+    if (env.signal?.aborted) return ABORTED_OUTCOME;
+    if (Date.now() >= deadline) break;
+    if (!(await sleepOrAbort(IDLE_POLL_MS, env.signal))) return ABORTED_OUTCOME;
+  }
+
+  // "Never stopped moving" is a real verdict about the app. "Never got a
+  // readable tree" is not — it must not masquerade as one.
+  if (!sawContent) {
+    return {
+      ok: false,
+      indeterminate: true,
+      reason: fetchError
+        ? // The underlying reader reports an instrumentation failure, whose
+          // remedy (relaunch the app) is the wrong repair for the commonest
+          // cause of it here: the app is simply not in the foreground, which
+          // reads exactly the same from the tree source. Name that first so
+          // the author checks it before relaunching anything.
+          `could not read the UI tree while waiting for the screen to settle — check the app is ` +
+          `still in the foreground (a backgrounded app reads the same as an uninstrumented one). ` +
+          `Underlying error: ${fetchError}`
+        : `the UI tree stayed empty for ${timeoutMs}ms — the screen never rendered content`,
+    };
+  }
+  return {
+    ok: false,
+    reason:
+      `the screen never held still for ${minStableMs}ms within ${timeoutMs}ms — it is still ` +
+      `animating, or something on it is permanently in motion (a spinner, a looping animation). ` +
+      `Gate on the element you actually need instead of on stillness.`,
+  };
 }
 
 function assertReason(

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -29,17 +29,18 @@ import {
   isUnmetUiWaitResult,
   vacuousHiddenSelectors,
 } from "../await-ui-element";
+import { SCREEN_FINGERPRINT_TOOL_ID, type ScreenFingerprintResult } from "../screen-fingerprint";
 import { AWAIT_SCREEN_IDLE_TOOL_ID } from "../await-screen-idle";
-import { selectorEstablishedInSteps } from "./flow-selector-evidence";
 import { runSequenceFailure } from "../run-sequence";
-import { probeWhenCondition } from "./flow-actions";
+import { selectorEstablishedInSteps } from "./flow-selector-evidence";
 import { NATIVE_READY_POLL_MS, NATIVE_READY_TIMEOUT_MS } from "./flow-run";
-import { summarizeStep } from "./flow-finish-recording";
 import { invokeSubTool } from "../../utils/sub-invoke";
 import { settleWithin, sleepOrAbort } from "../../utils/timing";
 import { resolveDevice } from "../../utils/device-info";
 import { stripDeviceKeys } from "./flow-device";
 import { fetchFlowTree } from "./flow-tree";
+import { probeWhenCondition } from "./flow-actions";
+import { summarizeStep } from "./flow-finish-recording";
 import type { DescribeFrame, DescribeNode, DescribeSource } from "../describe/contract";
 import {
   nodeAtPoint,
@@ -61,7 +62,7 @@ const zodSchema = z.object({
     .describe(
       "Absolute path to the project root of the flow being recorded — the same value passed to flow-start-recording. Together with `name` it identifies which recording this step belongs to."
     ),
-  command: z.string().describe('MCP tool name (e.g. "gesture-tap", "screenshot", "launch-app")'),
+  command: z.string().describe('MCP tool name (e.g. "gesture-tap", "screenshot", "restart-app")'),
   args: z
     .string()
     .optional()
@@ -123,82 +124,6 @@ function readinessMissesFor(session: RecordingSession): Set<string> {
   return misses;
 }
 
-async function awaitIosDevtoolsTarget(
-  registry: Registry,
-  device: DeviceInfo,
-  bundleId?: string,
-  signal?: AbortSignal
-): Promise<CaptureReadiness> {
-  if (signal?.aborted) return "aborted";
-  let api: NativeDevtoolsApi;
-  try {
-    const ndRef = nativeDevtoolsRef(device);
-    api = await registry.resolveService<NativeDevtoolsApi>(ndRef.urn, ndRef.options);
-  } catch {
-    return signal?.aborted ? "aborted" : "unavailable";
-  }
-  const deadline = Date.now() + NATIVE_READY_TIMEOUT_MS;
-  for (;;) {
-    if (signal?.aborted) return "aborted";
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) return "timed-out";
-
-    if (bundleId) {
-      try {
-        if (api.isConnected(bundleId)) return "ready";
-      } catch {
-        // Treat a transient connection read as not-ready and keep polling.
-      }
-    } else {
-      // Fragment auto-targeting must inspect app state, whose RPC can itself
-      // wedge. Race it against the remaining budget so the advertised
-      // 8-second gate stays a hard cap rather than 8 seconds between
-      // potentially multi-second getAppState calls.
-      const inspected = await settleWithin(inspectConnectedNativeApps(api), remaining, signal);
-      if (inspected.type === "aborted") return "aborted";
-      if (inspected.type === "timeout") return "timed-out";
-      if (inspected.type === "value" && chooseFrontmostConnectedApp(inspected.value)) {
-        return "ready";
-      }
-    }
-
-    const delayMs = Math.min(NATIVE_READY_POLL_MS, deadline - Date.now());
-    if (delayMs <= 0) return "timed-out";
-    if (!(await sleepOrAbort(delayMs, signal))) return "aborted";
-  }
-}
-
-function leadingLaunch(session: RecordingSession): Extract<FlowStep, { kind: "launch" }> | null {
-  const first = session.flow.steps.find((step) => step.kind !== "echo");
-  return first?.kind === "launch" ? first : null;
-}
-
-function recordedLaunchApp(session: RecordingSession, platform: string): string | null {
-  const launch = leadingLaunch(session);
-  return launch ? appIdForPlatform(launch.app, platform) : null;
-}
-
-function invalidateReadinessMissAfterAppStart(
-  session: RecordingSession,
-  command: string,
-  args: Record<string, unknown>,
-  result: unknown
-): void {
-  const didStart =
-    typeof result === "object" &&
-    result !== null &&
-    ((command === "restart-app" && (result as { restarted?: unknown }).restarted === true) ||
-      (command === "launch-app" && (result as { launched?: unknown }).launched === true));
-  if (!didStart) return;
-
-  const misses = readinessMissesFor(session);
-  // Both tools require a device id, but clearing all misses is the safe fallback
-  // for older/custom registry adapters that omit it: a successful app start is
-  // fresh evidence and another bounded probe is preferable to a stale miss.
-  if (typeof args.udid === "string") misses.delete(args.udid);
-  else misses.clear();
-}
-
 function platformOf(udid: unknown): string | undefined {
   try {
     if (typeof udid === "string") return resolveDevice(udid).platform;
@@ -256,75 +181,69 @@ function abortError(): Error {
   return err;
 }
 
-/**
- * The recorder and the runner read DIFFERENT trees. `await-ui-element`
- * evaluates against the accessibility tree; the `await:`/`assert:` DIRECTIVE
- * that polish converts this step into is evaluated against the runner's tree.
- * They overlap but neither contains the other — an id present in one can be
- * absent from the other, and on iOS even the role vocabularies are disjoint.
- * So a check can pass live and fail once converted, which makes "each step is
- * executed live so you verify it works" untrue exactly where it matters.
- *
- * Re-probe the same condition against the runner's tree and report the answer.
- * It is a WARNING, never a refusal: the step is recorded as a raw
- * `tool: await-ui-element`, and at replay that tool reads the SAME
- * accessibility tree it just passed against — so "it would fail every run" was
- * false for the form actually written. What the probe really tells the author
- * is whether the conversion is safe, which is a polish-time decision, and the
- * blocking audit is where a flow is held to it.
- */
-async function probeAgainstRunnerTree(
+async function awaitIosDevtoolsTarget(
   registry: Registry,
-  ctx: Parameters<typeof invokeSubTool>[1],
-  args: Record<string, unknown>
-): Promise<{ warning?: string }> {
-  const selector = args.selector;
-  const condition = args.condition;
-  if (typeof condition !== "string" || selector === null || typeof selector !== "object") {
-    return {};
-  }
-  if (typeof args.udid !== "string") return {}; // nothing to probe against
-  let device: DeviceInfo;
+  device: DeviceInfo,
+  bundleId?: string,
+  signal?: AbortSignal
+): Promise<CaptureReadiness> {
+  if (signal?.aborted) return "aborted";
+  let api: NativeDevtoolsApi;
   try {
-    device = resolveDevice(args.udid);
+    const ndRef = nativeDevtoolsRef(device);
+    api = await registry.resolveService<NativeDevtoolsApi>(ndRef.urn, ndRef.options);
   } catch {
-    return {}; // unresolvable device; the live result stands
+    return signal?.aborted ? "aborted" : "unavailable";
   }
-  const outcome = await probeWhenCondition(
-    // The signal rides on ActionEnv separately from `ctx`, so pass it too:
-    // a cancelled flow-add-step must stop this probe rather than polling on.
-    { registry, ctx, device, signal: ctx?.signal },
-    {
-      condition: condition as WaitCondition,
-      selector: selector as FlowSelector,
-      expectedText: typeof args.expectedText === "string" ? args.expectedText : undefined,
-      textMatch: args.textMatch as TextMatchMode | undefined,
+  const deadline = Date.now() + NATIVE_READY_TIMEOUT_MS;
+  for (;;) {
+    if (signal?.aborted) return "aborted";
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return "timed-out";
+
+    if (bundleId) {
+      try {
+        if (api.isConnected(bundleId)) return "ready";
+      } catch {
+        // Treat a transient connection read as not-ready and keep polling.
+      }
+    } else {
+      // Fragment auto-targeting must inspect app state, whose RPC can itself
+      // wedge. Race it against the remaining budget so the advertised
+      // 8-second gate stays a hard cap rather than 8 seconds between
+      // potentially multi-second getAppState calls.
+      const inspected = await settleWithin(inspectConnectedNativeApps(api), remaining, signal);
+      if (inspected.type === "aborted") return "aborted";
+      if (inspected.type === "timeout") return "timed-out";
+      if (inspected.type === "value" && chooseFrontmostConnectedApp(inspected.value)) {
+        return "ready";
+      }
     }
-  );
-  if (outcome.ok) return {};
-  if (outcome.aborted) throw abortError();
-  if (outcome.indeterminate) {
-    return {
-      // No trailing period: the caller joins this with ". " and a second one
-      // renders as "..". And no claim that the two trees DIFFER — nothing was
-      // compared. The runner's tree could not be read at all, which is an
-      // environment failure; reporting it as a known divergence sends the
-      // author to rewrite a selector that may be perfectly good.
-      warning:
-        `this check could not be re-verified against the tree the RUNNER reads ` +
-        `(${outcome.reason}), so it passed against the accessibility tree only. Whether it ` +
-        `would convert to \`await:\`/\`assert:\` is UNKNOWN, not known-bad — re-probe once that ` +
-        `tree source is back before trusting the conversion`,
-    };
+
+    const delayMs = Math.min(NATIVE_READY_POLL_MS, deadline - Date.now());
+    if (delayMs <= 0) return "timed-out";
+    if (!(await sleepOrAbort(delayMs, signal))) return "aborted";
   }
-  return {
-    warning:
-      `recorded, but this condition does NOT hold against the tree the runner resolves ` +
-      `directives against (${outcome.reason ?? "no match"}). As the raw ` +
-      `\`tool: ${AWAIT_UI_ELEMENT_TOOL_ID}\` step it replays fine — it reads the same tree it ` +
-      `just passed against — but converting it to \`await:\`/\`assert:\` at polish WILL fail. ` +
-      `Either keep it raw deliberately, or re-record the wait with a selector present in both`,
-  };
+}
+
+function leadingLaunch(session: RecordingSession): Extract<FlowStep, { kind: "launch" }> | null {
+  const first = session.flow.steps.find((step) => step.kind !== "echo");
+  return first?.kind === "launch" ? first : null;
+}
+
+function recordedLaunchApp(session: RecordingSession, platform: string): string | null {
+  const launch = leadingLaunch(session);
+  return launch ? appIdForPlatform(launch.app, platform) : null;
+}
+
+/**
+ * Whether the flow being recorded is a self-contained e2e flow (it starts the
+ * app itself) rather than a fragment. A fragment inherits nothing from a
+ * launch step at replay, so anything a step would have taken from one has to
+ * be baked in at record time.
+ */
+function hasLeadingLaunch(session: RecordingSession): boolean {
+  return leadingLaunch(session) !== null;
 }
 
 /**
@@ -515,15 +434,40 @@ async function captureTapSelector(
 }
 
 /**
+ * What to do about a tap whose selector could not be captured, now that the
+ * raw point has been kept.
+ *
+ * Two different failures, and they call for opposite responses: an element
+ * nothing can address, versus one that several things address equally. Saying
+ * "no selector could be derived" for the second sends the author to
+ * re-discover a selector they already have. The advice rides on the recorded
+ * step's warning because that is the only moment it is read while the screen
+ * is still there to retarget against — a coordinate step replays fine today
+ * and breaks on the first layout change, which is why the skills treat this
+ * warning as a stop rather than a note.
+ */
+function coordinateRemedy(captured: { ambiguous?: boolean }, udid: unknown): string {
+  return captured.ambiguous
+    ? `Disambiguate it: give the intended element its own testID, or tap a target whose id is ` +
+        `unique on this screen. At polish, a hand-written \`within\`/\`after\`/\`next\` scope can ` +
+        `also single out the element this point hit.`
+    : `Find the real target with ${treeReaderFor(udid)} and tap its centre; an element with no ` +
+        `id or label is usually worth fixing in the app.`;
+}
+
+/**
  * How far the recording has got, without mutating anything — for responses
  * that record nothing but must still say where the flow stands. Host mode
  * re-reads the file so manual edits made mid-recording are honored; client
  * mode's in-memory copy is authoritative.
  *
  * Deliberately NOT the flow's YAML. Returning the whole growing file on every
- * call made the recorder the single largest consumer of a session's context,
- * and that pressure was observed removing checks from tests. The full file
- * comes back once, from `flow-finish-recording`.
+ * call made the recorder the single largest consumer of a session's context —
+ * 55-77% of all tool-result text across the measured sessions, growing
+ * quadratically with step count — and that pressure was observed removing
+ * checks from tests ("context cost per recorded step is high, so I'll trim to
+ * the minimum discriminating check set"). The full file comes back once, from
+ * `flow-finish-recording`.
  */
 async function activeFlowState(
   session: RecordingSession
@@ -543,6 +487,158 @@ async function activeFlowState(
   return { stepCount: session.flow.steps.length };
 }
 
+// Replaying a fragment to set up state during recording is done by running it
+// through `flow-execute`. Recorded verbatim that becomes a brittle
+// `tool: flow-execute` step (baked-in project_root + device, no portability).
+// Instead, capture it as a `run: <name>` composition directive — mirroring the
+// gesture-tap → tap rewrite.
+const RUN_TARGET_COMMAND = "flow-execute";
+
+function flowExecuteRecordBlock(
+  result: unknown
+): { reason: string; mayHaveMutated: boolean } | null {
+  if (typeof result !== "object" || result === null) return null;
+  const value = result as { ok?: unknown; notice?: unknown };
+  if (value.ok === false) {
+    return { reason: "flow-execute returned ok: false", mayHaveMutated: true };
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "notice")) {
+    return {
+      reason:
+        typeof value.notice === "string"
+          ? `flow-execute returned a prerequisite notice: ${value.notice}`
+          : "flow-execute returned a prerequisite notice without executing steps",
+      mayHaveMutated: false,
+    };
+  }
+  return null;
+}
+
+function invalidateReadinessMissAfterAppStart(
+  session: RecordingSession,
+  command: string,
+  args: Record<string, unknown>,
+  result: unknown
+): void {
+  const didStart =
+    typeof result === "object" &&
+    result !== null &&
+    ((command === "restart-app" && (result as { restarted?: unknown }).restarted === true) ||
+      (command === "launch-app" && (result as { launched?: unknown }).launched === true));
+  if (!didStart) return;
+
+  const misses = readinessMissesFor(session);
+  // Both tools require a device id, but clearing all misses is the safe fallback
+  // for older/custom registry adapters that omit it: a successful app start is
+  // fresh evidence and another bounded probe is preferable to a stale miss.
+  if (typeof args.udid === "string") misses.delete(args.udid);
+  else misses.clear();
+}
+
+/**
+ * The recorder and the runner read DIFFERENT trees. `await-ui-element`
+ * evaluates against the accessibility tree; the `await:`/`assert:` DIRECTIVE
+ * that polish converts this step into is evaluated against the runner's tree.
+ * They overlap but neither contains the other — an id present in one can be
+ * absent from the other, and on iOS even the role vocabularies are disjoint.
+ * So a check can pass live and fail once converted, which makes "each step is
+ * executed live so you verify it works" untrue exactly where it matters.
+ *
+ * Re-probe the same condition against the runner's tree and report the answer.
+ * It is a WARNING, never a refusal: the step is recorded as a raw
+ * `tool: await-ui-element`, and at replay that tool reads the SAME
+ * accessibility tree it just passed against — so "it would fail every run" was
+ * false for the form actually written. What the probe really tells the author
+ * is whether the conversion is safe, which is a polish-time decision, and the
+ * blocking audit is where a flow is held to it.
+ */
+async function probeAgainstRunnerTree(
+  registry: Registry,
+  ctx: Parameters<typeof invokeSubTool>[1],
+  args: Record<string, unknown>
+): Promise<{ warning?: string }> {
+  const selector = args.selector;
+  const condition = args.condition;
+  if (typeof condition !== "string" || selector === null || typeof selector !== "object") {
+    return {};
+  }
+  if (typeof args.udid !== "string") return {}; // nothing to probe against
+  let device: DeviceInfo;
+  try {
+    device = resolveDevice(args.udid);
+  } catch {
+    return {}; // unresolvable device; the live result stands
+  }
+  const outcome = await probeWhenCondition(
+    // The signal rides on ActionEnv separately from `ctx`, so pass it too:
+    // a cancelled flow-add-step must stop this probe rather than polling on.
+    { registry, ctx, device, signal: ctx?.signal },
+    {
+      condition: condition as WaitCondition,
+      selector: selector as FlowSelector,
+      expectedText: typeof args.expectedText === "string" ? args.expectedText : undefined,
+      textMatch: args.textMatch as TextMatchMode | undefined,
+    }
+  );
+  if (outcome.ok) return {};
+  if (outcome.aborted) throw abortError();
+  if (outcome.indeterminate) {
+    return {
+      // No trailing period: the caller joins this with ". " and a second one
+      // renders as "..". And no claim that the two trees DIFFER — nothing was
+      // compared. The runner's tree could not be read at all, which is an
+      // environment failure; reporting it as a known divergence sends the
+      // author to rewrite a selector that may be perfectly good.
+      warning:
+        `this check could not be re-verified against the tree the RUNNER reads ` +
+        `(${outcome.reason}), so it passed against the accessibility tree only. Whether it ` +
+        `would convert to \`await:\`/\`assert:\` is UNKNOWN, not known-bad — re-probe once that ` +
+        `tree source is back before trusting the conversion`,
+    };
+  }
+  return {
+    warning:
+      `recorded, but this condition does NOT hold against the tree the runner resolves ` +
+      `directives against (${outcome.reason ?? "no match"}). As the raw ` +
+      `\`tool: ${AWAIT_UI_ELEMENT_TOOL_ID}\` step it replays fine — it reads the same tree it ` +
+      `just passed against — but converting it to \`await:\`/\`assert:\` at polish WILL fail. ` +
+      `Either keep it raw deliberately, or re-record the wait with a selector present in both`,
+  };
+}
+
+/**
+ * True when the flow being recorded has ALREADY established this selector
+ * positively — acted on it, or proved it present — in an earlier step.
+ *
+ * This is what makes a later `hidden` check falsifiable. The wait tool itself
+ * can only see its own poll window, so an element removed by the immediately
+ * preceding action reads as "never matched" even though the flow proves it
+ * existed two steps ago. Without this lookup the recorder would reject the
+ * correct authoring order (prove visible → act → prove gone) and push authors
+ * into adding absence checks by hand in YAML, which the skill forbids.
+ */
+function selectorEstablishedInFlow(session: RecordingSession, selector: unknown): boolean {
+  return selectorEstablishedInSteps(session.flow.steps, selector);
+}
+
+/**
+ * The route of the most recent `screen` gate already recorded, or undefined
+ * when the flow has none yet. Walks `when:` blocks too — a gate recorded inside
+ * one still establishes where the flow believes it is. Order matters, so the
+ * walk keeps the last hit rather than the first.
+ */
+function lastRecordedRoute(session: RecordingSession): string | undefined {
+  let latest: string | undefined;
+  const walk = (steps: FlowStep[]): void => {
+    for (const step of steps) {
+      if (step.kind === "screen") latest = step.route;
+      if (step.kind === "when") walk(step.steps);
+    }
+  };
+  walk(session.flow.steps);
+  return latest;
+}
+
 /**
  * `command` names an MCP tool, but the names an author has in mind while
  * recording are the flow file's own directives — so `command: "echo"` reaches
@@ -553,17 +649,18 @@ interface DirectiveHint {
   /** The tool to call instead. */
   tool: string;
   /**
-   * Whether the recorder REWRITES that tool call into this directive. Only the
-   * commands the step-shaping switch handles are rewritten; everything else is
-   * stored as a raw `tool:` step that the polish pass converts. Claiming a
-   * rewrite that does not happen sends the author looking for a directive that
-   * is not in the file.
+   * Whether the recorder REWRITES that tool call into this directive. Only
+   * four commands are rewritten (see the step-shaping switch); everything else
+   * is stored as a raw `tool:` step that the polish pass converts. Claiming
+   * a rewrite that does not happen sends the author looking for a directive
+   * that is not in the file.
    */
   rewritten: boolean;
 }
 
 const DIRECTIVE_COMMAND_HINTS: Record<string, DirectiveHint> = {
   tap: { tool: "gesture-tap", rewritten: true },
+  screen: { tool: SCREEN_FINGERPRINT_TOOL_ID, rewritten: true },
   launch: { tool: "restart-app", rewritten: true },
   run: { tool: "flow-execute", rewritten: true },
   type: { tool: "keyboard", rewritten: false },
@@ -621,7 +718,7 @@ function directiveCommandHint(command: string): string | undefined {
     return (
       `"wait" is a flow directive, not a tool, and there is no tool that records one — a fixed ` +
       `sleep is not a readiness signal. Record the thing you are actually waiting for with ` +
-      `\`${AWAIT_UI_ELEMENT_TOOL_ID}\` instead.`
+      `\`${AWAIT_UI_ELEMENT_TOOL_ID}\` instead, or \`${SCREEN_FINGERPRINT_TOOL_ID}\` for a navigation.`
     );
   }
   if (command === "long-press") {
@@ -643,26 +740,21 @@ function directiveCommandHint(command: string): string | undefined {
   );
 }
 
-/**
- * What to do about a tap whose selector could not be captured, now that the
- * raw point has been kept.
- *
- * Two different failures, and they call for opposite responses: an element
- * nothing can address, versus one that several things address equally. Saying
- * "no selector could be derived" for the second sends the author to
- * re-discover a selector they already have. The advice rides on the recorded
- * step's warning because that is the only moment it is read while the screen
- * is still there to retarget against — a coordinate step replays fine today
- * and breaks on the first layout change, which is why the skills treat this
- * warning as a stop rather than a note.
- */
-function coordinateRemedy(captured: { ambiguous?: boolean }, udid: unknown): string {
-  return captured.ambiguous
-    ? `Disambiguate it: give the intended element its own testID, or tap a target whose id is ` +
-        `unique on this screen. At polish, a hand-written \`within\`/\`after\`/\`next\` scope can ` +
-        `also single out the element this point hit.`
-    : `Find the real target with ${treeReaderFor(udid)} and tap its centre; an element with no ` +
-        `id or label is usually worth fixing in the app.`;
+function partialMutationWarning(command: "flow-execute" | "run-sequence"): string {
+  const stepKind = command === "flow-execute" ? "composed" : "nested";
+  return (
+    `Prior ${stepKind} steps may already have mutated device state. ` +
+    "Restore the device to the state produced by the recorded prefix before adding another " +
+    "step, or the remaining recording may not be reproducible."
+  );
+}
+
+function runSequenceProgress(result: unknown): string | null {
+  if (typeof result !== "object" || result === null) return null;
+  const { completed, total } = result as { completed?: unknown; total?: unknown };
+  return typeof completed === "number" && typeof total === "number"
+    ? `${completed}/${total} nested steps completed`
+    : null;
 }
 
 function rawCoordinateWarning(
@@ -707,65 +799,6 @@ function rawCoordinateWarning(
   }
   return undefined;
 }
-
-/**
- * True when the flow being recorded has ALREADY established this selector
- * positively — acted on it, or proved it present — in an earlier step.
- *
- * This is what makes a later `hidden` check falsifiable. The wait tool itself
- * can only see its own poll window, so an element removed by the immediately
- * preceding action reads as "never matched" even though the flow proves it
- * existed two steps ago. Without this lookup the recorder would reject the
- * correct authoring order (prove visible -> act -> prove gone) and push authors
- * into adding absence checks by hand in YAML, which the skill forbids.
- */
-function selectorEstablishedInFlow(session: RecordingSession, selector: unknown): boolean {
-  return selectorEstablishedInSteps(session.flow.steps, selector);
-}
-
-function flowExecuteRecordBlock(
-  result: unknown
-): { reason: string; mayHaveMutated: boolean } | null {
-  if (typeof result !== "object" || result === null) return null;
-  const value = result as { ok?: unknown; notice?: unknown };
-  if (value.ok === false) {
-    return { reason: "flow-execute returned ok: false", mayHaveMutated: true };
-  }
-  if (Object.prototype.hasOwnProperty.call(value, "notice")) {
-    return {
-      reason:
-        typeof value.notice === "string"
-          ? `flow-execute returned a prerequisite notice: ${value.notice}`
-          : "flow-execute returned a prerequisite notice without executing steps",
-      mayHaveMutated: false,
-    };
-  }
-  return null;
-}
-
-function partialMutationWarning(command: "flow-execute" | "run-sequence"): string {
-  const stepKind = command === "flow-execute" ? "composed" : "nested";
-  return (
-    `Prior ${stepKind} steps may already have mutated device state. ` +
-    "Restore the device to the state produced by the recorded prefix before adding another " +
-    "step, or the remaining recording may not be reproducible."
-  );
-}
-
-function runSequenceProgress(result: unknown): string | null {
-  if (typeof result !== "object" || result === null) return null;
-  const { completed, total } = result as { completed?: unknown; total?: unknown };
-  return typeof completed === "number" && typeof total === "number"
-    ? `${completed}/${total} nested steps completed`
-    : null;
-}
-
-// Replaying a fragment to set up state during recording is done by running it
-// through `flow-execute`. Recorded verbatim that becomes a brittle
-// `tool: flow-execute` step (baked-in project_root + device, no portability).
-// Instead, capture it as a `run: <name>` composition directive — mirroring the
-// gesture-tap → tap rewrite.
-const RUN_TARGET_COMMAND = "flow-execute";
 
 /**
  * The flows dir of a root, or null if it is not a valid one. Used only to
@@ -870,7 +903,10 @@ export function createFlowAddStepTool(registry: Registry): ToolDefinition<
       failedMsg: ({ params, failureSignal }) =>
         `Failed to add ${params.command} step to flow ${params.name}: ${failureSignal.error_code}`,
     },
-    description: `Execute a tool call and record it as a step in the flow named by \`name\` + \`project_root\` (the recording must already be open — see flow-start-recording). Use when recording a flow and you want to run and capture each action. A coordinate \`gesture-tap\` is recorded as a portable \`tap: { selector }\` step when the tapped element has stable text/identifier (otherwise coordinates are kept with a warning); a \`restart-app\` is recorded as a \`launch\` step (record one FIRST to make the flow a self-contained e2e flow).
+    description: `Execute a tool call and record it as a step in the flow named by \`name\` + \`project_root\` (the recording must already be open — see flow-start-recording). Use when recording a flow and you want to run and capture each action. A coordinate \`gesture-tap\` is recorded as a portable \`tap: { selector }\` step when the tapped element has stable text/identifier; a \`restart-app\` is recorded as a \`launch\` step (record one FIRST to make the flow a self-contained e2e flow); a \`screen-fingerprint\` read is recorded as the \`await: { screen: <route> }\` identity gate for the screen it just read.
+When no selector can be captured the point is kept, and the warning names both the reason and the retarget — treat it as a stop and repair the step, because a coordinate tap replays at a fixed point and breaks on any layout change.
+Three results are surfaced and NOT recorded, because each would bake a step that cannot prove what it appears to: an \`await-ui-element\` whose condition is not met (it would fail every replay); an \`await-ui-element\` \`hidden\` check that passed without its selector ever matching (it can never fail — record \`visible\` for that selector first, while the element is on screen); and a \`screen-fingerprint\` that could not read a route (there is no identity to gate on).
+A wait that held for the tool but would NOT hold against the tree the RUNNER reads IS recorded, with a warning: as the raw \`tool: await-ui-element\` step it replays against the same tree it just passed against, so it is only the \`await:\`/\`assert:\` conversion at polish that would fail. Act on that warning then — do not re-record the step, which would duplicate it.
 Returns { message, toolResult, stepCount, recorded, savedTo } - \`recorded\` is the one line that was appended, and \`stepCount\` how many steps the flow now has. The flow's full YAML is deliberately NOT returned per step; read it back from \`flow-finish-recording\`. \`savedTo\` is where the YAML landed: a host path, or, against a remote client, the directive that has the client write it (the only field naming the destination in that mode). If it fails an error is returned and nothing is recorded.
 If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-recording\` — editing the file while the recording is active can be overwritten by the in-memory copy.`,
     zodSchema,
@@ -971,7 +1007,9 @@ If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-
       // rather than a failure, so persisting it bakes a step that is green on
       // every replay whatever the screen does — the same unfalsifiable class
       // the `hidden` gate below exists to block. The skills already say never
-      // to persist it; without this gate the recorder did it silently.
+      // to persist it; without this gate the recorder did it silently, and
+      // since there is no recorder form of `await: { idle: true }`, the ONLY
+      // readiness gate an author could record was the decorative one.
       if (params.command === AWAIT_SCREEN_IDLE_TOOL_ID) {
         const { stepCount, note } = await activeFlowState(session);
         const settled = (toolResult as { settled?: unknown }).settled;
@@ -997,7 +1035,7 @@ If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-
       //
       // "Ever matched" is scoped to the wait's own poll window, which is too
       // narrow on its own: the action that removes an element runs BEFORE the
-      // check, so the normal authoring order (prove visible -> act -> prove
+      // check, so the normal authoring order (prove visible → act → prove
       // gone) always reaches here with everMatched false. The flow itself is
       // the wider evidence — if an earlier recorded step established this
       // selector, the check is falsifiable and is recorded.
@@ -1010,12 +1048,12 @@ If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-
       );
       if (vacuousHidden.length > 0) {
         const { stepCount, note } = await activeFlowState(session);
-        const wrapped = params.command !== AWAIT_UI_ELEMENT_TOOL_ID;
+        const nested = params.command !== AWAIT_UI_ELEMENT_TOOL_ID;
         return {
           message:
             `the \`hidden\` condition was met without the selector ever matching, and no earlier ` +
             `step in this flow established it — step NOT recorded.${
-              wrapped
+              nested
                 ? ` (Inside the \`${params.command}\` you passed; wrapping the wait does not make it provable, so the whole step is refused.)`
                 : ""
             } This check cannot fail, so ` +
@@ -1029,15 +1067,66 @@ If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-
         };
       }
 
-      // The wait held against the accessibility tree. Ask the tree the runner
-      // resolves DIRECTIVES against too, so the author learns now — rather than
-      // after polish — whether the conversion is safe.
+      // The wait held against the accessibility tree. Ask the tree the
+      // runner resolves DIRECTIVES against too, so the author learns now —
+      // rather than after polish — whether the conversion is safe.
       let crossTreeWarning: string | undefined;
+      // Set by the screen-fingerprint branch below; surfaced when the step is
+      // appended, since unlike the refusals above this one still records.
+      let sameRouteWarning: string | undefined;
       if (params.command === AWAIT_UI_ELEMENT_TOOL_ID) {
         const probe = await probeAgainstRunnerTree(registry, ctx, args);
         crossTreeWarning = probe.warning
           ? `${probe.warning}. ${treeDivergenceFor(args.udid)} ${treeReaderFor(args.udid)} reads the runner's side`
           : undefined;
+      }
+
+      // A screen-fingerprint read that could not name the screen is not a gate.
+      // Recording it raw would persist a `tool:` step whose output nothing
+      // checks; refusing keeps the failure where the evidence is.
+      if (params.command === SCREEN_FINGERPRINT_TOOL_ID) {
+        const fp = toolResult as ScreenFingerprintResult;
+        if (fp?.route == null) {
+          const { stepCount, note } = await activeFlowState(session);
+          return {
+            message:
+              `no screen identity could be read — step NOT recorded. ${fp?.reason ?? ""} ` +
+              (fp?.available === false
+                ? "Gate this navigation on a destination-only element instead."
+                : "Let the screen finish settling and call this again.") +
+              `${note ? ` ${note}` : ""}`,
+            toolResult,
+            stepCount,
+            savedTo: session.filePath,
+          };
+        }
+        // A route equal to the one the flow last gated on MAY prove nothing:
+        // an app whose sign-in form is presented inside its landing route
+        // reports one fingerprint for both screens, so a gate recorded after
+        // "tap Sign in" passes whether or not the tap landed.
+        //
+        // But it may equally be a return trip — Home → Search → Home — where
+        // the gate is perfectly falsifiable. Telling the two apart needs the
+        // route as it was IMMEDIATELY BEFORE the last action, and the recorder
+        // does not have it: `lastRecordedRoute` is the last route this flow
+        // GATED on, which says nothing about where the app went in between
+        // (the intermediate screen is routinely gated on an element instead —
+        // exactly what the skills prescribe for a route-less screen).
+        //
+        // So this warns and records, rather than refusing. A refusal needs
+        // certainty; without it, blocking would make the ordinary "go there,
+        // come back, verify" shape unrecordable, and `argent-qa-flows` calls a
+        // navigation with no identity gate a blocking defect — the recorder
+        // would be making its own contract unsatisfiable.
+        sameRouteWarning =
+          lastRecordedRoute(session) === fp.route
+            ? `this gate names the same route ("${fp.route}") as the last screen gate in this ` +
+              `flow. If the app did not actually leave that screen and come back, the two ` +
+              `screens are ONE route and this gate proves nothing — it would pass even if the ` +
+              `action never landed. Check that it changed; if it did not, prove this screen ` +
+              `with a destination-only element instead (one that exists here and NOT on the ` +
+              `previous screen).`
+            : undefined;
       }
 
       const sequenceFailure = runSequenceFailure(params.command, toolResult);
@@ -1124,11 +1213,10 @@ If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-
         warning = captured.warning;
       } else if (isTap) {
         // No stable selector — keep a coordinate tap, but still as a `tap:`
-        // directive so every tap reads uniformly.
-        // No stable selector — keep a coordinate tap, but recording the point
-        // is not an endorsement of it: say what failed AND what to do instead,
-        // since this warning is the whole of the author's signal that the flow
-        // just took on a step that survives only until the layout moves.
+        // directive so every tap reads uniformly. Recording the point is not
+        // an endorsement of it: say what failed AND what to do instead, since
+        // this warning is the whole of the author's signal that the flow just
+        // took on a step that survives only until the layout moves.
         step = { kind: "tap", x: args.x as number, y: args.y as number, ...tapTimes };
         warning = captured?.warning
           ? `${captured.warning}; kept coordinates, which replay at a fixed point and break on ` +
@@ -1138,6 +1226,53 @@ If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-
           : undefined;
       } else if (isLaunch) {
         step = { kind: "launch", app: strippedArgs.bundleId as string };
+      } else if (params.command === SCREEN_FINGERPRINT_TOOL_ID) {
+        // A fingerprint READ becomes a fingerprint CHECK: the route just
+        // observed is what the flow will require on replay. Recorded as the
+        // portable directive rather than a raw tool call, so the runner
+        // compares it instead of merely re-reading it.
+        const route = (toolResult as ScreenFingerprintResult).route as string;
+        const port = args.metro_port;
+        // At replay the runner reads the route from the app the flow's
+        // own `launch` named. A FRAGMENT has no launch step, so the gate would
+        // have nothing to read from and fail as an environment error — and
+        // only at replay, long after the recording looked fine. The
+        // fingerprint call had to name the app to run at all, so carry that id
+        // onto the step whenever the recording cannot supply one itself.
+        const appId = typeof args.app_id === "string" ? args.app_id : undefined;
+        const needsApp = !hasLeadingLaunch(session) && appId !== undefined;
+        step = {
+          kind: "screen",
+          mode: "await",
+          route,
+          ...(needsApp ? { app: appId } : {}),
+          ...(typeof port === "number" && port !== 8081 ? { metroPort: port } : {}),
+        };
+        if (needsApp) {
+          // One app id, not a per-platform map: this fragment's screen gate is
+          // pinned to the platform it was recorded on.
+          warning =
+            `this flow has no launch step, so the screen gate carries \`app: ${appId}\` — ` +
+            `without it the gate would have no app to read the route from at replay. That id ` +
+            `is platform-specific: to run this fragment on another platform, compose it from ` +
+            `an e2e flow whose \`launch\` declares that platform's app instead.`;
+        }
+        // A `screen` step has no `delayMs` field — the gate POLLS, so a fixed
+        // pre-step sleep would be the one thing it does not need. Every other
+        // rewrite refuses to convert while `delayMs` is set precisely so the
+        // delay survives; this one converts anyway, and dropping the author's
+        // parameter without a word is what must not happen. Say it, and name
+        // the parameter that does express the same intent.
+        const droppedDelay =
+          params.delayMs !== undefined
+            ? `\`delayMs: ${params.delayMs}\` was NOT carried onto this step — a \`screen\` gate ` +
+              `has no pre-step delay because it polls for the route. Raise its \`timeout:\` if ` +
+              `the navigation is slow, or record the wait you actually mean as its own step.`
+            : undefined;
+        // All three can apply at once, and the falsifiability one matters most,
+        // so it leads rather than replacing the others.
+        warning =
+          [sameRouteWarning, warning, droppedDelay].filter(Boolean).join(" Also: ") || undefined;
       } else if (runTarget?.flow) {
         step = { kind: "run", flow: runTarget.flow };
         // A resolved target can still carry a warning (a same-named sibling in

--- a/packages/tool-server/src/tools/flows/flow-finish-recording.ts
+++ b/packages/tool-server/src/tools/flows/flow-finish-recording.ts
@@ -237,6 +237,21 @@ export function summarizeStep(step: FlowStep, n: number): string {
       return `${n}. rotate: by ${step.by}°${step.selector ? ` on ${selectorLabel(step.selector)}` : ""}`;
     case "snapshot":
       return `${n}. snapshot: ${step.name}`;
+    case "screen": {
+      // Spell it the way the FILE does. `app` gets a warning of its own when it
+      // is written, but a non-default `metroPort` gets none — so a port-pinned
+      // gate was invisible in both the per-step line and the final summary,
+      // which is the author's only per-step view of a recorder that
+      // deliberately stopped returning the YAML.
+      const qualifiers = [
+        ...(step.app !== undefined ? [`app: ${step.app}`] : []),
+        ...(step.metroPort !== undefined ? [`metroPort: ${step.metroPort}`] : []),
+      ];
+      const suffix = qualifiers.length > 0 ? ` (${qualifiers.join(", ")})` : "";
+      return `${n}. ${step.mode}: screen ${step.route}${suffix}`;
+    }
+    case "idle":
+      return `${n}. await: screen idle`;
     case "tool":
     default:
       return `${n}. tool: ${step.name} ${renderToolArgs(step.args)}${delayLabel(step)}`;

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -39,6 +39,7 @@ import {
   invokeOnDevice,
   ABORTED_OUTCOME,
   probeWhenCondition,
+  resetRouteReaders,
   vacuousHiddenReason,
   type ActionEnv,
   type DirectiveOutcome,
@@ -61,7 +62,7 @@ import { runSnapshot, DEFAULT_MAX_MISMATCH, type SnapshotArtifacts } from "./flo
 import { describeVega } from "../describe/platforms/vega";
 import { pinStatusBar, restoreStatusBar } from "../../utils/status-bar";
 
-// `flow_name` is the parameter name callers reach for — the tool is
+// R21. `flow_name` is the parameter name callers reach for — the tool is
 // `flow-execute`, so "the flow's name" spells itself that way. Getting it
 // wrong used to return raw Zod JSON
 // (`[{"expected":"string","code":"invalid_type","path":["name"]}]`), which
@@ -452,6 +453,16 @@ async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcom
       reason: `no app id declared for platform "${device.platform}" — add a launch entry for it`,
     };
   }
+  // Remember which app a later `await: { screen: … }` reads the route from.
+  // Nested e2e flows pulled in via `run:` overwrite it in replay order, which
+  // matches whichever app is actually foreground. The chromium branch returned
+  // above, so a chromium run never records an app path here.
+  if (state.screenIdentity) state.screenIdentity.launchedAppId = bundleId;
+  // Terminating the app kills the JS runtime every memoized route reader is
+  // attached to. Forget them here so the first gate after this launch dials a
+  // fresh debugger session (retrying while the app re-registers with Metro)
+  // instead of probing a dead handle.
+  resetRouteReaders(state.screenIdentity);
   try {
     await invokeOnDevice(state, "restart-app", { bundleId });
   } catch (err) {
@@ -525,6 +536,14 @@ order), \`next: <selector>\` (CSS \`+\` — the nearest such follower, which unl
 non-matching neighbour rather than failing), plus \`any: true\` (CSS \`*\` — legal only WITH a scope and
 never beside text/id/role). Scopes nest to disambiguate — \`within: { id: card, within: { id: list } }\`
 reads "inside card inside list", each container's frame inside the next);
+\`await\`/\`assert\` additionally take two non-selector conditions: \`screen: "HomeTab>Profile"\` proves
+WHICH screen the app is on by exact React Navigation route match (identity, read from the app's own
+navigation state via the RN debugger — record it with the \`screen-fingerprint\` tool; the app defaults to
+the flow's last \`launch\`, override with \`app:\`/\`metroPort:\`); \`idle: true\` waits until the UI tree has
+content and holds still (readiness — and unlike the \`await-screen-idle\` tool it FAILS on timeout, so it
+is safe to persist). Identity and readiness are independent — a dropped tap leaves the
+source screen perfectly idle, and navigation state commits before the transition finishes animating —
+so a navigation wants both;
 \`scroll-to\` scrolls (momentum-free) until a target is visible; \`pinch\` zooms
 (\`pinch: { on?, scale }\` — scale > 1 in, < 1 out; screen center when \`on\` is omitted); \`rotate\` is the
 two-finger rotation gesture (\`rotate: { on?, by }\` — degrees, + clockwise, within ±3000°; screen center
@@ -600,8 +619,19 @@ returns a notice with the prerequisite instead of running.`,
         updateBaselines: Boolean(params.updateBaselines),
         reports: [],
         stopped: false,
-        pinned: statusBarPinned,
+        // One route reader per run, shared by every `screen` gate (see
+        // ScreenIdentityState) and filled in by the first `launch` step.
+        screenIdentity: {
+          readers: new Map(),
+          unsupported: new Set(),
+          connectExhausted: new Set(),
+          // An e2e flow opens with `launch:`, and a fragment runs against an
+          // app someone else just started; either way the run's first connect
+          // may land inside a cold start, so it starts the run armed.
+          coldSinceLaunch: true,
+        },
         establishedSelectors: new Set<string>(),
+        pinned: statusBarPinned,
         chromiumBooted: resolved.booted !== null,
         chromiumLaunched: false,
         ...(ctx?.emitProgress ? { onStepReport: ctx.emitProgress } : {}),
@@ -846,6 +876,14 @@ function stepTarget(step: FlowStep): string | undefined {
     case "await":
     case "assert":
       return conditionLabel(step, selectorLabel);
+    case "screen":
+      // The kind is already printed by the caller, so returning "screen …"
+      // here rendered as "screen screen HomeTab". Carry the mode instead,
+      // which the caller does NOT print and which distinguishes an `assert`
+      // from an `await` in the run log.
+      return step.mode === "assert" ? `assert ${step.route}` : step.route;
+    case "idle":
+      return "screen idle";
     case "when":
       return step.condition.kind === "platform"
         ? `platform ${step.condition.platform}`
@@ -1142,6 +1180,8 @@ async function execLeafStep(
     case "type":
     case "await":
     case "assert":
+    case "screen":
+    case "idle":
     case "scroll-to":
     case "pinch":
     case "rotate": {

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -513,6 +513,29 @@ export type FlowStep =
       expectedText?: string;
       textMatch?: TextMatchMode;
     }
+  /**
+   * Screen IDENTITY: the app's own focused React Navigation route path
+   * ("HomeTab>Profile"). Spelled `await: { screen: … }` / `assert: { screen: … }`
+   * in YAML — it is a condition like any other, but it takes a route rather
+   * than a selector because it reads navigation state instead of the UI tree.
+   * `mode` records which key it was written under so the step round-trips.
+   */
+  | {
+      kind: "screen";
+      mode: "await" | "assert";
+      route: string;
+      /** App whose route to read; defaults to the flow's last `launch` app. */
+      app?: string;
+      /** Metro port the app was launched from (default 8081). */
+      metroPort?: number;
+      timeout?: number;
+    }
+  /**
+   * Screen READINESS: the UI tree has content and stopped changing. Spelled
+   * `await: { idle: true }`. There is no `assert` form — "has it stopped
+   * moving yet" is inherently a wait.
+   */
+  | { kind: "idle"; timeout?: number; minStableMs?: number }
   | { kind: "wait"; ms: number }
   | { kind: "scroll-to"; target: FlowSelector; direction: ScrollDirection; within?: FlowSelector }
   | { kind: "pinch"; selector?: FlowSelector; scale: number }
@@ -650,6 +673,24 @@ type YamlWaitCondition =
 
 type YamlTextWaitCondition = Extract<YamlWaitCondition, { text: unknown }>;
 
+/**
+ * The non-selector conditions. They share the `await:` / `assert:` keys with
+ * {@link YamlWaitCondition} but do not take a selector, so they are parsed by
+ * their own functions and are deliberately NOT part of that union — a step body
+ * carries either a selector condition or one of these, never a mix.
+ *
+ *   - `{ screen: "HomeTab>Profile" }`      ← identity, read from navigation state
+ *   - `{ idle: true }`                     ← readiness, the tree stopped changing
+ */
+type YamlScreenCondition = {
+  screen: string;
+  app?: string;
+  metroPort?: number;
+  timeout?: number;
+};
+
+type YamlIdleCondition = { idle: true; minStableMs?: number; timeout?: number };
+
 /** `scroll-to` body: a bare target (scrolls down), or a map with options. */
 type YamlScrollBody =
   | YamlSelector
@@ -674,8 +715,10 @@ type YamlStep =
   | { tap: TapBody }
   | { "long-press": YamlTarget | { on: YamlTarget; duration?: number } }
   | { type: { into: YamlSelector; text: string; submit?: boolean } }
-  | { await: YamlWaitCondition & { timeout?: number } }
-  | { assert: YamlWaitCondition }
+  | {
+      await: (YamlWaitCondition & { timeout?: number }) | YamlScreenCondition | YamlIdleCondition;
+    }
+  | { assert: YamlWaitCondition | Omit<YamlScreenCondition, "timeout"> }
   | { wait: number }
   | { "scroll-to": YamlScrollBody }
   | { pinch: { on?: YamlSelector; scale: number } }
@@ -957,10 +1000,37 @@ function waitToYaml(
   return body;
 }
 
+/**
+ * Sugar a `screen` / `idle` step back under its `await:` or `assert:` key.
+ * Optional fields are emitted only when set, so the canonical minimal spelling
+ * (`await: { screen: "Home" }`) round-trips unchanged.
+ */
+function identityToYaml(step: Extract<FlowStep, { kind: "screen" | "idle" }>): YamlStep {
+  switch (step.kind) {
+    case "screen": {
+      const body: YamlScreenCondition = { screen: step.route };
+      if (step.app !== undefined) body.app = step.app;
+      if (step.metroPort !== undefined) body.metroPort = step.metroPort;
+      if (step.mode === "assert") return { assert: body };
+      if (step.timeout !== undefined) body.timeout = step.timeout;
+      return { await: body };
+    }
+    case "idle": {
+      const body: YamlIdleCondition = { idle: true };
+      if (step.minStableMs !== undefined) body.minStableMs = step.minStableMs;
+      if (step.timeout !== undefined) body.timeout = step.timeout;
+      return { await: body };
+    }
+  }
+}
+
 function toYamlStep(step: FlowStep): YamlStep {
   switch (step.kind) {
     case "echo":
       return { echo: step.message };
+    case "screen":
+    case "idle":
+      return identityToYaml(step);
     case "launch":
       return { launch: step.app };
     case "run":
@@ -1361,18 +1431,23 @@ type WaitFields = {
  * `assert` carrying one is rejected rather than silently ignored.
  */
 function parseWaitFields(raw: unknown, kind: "await" | "assert" | "when"): WaitFields {
+  // What the author is allowed to write, which is NOT the same as what this
+  // function parses: `screen` and `idle` are routed away to
+  // parseIdentityFields before we get here, so listing only the selector
+  // conditions told an author with a typo next to a `screen:` gate that
+  // `screen` itself was not a legal key. A `when:` guard genuinely has no
+  // identity form, so its list stays as it is.
+  const legalKeys =
+    kind === "when" ? WAIT_CONDITIONS : [...WAIT_CONDITIONS, ...IDENTITY_CONDITIONS];
   if (raw === null || typeof raw !== "object") {
-    badEntry({ [kind]: raw }, `${kind} needs a condition (${WAIT_CONDITIONS.join(", ")})`);
+    badEntry({ [kind]: raw }, `${kind} needs a condition (${legalKeys.join(", ")})`);
   }
   const b = raw as Record<string, unknown>;
 
   // The condition is the key; its value is the selector.
   const present = WAIT_CONDITIONS.filter((c) => c in b);
   if (present.length !== 1) {
-    badEntry(
-      { [kind]: b },
-      `${kind} needs exactly one condition key (${WAIT_CONDITIONS.join(", ")})`
-    );
+    badEntry({ [kind]: b }, `${kind} needs exactly one condition key (${legalKeys.join(", ")})`);
   }
   const condition = present[0]!;
 
@@ -1449,6 +1524,172 @@ function parseWaitFields(raw: unknown, kind: "await" | "assert" | "when"): WaitF
   }
 
   return { condition, selector: parseSelector(b[condition], `${kind}.${condition}`), timeout };
+}
+
+/**
+ * The non-selector condition keys. Their presence in an `await`/`assert` body
+ * routes parsing away from {@link parseWaitFields} — see {@link parseIdentityFields}.
+ */
+const IDENTITY_CONDITIONS = ["screen", "idle"] as const;
+type IdentityCondition = (typeof IDENTITY_CONDITIONS)[number];
+
+/** Ceiling shared by every condition timeout, matching `await.timeout`'s. */
+const MAX_IDLE_STABLE_MS = 10_000;
+
+/**
+ * Validate a route fingerprint: focused route names outermost→innermost joined
+ * with ">", exactly as `screen-fingerprint` reports it. Rejected here, at
+ * parse, so a typo fails deviceless instead of timing out against a live app
+ * that was on the right screen all along.
+ */
+function parseRouteFingerprint(entry: unknown, value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) {
+    badEntry(
+      entry,
+      'screen needs a route fingerprint string as reported by `screen-fingerprint` (e.g. "HomeTab>Profile")'
+    );
+  }
+  const segments = (value as string).split(">");
+  if (segments.some((segment) => segment.trim().length === 0)) {
+    badEntry(
+      entry,
+      `screen route "${value as string}" has an empty path segment — join focused route names ` +
+        'with ">" and no leading, trailing, or doubled separator (e.g. "HomeTab>Profile")'
+    );
+  }
+  return value as string;
+}
+
+/** Positive-integer option shared by the identity conditions' numeric keys. */
+function parseBoundedMs(entry: unknown, value: unknown, where: string, max: number): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > max) {
+    badEntry(entry, `${where} needs an integer between 0 and ${max} (milliseconds)`);
+  }
+  return value as number;
+}
+
+/**
+ * Parse an `await`/`assert` body carrying one of the non-selector conditions.
+ * Returns the finished step, because unlike the selector conditions these two
+ * have nothing in common to hand back as fields.
+ *
+ * `assert` is rejected for `idle` (waiting is the whole point of the check) and
+ * carries no `timeout` for `screen`, matching {@link parseWaitFields}.
+ */
+function parseIdentityFields(
+  raw: Record<string, unknown>,
+  condition: IdentityCondition,
+  kind: "await" | "assert"
+): FlowStep {
+  const entry = { [kind]: raw };
+
+  if (condition === "idle" && kind !== "await") {
+    badEntry(
+      entry,
+      "idle has no assert form — it waits for the screen to stop changing, which is an `await`"
+    );
+  }
+  if ("timeout" in raw && kind === "assert") {
+    badEntry(
+      entry,
+      "assert has no timeout — it is an immediate check; use `await` for a timed wait"
+    );
+  }
+
+  const allowed = condition === "screen" ? ["screen", "app", "metroPort"] : ["idle", "minStableMs"];
+  rejectUnknownKeys(entry, raw, kind === "await" ? [...allowed, "timeout"] : allowed, kind);
+
+  const timeout =
+    "timeout" in raw
+      ? {
+          timeout: (() => {
+            if (
+              typeof raw.timeout !== "number" ||
+              !Number.isFinite(raw.timeout) ||
+              raw.timeout <= 0
+            ) {
+              badEntry(
+                entry,
+                "await.timeout needs a positive number of milliseconds (e.g. `timeout: 10000`)"
+              );
+            }
+            return raw.timeout as number;
+          })(),
+        }
+      : {};
+
+  if (condition === "screen") {
+    const step: Extract<FlowStep, { kind: "screen" }> = {
+      kind: "screen",
+      mode: kind,
+      route: parseRouteFingerprint(entry, raw.screen),
+      ...timeout,
+    };
+    if (raw.app !== undefined) {
+      if (typeof raw.app !== "string" || raw.app.length === 0) {
+        badEntry(entry, "screen.app needs a non-empty app id (bundle id / package name)");
+      }
+      step.app = raw.app;
+    }
+    if (raw.metroPort !== undefined) {
+      if (
+        typeof raw.metroPort !== "number" ||
+        !Number.isInteger(raw.metroPort) ||
+        raw.metroPort < 1 ||
+        raw.metroPort > 65535
+      ) {
+        badEntry(entry, "screen.metroPort needs an integer TCP port between 1 and 65535");
+      }
+      step.metroPort = raw.metroPort;
+    }
+    return step;
+  }
+
+  // `idle: true` only. A falsey value would spell "assert the screen is NOT
+  // settled", which no flow wants and the runner cannot answer.
+  if (raw.idle !== true) {
+    badEntry(entry, "idle takes only `true` (`await: { idle: true }`)");
+  }
+  const step: Extract<FlowStep, { kind: "idle" }> = { kind: "idle", ...timeout };
+  if (raw.minStableMs !== undefined) {
+    step.minStableMs = parseBoundedMs(
+      entry,
+      raw.minStableMs,
+      "idle.minStableMs",
+      MAX_IDLE_STABLE_MS
+    );
+  }
+  return step;
+}
+
+/**
+ * The identity condition named by an `await`/`assert` body, or undefined when
+ * the body is an ordinary selector condition. Rejects a body that mixes the two
+ * families, or names two identity conditions, rather than silently preferring one.
+ */
+function identityConditionOf(
+  raw: unknown,
+  kind: "await" | "assert"
+): IdentityCondition | undefined {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const body = raw as Record<string, unknown>;
+  const present = IDENTITY_CONDITIONS.filter((c) => c in body);
+  if (present.length === 0) return undefined;
+  if (present.length > 1) {
+    badEntry(
+      { [kind]: body },
+      `${kind} needs exactly one condition key, not ${present.join(" + ")}`
+    );
+  }
+  const selectorConditions = WAIT_CONDITIONS.filter((c) => c in body);
+  if (selectorConditions.length > 0) {
+    badEntry(
+      { [kind]: body },
+      `${kind} mixes \`${present[0]!}\` with \`${selectorConditions.join("`, `")}\` — a step ` +
+        `checks exactly one condition`
+    );
+  }
+  return present[0];
 }
 
 /**
@@ -1955,12 +2196,26 @@ function fromYamlStep(raw: YamlStep, whenDepth = 0): FlowStep {
     return step;
   }
 
+  // `await:` / `assert:` carry two families of condition: the selector ones
+  // (visible/hidden/exists/text, matched against the UI tree) and the
+  // non-selector ones (screen/idle, which read navigation state and tree
+  // stability). The body's key decides which.
   if ("await" in raw) {
-    return { kind: "await", ...parseWaitFields((raw as { await: unknown }).await, "await") };
+    const body = (raw as { await: unknown }).await;
+    const identity = identityConditionOf(body, "await");
+    if (identity !== undefined) {
+      return parseIdentityFields(body as Record<string, unknown>, identity, "await");
+    }
+    return { kind: "await", ...parseWaitFields(body, "await") };
   }
 
   if ("assert" in raw) {
-    return { kind: "assert", ...parseWaitFields((raw as { assert: unknown }).assert, "assert") };
+    const body = (raw as { assert: unknown }).assert;
+    const identity = identityConditionOf(body, "assert");
+    if (identity !== undefined) {
+      return parseIdentityFields(body as Record<string, unknown>, identity, "assert");
+    }
+    return { kind: "assert", ...parseWaitFields(body, "assert") };
   }
 
   if ("wait" in raw) {

--- a/packages/tool-server/src/tools/screen-fingerprint/index.ts
+++ b/packages/tool-server/src/tools/screen-fingerprint/index.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import type { Registry, ToolContext, ToolDefinition } from "@argent/registry";
+import { resolveFlowDevice } from "../flows/flow-device";
+import { connectRouteReader, probeRoute, routeFingerprint } from "../../utils/route-identity";
+import { metroServerRunning } from "../../utils/debugger/discovery";
+
+/**
+ * Whether a Metro dev server is answering on `port` at all. Never throws.
+ *
+ * Asks only whether the SERVER is up — see {@link metroServerRunning}. Target
+ * discovery cannot answer it: a Metro serving one app reports an empty target
+ * list for the several seconds after that app relaunches, which is exactly
+ * when this tool is called, and reading that as "Metro is down" produced the
+ * one message the branch below exists to avoid.
+ */
+async function metroReachable(port: number): Promise<boolean> {
+  return metroServerRunning(port);
+}
+
+/**
+ * Read the current screen's route fingerprint from the running app — the
+ * recorder's source for a flow's `await: { screen: … }` gate. A thin,
+ * device-only probe: nothing is tapped and no file is touched.
+ */
+
+export const SCREEN_FINGERPRINT_TOOL_ID = "screen-fingerprint";
+
+// chromium is deliberately absent: an Electron app has no React Navigation
+// state to read, so there is nothing this tool could return for it.
+const FINGERPRINT_PLATFORMS = ["ios", "android", "vega"] as const;
+
+const zodSchema = z.object({
+  app_id: z
+    .string()
+    .min(1)
+    .describe(
+      "Bundle id / package name of the app under test — guards against reading a foreign " +
+        "app's Metro on the same port."
+    ),
+  platform: z
+    .enum(FINGERPRINT_PLATFORMS)
+    .optional()
+    .describe(
+      "Platform of the device under test. Only needed to disambiguate when several platforms " +
+        "have a booted device."
+    ),
+  device: z
+    .string()
+    .optional()
+    .describe(
+      "Device id to probe (iOS UDID, Android/Vega serial). Auto-detected from the single " +
+        "booted device when omitted."
+    ),
+  metro_port: z
+    .number()
+    .int()
+    .min(1)
+    .max(65535)
+    .optional()
+    .describe("Metro dev-server port the app was launched from (default 8081)."),
+});
+
+type Params = z.infer<typeof zodSchema>;
+
+export interface ScreenFingerprintResult {
+  /** false = no reader for this app (not a Metro-served debuggable RN app). */
+  available: boolean;
+  /** The fingerprint to gate on, or null when none could be read. */
+  route: string | null;
+  /** Focused route names outermost→innermost (what `route` joins). */
+  path?: string[];
+  /**
+   * The leaf route's params — evidence the screen is parameterized (one route
+   * serves every instance). Data about the screen, never its identity.
+   */
+  params?: Record<string, unknown> | null;
+  reason?: string;
+  hint?: string;
+}
+
+export function createScreenFingerprintTool(
+  registry: Registry
+): ToolDefinition<Params, ScreenFingerprintResult> {
+  return {
+    id: SCREEN_FINGERPRINT_TOOL_ID,
+    interaction: {
+      startedMsg: ({ params }) => `Reading screen identity of ${params.app_id}`,
+      // A read that returns no route still succeeds, so the message has to say
+      // which of the two happened — "read the screen" would imply a fingerprint
+      // that the caller may not have got.
+      completedMsg: ({ params, result }) =>
+        result.route === null
+          ? `Read no focused route for ${params.app_id}`
+          : `Read screen ${result.route}`,
+      failedMsg: ({ params, failureSignal }) =>
+        `Failed to read screen identity of ${params.app_id}: ${failureSignal.error_code}`,
+    },
+    description: `Read which screen the app is on, as its focused React Navigation route path ("HomeTab>Profile"), via the RN debugger over Metro.
+This is screen IDENTITY, and it is stronger than any element check: it comes from the app's own navigation state, so it does not depend on which tree source rendered \`describe\`, on content, on count, or on locale, and every instance of a parameterized screen (one profile vs another) shares one route. Gate a flow on it with \`await: { screen: "HomeTab>Profile" }\`, or record that step by passing this command to \`flow-add-step\`.
+It answers "which screen" and nothing else. It does NOT prove the screen finished animating (navigation state commits before the transition ends) and it does NOT see a native overlay above the screen (a permission alert, a share sheet, an RN <Modal> leave the route unchanged) — pair it with \`await: { idle: true }\` for readiness and an element check for the overlay.
+Only Metro-served debuggable RN apps have routes: \`available: false\` means this app has no reader (release build, fully native, chromium) — gate on elements instead. \`route: null\` with \`available: true\` means no focused route right now (a native screen, or a transition mid-flight) — let the screen settle and probe again.`,
+    searchHint:
+      "screen identity fingerprint which screen route react navigation current screen prove navigation",
+    zodSchema,
+    services: () => ({}),
+    async execute(_services, params, ctx?: ToolContext) {
+      const device = await resolveFlowDevice(registry, ctx, {
+        ...(params.device !== undefined ? { device: params.device } : {}),
+        ...(params.platform !== undefined ? { platform: params.platform } : {}),
+      });
+      const metroPort = params.metro_port ?? 8081;
+      if (device.platform === "chromium") {
+        return {
+          available: false,
+          route: null,
+          reason:
+            "chromium apps have no React Navigation route identity — gate on a destination-only " +
+            "element instead.",
+        };
+      }
+      // "ios-remote" is an iOS simulator over a remote bridge — same runtime.
+      const platform = device.platform === "ios-remote" ? "ios" : device.platform;
+      const reader = await connectRouteReader(registry, ctx, {
+        udid: device.id,
+        bundleId: params.app_id,
+        metroPort,
+        platform,
+      });
+      if (reader === undefined) {
+        // Which cause holds is checkable, so check it. Asserting "Metro is
+        // down" while Metro is demonstrably up — the routine case, because an
+        // app re-registers a few seconds AFTER it relaunches and the recorder
+        // probes immediately — sent authors to repair a working dev server,
+        // and the conclusion the old wording drew for them ("screens of this
+        // app can only be recognized by element checks") deleted the identity
+        // proof for the whole flow on the strength of a transient miss.
+        const metroUp = await metroReachable(metroPort);
+        return {
+          available: false,
+          route: null,
+          reason: metroUp
+            ? `Metro is running on port ${metroPort}, but no debuggable target for ` +
+              `${params.app_id} is registered there. If the app was just launched or restarted, ` +
+              `it re-registers a few seconds later — wait for the screen to settle and probe ` +
+              `again. If it stays this way, the app is not a debuggable RN build, or this port ` +
+              `serves a different app.`
+            : `No Metro dev server is answering on port ${metroPort}, so ${params.app_id} has ` +
+              `no route reader. Start Metro (or pass the right \`metro_port\`); if this app is ` +
+              `not a debuggable RN build at all, its screens can only be recognized by element ` +
+              `checks.`,
+        };
+      }
+      const route = await probeRoute(reader, {
+        ...(ctx?.signal !== undefined ? { signal: ctx.signal } : {}),
+      });
+      if (route === null) {
+        return {
+          available: true,
+          route: null,
+          reason:
+            "The app exposes no focused React Navigation route right now — a fully native " +
+            "screen, or a transition mid-flight. Let the screen settle and probe again; if it " +
+            "stays null, this screen has no route identity (gate on an element instead).",
+        };
+      }
+      const fingerprint = routeFingerprint(route);
+      return {
+        available: true,
+        route: fingerprint,
+        path: route.path,
+        params: route.params,
+        hint:
+          `Gate on it with: - await: { screen: "${fingerprint}" }, PAIRED with a readiness ` +
+          `check — navigation state commits before the screen renders, so this route is already ` +
+          `reported while the app is still blank. If the screen you just navigated FROM reports ` +
+          `this same route, the two are one route and gating on it would prove nothing: use a ` +
+          `destination-only element instead. ` +
+          `Non-null params mean the screen is parameterized — the route still identifies it, ` +
+          `but do not also gate on the specific instance's content.`,
+      };
+    },
+  };
+}

--- a/packages/tool-server/src/utils/debugger/discovery.ts
+++ b/packages/tool-server/src/utils/debugger/discovery.ts
@@ -6,6 +6,8 @@ export interface CDPTarget {
   description: string;
   webSocketDebuggerUrl: string;
   deviceName?: string;
+  /** Bundle id / package name of the app that registered the target (modern RN). */
+  appId?: string;
   /** Legacy inspector-proxy only. Its synthetic reload page reports "don't use". */
   vm?: string;
   reactNative?: {
@@ -33,6 +35,28 @@ export interface MetroInfo {
  * reports no pages) correctly reads as "no targets" instead of connecting to it.
  */
 const DECOY_VM = "don't use";
+
+/**
+ * Is a Metro dev server LISTENING on `port` — regardless of whether any app is
+ * currently attached to it? Probes `/status` only. Never throws.
+ *
+ * Deliberately not `discoverMetro`, which also requires at least one CDP
+ * target and throws `DEBUGGER_METRO_NO_TARGETS` otherwise. That distinction is
+ * the whole point here: a Metro serving ONE app has an empty target list for
+ * several seconds after that app is relaunched, so "no targets" is the normal
+ * post-launch state, not a down server. Callers that used discovery for this
+ * question therefore concluded "Metro is down" exactly when an app was coming
+ * back up — telling the author to start a server that was already running, and
+ * skipping the extended connect budget that window exists to cover.
+ */
+export async function metroServerRunning(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://localhost:${port}/status`);
+    return (await res.text()).includes("packager-status:running");
+  } catch {
+    return false;
+  }
+}
 
 export async function discoverMetro(port: number): Promise<MetroInfo> {
   let statusRes: Response;

--- a/packages/tool-server/src/utils/route-identity.ts
+++ b/packages/tool-server/src/utils/route-identity.ts
@@ -1,0 +1,448 @@
+import type { Registry, ToolContext } from "@argent/registry";
+import { invokeSubTool } from "./sub-invoke";
+import { sleepOrAbort } from "./timing";
+import { discoverMetro, type CDPTarget, type MetroInfo } from "./debugger/discovery";
+import { listIosSimulators } from "./ios-devices";
+import { adbShell } from "./adb";
+
+/**
+ * React Native route identity — a stable answer to "which screen is this?".
+ *
+ * Every other screen check argent has proxies identity through one element of
+ * the UI tree, and an element is a weak proxy: a shared header matches on two
+ * screens, a positional id encodes how many siblings exist, and during a push
+ * or modal presentation source and destination are in the tree together, so a
+ * destination landmark matches while the destination is still animating in.
+ * Worse, the vocabulary of the tree is source-dependent — iOS `describe`
+ * prefers the ax-service and falls back to native-devtools when the AX read
+ * comes back empty, flipping labels to testIDs mid-session.
+ *
+ * The focused React Navigation route path has none of that. It is read from
+ * the app's own navigation state, so it is independent of the tree source, of
+ * content (`/user/alice` and `/user/bob` share a route), and of locale. One
+ * route names one screen.
+ *
+ * We read it the black-box way argent already uses for the RN component tree:
+ * walk the fiber tree via `__REACT_DEVTOOLS_GLOBAL_HOOK__` and collect the
+ * focused `route`/`navigation` prop pairs. No app cooperation is needed — the
+ * app does not have to export its `navigationRef`. Only debuggable RN apps
+ * served by Metro qualify; a release build, a fully native app, or a chromium
+ * app has no reader, and callers fall back to element checks.
+ *
+ * Two limits, both accepted and both load-bearing for callers:
+ *
+ * 1. A native overlay ABOVE an RN screen (a system permission alert, a share
+ *    sheet, an RN `<Modal>`) does not change the focused route, so the probe
+ *    reports the screen beneath it. Route identity answers "which screen",
+ *    never "is anything covering it".
+ * 2. Navigation state commits when the navigator commits, which is BEFORE the
+ *    transition finishes animating. Route identity is therefore not a
+ *    readiness signal either — pair it with one.
+ */
+
+/** The focused navigation route path of the current screen, read at runtime. */
+export interface RouteContext {
+  /** Focused route names outermost→innermost, e.g. ["HomeTab", "Profile"]. */
+  path: string[];
+  /** The innermost (leaf) focused route name — the screen the user is looking at. */
+  name: string;
+  /** The leaf route's params (dynamic-segment values), or null. Data, not identity. */
+  params: Record<string, unknown> | null;
+}
+
+/**
+ * JS evaluated in the app's Hermes runtime (via debugger-evaluate). Walks the
+ * React fiber tree, gathers every fiber carrying a `route.name` +
+ * `navigation.isFocused()` prop pair (React Navigation's screen wrappers), keeps
+ * the focused ones, and returns them ordered outermost→innermost by fiber
+ * depth. Self-contained (no closures over TS scope), defensive (never throws
+ * out), and bounded (fiber-count cap) so it can't hang navigation. Returns a
+ * JSON string — debugger-evaluate serializes by value, and a plain string is
+ * always safe (RN route/navigation objects are cyclic and would fail to
+ * serialize).
+ */
+export const ROUTE_PROBE_EXPRESSION = `(() => {
+  try {
+    var g = typeof globalThis !== "undefined" ? globalThis : global;
+    var hook = g.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    if (!hook || typeof hook.getFiberRoots !== "function") {
+      return JSON.stringify({ ok: false, reason: "no-devtools-hook" });
+    }
+    var rendererIds = [];
+    try {
+      if (hook.renderers && typeof hook.renderers.keys === "function") {
+        var it = hook.renderers.keys();
+        for (var step = it.next(); !step.done; step = it.next()) rendererIds.push(step.value);
+      }
+    } catch (e) {}
+    if (rendererIds.length === 0) rendererIds = [1];
+    var roots = [];
+    for (var i = 0; i < rendererIds.length; i++) {
+      try {
+        hook.getFiberRoots(rendererIds[i]).forEach(function (r) { roots.push(r); });
+      } catch (e) {}
+    }
+    if (roots.length === 0) return JSON.stringify({ ok: false, reason: "no-fiber-roots" });
+    var byKey = {};
+    var stack = [];
+    for (var j = 0; j < roots.length; j++) {
+      if (roots[j] && roots[j].current) stack.push({ f: roots[j].current, d: 0 });
+    }
+    var visited = 0;
+    while (stack.length) {
+      var top = stack.pop();
+      var fiber = top.f;
+      var depth = top.d;
+      visited++;
+      if (visited > 300000) break;
+      var props = fiber.memoizedProps;
+      if (
+        props && props.route && typeof props.route.name === "string" &&
+        props.navigation && typeof props.navigation.isFocused === "function"
+      ) {
+        var key = props.route.key || props.route.name;
+        var entry = byKey[key];
+        if (!entry) {
+          var focused = false;
+          try { focused = props.navigation.isFocused(); } catch (e) {}
+          var params = null;
+          try {
+            var raw = props.route.params;
+            if (raw && typeof raw === "object") {
+              params = {};
+              var ks = Object.keys(raw);
+              for (var k = 0; k < ks.length && k < 20; k++) {
+                var v = raw[ks[k]];
+                var t = typeof v;
+                params[ks[k]] =
+                  t === "string" || t === "number" || t === "boolean" || v === null
+                    ? v : "<" + t + ">";
+              }
+            }
+          } catch (e) {}
+          byKey[key] = { name: props.route.name, depth: depth, params: params, focused: focused };
+        } else if (depth < entry.depth) {
+          entry.depth = depth;
+        }
+      }
+      if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
+      if (fiber.child) stack.push({ f: fiber.child, d: depth + 1 });
+    }
+    var focused = [];
+    for (var key2 in byKey) { if (byKey[key2].focused) focused.push(byKey[key2]); }
+    focused.sort(function (a, b) { return a.depth - b.depth; });
+    if (focused.length === 0) return JSON.stringify({ ok: false, reason: "no-focused-route" });
+    var leaf = focused[focused.length - 1];
+    return JSON.stringify({
+      ok: true,
+      path: focused.map(function (r) { return r.name; }),
+      name: leaf.name,
+      params: leaf.params,
+    });
+  } catch (e) {
+    return JSON.stringify({ ok: false, reason: String((e && e.message) || e) });
+  }
+})()`;
+
+/** A route reader: one probe of the currently focused route, null on any failure. */
+export type RouteReader = () => Promise<RouteContext | null>;
+
+// Android's RN inspector registers devices with Metro as
+// "<Build.MODEL> - <release> - API <sdk>"; iOS registers a bare device name.
+// The suffix is the only platform signal the target list carries — the names
+// themselves are runtime-reported and need not match simctl/adb labels.
+const ANDROID_DEVICE_NAME_PATTERN = / - API \d+$/;
+
+/**
+ * The name OUR device would register with Metro under: an iOS simulator
+ * registers as its simctl device name ("iPhone 16 Pro"); Android registers
+ * "<Build.MODEL> - …" (prefix-matched by the caller). Best-effort — undefined
+ * (no strict pinning possible) when the lookup fails or the platform has no
+ * stable convention (vega).
+ */
+async function metroDeviceName(
+  udid: string,
+  platform: "ios" | "android" | "vega"
+): Promise<string | undefined> {
+  try {
+    if (platform === "ios") {
+      const sims = await listIosSimulators();
+      return sims.find((sim) => sim.udid === udid)?.name;
+    }
+    if (platform === "android") {
+      const model = (await adbShell(udid, "getprop ro.product.model")).trim();
+      return model === "" ? undefined : model;
+    }
+  } catch {
+    // Lookup tooling unavailable — the caller falls back to the platform
+    // heuristic below.
+  }
+  return undefined;
+}
+
+function targetNameMatches(
+  target: CDPTarget,
+  platform: "ios" | "android" | "vega",
+  deviceName: string
+): boolean {
+  const name = target.deviceName ?? "";
+  if (platform === "android") return name === deviceName || name.startsWith(`${deviceName} - `);
+  return name === deviceName;
+}
+
+/**
+ * The Metro logicalDeviceId of OUR device running `bundleId`, from a
+ * /json/list target dump — or undefined when no target can be pinned to the
+ * device (never guess: reading a foreign runtime's route would fingerprint
+ * every screen of the app under test with another device's state — a physical
+ * phone on the LAN sharing the dev Metro is a routine setup).
+ *
+ * Needed because debugger-connect matches targets by logicalDeviceId, which a
+ * sim udid / adb serial never equals. When `deviceName` is known the match is
+ * strict: only a target registered under that name counts, and zero matches
+ * means OUR device has no target (an unloaded dev-client, a foreign device's
+ * target sitting on the list). Only when the name is unknown does the
+ * platform-shaped-name heuristic run, and only a unique candidate wins.
+ * Legacy-inspector targets (no logicalDeviceId) are always skipped — they
+ * cannot be singled out of a shared Metro.
+ */
+export function pickLogicalDeviceId(
+  targets: CDPTarget[],
+  bundleId: string,
+  platform: "ios" | "android" | "vega",
+  deviceName?: string
+): string | undefined {
+  const wanted = bundleId.toLowerCase();
+  const ids = new Set<string>();
+  for (const target of targets) {
+    const logicalId = target.reactNative?.logicalDeviceId;
+    if (!logicalId) continue;
+    const appId = target.appId?.toLowerCase() ?? "";
+    // Older RN omits appId; its titles read "<bundleId> (<device>)".
+    const ownsApp = appId !== "" ? appId === wanted : target.title.toLowerCase().includes(wanted);
+    if (!ownsApp) continue;
+    if (deviceName !== undefined) {
+      if (!targetNameMatches(target, platform, deviceName)) continue;
+    } else {
+      const androidName = ANDROID_DEVICE_NAME_PATTERN.test(target.deviceName ?? "");
+      if ((platform === "android") !== androidName) continue;
+    }
+    ids.add(logicalId);
+  }
+  if (ids.size !== 1) return undefined;
+  return ids.values().next().value;
+}
+
+/**
+ * Attach a JS-runtime debugger to a Metro-served RN app and return a route
+ * reader ({@link RouteReader}). A failure to connect (Metro down, not an RN
+ * app, a release build with no inspector) is expected and non-fatal: return
+ * undefined so the caller falls back to landmarks. Best-effort — never throws.
+ *
+ * `discover` is injectable for tests; production always reads the real Metro.
+ */
+export async function connectRouteReader(
+  registry: Registry,
+  ctx: ToolContext | undefined,
+  opts: {
+    udid: string;
+    bundleId: string;
+    metroPort: number;
+    platform: "ios" | "android" | "vega";
+    /** Metro registration name of the device; resolved from udid when omitted. */
+    deviceName?: string;
+  },
+  discover: (port: number) => Promise<MetroInfo> = discoverMetro
+): Promise<RouteReader | undefined> {
+  // Resolve the target ourselves when possible (see pickLogicalDeviceId).
+  let connectId = opts.udid;
+  let matchedByAppId = false;
+  try {
+    const metro = await discover(opts.metroPort);
+    // Name lookup only once the app is known to be served here — it shells
+    // simctl/adb, which is wasted on the (common) no-Metro / foreign-Metro
+    // paths.
+    const served = metro.targets.some(
+      (t) =>
+        t.reactNative?.logicalDeviceId !== undefined &&
+        ((t.appId ?? "").toLowerCase() === opts.bundleId.toLowerCase() ||
+          ((t.appId ?? "") === "" && t.title.toLowerCase().includes(opts.bundleId.toLowerCase())))
+    );
+    if (served) {
+      const deviceName = opts.deviceName ?? (await metroDeviceName(opts.udid, opts.platform));
+      const logicalId = pickLogicalDeviceId(
+        metro.targets,
+        opts.bundleId,
+        opts.platform,
+        deviceName
+      );
+      if (logicalId !== undefined) {
+        connectId = logicalId;
+        matchedByAppId = true;
+      } else if (deviceName !== undefined) {
+        // The app is served on this Metro but no target is pinned to OUR
+        // device (its dev-client hasn't loaded the app, or only foreign
+        // devices are attached). The udid fallback below would land on a
+        // foreign device's runtime — refuse instead.
+        return undefined;
+      }
+    }
+  } catch {
+    // Metro unreachable or unparseable — let the connect below be the judge.
+  }
+  let deviceId: string;
+  try {
+    const res = await invokeSubTool<{
+      logicalDeviceId?: string;
+      connected?: boolean;
+      appName?: string;
+    }>(registry, ctx, "debugger-connect", { port: opts.metroPort, device_id: connectId });
+    if (!res.connected) return undefined;
+    // Guard the udid-fallback path against binding to a FOREIGN app's Metro:
+    // an unmatched udid makes debugger-connect fall back to whichever single
+    // app Metro serves on this port. If that is a different app (another
+    // project's dev server on 8081), its route would fingerprint EVERY screen
+    // of the app under test — strictly worse than landmarks. The RN inspector
+    // titles a target "<bundleId> (<device>)", so require the connected app to
+    // name our bundle; when the title is unrecognizable (empty), proceed
+    // rather than over-reject. A target resolved by appId already proved
+    // ownership.
+    const appName = res.appName ?? "";
+    if (
+      !matchedByAppId &&
+      appName &&
+      !appName.toLowerCase().includes(opts.bundleId.toLowerCase())
+    ) {
+      return undefined;
+    }
+    // Subsequent debugger-* calls must be pinned to the session's logical id.
+    deviceId = res.logicalDeviceId ?? connectId;
+  } catch {
+    return undefined;
+  }
+  return async () => {
+    try {
+      const res = await invokeSubTool<{ result: unknown }>(registry, ctx, "debugger-evaluate", {
+        port: opts.metroPort,
+        device_id: deviceId,
+        expression: ROUTE_PROBE_EXPRESSION,
+      });
+      return parseRouteResult(res.result);
+    } catch {
+      // A transient eval failure (runtime busy, reload in flight) must not fail
+      // the observation — the caller falls back to landmarks for this read.
+      return null;
+    }
+  };
+}
+
+/** Parse the probe's JSON-string result into a RouteContext, or null on any failure. */
+export function parseRouteResult(raw: unknown): RouteContext | null {
+  let obj: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const rec = obj as Record<string, unknown>;
+  if (rec.ok !== true) return null;
+  const path = rec.path;
+  const name = rec.name;
+  if (!Array.isArray(path) || path.length === 0 || typeof name !== "string" || name.length === 0) {
+    return null;
+  }
+  const cleanPath = path.filter((p): p is string => typeof p === "string" && p.length > 0);
+  if (cleanPath.length === 0) return null;
+  const params =
+    rec.params && typeof rec.params === "object" && !Array.isArray(rec.params)
+      ? (rec.params as Record<string, unknown>)
+      : null;
+  return { path: cleanPath, name, params };
+}
+
+/**
+ * The fingerprint string a screen records: the focused route PATH joined with
+ * ">" ("HomeTab>Profile"). Params are deliberately excluded so every instance
+ * of a parameterized screen shares one fingerprint.
+ */
+export function routeFingerprint(route: RouteContext): string {
+  return route.path.join(">");
+}
+
+// The route state lags the visual transition by a beat; a single null read
+// right after a tap does not mean "no route".
+const ROUTE_PROBE_ATTEMPTS = 3;
+const ROUTE_PROBE_RETRY_MS = 250;
+
+/**
+ * Probe the focused route, retrying a null read (mid-transition, runtime busy)
+ * a few times before conceding. Returns null when every attempt failed or the
+ * signal aborted — callers re-check the signal themselves.
+ */
+export async function probeRoute(
+  reader: RouteReader,
+  opts?: { attempts?: number; retryMs?: number; signal?: AbortSignal }
+): Promise<RouteContext | null> {
+  const attempts = opts?.attempts ?? ROUTE_PROBE_ATTEMPTS;
+  const retryMs = opts?.retryMs ?? ROUTE_PROBE_RETRY_MS;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (opts?.signal?.aborted) return null;
+    const route = await reader();
+    if (route !== null) return route;
+    if (attempt < attempts - 1 && !(await sleepOrAbort(retryMs, opts?.signal))) return null;
+  }
+  return null;
+}
+
+/** Verdict of {@link verifyRouteFingerprint}. */
+export interface RouteVerifyOutcome {
+  /** True only when a probe read the expected fingerprint before the deadline. */
+  ok: boolean;
+  /** The run was cancelled mid-poll — not a verdict about the app. */
+  aborted?: boolean;
+  /**
+   * Fingerprint of the last SUCCESSFUL probe. Absent means every probe came
+   * back null (the reader died, the screen is native, or the transition never
+   * settled) — the caller must not report the app as being on a screen it
+   * never actually read.
+   */
+  observedRoute?: string;
+}
+
+/**
+ * Poll the route reader until the focused route's fingerprint equals
+ * `expected` or the deadline passes. `timeoutMs: 0` probes exactly once — the
+ * immediate "am I where I claim to be" check.
+ *
+ * A null probe (transition mid-flight, runtime busy, reader lost) keeps
+ * polling rather than deciding: the distinction between "read a different
+ * screen" and "read nothing" is the whole diagnostic value here, so it is
+ * carried out in {@link RouteVerifyOutcome.observedRoute} rather than
+ * collapsed into a boolean.
+ */
+export async function verifyRouteFingerprint(
+  readRoute: RouteReader,
+  expected: string,
+  timeoutMs: number,
+  pollMs: number,
+  signal?: AbortSignal
+): Promise<RouteVerifyOutcome> {
+  const deadline = Date.now() + timeoutMs;
+  let observedRoute: string | undefined;
+  for (;;) {
+    if (signal?.aborted) return { ok: false, aborted: true };
+    const route = await readRoute();
+    if (route !== null) {
+      observedRoute = routeFingerprint(route);
+      if (observedRoute === expected) return { ok: true, observedRoute };
+    }
+    if (signal?.aborted) return { ok: false, aborted: true };
+    if (Date.now() >= deadline) {
+      return { ok: false, ...(observedRoute !== undefined ? { observedRoute } : {}) };
+    }
+    if (!(await sleepOrAbort(pollMs, signal))) return { ok: false, aborted: true };
+  }
+}

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -50,6 +50,7 @@ import { networkRequestTool } from "../tools/network/network-request";
 import { createDescribeTool } from "../tools/describe";
 import { createAwaitUiElementTool } from "../tools/await-ui-element";
 import { createAwaitScreenIdleTool } from "../tools/await-screen-idle";
+import { createScreenFingerprintTool } from "../tools/screen-fingerprint";
 import { createReactProfilerStartTool } from "../tools/profiler/react/react-profiler-start";
 import { createReactProfilerStopTool } from "../tools/profiler/react/react-profiler-stop";
 import { createReactProfilerStatusTool } from "../tools/profiler/react/react-profiler-status";
@@ -148,6 +149,7 @@ export function createRegistry(): Registry {
   registry.registerTool(createDescribeTool(registry));
   registry.registerTool(createAwaitUiElementTool(registry));
   registry.registerTool(createAwaitScreenIdleTool(registry));
+  registry.registerTool(createScreenFingerprintTool(registry));
   registry.registerTool(createReactProfilerStartTool(registry));
   registry.registerTool(createReactProfilerStopTool(registry));
   registry.registerTool(createReactProfilerStatusTool(registry));

--- a/packages/tool-server/test/debugger/metro-server-running.test.ts
+++ b/packages/tool-server/test/debugger/metro-server-running.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as http from "node:http";
+import { discoverMetro, metroServerRunning } from "../../src/utils/debugger/discovery";
+
+/**
+ * `metroServerRunning` answers "is the dev server up", NOT "is an app attached
+ * to it". The distinction is load-bearing for every `screen` gate: a Metro
+ * serving one app has an EMPTY target list for the seconds after that app is
+ * relaunched, which is exactly when the post-launch identity gate runs.
+ *
+ * These tests drive a real socket rather than a stub, because the defect they
+ * pin was introduced by a stub: a test double answered "reachable" for a
+ * zero-target list while the real `discoverMetro` throws on one, so the
+ * post-launch connect budget silently lost its extension and the failure told
+ * the author to start a server that was already running.
+ */
+
+let server: http.Server | undefined;
+
+async function startMetro(targets: unknown[], status = "packager-status:running"): Promise<number> {
+  server = http.createServer((req, res) => {
+    if (req.url?.startsWith("/status")) {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(status);
+      return;
+    }
+    if (req.url?.startsWith("/json/list")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(targets));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+  return (server!.address() as { port: number }).port;
+}
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = undefined;
+});
+
+describe("metroServerRunning", () => {
+  it("is true for a running server with NO attached targets — the post-launch window", async () => {
+    const port = await startMetro([]);
+
+    // The state this exists for: the server is plainly up ...
+    await expect(metroServerRunning(port)).resolves.toBe(true);
+    // ... while discovery, which additionally demands a target, rejects it.
+    // Answering "is Metro up" with discovery is what read a relaunching app as
+    // a down dev server.
+    await expect(discoverMetro(port)).rejects.toThrow(/no CDP targets/);
+  });
+
+  it("is true for a running server that does have targets", async () => {
+    const port = await startMetro([
+      { id: "1", title: "app (Device)", description: "", webSocketDebuggerUrl: "ws://x" },
+    ]);
+    await expect(metroServerRunning(port)).resolves.toBe(true);
+  });
+
+  it("is false when nothing is listening on the port", async () => {
+    const port = await startMetro([]);
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = undefined;
+    await expect(metroServerRunning(port)).resolves.toBe(false);
+  });
+
+  it("is false when the port answers but is not Metro", async () => {
+    const port = await startMetro([], "<!doctype html><html>some other server</html>");
+    await expect(metroServerRunning(port)).resolves.toBe(false);
+  });
+});

--- a/packages/tool-server/test/flows/flow-identity-conditions.test.ts
+++ b/packages/tool-server/test/flows/flow-identity-conditions.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { parseFlow, serializeFlow, type FlowStep } from "../../src/tools/flows/flow-utils";
+
+// The two non-selector conditions: `screen` (identity) and `idle`
+// (readiness). They share the `await:` / `assert:` keys with the selector
+// conditions, so the parse/serialize round trip and the mutual exclusion
+// between the two families are the load-bearing behaviors.
+
+const flow = (steps: string): string => `executionPrerequisite: ""\nsteps:\n${steps}`;
+
+function parseSteps(steps: string): FlowStep[] {
+  return parseFlow(flow(steps)).steps;
+}
+
+/** A flow's steps survive serialize → parse unchanged (canonical spelling). */
+function expectRoundTrip(steps: string): FlowStep[] {
+  const parsed = parseSteps(steps);
+  expect(parseFlow(serializeFlow({ executionPrerequisite: "", steps: parsed })).steps).toEqual(
+    parsed
+  );
+  return parsed;
+}
+
+describe("await/assert { screen }", () => {
+  it("parses the identity gate and round-trips its minimal spelling", () => {
+    const steps = expectRoundTrip(`  - await: { screen: "HomeTab>Profile" }\n`);
+    expect(steps).toEqual([{ kind: "screen", mode: "await", route: "HomeTab>Profile" }]);
+    // Minimal in, minimal out — no defaults materialize into the file.
+    expect(serializeFlow({ executionPrerequisite: "", steps })).toContain(
+      "await:\n      screen: HomeTab>Profile"
+    );
+  });
+
+  it("keeps the assert form immediate and distinct from await", () => {
+    expect(parseSteps(`  - assert: { screen: "Settings" }\n`)).toEqual([
+      { kind: "screen", mode: "assert", route: "Settings" },
+    ]);
+    expect(() => parseSteps(`  - assert: { screen: "Settings", timeout: 5000 }\n`)).toThrow(
+      /assert has no timeout/
+    );
+  });
+
+  it("carries the optional app and metro port", () => {
+    const steps = expectRoundTrip(
+      `  - await: { screen: "Home", app: com.acme.notes, metroPort: 8082, timeout: 12000 }\n`
+    );
+    expect(steps).toEqual([
+      {
+        kind: "screen",
+        mode: "await",
+        route: "Home",
+        app: "com.acme.notes",
+        metroPort: 8082,
+        timeout: 12000,
+      },
+    ]);
+  });
+
+  it("rejects a malformed route fingerprint at parse, not against a live app", () => {
+    expect(() => parseSteps(`  - await: { screen: "" }\n`)).toThrow(/route fingerprint/);
+    expect(() => parseSteps(`  - await: { screen: ">Home" }\n`)).toThrow(/empty path segment/);
+    expect(() => parseSteps(`  - await: { screen: "Home>" }\n`)).toThrow(/empty path segment/);
+    expect(() => parseSteps(`  - await: { screen: "Home>>Profile" }\n`)).toThrow(
+      /empty path segment/
+    );
+  });
+
+  it("rejects a bad app id or port", () => {
+    expect(() => parseSteps(`  - await: { screen: "Home", app: "" }\n`)).toThrow(/screen.app/);
+    expect(() => parseSteps(`  - await: { screen: "Home", metroPort: 0 }\n`)).toThrow(
+      /screen.metroPort/
+    );
+    expect(() => parseSteps(`  - await: { screen: "Home", metroPort: 70000 }\n`)).toThrow(
+      /screen.metroPort/
+    );
+  });
+});
+
+describe("await { idle }", () => {
+  it("parses the readiness gate and round-trips", () => {
+    expect(expectRoundTrip(`  - await: { idle: true }\n`)).toEqual([{ kind: "idle" }]);
+    expect(expectRoundTrip(`  - await: { idle: true, minStableMs: 400, timeout: 9000 }\n`)).toEqual(
+      [{ kind: "idle", minStableMs: 400, timeout: 9000 }]
+    );
+  });
+
+  it("has no assert form — waiting is the whole point of the check", () => {
+    expect(() => parseSteps(`  - assert: { idle: true }\n`)).toThrow(/idle has no assert form/);
+  });
+
+  it("takes only `true` — there is no useful 'prove the screen is moving'", () => {
+    expect(() => parseSteps(`  - await: { idle: false }\n`)).toThrow(/idle takes only/);
+  });
+
+  it("bounds minStableMs", () => {
+    expect(() => parseSteps(`  - await: { idle: true, minStableMs: -1 }\n`)).toThrow(
+      /idle.minStableMs/
+    );
+    expect(() => parseSteps(`  - await: { idle: true, minStableMs: 99999 }\n`)).toThrow(
+      /idle.minStableMs/
+    );
+  });
+});
+
+describe("condition families are mutually exclusive", () => {
+  it("rejects mixing a selector condition with an identity one", () => {
+    expect(() => parseSteps(`  - await: { screen: "Home", visible: { id: x } }\n`)).toThrow(
+      /mixes `screen` with `visible`/
+    );
+  });
+
+  it("rejects naming two identity conditions in one step", () => {
+    expect(() => parseSteps(`  - await: { screen: "Home", idle: true }\n`)).toThrow(
+      /exactly one condition key, not screen \+ idle/
+    );
+  });
+
+  it("rejects a stray key rather than ignoring it", () => {
+    expect(() => parseSteps(`  - await: { screen: "Home", settleMs: 500 }\n`)).toThrow(/settleMs/);
+    expect(() => parseSteps(`  - await: { idle: true, metroPort: 8081 }\n`)).toThrow(/metroPort/);
+  });
+
+  // A typo next to a `screen:` gate used to be told that `screen` itself was
+  // not a legal key — the parser lists what the AUTHOR may write, which is not
+  // the same set as what its selector-condition branch parses.
+  it("offers the identity conditions when an await/assert names no legal one", () => {
+    expect(() => parseSteps(`  - await: { visble: { id: home } }\n`)).toThrow(
+      /await needs exactly one condition key \(exists, visible, hidden, text, screen, idle\)/
+    );
+    expect(() => parseSteps(`  - assert: { visble: { id: home } }\n`)).toThrow(
+      /assert needs exactly one condition key \(exists, visible, hidden, text, screen, idle\)/
+    );
+    // Same list when the body isn't a condition map at all.
+    expect(() => parseSteps(`  - await: visible\n`)).toThrow(
+      /await needs a condition \(exists, visible, hidden, text, screen, idle\)/
+    );
+  });
+
+  it("does not offer them to a `when:` guard, which has no identity form", () => {
+    const guard = (body: string) => (): FlowStep[] =>
+      parseSteps(`  - when: ${body}\n    steps:\n      - echo: guarded\n`);
+
+    // A stray key carrying neither substring, so the rejected entry echoed
+    // back into the message cannot satisfy the negative assertions.
+    const stray = guard("{ visble: { id: home } }");
+    expect(stray).toThrow(
+      /when needs exactly one condition key \(exists, visible, hidden, text, platform\)/
+    );
+    expect(stray).not.toThrow(/screen/);
+    expect(stray).not.toThrow(/idle/);
+
+    // And the identity conditions themselves are not guards.
+    expect(guard('{ screen: "Home" }')).toThrow(/when needs exactly one condition key/);
+    expect(guard("{ idle: true }")).toThrow(/when needs exactly one condition key/);
+  });
+
+  it("leaves the selector conditions untouched", () => {
+    expect(parseSteps(`  - await: { visible: { id: home-screen } }\n`)).toEqual([
+      { kind: "await", condition: "visible", selector: { identifier: "home-screen" } },
+    ]);
+  });
+});

--- a/packages/tool-server/test/flows/flow-record-identity.test.ts
+++ b/packages/tool-server/test/flows/flow-record-identity.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+
+import { flowStartRecordingTool } from "../../src/tools/flows/flow-start-recording";
+import { createFlowAddStepTool } from "../../src/tools/flows/flow-add-step";
+import {
+  __resetRecordingsForTesting,
+  appendStepToFlow,
+  parseFlow,
+  requireRecordingSession,
+} from "../../src/tools/flows/flow-utils";
+
+/**
+ * The flow as PERSISTED. The recorder deliberately no longer returns the whole
+ * growing YAML per step (it was the single largest consumer of a session's
+ * context), so the file on disk is the assertion surface.
+ */
+async function onDisk(name: string, root = tmpDir): Promise<string> {
+  return fs.readFile(path.join(root, ".argent", "flows", `${name}.yaml`), "utf8");
+}
+
+const PREREQ = "App on home screen";
+let tmpDir: string;
+
+function registryReturning(result: unknown): Registry {
+  return {
+    invokeTool: vi.fn(async () => result),
+    getTool: vi.fn(() => undefined),
+  } as unknown as Registry;
+}
+
+/** A screen-fingerprint read that reports `routes` in order, one per call. */
+function registryReadingRoutes(routes: string[]): Registry {
+  let call = 0;
+  return {
+    invokeTool: vi.fn(async () => ({
+      available: true,
+      route: routes[Math.min(call++, routes.length - 1)],
+      params: null,
+    })),
+    getTool: vi.fn(() => undefined),
+  } as unknown as Registry;
+}
+
+async function startRecording(name: string): Promise<void> {
+  await flowStartRecordingTool.execute(
+    {},
+    { name, project_root: tmpDir, executionPrerequisite: PREREQ }
+  );
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-record-identity-"));
+  __resetRecordingsForTesting();
+});
+
+afterEach(async () => {
+  __resetRecordingsForTesting();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+// A `hidden` check whose selector never matched is true before the wait, true
+// after it, and true on the wrong screen or against a typo. The live tool
+// reports that honestly in its note; the recorder must not bake it into a
+// flow, where it becomes a gate that can never fail.
+describe("vacuously-met hidden waits are not recorded", () => {
+  const VACUOUS = {
+    success: true,
+    elapsed: 128,
+    note:
+      "condition met immediately — the selector never matched any element, so it may have " +
+      "already been hidden before the wait, or the selector is wrong",
+  };
+
+  it("refuses the step and says how to establish the check properly", async () => {
+    const tool = createFlowAddStepTool(registryReturning(VACUOUS));
+    await startRecording("vacuous-hidden");
+
+    const result = await tool.execute(
+      {},
+      {
+        name: "vacuous-hidden",
+        project_root: tmpDir,
+        command: "await-ui-element",
+        args: '{"udid":"ABC","condition":"hidden","selector":{"text":"Dark theme"}}',
+      }
+    );
+
+    expect(result.message).toContain("step NOT recorded");
+    expect(result.message).toContain("cannot fail");
+    expect(result.message).toContain("Record a `visible` check for the same selector");
+    expect(parseFlow(await onDisk("vacuous-hidden")).steps).toEqual([]);
+  });
+
+  it("records a hidden wait that genuinely observed the element leave", async () => {
+    // No note: the element matched at least once, so its disappearance is real
+    // evidence and the gate can fail on replay.
+    const tool = createFlowAddStepTool(registryReturning({ success: true, elapsed: 900 }));
+    await startRecording("real-hidden");
+
+    const result = await tool.execute(
+      {},
+      {
+        name: "real-hidden",
+        project_root: tmpDir,
+        command: "await-ui-element",
+        args: '{"udid":"ABC","condition":"hidden","selector":{"text":"Saving…"}}',
+      }
+    );
+
+    expect(result.message).toContain("Step added");
+    expect(parseFlow(await onDisk("real-hidden")).steps).toHaveLength(1);
+  });
+});
+
+// A fingerprint READ becomes a fingerprint CHECK: recording it as a raw tool
+// step would persist a call whose output nothing compares.
+describe("screen-fingerprint records the identity gate", () => {
+  it("rewrites a successful read into `await: { screen }`", async () => {
+    const tool = createFlowAddStepTool(
+      registryReturning({
+        available: true,
+        route: "HomeTab>Profile",
+        path: ["HomeTab", "Profile"],
+        params: null,
+      })
+    );
+    await startRecording("identity");
+
+    const result = await tool.execute(
+      {},
+      {
+        name: "identity",
+        project_root: tmpDir,
+        command: "screen-fingerprint",
+        args: '{"app_id":"com.acme.notes"}',
+      }
+    );
+
+    expect(result.message).toContain("Step added");
+    // This recording has no `launch` step, so at replay the gate would
+    // have no app to read the route from — and would fail as an environment
+    // error, discovered only then. The app id the fingerprint call had to
+    // name is carried onto the step, and the platform pinning is disclosed.
+    expect(parseFlow(await onDisk("identity")).steps).toEqual([
+      { kind: "screen", mode: "await", route: "HomeTab>Profile", app: "com.acme.notes" },
+    ]);
+    expect(result.message).toContain("this flow has no launch step");
+  });
+
+  it("leaves the app implicit when the flow launches it itself", async () => {
+    const tool = createFlowAddStepTool(
+      registryReturning({
+        available: true,
+        route: "HomeTab>Profile",
+        path: ["HomeTab", "Profile"],
+        params: null,
+      })
+    );
+    // An e2e flow launches its own app, so it declares no prerequisite.
+    await flowStartRecordingTool.execute(
+      {},
+      { name: "identity-e2e", project_root: tmpDir, executionPrerequisite: "" }
+    );
+    // A leading `launch` makes this a self-contained e2e flow: the runner
+    // already knows which app to read from, and baking one id in would only
+    // pin an otherwise cross-platform flow to one platform.
+    await appendStepToFlow(requireRecordingSession(tmpDir, "identity-e2e"), {
+      kind: "launch",
+      app: "com.acme.notes",
+    });
+
+    await tool.execute(
+      {},
+      {
+        name: "identity-e2e",
+        project_root: tmpDir,
+        command: "screen-fingerprint",
+        args: '{"app_id":"com.acme.notes"}',
+      }
+    );
+
+    expect(parseFlow(await onDisk("identity-e2e")).steps).toEqual([
+      { kind: "launch", app: "com.acme.notes" },
+      { kind: "screen", mode: "await", route: "HomeTab>Profile" },
+    ]);
+    expect(await onDisk("identity-e2e")).not.toContain("app:");
+  });
+
+  it("keeps a non-default metro port so replay reads the same runtime", async () => {
+    const tool = createFlowAddStepTool(
+      registryReturning({ available: true, route: "Settings", params: null })
+    );
+    await startRecording("identity-port");
+
+    const result = await tool.execute(
+      {},
+      {
+        name: "identity-port",
+        project_root: tmpDir,
+        command: "screen-fingerprint",
+        args: '{"app_id":"com.acme.notes","metro_port":8082}',
+      }
+    );
+
+    expect(parseFlow(await onDisk("identity-port")).steps).toEqual([
+      { kind: "screen", mode: "await", route: "Settings", app: "com.acme.notes", metroPort: 8082 },
+    ]);
+    // `recorded` is the author's only per-step view of what was appended — the
+    // recorder stopped returning the growing YAML — so a gate pinned to one app
+    // and one port must say so there.
+    expect(result.recorded).toBe(
+      "1. await: screen Settings (app: com.acme.notes, metroPort: 8082)"
+    );
+  });
+
+  it("records nothing when the app has no route reader at all", async () => {
+    const tool = createFlowAddStepTool(
+      registryReturning({
+        available: false,
+        route: null,
+        reason: "No route reader for com.acme.notes on Metro port 8081 — Metro is down.",
+      })
+    );
+    await startRecording("identity-unavailable");
+
+    const result = await tool.execute(
+      {},
+      {
+        name: "identity-unavailable",
+        project_root: tmpDir,
+        command: "screen-fingerprint",
+        args: '{"app_id":"com.acme.notes"}',
+      }
+    );
+
+    expect(result.message).toContain("step NOT recorded");
+    expect(result.message).toContain("Gate this navigation on a destination-only element");
+    expect(parseFlow(await onDisk("identity-unavailable")).steps).toEqual([]);
+  });
+
+  it("records nothing mid-transition, and says to probe again", async () => {
+    const tool = createFlowAddStepTool(
+      registryReturning({
+        available: true,
+        route: null,
+        reason: "The app exposes no focused React Navigation route right now.",
+      })
+    );
+    await startRecording("identity-transient");
+
+    const result = await tool.execute(
+      {},
+      {
+        name: "identity-transient",
+        project_root: tmpDir,
+        command: "screen-fingerprint",
+        args: '{"app_id":"com.acme.notes"}',
+      }
+    );
+
+    expect(result.message).toContain("step NOT recorded");
+    expect(result.message).toContain("Let the screen finish settling");
+    expect(parseFlow(await onDisk("identity-transient")).steps).toEqual([]);
+  });
+});
+
+// Device-proven on Bluesky: its sign-in form is presented inside the landing
+// route, so both screens report `HomeTab`. A gate recorded after "tap Sign in"
+// then passes whether or not the tap landed — route identity is only identity
+// when the routes actually differ.
+describe("a screen gate repeating the flow's last route is not recorded", () => {
+  async function readScreen(
+    name: string,
+    registry: Registry
+  ): Promise<{
+    message: string;
+    stepCount: number;
+  }> {
+    return createFlowAddStepTool(registry).execute(
+      {},
+      {
+        name,
+        project_root: tmpDir,
+        command: "screen-fingerprint",
+        args: '{"app_id":"com.acme.notes"}',
+      }
+    );
+  }
+
+  // Warns rather than refuses. The recorder cannot tell "the app never left"
+  // from "it left and came back" — that needs the route as it was immediately
+  // before the last action, and the only route it has is the last one this flow
+  // GATED on. A device run proved the difference matters: Home → Search → Home,
+  // with the intermediate screen gated on an element (what the skills prescribe
+  // for a route-less screen), was refused with a reason that was simply false.
+  it("records it, but warns that the gate may prove nothing", async () => {
+    const registry = registryReadingRoutes(["HomeTab", "HomeTab"]);
+    await startRecording("same-route");
+
+    const first = await readScreen("same-route", registry);
+    const second = await readScreen("same-route", registry);
+
+    expect(first.message).toContain("Step added");
+    expect(second.message).toContain("Step added");
+    expect(second.message).toContain('same route ("HomeTab")');
+    expect(second.message).toContain("destination-only element");
+    // The claim is conditional — it must never assert the navigation failed.
+    expect(second.message).toContain("If the app did not actually leave");
+    expect(second.stepCount).toBe(first.stepCount + 1);
+    expect(parseFlow(await onDisk("same-route")).steps).toHaveLength(2);
+  });
+
+  it("records a gate whose route actually changed", async () => {
+    const registry = registryReadingRoutes(["HomeTab", "Settings"]);
+    await startRecording("moved");
+
+    await readScreen("moved", registry);
+    const second = await readScreen("moved", registry);
+
+    expect(second.message).toContain("Step added");
+    expect(parseFlow(await onDisk("moved")).steps).toMatchObject([
+      { kind: "screen", route: "HomeTab" },
+      { kind: "screen", route: "Settings" },
+    ]);
+  });
+
+  it("says nothing when the route the flow last gated on was a different one", async () => {
+    // A→B→A: the previous gate is B, so the A gate is unambiguous and silent.
+    const registry = registryReadingRoutes(["HomeTab", "Settings", "HomeTab"]);
+    await startRecording("round-trip");
+
+    await readScreen("round-trip", registry);
+    await readScreen("round-trip", registry);
+    const third = await readScreen("round-trip", registry);
+
+    expect(third.message).toContain("Step added");
+    expect(third.message).not.toContain("same route");
+    expect(parseFlow(await onDisk("round-trip")).steps).toHaveLength(3);
+  });
+});
+
+// The recorder's own poll window is too narrow to judge a `hidden` check: the
+// action that removes an element runs BEFORE the check, so the correct
+// authoring order always reaches the gate with "never matched". The flow is
+// the wider evidence.
+describe("a hidden check the flow already established IS recorded", () => {
+  const VACUOUS = {
+    success: true,
+    elapsed: 40,
+    note:
+      "condition met immediately — the selector never matched any element, so it may have " +
+      "already been hidden before the wait, or the selector is wrong",
+  };
+
+  async function recordPair(
+    establish: () => Promise<unknown>,
+    hiddenSelector: string
+  ): Promise<string> {
+    const tool = createFlowAddStepTool(registryReturning(VACUOUS));
+    await startRecording("established");
+    await establish();
+    const result = await tool.execute(
+      {},
+      {
+        name: "established",
+        project_root: tmpDir,
+        command: "await-ui-element",
+        args: `{"udid":"ABC","condition":"hidden","selector":${hiddenSelector}}`,
+      }
+    );
+    return result.message;
+  }
+
+  it("accepts it after an earlier visible check on the same id", async () => {
+    const tool = createFlowAddStepTool(registryReturning({ success: true, elapsed: 10 }));
+    const message = await recordPair(
+      () =>
+        tool.execute(
+          {},
+          {
+            name: "established",
+            project_root: tmpDir,
+            command: "await-ui-element",
+            args: '{"udid":"ABC","condition":"visible","selector":{"identifier":"toast-saved"}}',
+          }
+        ),
+      '{"identifier":"toast-saved"}'
+    );
+    expect(message).toContain("Step added");
+  });
+
+  it("accepts it after the element was tapped", async () => {
+    const tool = createFlowAddStepTool(registryReturning({ tapped: true }));
+    const message = await recordPair(
+      () =>
+        tool
+          .execute(
+            {},
+            {
+              name: "established",
+              project_root: tmpDir,
+              command: "gesture-tap",
+              args: '{"udid":"ABC","x":0.5,"y":0.5}',
+            }
+          )
+          .catch(() => undefined),
+      '{"identifier":"remove-row"}'
+    );
+    // The tap captured no selector here, so nothing was established.
+    expect(message).toContain("step NOT recorded");
+  });
+
+  it("still refuses when only a DIFFERENT selector was established", async () => {
+    const tool = createFlowAddStepTool(registryReturning({ success: true, elapsed: 10 }));
+    const message = await recordPair(
+      () =>
+        tool.execute(
+          {},
+          {
+            name: "established",
+            project_root: tmpDir,
+            command: "await-ui-element",
+            args: '{"udid":"ABC","condition":"visible","selector":{"identifier":"other-thing"}}',
+          }
+        ),
+      '{"identifier":"toast-saved"}'
+    );
+    expect(message).toContain("no earlier step in this flow established it");
+  });
+
+  it("does not treat an earlier hidden check as positive evidence", async () => {
+    const tool = createFlowAddStepTool(registryReturning(VACUOUS));
+    await startRecording("hidden-chain");
+    // First one is refused, so it never enters the flow to vouch for the second.
+    const first = await tool.execute(
+      {},
+      {
+        name: "hidden-chain",
+        project_root: tmpDir,
+        command: "await-ui-element",
+        args: '{"udid":"ABC","condition":"hidden","selector":{"text":"Saving…"}}',
+      }
+    );
+    const second = await tool.execute(
+      {},
+      {
+        name: "hidden-chain",
+        project_root: tmpDir,
+        command: "await-ui-element",
+        args: '{"udid":"ABC","condition":"hidden","selector":{"text":"Saving…"}}',
+      }
+    );
+    expect(first.message).toContain("step NOT recorded");
+    expect(second.message).toContain("step NOT recorded");
+  });
+});

--- a/packages/tool-server/test/flows/flow-screen-connect-budget.test.ts
+++ b/packages/tool-server/test/flows/flow-screen-connect-budget.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { RouteContext, RouteReader } from "../../src/utils/route-identity";
+
+// The route reader's CONNECT, as opposed to the route poll that follows it.
+// Measured on a real simulator: a React Native app takes ~12.5s to re-register
+// with Metro after `restart-app`, so the gate in the position both flow skills
+// mandate — `launch:` then `await: { screen: … }` — connects into a window
+// where the app is not merely slow to answer but absent from Metro entirely.
+// Capping that connect at a few seconds made the gate unreachable, and raising
+// the step's `timeout:` did not help because the connect was charged against it.
+
+/** Which attempt (1-based) produces a reader. Replaced per test. */
+let connectLands: (attempt: number) => boolean;
+/** Wall-clock of every connect attempt — the retry budget is what's under test. */
+let attemptTimes: number[];
+let routes: Array<RouteContext | null>;
+let metroUp: boolean;
+
+// Stub only the debugger attach and the Metro reachability probe; the budget
+// arithmetic between them is real.
+vi.mock("../../src/utils/route-identity", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/utils/route-identity")>();
+  return {
+    ...actual,
+    connectRouteReader: vi.fn(async (): Promise<RouteReader | undefined> => {
+      attemptTimes.push(Date.now());
+      if (!connectLands(attemptTimes.length)) return undefined;
+      return async () => routes.shift() ?? null;
+    }),
+  };
+});
+
+// `metroServerRunning`, NOT `discoverMetro`. Stubbing discovery here is what
+// let the defect below ship: the stub answered "reachable" for a target list of
+// `[]`, while the real `discoverMetro` THROWS on an empty list — and an empty
+// list is the normal state of a single-app Metro for the seconds after that app
+// relaunches, i.e. every post-launch gate. See discovery.metroServerRunning.
+vi.mock("../../src/utils/debugger/discovery", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/utils/debugger/discovery")>();
+  return {
+    ...actual,
+    metroServerRunning: vi.fn(async () => metroUp),
+  };
+});
+
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+
+const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
+const PORT = 59999;
+
+/**
+ * Mirrors of the src constants the budget is built from. The retry interval
+ * sets what "N attempts" costs in wall-clock; the floor is the budget a step
+ * gets when it is NOT in a launch window, and the window is the much larger
+ * one it gets when it is.
+ */
+const RETRY_INTERVAL_MS = 400;
+const PLAIN_CONNECT_FLOOR_MS = 2500;
+const POST_LAUNCH_WINDOW_MS = 20_000;
+
+let tmpDir: string;
+
+const route = (path: string[]): RouteContext => ({
+  path,
+  name: path[path.length - 1]!,
+  params: null,
+});
+
+function mockRegistry(): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string) => {
+      if (id === "list-devices") return { devices: [] };
+      if (id === "restart-app") return { restarted: true };
+      return { ok: true };
+    }),
+    getTool: vi.fn(() => undefined),
+    // The launch step gates on native devtools being connected before it
+    // hands control to the next step (treeSourceGate).
+    resolveService: vi.fn(async () => ({ isConnected: () => true })),
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: string): Promise<void> {
+  const dir = path.join(tmpDir, ".argent", "flows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.yaml`), yaml, "utf8");
+}
+
+async function run(name: string): Promise<FlowRunResult> {
+  const tool = createRunFlowTool(mockRegistry());
+  const result = await tool.execute({}, { name, project_root: tmpDir, device: DEVICE }, undefined);
+  if (!("steps" in result)) throw new Error("expected a run result");
+  return result;
+}
+
+/** How long the connect kept retrying, from attempt `from` to the last one. */
+function connectSpanMs(from = 0): number {
+  return attemptTimes.at(-1)! - attemptTimes[from]!;
+}
+
+// Every fixture pins a SMALL `timeout:`. Left at the 7500ms default the step's
+// own budget would already cover a multi-second connect, and none of these
+// tests would be able to tell the launch window from it.
+const AFTER_LAUNCH = `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: ${PORT}, timeout: 1000 }
+`;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-connect-budget-"));
+  connectLands = () => true;
+  attemptTimes = [];
+  routes = [];
+  metroUp = true;
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("post-launch route-reader connect budget", () => {
+  it("keeps retrying past the plain floor for the gate that follows a launch", async () => {
+    // Nine attempts ~400ms apart ≈ 3.2s of connecting — longer than any budget
+    // the step's own `timeout:` can buy, and the exact shape of an app still
+    // re-registering with Metro.
+    connectLands = (attempt) => attempt >= 9;
+    routes = [route(["Home"])];
+    await writeFlow("cold", AFTER_LAUNCH);
+
+    const r = await run("cold");
+
+    expect(r.ok).toBe(true);
+    expect(r.steps.at(-1)).toMatchObject({ kind: "screen", status: "pass" });
+    expect(attemptTimes).toHaveLength(9);
+    expect(connectSpanMs()).toBeGreaterThan(PLAIN_CONNECT_FLOOR_MS);
+  }, 30_000);
+
+  it("spends the launch window only while Metro is reachable", async () => {
+    // No Metro at all — a release build, a fully native app. There is nothing
+    // to wait for, so the step must not sit out the whole launch window to say
+    // what it could say immediately.
+    metroUp = false;
+    connectLands = () => false;
+    await writeFlow("no-metro", AFTER_LAUNCH);
+
+    const r = await run("no-metro");
+
+    expect(r.ok).toBe(false);
+    const step = r.steps.at(-1)!;
+    // Indeterminate, not a verdict about the app: identity was never read.
+    expect(step.status).toBe("error");
+    expect(step.reason).toContain(`no Metro dev server is answering on port ${PORT}`);
+    expect(connectSpanMs()).toBeLessThan(POST_LAUNCH_WINDOW_MS / 2);
+  }, 30_000);
+
+  it("leaves the step's `timeout:` to the route poll, not to the connect", async () => {
+    // The connect alone outlasts the 1200ms timeout below. Charged against it,
+    // the poll would open with a spent budget: one probe, landing on the first
+    // of the two nulls a mid-transition read returns.
+    connectLands = (attempt) => attempt >= 5;
+    routes = [null, null, route(["Home"])];
+    await writeFlow(
+      "poll-budget",
+      `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: ${PORT}, timeout: 1200 }
+`
+    );
+
+    const r = await run("poll-budget");
+
+    expect(r.ok).toBe(true);
+    expect(connectSpanMs()).toBeGreaterThan(1200);
+    // All three probes were spent: the poll opened with its full budget rather
+    // than the single probe a spent one gets.
+    expect(routes).toHaveLength(0);
+  }, 30_000);
+
+  it("re-arms the window at the next launch", async () => {
+    // The first gate connects instantly, which clears the cold epoch. The
+    // second launch terminates the app again, so its gate faces the same cold
+    // start as the first one did and must get the same window.
+    connectLands = (attempt) => attempt === 1 || attempt >= 10;
+    routes = [route(["Home"]), route(["Home"])];
+    await writeFlow(
+      "relaunch",
+      `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: ${PORT}, timeout: 1000 }
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: ${PORT}, timeout: 1000 }
+`
+    );
+
+    const r = await run("relaunch");
+
+    expect(r.ok).toBe(true);
+    expect(attemptTimes).toHaveLength(10);
+    // Attempt 2 opens the second epoch; it ran past the plain floor to land.
+    expect(connectSpanMs(1)).toBeGreaterThan(PLAIN_CONNECT_FLOOR_MS);
+  }, 30_000);
+
+  it("does not buy the window again once a connect has landed in this epoch", async () => {
+    // A second gate reading a different runtime reconnects, but the app is
+    // long past its cold start by then: it must fail on the plain floor rather
+    // than making the run sit out the launch window for an app that will never
+    // register.
+    connectLands = (attempt) => attempt === 1;
+    routes = [route(["Home"])];
+    await writeFlow(
+      "second-runtime",
+      `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: ${PORT}, timeout: 1000 }
+  - await: { screen: "Home", metroPort: 8082, timeout: 1000 }
+`
+    );
+
+    const r = await run("second-runtime");
+
+    expect(r.ok).toBe(false);
+    const step = r.steps.at(-1)!;
+    expect(step.status).toBe("error");
+    expect(step.reason).toContain("Metro is running on port 8082");
+    expect(connectSpanMs(1)).toBeLessThan(POST_LAUNCH_WINDOW_MS / 2);
+    // Retries were still spent — the floor, not a single hopeless attempt.
+    expect(attemptTimes.length).toBeGreaterThan(PLAIN_CONNECT_FLOOR_MS / RETRY_INTERVAL_MS);
+  }, 30_000);
+});

--- a/packages/tool-server/test/flows/flow-screen-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-screen-idle-run.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
+import type { RouteContext, RouteReader } from "../../src/utils/route-identity";
+
+// Serve the flow tree directly (see flow-when.test.ts) — `idle` polls it.
+let currentTree: () => DescribeNode;
+vi.mock("../../src/tools/flows/flow-tree", () => ({
+  fetchFlowTree: vi.fn(
+    async (): Promise<DescribeTreeData> => ({
+      tree: currentTree(),
+      source: "native-devtools",
+      screen: { width: 390, height: 844 },
+    })
+  ),
+}));
+
+// Stub only the debugger attach; the verification loop under test is real.
+let routes: Array<RouteContext | null>;
+let readerAvailable: boolean;
+let connectCalls: number;
+vi.mock("../../src/utils/route-identity", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/utils/route-identity")>();
+  return {
+    ...actual,
+    connectRouteReader: vi.fn(async (): Promise<RouteReader | undefined> => {
+      connectCalls += 1;
+      if (!readerAvailable) return undefined;
+      return async () => routes.shift() ?? null;
+    }),
+  };
+});
+
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+import { connectRouteReader } from "../../src/utils/route-identity";
+
+const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
+let tmpDir: string;
+
+function n(partial: Partial<DescribeNode> & { frame: DescribeNode["frame"] }): DescribeNode {
+  return { role: "AXOther", children: [], ...partial };
+}
+
+const FULL: DescribeNode["frame"] = { x: 0, y: 0, width: 1, height: 1 };
+
+function screenWith(label: string): DescribeNode {
+  return n({
+    role: "AXWindow",
+    frame: FULL,
+    children: [n({ frame: { x: 0, y: 0, width: 1, height: 0.1 }, label })],
+  });
+}
+
+const route = (path: string[]): RouteContext => ({
+  path,
+  name: path[path.length - 1]!,
+  params: null,
+});
+
+function mockRegistry(): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string) => {
+      if (id === "list-devices") return { devices: [] };
+      if (id === "restart-app") return { restarted: true };
+      return { ok: true };
+    }),
+    getTool: vi.fn(() => undefined),
+    // The launch step gates on native devtools being connected before it
+    // hands control to the next step (treeSourceGate).
+    resolveService: vi.fn(async () => ({ isConnected: () => true })),
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: string): Promise<void> {
+  const dir = path.join(tmpDir, ".argent", "flows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.yaml`), yaml, "utf8");
+}
+
+async function run(name: string): Promise<FlowRunResult> {
+  const tool = createRunFlowTool(mockRegistry());
+  const result = await tool.execute({}, { name, project_root: tmpDir, device: DEVICE }, undefined);
+  if (!("steps" in result)) throw new Error("expected a run result");
+  return result;
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-screen-"));
+  currentTree = () => screenWith("Home");
+  routes = [];
+  readerAvailable = true;
+  connectCalls = 0;
+  // `vi.clearAllMocks()` clears recorded calls but NOT implementations, so a
+  // test that overrides the connect would otherwise leak it into the next one.
+  vi.mocked(connectRouteReader).mockImplementation(async () => {
+    connectCalls += 1;
+    if (!readerAvailable) return undefined;
+    return async () => routes.shift() ?? null;
+  });
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+// A `screen` gate is the identity half of proving a navigation: it answers
+// which screen the app is on, and must never answer "probably".
+describe("await: { screen }", () => {
+  const FLOW = `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "HomeTab>Profile", metroPort: 59999 }
+`;
+
+  it("passes when the focused route matches", async () => {
+    routes = [route(["HomeTab", "Profile"])];
+    await writeFlow("nav", FLOW);
+    const r = await run("nav");
+    expect(r.ok).toBe(true);
+    expect(r.steps.at(-1)).toMatchObject({ kind: "screen", status: "pass" });
+  });
+
+  it("tolerates the transition lag before the route commits", async () => {
+    // Two null reads (mid-push), then the destination — the exact shape a
+    // fixed `wait:` was previously papering over.
+    routes = [null, null, route(["HomeTab", "Profile"])];
+    await writeFlow("nav", FLOW);
+    expect((await run("nav")).ok).toBe(true);
+  });
+
+  it("fails naming the screen the app actually reached", async () => {
+    routes = Array.from({ length: 200 }, () => route(["HomeTab", "Feed"]));
+    await writeFlow(
+      "nav",
+      `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "HomeTab>Profile", metroPort: 59999, timeout: 400 }
+`
+    );
+    const r = await run("nav");
+    expect(r.ok).toBe(false);
+    const step = r.steps.at(-1)!;
+    expect(step.status).toBe("fail");
+    expect(step.reason).toContain('the app is on "HomeTab>Feed", not "HomeTab>Profile"');
+  });
+
+  // A connect that never lands now retries for its whole budget before
+  // conceding, so this case legitimately spends several seconds.
+  it("reports an unreadable route as unknown identity, never as arrival", async () => {
+    readerAvailable = false;
+    await writeFlow("nav", FLOW);
+    const r = await run("nav");
+    expect(r.ok).toBe(false);
+    const step = r.steps.at(-1)!;
+    expect(step.status).toBe("error");
+    // The reason names the cause it can actually CHECK. This fixture points at
+    // a dead port (59999), so the honest answer is that no Metro is answering
+    // there — not the old blanket "Metro is down, the app is not a debuggable
+    // RN build, or the port serves a different app", which asserted three
+    // causes and was wrong about at least two of them on every real failure.
+    expect(step.reason).toContain("no Metro dev server is answering on port 59999");
+    expect(step.reason).toContain("environment failure, not a verdict about the app");
+  }, 20_000);
+
+  it("connects the debugger once per run, not once per gate", async () => {
+    routes = [route(["Home"]), route(["Home"]), route(["Home"])];
+    await writeFlow(
+      "nav",
+      `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: 59999 }
+  - await: { screen: "Home", metroPort: 59999 }
+  - assert: { screen: "Home", metroPort: 59999 }
+`
+    );
+    expect((await run("nav")).ok).toBe(true);
+    expect(connectCalls).toBe(1);
+  });
+
+  // R2: the connect used to be memoized INCLUDING its failure, so one gate
+  // that raced the app's re-registration with Metro condemned every later
+  // gate in the run to an instant, unwaitable failure.
+  it("retries a failed connect instead of condemning the rest of the run", async () => {
+    // Fail the first two attempts, as a gate firing into the post-launch gap
+    // does, then let the app finish registering.
+    let attempts = 0;
+    readerAvailable = false;
+    vi.mocked(connectRouteReader).mockImplementation(async () => {
+      connectCalls += 1;
+      attempts += 1;
+      if (attempts <= 2) return undefined;
+      return async () => routes.shift() ?? null;
+    });
+    routes = [route(["Home"]), route(["Home"])];
+    await writeFlow(
+      "nav",
+      `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: 59999 }
+  - await: { screen: "Home", metroPort: 59999 }
+`
+    );
+    const r = await run("nav");
+    expect(r.ok).toBe(true);
+    expect(attempts).toBe(3);
+    // And once it lands, the success is memoized: the second gate reuses it.
+    expect(r.steps.filter((s) => s.kind === "screen").every((s) => s.status === "pass")).toBe(true);
+  });
+
+  // A `launch` terminates the app, taking the JS runtime every reader is
+  // attached to with it — and re-arming the retry budget the previous epoch
+  // may have spent.
+  it("reconnects after a launch instead of probing the dead runtime", async () => {
+    routes = [route(["Home"]), route(["Home"])];
+    await writeFlow(
+      "nav",
+      `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: 59999 }
+  - launch: com.acme.notes
+  - await: { screen: "Home", metroPort: 59999 }
+`
+    );
+    expect((await run("nav")).ok).toBe(true);
+    expect(connectCalls).toBe(2);
+  });
+
+  // The run log prints the step's kind next to its target, so a target that
+  // repeats the kind rendered as "screen screen HomeTab>Profile" — and the
+  // mode, which the log does NOT print, was the thing actually missing from it.
+  it("labels the step with the route alone, and marks the assert form", async () => {
+    routes = [route(["HomeTab", "Profile"]), route(["HomeTab", "Profile"])];
+    await writeFlow(
+      "labelled",
+      `executionPrerequisite: ""
+steps:
+  - launch: com.acme.notes
+  - await: { screen: "HomeTab>Profile", metroPort: 59999 }
+  - assert: { screen: "HomeTab>Profile", metroPort: 59999 }
+`
+    );
+    const r = await run("labelled");
+    expect(r.ok).toBe(true);
+    expect(r.steps.filter((s) => s.kind === "screen").map((s) => s.target)).toEqual([
+      "HomeTab>Profile",
+      "assert HomeTab>Profile",
+    ]);
+  });
+
+  it("refuses to guess the app when the flow never launched one", async () => {
+    await writeFlow(
+      "frag",
+      `executionPrerequisite: "on Home"
+steps:
+  - await: { screen: "Home", metroPort: 59999 }
+`
+    );
+    const tool = createRunFlowTool(mockRegistry());
+    const result = await tool.execute(
+      {},
+      { name: "frag", project_root: tmpDir, device: DEVICE, prerequisiteAcknowledged: true },
+      undefined
+    );
+    if (!("steps" in result)) throw new Error("expected a run result");
+    expect(result.steps.at(-1)!.reason).toContain("no app to read the route from");
+  });
+});
+
+// `idle` is the readiness half. Its whole reason to exist is that it FAILS —
+// the `await-screen-idle` tool reports `settled: false` softly, which cannot
+// carry a regression verdict on an unattended replay.
+describe("await: { idle }", () => {
+  it("passes once the tree holds still", async () => {
+    await writeFlow(
+      "ready",
+      `executionPrerequisite: ""
+steps:
+  - await: { idle: true, minStableMs: 0 }
+`
+    );
+    const r = await run("ready");
+    expect(r.ok).toBe(true);
+  });
+
+  it("fails when the screen never stops changing", async () => {
+    let tick = 0;
+    currentTree = () => screenWith(`frame ${tick++}`);
+    await writeFlow(
+      "ready",
+      `executionPrerequisite: ""
+steps:
+  - await: { idle: true, timeout: 600, minStableMs: 300 }
+`
+    );
+    const r = await run("ready");
+    expect(r.ok).toBe(false);
+    const step = r.steps.at(-1)!;
+    expect(step.status).toBe("fail");
+    expect(step.reason).toContain("never held still");
+  });
+
+  it("distinguishes a screen that never rendered from one that never settled", async () => {
+    currentTree = () => n({ role: "AXWindow", frame: FULL, children: [] });
+    await writeFlow(
+      "ready",
+      `executionPrerequisite: ""
+steps:
+  - await: { idle: true, timeout: 500 }
+`
+    );
+    const r = await run("ready");
+    expect(r.steps.at(-1)!.reason).toContain("never rendered content");
+  });
+});

--- a/packages/tool-server/test/interaction-messages.test.ts
+++ b/packages/tool-server/test/interaction-messages.test.ts
@@ -38,7 +38,7 @@ function definitionsById(registry: Registry): Map<string, ToolDefinition<any, an
 describe("tool interaction messages", () => {
   it("defines all three formatters for every tool", () => {
     const definitions = definitionsById(createRegistry());
-    expect(definitions.size).toBe(77);
+    expect(definitions.size).toBe(78);
 
     for (const [id, definition] of definitions) {
       expect(definition.interaction?.startedMsg, `${id}.startedMsg`).toBeTypeOf("function");

--- a/packages/tool-server/test/route-identity.test.ts
+++ b/packages/tool-server/test/route-identity.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from "vitest";
+import type { Registry } from "@argent/registry";
+import type { CDPTarget, MetroInfo } from "../src/utils/debugger/discovery";
+import {
+  connectRouteReader,
+  parseRouteResult,
+  pickLogicalDeviceId,
+  probeRoute,
+  routeFingerprint,
+  verifyRouteFingerprint,
+  type RouteContext,
+  type RouteReader,
+} from "../src/utils/route-identity";
+
+const route = (path: string[], params: Record<string, unknown> | null = null): RouteContext => ({
+  path,
+  name: path[path.length - 1]!,
+  params,
+});
+
+describe("routeFingerprint", () => {
+  it("keys identity on the route PATH, ignoring params (the dynamic-screen collapse)", () => {
+    const alice = route(["HomeTab", "Profile"], { name: "alice" });
+    const bob = route(["HomeTab", "Profile"], { name: "bob" });
+    expect(routeFingerprint(alice)).toBe("HomeTab>Profile");
+    expect(routeFingerprint(alice)).toBe(routeFingerprint(bob));
+  });
+
+  it("distinguishes different route paths", () => {
+    expect(routeFingerprint(route(["HomeTab", "Profile"]))).not.toBe(
+      routeFingerprint(route(["SearchTab", "Profile"]))
+    );
+    expect(routeFingerprint(route(["HomeTab", "Feed"]))).not.toBe(
+      routeFingerprint(route(["HomeTab", "Profile"]))
+    );
+  });
+});
+
+describe("parseRouteResult", () => {
+  it("parses a successful probe payload (string or object)", () => {
+    const payload = { ok: true, path: ["HomeTab", "Profile"], name: "Profile", params: { id: 7 } };
+    const expected = { path: ["HomeTab", "Profile"], name: "Profile", params: { id: 7 } };
+    expect(parseRouteResult(JSON.stringify(payload))).toEqual(expected);
+    expect(parseRouteResult(payload)).toEqual(expected);
+  });
+
+  it("returns null for every failure shape", () => {
+    expect(parseRouteResult(JSON.stringify({ ok: false, reason: "no-devtools-hook" }))).toBeNull();
+    expect(parseRouteResult(JSON.stringify({ ok: true, path: [], name: "X" }))).toBeNull();
+    expect(parseRouteResult(JSON.stringify({ ok: true, path: ["A"], name: "" }))).toBeNull();
+    expect(parseRouteResult("not json")).toBeNull();
+    expect(parseRouteResult(undefined)).toBeNull();
+    expect(parseRouteResult(42)).toBeNull();
+  });
+
+  it("normalizes a non-object params to null and drops empty path segments", () => {
+    expect(parseRouteResult({ ok: true, path: ["A", "", "B"], name: "B", params: "x" })).toEqual({
+      path: ["A", "B"],
+      name: "B",
+      params: null,
+    });
+  });
+});
+
+/** Metro /json/list target shorthand. */
+function target(opts: {
+  logicalId?: string;
+  appId?: string;
+  title?: string;
+  deviceName?: string;
+}): CDPTarget {
+  return {
+    id: "t",
+    title: opts.title ?? `${opts.appId ?? "app"} (${opts.deviceName ?? "device"})`,
+    description: "React Native Bridge [C++ connection]",
+    webSocketDebuggerUrl: "ws://localhost:8081/debugger",
+    ...(opts.deviceName !== undefined ? { deviceName: opts.deviceName } : {}),
+    ...(opts.appId !== undefined ? { appId: opts.appId } : {}),
+    ...(opts.logicalId !== undefined ? { reactNative: { logicalDeviceId: opts.logicalId } } : {}),
+  };
+}
+
+describe("pickLogicalDeviceId", () => {
+  const APP = "com.example.app";
+  // The routine RN-dev shape: one Metro serving the same app on an iOS sim
+  // AND an Android emulator (plus per-device Reanimated runtime targets).
+  const shared = [
+    target({ logicalId: "android1", appId: APP, deviceName: "sdk_gphone64_arm64 - 14 - API 34" }),
+    target({ logicalId: "android1", appId: APP, deviceName: "sdk_gphone64_arm64 - 14 - API 34" }),
+    target({ logicalId: "ios1", appId: APP, deviceName: "iPhone 17 Pro" }),
+    target({ logicalId: "ios1", appId: APP, deviceName: "iPhone 17 Pro" }),
+  ];
+
+  it("singles out the right platform's device on a Metro shared across platforms", () => {
+    expect(pickLogicalDeviceId(shared, APP, "ios")).toBe("ios1");
+    expect(pickLogicalDeviceId(shared, APP, "android")).toBe("android1");
+  });
+
+  it("ignores foreign apps and matches by title when appId is absent (older RN)", () => {
+    const targets = [
+      target({ logicalId: "other", appId: "com.other.app", deviceName: "iPhone 15" }),
+      target({ logicalId: "ios1", title: `${APP} (iPhone 17 Pro)`, deviceName: "iPhone 17 Pro" }),
+    ];
+    expect(pickLogicalDeviceId(targets, APP, "ios")).toBe("ios1");
+  });
+
+  it("refuses to guess between two same-platform devices running the app", () => {
+    const twoSims = [
+      target({ logicalId: "ios1", appId: APP, deviceName: "iPhone 17 Pro" }),
+      target({ logicalId: "ios2", appId: APP, deviceName: "iPhone 16e" }),
+    ];
+    expect(pickLogicalDeviceId(twoSims, APP, "ios")).toBeUndefined();
+  });
+
+  it("pins strictly by device name when known — a foreign phone on the LAN never matches", () => {
+    // The live incident shape: our sim ("iPhone 16 Pro") has no target yet
+    // (dev-client launcher up), while a physical iPhone 17 Pro on the LAN
+    // serves the same app from the same Metro. The heuristic would pick the
+    // phone; the name pin must refuse.
+    const foreignOnly = [target({ logicalId: "phone1", appId: APP, deviceName: "iPhone 17 Pro" })];
+    expect(pickLogicalDeviceId(foreignOnly, APP, "ios", "iPhone 16 Pro")).toBeUndefined();
+    expect(pickLogicalDeviceId(foreignOnly, APP, "ios", "iPhone 17 Pro")).toBe("phone1");
+  });
+
+  it("matches Android names by model prefix (Metro appends release and API level)", () => {
+    const emulator = [
+      target({
+        logicalId: "android1",
+        appId: APP,
+        deviceName: "sdk_gphone64_arm64 - 14 - API 34",
+      }),
+    ];
+    expect(pickLogicalDeviceId(emulator, APP, "android", "sdk_gphone64_arm64")).toBe("android1");
+    expect(pickLogicalDeviceId(emulator, APP, "android", "Pixel 7")).toBeUndefined();
+  });
+
+  it("skips legacy-inspector targets (no logicalDeviceId) and empty lists", () => {
+    expect(pickLogicalDeviceId([target({ appId: APP })], APP, "ios")).toBeUndefined();
+    expect(pickLogicalDeviceId([], APP, "ios")).toBeUndefined();
+  });
+});
+
+describe("connectRouteReader", () => {
+  // Fake registry answering the two debugger tools connectRouteReader calls.
+  function reg(
+    opts: { connect: Record<string, unknown> | Error; evalResult?: unknown },
+    calls: { tool: string; args: Record<string, unknown> }[] = []
+  ): Registry {
+    return {
+      invokeTool: async (id: string, args: Record<string, unknown>) => {
+        calls.push({ tool: id, args });
+        if (id === "debugger-connect") {
+          if (opts.connect instanceof Error) throw opts.connect;
+          return opts.connect;
+        }
+        if (id === "debugger-evaluate") return { result: opts.evalResult };
+        return {};
+      },
+    } as unknown as Registry;
+  }
+
+  const args = {
+    udid: "SIM",
+    bundleId: "com.example.app",
+    metroPort: 8081,
+    platform: "ios" as const,
+  };
+  /** No Metro reachable — forces the udid-fallback connect path. */
+  const noMetro = async (): Promise<MetroInfo> => {
+    throw new Error("Metro at port 8081 is not running");
+  };
+
+  const sharedMetro = async (): Promise<MetroInfo> => ({
+    port: 8081,
+    projectRoot: "",
+    targets: [
+      target({
+        logicalId: "android1",
+        appId: args.bundleId,
+        deviceName: "sdk_gphone64_arm64 - 14 - API 34",
+      }),
+      target({ logicalId: "ios1", appId: args.bundleId, deviceName: "iPhone 17 Pro" }),
+    ],
+  });
+
+  it("resolves the logicalDeviceId from Metro's target list and connects with it", async () => {
+    const calls: { tool: string; args: Record<string, unknown> }[] = [];
+    const registry = reg(
+      {
+        // The connected app's own title — matchedByAppId skips the name guard.
+        connect: { connected: true, logicalDeviceId: "ios1", appName: "whatever" },
+        evalResult: JSON.stringify({ ok: true, path: ["Root"], name: "Root", params: null }),
+      },
+      calls
+    );
+
+    const reader = await connectRouteReader(
+      registry,
+      undefined,
+      { ...args, deviceName: "iPhone 17 Pro" },
+      sharedMetro
+    );
+
+    expect(reader).toBeDefined();
+    expect(calls.find((c) => c.tool === "debugger-connect")?.args).toMatchObject({
+      device_id: "ios1",
+    });
+    expect(await reader!()).toEqual({ path: ["Root"], name: "Root", params: null });
+  });
+
+  it("refuses (no udid fallback) when the app is served here but OUR device has no target", async () => {
+    const calls: { tool: string; args: Record<string, unknown> }[] = [];
+    const registry = reg(
+      { connect: { connected: true, logicalDeviceId: "phone1", appName: args.bundleId } },
+      calls
+    );
+
+    const reader = await connectRouteReader(
+      registry,
+      undefined,
+      { ...args, deviceName: "iPhone 16 Pro" },
+      sharedMetro
+    );
+
+    expect(reader).toBeUndefined();
+    // Falling through to a udid connect would bind a foreign device's runtime.
+    expect(calls.filter((c) => c.tool === "debugger-connect")).toEqual([]);
+  });
+
+  it("returns a working reader when the connected app names our bundle", async () => {
+    const registry = reg({
+      connect: {
+        connected: true,
+        logicalDeviceId: "dev1",
+        appName: "com.example.app (iPhone 17 Pro)",
+      },
+      evalResult: JSON.stringify({
+        ok: true,
+        path: ["HomeTab", "Home"],
+        name: "Home",
+        params: null,
+      }),
+    });
+    const reader = await connectRouteReader(registry, undefined, args, noMetro);
+    expect(reader).toBeDefined();
+    expect(await reader!()).toEqual({ path: ["HomeTab", "Home"], name: "Home", params: null });
+  });
+
+  it("refuses (→ landmark fallback) when Metro serves a DIFFERENT app", async () => {
+    // A foreign RN project's dev server on 8081: its title names another bundle.
+    const registry = reg({
+      connect: {
+        connected: true,
+        logicalDeviceId: "dev1",
+        appName: "com.other.app (iPhone 17 Pro)",
+      },
+    });
+    expect(await connectRouteReader(registry, undefined, args, noMetro)).toBeUndefined();
+  });
+
+  it("returns undefined when not connected or connect throws (non-RN app)", async () => {
+    expect(
+      await connectRouteReader(reg({ connect: { connected: false } }), undefined, args, noMetro)
+    ).toBeUndefined();
+    expect(
+      await connectRouteReader(reg({ connect: new Error("Metro down") }), undefined, args, noMetro)
+    ).toBeUndefined();
+  });
+
+  it("proceeds when the target title is unknown (no over-rejection)", async () => {
+    const registry = reg({
+      connect: { connected: true, logicalDeviceId: "dev1", appName: "" },
+      evalResult: JSON.stringify({ ok: true, path: ["Root"], name: "Root", params: null }),
+    });
+    const reader = await connectRouteReader(registry, undefined, args, noMetro);
+    expect(reader).toBeDefined();
+    expect(await reader!()).toEqual({ path: ["Root"], name: "Root", params: null });
+  });
+});
+
+describe("probeRoute", () => {
+  it("retries a null read (mid-transition) and returns the route once it appears", async () => {
+    let reads = 0;
+    const reader = async (): Promise<RouteContext | null> =>
+      ++reads < 3 ? null : route(["HomeTab", "Feed"]);
+
+    const result = await probeRoute(reader, { retryMs: 1 });
+
+    expect(result).toEqual(route(["HomeTab", "Feed"]));
+    expect(reads).toBe(3);
+  });
+
+  it("concedes null after the attempts are exhausted", async () => {
+    let reads = 0;
+    const reader = async (): Promise<RouteContext | null> => {
+      reads++;
+      return null;
+    };
+
+    expect(await probeRoute(reader, { attempts: 2, retryMs: 1 })).toBeNull();
+    expect(reads).toBe(2);
+  });
+
+  it("returns null immediately on an aborted signal without reading", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let reads = 0;
+    const reader = async (): Promise<RouteContext | null> => {
+      reads++;
+      return route(["A"]);
+    };
+
+    expect(await probeRoute(reader, { signal: controller.signal })).toBeNull();
+    expect(reads).toBe(0);
+  });
+});
+
+// The verification primitive the flow `screen` gate is built on. Its whole
+// value is keeping "read a different screen" and "read nothing" apart: the
+// first is a verdict about the app, the second is a broken probe, and
+// collapsing them is how a green run comes to prove nothing.
+describe("verifyRouteFingerprint", () => {
+  const reads = (...values: Array<RouteContext | null>): RouteReader => {
+    const queue = [...values];
+    return async () => queue.shift() ?? null;
+  };
+
+  it("passes on the first probe when the route already matches", async () => {
+    const outcome = await verifyRouteFingerprint(
+      reads(route(["HomeTab", "Profile"])),
+      "HomeTab>Profile",
+      0,
+      1
+    );
+    expect(outcome).toEqual({ ok: true, observedRoute: "HomeTab>Profile" });
+  });
+
+  it("keeps polling through the transition until the route commits", async () => {
+    const outcome = await verifyRouteFingerprint(
+      reads(null, route(["HomeTab", "Feed"]), route(["HomeTab", "Profile"])),
+      "HomeTab>Profile",
+      2000,
+      1
+    );
+    expect(outcome.ok).toBe(true);
+  });
+
+  it("reports the screen it actually observed when the route is wrong", async () => {
+    const outcome = await verifyRouteFingerprint(
+      reads(route(["HomeTab", "Feed"])),
+      "HomeTab>Profile",
+      0,
+      1
+    );
+    expect(outcome).toEqual({ ok: false, observedRoute: "HomeTab>Feed" });
+  });
+
+  it("reports NO observed route when every probe came back null", async () => {
+    // Absent observedRoute is the caller's signal that identity is unknown
+    // rather than wrong — it must not be dressed up as arrival or as failure.
+    const outcome = await verifyRouteFingerprint(reads(null), "Home", 0, 1);
+    expect(outcome).toEqual({ ok: false });
+  });
+
+  it("reports an abort distinctly from a failed match", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const outcome = await verifyRouteFingerprint(
+      reads(route(["A"])),
+      "B",
+      500,
+      1,
+      controller.signal
+    );
+    expect(outcome).toEqual({ ok: false, aborted: true });
+  });
+});


### PR DESCRIPTION
> Stacked on #728.

## What changes

A `screen-fingerprint` call made through `flow-add-step` is rewritten into the `await: { screen: <route> }` gate for the screen it just read.

A fingerprint **read** becomes a fingerprint **check** — recorded as the portable directive rather than a raw tool call, so the runner *compares* the route instead of merely re-reading it and discarding the answer. It is the same shape as the existing `gesture-tap` → `tap:` and `restart-app` → `launch:` rewrites.

## Three cases the rewrite has to get right

**A fingerprint that could not name the screen is refused.** There is no identity to gate on. Recording it raw would persist a `tool:` step whose output nothing checks; the failure belongs where the evidence still is. The refusal distinguishes "this app can never have a reader" (gate on an element instead) from "no route at this instant" (let it settle and call again).

**A fragment has no `launch` step**, so at replay the gate would have no app to read the route from and would fail as an environment error — discovered long after the recording looked fine. The fingerprint call had to name the app to run at all, so that id is carried onto the step, with a warning that it pins the fragment to one platform and how to avoid that (compose it from an e2e flow whose `launch` declares the app).

**A route equal to the flow's last gated route warns, but still records.**

This one is a judgement call worth stating. Such a gate *may* prove nothing: an app whose sign-in form is presented inside its landing route reports one fingerprint for both screens, so a gate recorded after "tap Sign in" passes whether or not the tap landed.

But it may equally be a **return trip** — Home → Search → Home — where the gate is perfectly falsifiable. Telling the two apart needs the route as it was *immediately before the last action*, and the recorder does not have it: the last route it gated on says nothing about where the app went in between, since intermediate screens are routinely gated on an element instead — exactly what the skills prescribe for a route-less screen.

So it warns. A refusal needs certainty, and without it blocking would make the ordinary "go there, come back, verify" shape unrecordable — while the QA contract calls a navigation with no identity gate a blocking defect. The recorder would be making its own contract unsatisfiable.

## `delayMs` is dropped loudly

A `screen` gate has no pre-step delay because it **polls**. Every other rewrite refuses to convert while `delayMs` is set, precisely so the delay survives; this one converts anyway — and dropping an author's parameter without a word is what must not happen. The warning names `timeout:` as the field that expresses the same intent.