### PR TITLE
fix(installer): write rules and agents through a symlinked target

### DIFF
--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -19,6 +19,7 @@ import {
   readYaml,
   writeYaml,
   copyDir,
+  realpathOrSelf,
   editJsoncFile,
   isYarnPnp,
   getLocalArgentBinRelPath,
@@ -1818,9 +1819,19 @@ export interface ManagedContentTargets {
 
 // A symlinked target is written through rather than replaced (see copyDir), so
 // the files can land somewhere other than the configured path. Naming both
-// keeps that redirect auditable in the install output instead of silent.
-function formatCopyDestination(targetPath: string, writtenPath: string): string {
-  return writtenPath === targetPath ? targetPath : `${targetPath} -> ${writtenPath}`;
+// keeps that redirect auditable in the install output instead of silent — in
+// the same shortened form the rest of the managed-content output uses, so a
+// destination that escapes the workspace stays absolute and stands out.
+function formatCopyDestination(
+  target: ManagedContentTarget,
+  writtenPath: string,
+  root: string
+): string {
+  if (writtenPath === target.targetPath) return target.label;
+  // The written path came back from realpath, so shorten it against the same:
+  // a workspace reached through a link (macOS /var, a symlinked home) would
+  // otherwise never look relative to its own root.
+  return `${target.label} -> ${formatManagedPathLabel(writtenPath, realpathOrSelf(root))}`;
 }
 
 function formatManagedPathLabel(targetPath: string, root: string): string {
@@ -2024,7 +2035,7 @@ export function copyRulesAndAgents(
     try {
       const written = copyDir(rulesDir, target.targetPath);
       if (written) {
-        results.push(`  Copied rules to ${formatCopyDestination(target.targetPath, written)}`);
+        results.push(`  Copied rules to ${formatCopyDestination(target, written, root)}`);
       }
     } catch (err) {
       results.push(`  Could not copy rules to ${target.targetPath}: ${err}`);
@@ -2035,7 +2046,7 @@ export function copyRulesAndAgents(
     try {
       const written = copyDir(agentsDir, target.targetPath);
       if (written) {
-        results.push(`  Copied agents to ${formatCopyDestination(target.targetPath, written)}`);
+        results.push(`  Copied agents to ${formatCopyDestination(target, written, root)}`);
       }
     } catch (err) {
       results.push(`  Could not copy agents to ${target.targetPath}: ${err}`);

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -18,6 +18,7 @@ import {
   writeToml,
   readYaml,
   writeYaml,
+  copyDir,
   editJsoncFile,
   isYarnPnp,
   getLocalArgentBinRelPath,
@@ -1815,6 +1816,13 @@ export interface ManagedContentTargets {
   skillsLockTargets: ManagedContentTarget[];
 }
 
+// A symlinked target is written through rather than replaced (see copyDir), so
+// the files can land somewhere other than the configured path. Naming both
+// keeps that redirect auditable in the install output instead of silent.
+function formatCopyDestination(targetPath: string, writtenPath: string): string {
+  return writtenPath === targetPath ? targetPath : `${targetPath} -> ${writtenPath}`;
+}
+
 function formatManagedPathLabel(targetPath: string, root: string): string {
   const home = homedir();
   if (targetPath === home || targetPath.startsWith(`${home}${path.sep}`)) {
@@ -2014,10 +2022,9 @@ export function copyRulesAndAgents(
 
   for (const target of managedTargets.ruleTargets) {
     try {
-      if (fs.existsSync(rulesDir)) {
-        fs.mkdirSync(target.targetPath, { recursive: true });
-        fs.cpSync(rulesDir, target.targetPath, { recursive: true });
-        results.push(`  Copied rules to ${target.targetPath}`);
+      const written = copyDir(rulesDir, target.targetPath);
+      if (written) {
+        results.push(`  Copied rules to ${formatCopyDestination(target.targetPath, written)}`);
       }
     } catch (err) {
       results.push(`  Could not copy rules to ${target.targetPath}: ${err}`);
@@ -2026,10 +2033,9 @@ export function copyRulesAndAgents(
 
   for (const target of managedTargets.agentTargets) {
     try {
-      if (fs.existsSync(agentsDir)) {
-        fs.mkdirSync(target.targetPath, { recursive: true });
-        fs.cpSync(agentsDir, target.targetPath, { recursive: true });
-        results.push(`  Copied agents to ${target.targetPath}`);
+      const written = copyDir(agentsDir, target.targetPath);
+      if (written) {
+        results.push(`  Copied agents to ${formatCopyDestination(target.targetPath, written)}`);
       }
     } catch (err) {
       results.push(`  Could not copy agents to ${target.targetPath}: ${err}`);

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -364,11 +364,85 @@ export function editJsoncFile(filePath: string, jsonPath: JSONPath, value: unkno
 
 // ── Directory helpers ─────────────────────────────────────────────────────────
 
-export function copyDir(src: string, dest: string): boolean {
-  if (!fs.existsSync(src)) return false;
-  fs.mkdirSync(dest, { recursive: true });
-  fs.cpSync(src, dest, { recursive: true });
-  return true;
+function realpathOrSelf(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+// The path a copy destination names: itself, or — when it is a symlink — what
+// it points at, so the copy writes *through* the link instead of replacing it.
+// A link whose target does not exist yet resolves to the path it names, so the
+// caller materializes it; cp(1) refuses that case, but a link written before
+// its target is the friendlier reading, and it keeps a dangling link away from
+// `fs.cp` (see copyDir).
+function resolveLinkedDestination(dest: string): string {
+  try {
+    if (!fs.lstatSync(dest).isSymbolicLink()) return dest;
+    return fs.realpathSync(dest);
+  } catch {
+    // Absent, or a link whose target is missing — fall through and read it.
+  }
+
+  try {
+    // A relative target resolves against the directory the link really lives
+    // in, which is not the lexical dirname when a parent is itself a link into
+    // another subtree.
+    return path.resolve(fs.realpathSync(path.dirname(dest)), fs.readlinkSync(dest));
+  } catch {
+    return dest; // absent or unreadable — let the caller report why
+  }
+}
+
+// Copy a directory tree, writing *through* every symlink it lands on — file or
+// directory, at any depth — rather than replacing it. Returns the directory
+// actually written (which differs from `dest` when that was a symlink), or null
+// when there is nothing to copy.
+//
+// Writing through matters because agent definitions are increasingly the same
+// content across harnesses: people keep the canonical copy in one neutral
+// directory and point each vendor path at it — the whole directory
+// (`.claude/agents -> ../.agents/agents`) or a single file inside it. The host
+// tools already tolerate that — Claude Code documents symlinks for
+// `.claude/rules/` — so argent's writer should too (issue #701).
+//
+// The recursion is what `fs.cpSync(src, dest, { recursive: true })` would do on
+// its own, minus its handling of a symlinked `dest`: it refuses one outright
+// (ERR_FS_CP_DIR_TO_NON_DIR, "cannot overwrite non-directory with directory"),
+// and on a dangling one it does not throw but aborts the process, via an
+// uncatchable C++ std::filesystem exception no try/catch can reach. Resolving
+// each level here keeps both cases away from it.
+export function copyDir(src: string, dest: string): string | null {
+  if (!fs.existsSync(src)) return null;
+
+  const target = resolveLinkedDestination(dest);
+
+  // `fs.cp` refuses to copy a tree into itself. Hand-rolled, the recursion
+  // below would instead keep re-creating the directory it is about to read,
+  // burrowing into the source until the path outgrows the platform limit. The
+  // comparison is between real paths, since the two can name one directory
+  // through different links.
+  const realTarget = path.join(realpathOrSelf(path.dirname(target)), path.basename(target));
+  const fromSource = path.relative(fs.realpathSync(src), realTarget);
+  if (!fromSource.startsWith("..") && !path.isAbsolute(fromSource)) {
+    throw new Error(`Cannot copy ${src} into a subdirectory of itself (${target})`);
+  }
+
+  fs.mkdirSync(target, { recursive: true });
+
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const from = path.join(src, entry.name);
+    const to = path.join(target, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(from, to);
+    } else {
+      fs.cpSync(from, resolveLinkedDestination(to), { recursive: true });
+    }
+  }
+
+  return target;
 }
 
 export function dirExists(p: string): boolean {

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -364,7 +364,11 @@ export function editJsoncFile(filePath: string, jsonPath: JSONPath, value: unkno
 
 // ── Directory helpers ─────────────────────────────────────────────────────────
 
-function realpathOrSelf(p: string): string {
+// How many links a destination chain may traverse before we give up, matching
+// the kernel's own ELOOP ceiling.
+const MAX_SYMLINK_HOPS = 40;
+
+export function realpathOrSelf(p: string): string {
   try {
     return fs.realpathSync(p);
   } catch {
@@ -373,74 +377,85 @@ function realpathOrSelf(p: string): string {
 }
 
 // The path a copy destination names: itself, or — when it is a symlink — what
-// it points at, so the copy writes *through* the link instead of replacing it.
-// A link whose target does not exist yet resolves to the path it names, so the
-// caller materializes it; cp(1) refuses that case, but a link written before
-// its target is the friendlier reading, and it keeps a dangling link away from
-// `fs.cp` (see copyDir).
+// it points at, following a chain to its end. Each hop resolves against the
+// directory the link really lives in, which is not the lexical dirname when a
+// parent is itself a link into another subtree.
+//
+// A link whose target does not exist is completed, but only into a directory
+// that already exists: finishing `.claude/agents -> ../.agents/agents` for
+// someone who has made `.agents` is helpful, conjuring a whole tree at the end
+// of an arbitrary link is not. Anything else resolves back to the path we were
+// given, so the caller fails naming the link the user actually wrote.
 function resolveLinkedDestination(dest: string): string {
-  try {
-    if (!fs.lstatSync(dest).isSymbolicLink()) return dest;
-    return fs.realpathSync(dest);
-  } catch {
-    // Absent, or a link whose target is missing — fall through and read it.
+  let current = dest;
+
+  for (let hop = 0; hop < MAX_SYMLINK_HOPS; hop++) {
+    let entry: fs.Stats;
+    try {
+      entry = fs.lstatSync(current);
+    } catch {
+      // Nothing here: either `dest` itself is simply missing, or we walked a
+      // chain to a target that was never created.
+      return current === dest || dirExists(path.dirname(current)) ? current : dest;
+    }
+
+    if (!entry.isSymbolicLink()) return current;
+
+    try {
+      current = path.resolve(realpathOrSelf(path.dirname(current)), fs.readlinkSync(current));
+    } catch {
+      return dest;
+    }
   }
 
-  try {
-    // A relative target resolves against the directory the link really lives
-    // in, which is not the lexical dirname when a parent is itself a link into
-    // another subtree.
-    return path.resolve(fs.realpathSync(path.dirname(dest)), fs.readlinkSync(dest));
-  } catch {
-    return dest; // absent or unreadable — let the caller report why
+  return dest;
+}
+
+// Create every directory the copy is going to land in, resolving links on the
+// way down.
+//
+// `fs.cp` would make them itself, but its directory creation fails in a way no
+// caller can survive: handed a dangling link, or a directory it may not write
+// to, it does not throw — it aborts the process through an uncatchable C++
+// std::filesystem exception. Doing it here turns both into ordinary errors the
+// installer can report, and leaves `fs.cp` only the work it does correctly.
+function createDestinationTree(src: string, dest: string): void {
+  // Read the source before creating anything: a destination that resolves back
+  // inside the source would otherwise grow the very tree being walked.
+  const subdirectories = fs
+    .readdirSync(src, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  fs.mkdirSync(dest, { recursive: true });
+
+  for (const name of subdirectories) {
+    createDestinationTree(path.join(src, name), resolveLinkedDestination(path.join(dest, name)));
   }
 }
 
-// Copy a directory tree, writing *through* every symlink it lands on — file or
-// directory, at any depth — rather than replacing it. Returns the directory
-// actually written (which differs from `dest` when that was a symlink), or null
-// when there is nothing to copy.
+// Copy a directory tree onto `dest`, writing *through* it when it is a symlink
+// rather than replacing it. Returns the directory actually written (which
+// differs from `dest` when that was a link), or null when there is nothing to
+// copy.
 //
 // Writing through matters because agent definitions are increasingly the same
 // content across harnesses: people keep the canonical copy in one neutral
-// directory and point each vendor path at it — the whole directory
-// (`.claude/agents -> ../.agents/agents`) or a single file inside it. The host
-// tools already tolerate that — Claude Code documents symlinks for
-// `.claude/rules/` — so argent's writer should too (issue #701).
-//
-// The recursion is what `fs.cpSync(src, dest, { recursive: true })` would do on
-// its own, minus its handling of a symlinked `dest`: it refuses one outright
-// (ERR_FS_CP_DIR_TO_NON_DIR, "cannot overwrite non-directory with directory"),
-// and on a dangling one it does not throw but aborts the process, via an
-// uncatchable C++ std::filesystem exception no try/catch can reach. Resolving
-// each level here keeps both cases away from it.
+// directory and point each vendor path at it (`.claude/agents ->
+// ../.agents/agents`). The host tools already tolerate that — Claude Code
+// documents symlinks for `.claude/rules/` — so argent's writer should too
+// (issue #701). `fs.cp` does write through a symlinked file, and a symlinked
+// directory below the top level; it just refuses the top level itself, with
+// ERR_FS_CP_DIR_TO_NON_DIR ("cannot overwrite non-directory with directory").
+// Resolving that one path up front is the whole fix — everything below it stays
+// `fs.cp`'s own behaviour, including its guard against copying a tree into
+// itself.
 export function copyDir(src: string, dest: string): string | null {
   if (!fs.existsSync(src)) return null;
 
   const target = resolveLinkedDestination(dest);
-
-  // `fs.cp` refuses to copy a tree into itself. Hand-rolled, the recursion
-  // below would instead keep re-creating the directory it is about to read,
-  // burrowing into the source until the path outgrows the platform limit. The
-  // comparison is between real paths, since the two can name one directory
-  // through different links.
-  const realTarget = path.join(realpathOrSelf(path.dirname(target)), path.basename(target));
-  const fromSource = path.relative(fs.realpathSync(src), realTarget);
-  if (!fromSource.startsWith("..") && !path.isAbsolute(fromSource)) {
-    throw new Error(`Cannot copy ${src} into a subdirectory of itself (${target})`);
-  }
-
-  fs.mkdirSync(target, { recursive: true });
-
-  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
-    const from = path.join(src, entry.name);
-    const to = path.join(target, entry.name);
-    if (entry.isDirectory()) {
-      copyDir(from, to);
-    } else {
-      fs.cpSync(from, resolveLinkedDestination(to), { recursive: true });
-    }
-  }
+  createDestinationTree(src, target);
+  fs.cpSync(src, target, { recursive: true });
 
   return target;
 }

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -411,53 +411,48 @@ function resolveLinkedDestination(dest: string): string {
   return dest;
 }
 
-// Create every directory the copy is going to land in, resolving links on the
-// way down.
-//
-// `fs.cp` would make them itself, but its directory creation fails in a way no
-// caller can survive: handed a dangling link, or a directory it may not write
-// to, it does not throw — it aborts the process through an uncatchable C++
-// std::filesystem exception. Doing it here turns both into ordinary errors the
-// installer can report, and leaves `fs.cp` only the work it does correctly.
-function createDestinationTree(src: string, dest: string): void {
-  // Read the source before creating anything: a destination that resolves back
-  // inside the source would otherwise grow the very tree being walked.
-  const subdirectories = fs
-    .readdirSync(src, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name);
-
-  fs.mkdirSync(dest, { recursive: true });
-
-  for (const name of subdirectories) {
-    createDestinationTree(path.join(src, name), resolveLinkedDestination(path.join(dest, name)));
-  }
-}
-
-// Copy a directory tree onto `dest`, writing *through* it when it is a symlink
-// rather than replacing it. Returns the directory actually written (which
-// differs from `dest` when that was a link), or null when there is nothing to
-// copy.
+// Copy a directory tree onto `dest`, writing *through* every symlink it lands
+// on — file or directory, at any depth — rather than replacing it. Returns the
+// directory actually written (which differs from `dest` when that was a link),
+// or null when there is nothing to copy.
 //
 // Writing through matters because agent definitions are increasingly the same
 // content across harnesses: people keep the canonical copy in one neutral
-// directory and point each vendor path at it (`.claude/agents ->
-// ../.agents/agents`). The host tools already tolerate that — Claude Code
-// documents symlinks for `.claude/rules/` — so argent's writer should too
-// (issue #701). `fs.cp` does write through a symlinked file, and a symlinked
-// directory below the top level; it just refuses the top level itself, with
-// ERR_FS_CP_DIR_TO_NON_DIR ("cannot overwrite non-directory with directory").
-// Resolving that one path up front is the whole fix — everything below it stays
-// `fs.cp`'s own behaviour, including its guard against copying a tree into
-// itself.
+// directory and point each vendor path at it — the whole directory
+// (`.claude/agents -> ../.agents/agents`) or a single file inside it. The host
+// tools already tolerate that — Claude Code documents symlinks for
+// `.claude/rules/` — so argent's writer should too (issue #701).
+//
+// `fs.cp` cannot do any of this, because what it does with a symlinked
+// destination depends on which runtime you are on. Node 20 refuses one at any
+// level (ERR_FS_CP_DIR_TO_NON_DIR) and quietly replaces a symlinked file,
+// leaving the canonical copy stale; Node 22 writes through both, but aborts
+// the process — an uncatchable C++ std::filesystem exception no try/catch can
+// reach — whenever it has to create a directory and cannot, whether that is a
+// dangling link or one it may not write to. Argent supports both. Walking the
+// tree here is what makes the behaviour the same on every supported runtime,
+// and `fs.copyFileSync` reports each failure as a plain, catchable errno.
 export function copyDir(src: string, dest: string): string | null {
   if (!fs.existsSync(src)) return null;
 
   const target = resolveLinkedDestination(dest);
-  createDestinationTree(src, target);
-  fs.cpSync(src, target, { recursive: true });
-
+  copyTree(src, target);
   return target;
+}
+
+function copyTree(src: string, dest: string): void {
+  // Read the source before creating anything: a destination that resolves back
+  // inside the source would otherwise grow the very tree being walked.
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  fs.mkdirSync(dest, { recursive: true });
+
+  for (const entry of entries) {
+    const from = path.join(src, entry.name);
+    const to = resolveLinkedDestination(path.join(dest, entry.name));
+    if (entry.isDirectory()) copyTree(from, to);
+    else fs.copyFileSync(from, to);
+  }
 }
 
 export function dirExists(p: string): boolean {

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -1644,6 +1644,10 @@ describe("copyRulesAndAgents", () => {
     fs.mkdirSync(agentsDir, { recursive: true });
     fs.writeFileSync(path.join(rulesDir, "argent.md"), "# Rule");
     fs.writeFileSync(path.join(agentsDir, "environment-inspector.md"), "# Agent");
+    // The bundled agents tree is not flat — it carries a references/
+    // subdirectory — so the fixture mirrors that shape.
+    fs.mkdirSync(path.join(agentsDir, "references"), { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, "references", "checklist.md"), "# Checklist");
   });
 
   it("copies rules to .claude/rules for Claude Code adapter (local)", () => {
@@ -1697,6 +1701,56 @@ describe("copyRulesAndAgents", () => {
     expect(
       fs.existsSync(path.join(homedirOverride, ".gemini", "agents", "environment-inspector.md"))
     ).toBe(true);
+  });
+
+  // Issue #701: a `.claude/agents -> ../.agents/agents` layout keeps one
+  // canonical copy of the agent definitions and points each harness's path at
+  // it. Before the fix the copy tried to replace the link with a directory and
+  // failed, so argent-environment-inspector never landed even though
+  // rules/argent.md kept referencing it.
+  // Skipped on Windows, where creating symlinks needs admin rights.
+  describe.skipIf(process.platform === "win32")("symlinked targets", () => {
+    it("installs agents into a symlinked .claude/agents, including nested files", () => {
+      const claudeAdapter = ALL_ADAPTERS.find((a) => a.name === "Claude Code")!;
+      const canonical = path.join(tmpDir, ".agents", "agents");
+      const link = path.join(tmpDir, ".claude", "agents");
+      fs.mkdirSync(canonical, { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, ".claude"), { recursive: true });
+      fs.symlinkSync(path.join("..", ".agents", "agents"), link);
+
+      const results = copyRulesAndAgents([claudeAdapter], tmpDir, "local", rulesDir, agentsDir);
+
+      expect(fs.existsSync(path.join(canonical, "environment-inspector.md"))).toBe(true);
+      expect(fs.existsSync(path.join(canonical, "references", "checklist.md"))).toBe(true);
+      expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+      expect(results.some((r) => r.includes("Could not copy agents"))).toBe(false);
+    });
+
+    it("names both paths when a target redirects through a symlink", () => {
+      const claudeAdapter = ALL_ADAPTERS.find((a) => a.name === "Claude Code")!;
+      const canonical = path.join(tmpDir, ".agents", "agents");
+      const link = path.join(tmpDir, ".claude", "agents");
+      fs.mkdirSync(canonical, { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, ".claude"), { recursive: true });
+      fs.symlinkSync(path.join("..", ".agents", "agents"), link);
+
+      const results = copyRulesAndAgents([claudeAdapter], tmpDir, "local", rulesDir, agentsDir);
+      const agentsLine = results.find((r) => r.includes("Copied agents"))!;
+
+      expect(agentsLine).toContain(`${link} -> ${fs.realpathSync(canonical)}`);
+    });
+
+    it("installs rules into a symlinked .claude/rules", () => {
+      const claudeAdapter = ALL_ADAPTERS.find((a) => a.name === "Claude Code")!;
+      const canonical = path.join(tmpDir, ".agents", "rules");
+      fs.mkdirSync(canonical, { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, ".claude"), { recursive: true });
+      fs.symlinkSync(path.join("..", ".agents", "rules"), path.join(tmpDir, ".claude", "rules"));
+
+      copyRulesAndAgents([claudeAdapter], tmpDir, "local", rulesDir, agentsDir);
+
+      expect(fs.existsSync(path.join(canonical, "argent.md"))).toBe(true);
+    });
   });
 
   it("injects Codex rules into developer_instructions in config.toml (local)", () => {

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -1667,6 +1667,14 @@ describe("copyRulesAndAgents", () => {
     );
   });
 
+  it("names the target plainly when nothing redirects", () => {
+    const claudeAdapter = ALL_ADAPTERS.find((a) => a.name === "Claude Code")!;
+
+    const results = copyRulesAndAgents([claudeAdapter], tmpDir, "local", rulesDir, agentsDir);
+
+    expect(results.every((r) => !r.includes(" -> "))).toBe(true);
+  });
+
   it("copies rules to .cursor/rules for Cursor adapter (local)", () => {
     const cursorAdapter = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
     copyRulesAndAgents([cursorAdapter], tmpDir, "local", rulesDir, agentsDir);
@@ -1737,7 +1745,7 @@ describe("copyRulesAndAgents", () => {
       const results = copyRulesAndAgents([claudeAdapter], tmpDir, "local", rulesDir, agentsDir);
       const agentsLine = results.find((r) => r.includes("Copied agents"))!;
 
-      expect(agentsLine).toContain(`${link} -> ${fs.realpathSync(canonical)}`);
+      expect(agentsLine).toContain(`.claude/agents -> ${path.join(".agents", "agents")}`);
     });
 
     it("installs rules into a symlinked .claude/rules", () => {

--- a/packages/argent-installer/test/utils.test.ts
+++ b/packages/argent-installer/test/utils.test.ts
@@ -251,6 +251,7 @@ describe("copyDir", () => {
     it("resolves a dangling relative target from behind a symlinked parent", () => {
       const src = stageSource();
       fs.mkdirSync(path.join(tmpDir, "dotfiles", "claude"), { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, "dotfiles", "shared"), { recursive: true });
       fs.mkdirSync(path.join(tmpDir, "home"), { recursive: true });
       fs.symlinkSync(path.join("..", "dotfiles", "claude"), path.join(tmpDir, "home", ".claude"));
       fs.symlinkSync(
@@ -264,6 +265,42 @@ describe("copyDir", () => {
       expect(fs.existsSync(path.join(tmpDir, "home", ".claude", "rules", "a.txt"))).toBe(true);
     });
 
+    it("follows a chain of destination links to its end", () => {
+      const src = stageSource();
+      const real = path.join(tmpDir, "canonical");
+      fs.mkdirSync(real);
+      fs.symlinkSync("canonical", path.join(tmpDir, "hop"));
+      fs.symlinkSync("hop", path.join(tmpDir, "dest"));
+
+      expect(copyDir(src, path.join(tmpDir, "dest"))).toBe(fs.realpathSync(real));
+      expect(fs.readFileSync(path.join(real, "a.txt"), "utf8")).toBe("hello");
+    });
+
+    // Completing a link is a courtesy for a canonical directory the user has
+    // already made — not a licence to build a tree wherever a link points.
+    it("refuses a dangling link whose parent does not exist, creating nothing", () => {
+      const src = stageSource();
+      const link = path.join(tmpDir, "dest");
+      fs.symlinkSync(path.join("nowhere", "canonical"), link);
+
+      expect(() => copyDir(src, link)).toThrow();
+      expect(fs.existsSync(path.join(tmpDir, "nowhere"))).toBe(false);
+    });
+
+    // Guards a design that resolved these itself and handed the result to
+    // fs.cp, which terminates the runtime on a dangling link rather than
+    // throwing. Left to fs.cp, a leaf link is a plain catchable error.
+    it("reports a dangling chain on a destination file without crashing", () => {
+      const src = stageSource();
+      const dest = path.join(tmpDir, "dest");
+      fs.mkdirSync(path.join(tmpDir, "neutral"), { recursive: true });
+      fs.mkdirSync(dest);
+      fs.symlinkSync(path.join("..", "neutral", "a.txt"), path.join(dest, "a.txt"));
+      fs.symlinkSync(path.join("..", "gone", "a.txt"), path.join(tmpDir, "neutral", "a.txt"));
+
+      expect(() => copyDir(src, dest)).toThrow();
+    });
+
     it("refuses a destination link pointing at a file, without touching it", () => {
       const src = stageSource();
       const file = path.join(tmpDir, "occupied");
@@ -271,7 +308,7 @@ describe("copyDir", () => {
       fs.writeFileSync(file, "mine");
       fs.symlinkSync("occupied", link);
 
-      expect(() => copyDir(src, link)).toThrow(/EEXIST/);
+      expect(() => copyDir(src, link)).toThrow(expect.objectContaining({ code: "EEXIST" }));
       expect(fs.readFileSync(file, "utf8")).toBe("mine");
     });
   });
@@ -288,11 +325,28 @@ describe("copyDir", () => {
     expect(fs.readFileSync(path.join(dest, "sub", "b.txt"), "utf8")).toBe("world");
   });
 
-  it("refuses to copy a tree into a subdirectory of itself", () => {
+  // fs.cp refuses this itself. What matters here is that the walk which
+  // precedes it does not chase its own output down an unbounded path.
+  it("refuses to copy a tree into a subdirectory of itself, without burrowing", () => {
     const src = stageSource();
 
-    expect(() => copyDir(src, path.join(src, "sub"))).toThrow(/subdirectory of itself/);
-    expect(fs.readdirSync(path.join(src, "sub"))).toEqual(["b.txt"]);
+    expect(() => copyDir(src, path.join(src, "sub"))).toThrow();
+    expect(fs.existsSync(path.join(src, "sub", "sub", "sub"))).toBe(false);
+  });
+
+  // fs.cp aborts the process outright when it cannot create a directory, so
+  // the copy makes them itself and reports the failure like any other.
+  it("reports an unwritable destination instead of dying", () => {
+    const src = stageSource();
+    const dest = path.join(tmpDir, "dest");
+    fs.mkdirSync(dest);
+    fs.chmodSync(dest, 0o555);
+
+    try {
+      expect(() => copyDir(src, dest)).toThrow(expect.objectContaining({ code: "EACCES" }));
+    } finally {
+      fs.chmodSync(dest, 0o755);
+    }
   });
 });
 

--- a/packages/argent-installer/test/utils.test.ts
+++ b/packages/argent-installer/test/utils.test.ts
@@ -148,20 +148,151 @@ describe("writeJson", () => {
 // ── copyDir ───────────────────────────────────────────────────────────────────
 
 describe("copyDir", () => {
-  it("returns false when source does not exist", () => {
-    expect(copyDir(path.join(tmpDir, "nope"), path.join(tmpDir, "dest"))).toBe(false);
-  });
-
-  it("copies directory recursively", () => {
+  // Two files and a nested directory, matching the shape of the bundled
+  // rules/agents trees this copies in practice.
+  function stageSource(): string {
     const src = path.join(tmpDir, "src");
-    const dest = path.join(tmpDir, "dest");
     fs.mkdirSync(path.join(src, "sub"), { recursive: true });
     fs.writeFileSync(path.join(src, "a.txt"), "hello");
     fs.writeFileSync(path.join(src, "sub", "b.txt"), "world");
+    return src;
+  }
 
-    expect(copyDir(src, dest)).toBe(true);
+  it("returns null when source does not exist", () => {
+    expect(copyDir(path.join(tmpDir, "nope"), path.join(tmpDir, "dest"))).toBeNull();
+  });
+
+  it("copies directory recursively and reports where it wrote", () => {
+    const src = stageSource();
+    const dest = path.join(tmpDir, "dest");
+
+    expect(copyDir(src, dest)).toBe(dest);
     expect(fs.readFileSync(path.join(dest, "a.txt"), "utf8")).toBe("hello");
     expect(fs.readFileSync(path.join(dest, "sub", "b.txt"), "utf8")).toBe("world");
+  });
+
+  // Symlinked destinations (issue #701): the canonical copy lives in one
+  // harness-neutral directory and each vendor path is a link at it, so the copy
+  // has to write *through* the link instead of trying to replace it.
+  // Skipped on Windows, where creating symlinks needs admin rights.
+  describe.skipIf(process.platform === "win32")("symlinked destinations", () => {
+    it("writes through a symlinked destination, leaving the link intact", () => {
+      const src = stageSource();
+      const real = path.join(tmpDir, "canonical");
+      const link = path.join(tmpDir, "dest");
+      fs.mkdirSync(real);
+      fs.symlinkSync("canonical", link);
+
+      expect(copyDir(src, link)).toBe(fs.realpathSync(real));
+      expect(fs.readFileSync(path.join(real, "a.txt"), "utf8")).toBe("hello");
+      expect(fs.readFileSync(path.join(real, "sub", "b.txt"), "utf8")).toBe("world");
+      expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+    });
+
+    it("writes through a symlinked subdirectory of the destination", () => {
+      const src = stageSource();
+      const dest = path.join(tmpDir, "dest");
+      const real = path.join(tmpDir, "canonical-sub");
+      fs.mkdirSync(dest);
+      fs.mkdirSync(real);
+      fs.symlinkSync("../canonical-sub", path.join(dest, "sub"));
+
+      copyDir(src, dest);
+
+      expect(fs.readFileSync(path.join(real, "b.txt"), "utf8")).toBe("world");
+      expect(fs.readFileSync(path.join(dest, "a.txt"), "utf8")).toBe("hello");
+      expect(fs.lstatSync(path.join(dest, "sub")).isSymbolicLink()).toBe(true);
+    });
+
+    // A single symlinked file is the layout a dotfile manager produces when the
+    // directory has to stay real because it holds the user's own agents too.
+    it("writes through a symlinked file in the destination", () => {
+      const src = stageSource();
+      const dest = path.join(tmpDir, "dest");
+      const canonical = path.join(tmpDir, "canonical", "a.txt");
+      fs.mkdirSync(path.join(tmpDir, "canonical"));
+      fs.mkdirSync(dest);
+      fs.writeFileSync(canonical, "stale");
+      fs.symlinkSync(path.join("..", "canonical", "a.txt"), path.join(dest, "a.txt"));
+
+      copyDir(src, dest);
+
+      expect(fs.readFileSync(canonical, "utf8")).toBe("hello");
+      expect(fs.lstatSync(path.join(dest, "a.txt")).isSymbolicLink()).toBe(true);
+    });
+
+    it("creates the target of a dangling destination link", () => {
+      const src = stageSource();
+      const link = path.join(tmpDir, "dest");
+      fs.symlinkSync("canonical", link);
+
+      copyDir(src, link);
+
+      expect(fs.readFileSync(path.join(tmpDir, "canonical", "a.txt"), "utf8")).toBe("hello");
+      expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+    });
+
+    // The case that aborted the whole process before: fs.cp does not throw on a
+    // dangling link it must turn into a directory, it terminates the runtime.
+    it("creates the target of a dangling link nested in the destination", () => {
+      const src = stageSource();
+      const dest = path.join(tmpDir, "dest");
+      fs.mkdirSync(dest);
+      fs.symlinkSync(path.join("..", "canonical-sub"), path.join(dest, "sub"));
+
+      copyDir(src, dest);
+
+      expect(fs.readFileSync(path.join(tmpDir, "canonical-sub", "b.txt"), "utf8")).toBe("world");
+    });
+
+    // A relative link target resolves against the directory the link really
+    // lives in — here `dotfiles/claude`, not the `home/.claude` path we were
+    // handed — so `..` has to be walked from the real parent.
+    it("resolves a dangling relative target from behind a symlinked parent", () => {
+      const src = stageSource();
+      fs.mkdirSync(path.join(tmpDir, "dotfiles", "claude"), { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, "home"), { recursive: true });
+      fs.symlinkSync(path.join("..", "dotfiles", "claude"), path.join(tmpDir, "home", ".claude"));
+      fs.symlinkSync(
+        path.join("..", "shared", "rules"),
+        path.join(tmpDir, "dotfiles", "claude", "rules")
+      );
+
+      const written = copyDir(src, path.join(tmpDir, "home", ".claude", "rules"));
+
+      expect(written).toBe(path.join(fs.realpathSync(tmpDir), "dotfiles", "shared", "rules"));
+      expect(fs.existsSync(path.join(tmpDir, "home", ".claude", "rules", "a.txt"))).toBe(true);
+    });
+
+    it("refuses a destination link pointing at a file, without touching it", () => {
+      const src = stageSource();
+      const file = path.join(tmpDir, "occupied");
+      const link = path.join(tmpDir, "dest");
+      fs.writeFileSync(file, "mine");
+      fs.symlinkSync("occupied", link);
+
+      expect(() => copyDir(src, link)).toThrow(/EEXIST/);
+      expect(fs.readFileSync(file, "utf8")).toBe("mine");
+    });
+  });
+
+  it("overwrites an existing destination on a repeat copy", () => {
+    const src = stageSource();
+    const dest = path.join(tmpDir, "dest");
+    copyDir(src, dest);
+    fs.writeFileSync(path.join(src, "a.txt"), "second");
+
+    copyDir(src, dest);
+
+    expect(fs.readFileSync(path.join(dest, "a.txt"), "utf8")).toBe("second");
+    expect(fs.readFileSync(path.join(dest, "sub", "b.txt"), "utf8")).toBe("world");
+  });
+
+  it("refuses to copy a tree into a subdirectory of itself", () => {
+    const src = stageSource();
+
+    expect(() => copyDir(src, path.join(src, "sub"))).toThrow(/subdirectory of itself/);
+    expect(fs.readdirSync(path.join(src, "sub"))).toEqual(["b.txt"]);
   });
 });
 

--- a/packages/argent-installer/test/utils.test.ts
+++ b/packages/argent-installer/test/utils.test.ts
@@ -325,17 +325,20 @@ describe("copyDir", () => {
     expect(fs.readFileSync(path.join(dest, "sub", "b.txt"), "utf8")).toBe("world");
   });
 
-  // fs.cp refuses this itself. What matters here is that the walk which
-  // precedes it does not chase its own output down an unbounded path.
-  it("refuses to copy a tree into a subdirectory of itself, without burrowing", () => {
+  // Nothing sensible asks for this, but the walk must not chase its own output
+  // down an unbounded path, and must not truncate a file by copying it over
+  // itself.
+  it("does not burrow when the destination is inside the source", () => {
     const src = stageSource();
 
-    expect(() => copyDir(src, path.join(src, "sub"))).toThrow();
+    copyDir(src, path.join(src, "sub"));
+
     expect(fs.existsSync(path.join(src, "sub", "sub", "sub"))).toBe(false);
+    expect(fs.readFileSync(path.join(src, "a.txt"), "utf8")).toBe("hello");
+    expect(fs.readFileSync(path.join(src, "sub", "b.txt"), "utf8")).toBe("world");
   });
 
-  // fs.cp aborts the process outright when it cannot create a directory, so
-  // the copy makes them itself and reports the failure like any other.
+  // Creating a directory is what fs.cp cannot survive, so the copy does it.
   it("reports an unwritable destination instead of dying", () => {
     const src = stageSource();
     const dest = path.join(tmpDir, "dest");


### PR DESCRIPTION
Fixes #701.

## The problem

`copyRulesAndAgents` copied the bundled trees onto each managed directory with one recursive `fs.cpSync`. When the destination is a symlink at a directory elsewhere, `fs.cp` refuses to overwrite it:

```
Could not copy agents to /repo/.claude/agents: Error: Cannot overwrite non-directory
/repo/.claude/agents with directory .../@swmansion/argent/agents
```

Everything else installs, so it reads as a success apart from one warning line — but `argent-environment-inspector` never lands, while `rules/argent.md` keeps telling the agent to use it.

The layout is the point of the report: keep one canonical, harness-neutral copy of the definitions and symlink each vendor path at it, so there's one definition to edit and no drift. The host tools already support that — Claude Code documents symlinks for `.claude/rules/`, and loads argent's skills through exactly such a link today. `rules/` had the same defect; the reporter just hadn't symlinked it.

## It is worse than the report on Node 20

`fs.cp`'s handling of a symlinked destination depends on which runtime you are on — Node 20 and Node 22 ship different implementations, and they disagree exactly here. Measured on both:

| destination | Node 20 (JS impl) | Node 22 (C++ impl) |
|---|---|---|
| top-level symlinked dir | refuses (the reported bug) | refuses (the reported bug) |
| nested symlinked dir | refuses | writes through |
| symlinked **file** | **replaces the link, canonical left stale** | writes through |
| dangling / unwritable dir | catchable throw | **aborts the process, exit 134** |

So on Node 20 — which is what this repo's own CI runs — released 0.18.1 silently leaves a symlinked agent file stale on every `update`, with no warning at all. Verified against the released CLI:

```
released 0.18.1, Node 20:  symlinked file: canon=stale  link=intact   (0 warnings)
                           nested symlinked dir: files-in-canonical=0
```

## The fix

The copy walks the tree itself, resolving each destination as it goes, and copies leaves with `fs.copyFileSync`. Nothing is delegated to `fs.cp`: that is what makes the behaviour the same on every supported runtime, and `copyFileSync` reports each failure — dangling link, loop, unwritable directory, a link pointing at a directory — as a plain catchable errno.

The fix lives in `copyDir` rather than in a new helper because that function was already an exact, unused copy of the same buggy shape. Routing `copyRulesAndAgents` through it covers rules and agents, init and update, and removes the latent duplicate.

That also settles the case that kills the install outright on Node 22: `fs.cp` does not throw when it cannot create a directory, it aborts through an uncatchable C++ `std::filesystem` exception. Two reachable shapes, both verified against released 0.18.1:

- a broken `.claude/agents/references` link (the bundled agents tree really does have that subdirectory) — `argent init` dies at exit 134 mid-run;
- **a read-only `.claude/agents`** — same abort, and this one needs no symlink at all, so it hits users of today's release.

Both are now ordinary reported warnings.

Resolution follows a link chain to its end, resolves each hop against the directory the link really lives in (not the lexical parent — they differ when a parent is itself a link into another subtree), and completes a dangling link only into a directory that already exists, so a link can't conjure a tree at an arbitrary path.

Where the bytes land can now differ from the configured path, so the output names both — in the same shortened form the rest of the managed-content output uses: `Copied agents to .claude/agents -> .agents/agents`. A destination outside the workspace stays absolute, so an escape stands out. Nothing changes for a layout with no symlinks.

## Verification

Reproduced against released 0.18.1 and a local build, then re-run against the fix. Every row below was executed end-to-end through the real `argent init`:

| scenario | before | after |
|---|---|---|
| `.claude/agents -> ../.agents/agents` (the report) | warning, no files | both files land, link intact |
| single symlinked `.md` file inside a real `.claude/agents` | worked | still works (regression test added) |
| symlink chain to a real directory | warning, no files | resolves, files land |
| link created before its target directory | warning, no files | target completed, files land |
| dangling `.claude/agents/references` | **abort, exit 134** | files land, no warning |
| **read-only `.claude/agents`, no symlinks** | **abort, exit 134** | `EACCES` warning, install completes |
| link at a file / dangling into a missing tree | warning | warning, victim untouched, nothing created |
| destination outside the project | writes there | writes there, disclosed absolutely |
| `.gemini` / `.opencode` / `.cursor` targets, global `~/.claude` scope | refused | land correctly |
| uninstall over a symlinked layout | — | removes only argent's files; user's files, link and directory kept |
| re-run over a populated layout (`update`) | — | clean, no warnings |
| symlinked file, **Node 20** | **silently stale, no warning** | canonical updated, link intact |
| nested symlinked dir, **Node 20** | refused | writes through, link intact |
| no symlinks anywhere | works | unchanged, no redirect in output |

Every row was run under **both Node 20 and Node 22**, with identical outcomes on each. 15 new unit tests; 552 green on both runtimes. Build, eslint, prettier and the test typecheck all pass. Symlink tests skip on Windows, matching `update.test.ts`.

`argent update` is not run here because it acts on the real global npm install, but its call site is byte-identical to init's and the same function was exercised directly in both scopes.

## Deliberately not in this PR

- **The summary still prints a green "Rules & agents copied" when a copy failed** (`copiedRules: copyResults.length > 0` in `init.ts`). The issue calls this out as why the failure was easy to overlook. Fixing it honestly means giving `copyRulesAndAgents` a structured return and deciding whether a failed copy should make `argent update` exit non-zero — a separate change, and the general case isn't symlink-specific. Happy to follow up.
- **Uninstall leaves both halves of a symlinked layout.** It removes argent's files through the link correctly and never touches the user's link or their other files; it just can't prune the emptied canonical directory (`rmdir` on a symlink fails `ENOTDIR`, swallowed). Not a regression, and arguably right.
- **Writing through a link can leave the workspace.** That is pre-existing — `fs.cp` already wrote through symlinked files and nested symlinked directories before this change — and confining it would break the very layout the issue asks for. What this PR does add is bounded: a dangling link is completed only where its parent already exists.
