### PR TITLE
fix(installer): stop Cursor updates from forcing a partial MCP allowlist

### DIFF
--- a/packages/argent-installer/src/init-allowlist.ts
+++ b/packages/argent-installer/src/init-allowlist.ts
@@ -16,18 +16,37 @@ export async function configureAllowlist(args: {
   effectiveRoot: string;
   scope: "local" | "global";
   nonInteractive: boolean;
+  /** --no-allowlist: skip writing editor auto-approve lists */
+  noAllowlist?: boolean;
 }): Promise<AllowlistResult> {
-  const { adapters, effectiveRoot, scope, nonInteractive } = args;
+  const { adapters, effectiveRoot, scope, nonInteractive, noAllowlist } = args;
   const adaptersWithAllowlist = adapters.filter((a) => a.addAllowlist);
   const adaptersWithoutAllowlist = adapters.filter((a) => !a.addAllowlist);
 
   let enabled = false;
 
+  if (noAllowlist) {
+    p.log.info(
+      pc.dim(
+        "Skipped editor auto-approve allowlists (--no-allowlist). " +
+          "Use Cursor/editor Run Everything if you want tools unprompted."
+      )
+    );
+    return { enabled: false, lines: [] };
+  }
+
   if (adaptersWithAllowlist.length > 0) {
+    const hasCursor = adaptersWithAllowlist.some((a) => a.name === "Cursor");
     p.log.info(
       `By default, editors ask for confirmation before running each MCP tool.\n` +
         `  Adding Argent to the auto-approve allowlist lets tools run without\n` +
-        `  repeated prompts. This is ${pc.cyan("recommended")} for a smooth experience.`
+        `  repeated prompts. This is ${pc.cyan("recommended")} for a smooth experience.` +
+        (hasCursor
+          ? `\n\n  ${pc.yellow("Cursor note:")} writing ~/.cursor/permissions.json with only\n` +
+            `  ${pc.cyan("argent:*")} enables MCP allowlist mode — other MCP servers will still\n` +
+            `  prompt. If you use Cursor "allow all" / Run Everything, choose ${pc.cyan("No")}\n` +
+            `  (or pass ${pc.cyan("--no-allowlist")}).`
+          : "")
     );
 
     if (nonInteractive) {

--- a/packages/argent-installer/src/init-args.ts
+++ b/packages/argent-installer/src/init-args.ts
@@ -6,6 +6,8 @@ export interface InitArgs {
   nonInteractive: boolean;
   /** --no-telemetry */
   noTelemetry: boolean;
+  /** --no-allowlist skip writing editor MCP auto-approve allowlists */
+  noAllowlist: boolean;
   /** --from <path>  reinstall from a local tarball/path (developer flow) */
   fromTar: string | null;
   /** --local  force the local (devDependency) install mode */
@@ -31,6 +33,7 @@ export function parseInitArgs(args: string[]): InitArgs {
   return {
     nonInteractive: args.includes("--yes") || args.includes("-y"),
     noTelemetry: args.includes("--no-telemetry"),
+    noAllowlist: args.includes("--no-allowlist"),
     fromTar,
     wantsLocal: args.includes("--local"),
     wantsGlobal: args.includes("--global"),

--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -249,6 +249,7 @@ export async function init(args: string[]): Promise<void> {
       effectiveRoot,
       scope: normalizedScope,
       nonInteractive: parsed.nonInteractive,
+      noAllowlist: parsed.noAllowlist,
     });
     track("installation:allowlist_decision", { is_enabled: allowlist.enabled });
     if (allowlist.enabled && allowlist.lines.length > 0) {

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -93,7 +93,14 @@ export interface McpConfigAdapter {
   // pair that the client resolves ahead of (or gates) the entry written at
   // `writtenScope`. Only clients with hidden scopes implement this.
   findShadowingConfigs?(root: string, writtenScope: "local" | "global"): ShadowingConfigFinding[];
-  addAllowlist?(root: string, scope: "local" | "global"): void;
+  // `createIfMissing` defaults to true (init / explicit opt-in). `update`
+  // passes false so a user who deleted or cleared the allowlist (e.g. Cursor
+  // "allow all" / Run Everything) is not forced back into a partial allowlist.
+  addAllowlist?(
+    root: string,
+    scope: "local" | "global",
+    options?: { createIfMissing?: boolean }
+  ): void;
   removeAllowlist?(root: string, scope: "local" | "global"): void;
 }
 
@@ -723,11 +730,27 @@ const cursorAdapter: McpConfigAdapter = {
   // only { mcpAllowlist }, dropping every foreign rule and comment. Newly matters
   // because `hasArgentEntry` now reads mcp.json with readJsonc, so `update`
   // detects a commented config as configured and calls this.
-  addAllowlist(): void {
+  //
+  // Cursor gotcha: a permissions.json whose mcpAllowlist is only `argent:*`
+  // puts MCP tools into allowlist mode. Other MCP servers (Expo, PostHog, …)
+  // then prompt on every call, which fights users who set Cursor to
+  // "allow all" / Run Everything. `update` therefore passes
+  // `{ createIfMissing: false }` so deleting the file (or clearing argent from
+  // the list) is treated as a durable opt-out.
+  addAllowlist(
+    _root?: string,
+    _scope?: "local" | "global",
+    options?: { createIfMissing?: boolean }
+  ): void {
+    const createIfMissing = options?.createIfMissing !== false;
     const permPath = path.join(homedir(), ".cursor", "permissions.json");
+    if (!createIfMissing && !fs.existsSync(permPath)) return;
     const config = readJsonc(permPath);
     const list = Array.isArray(config.mcpAllowlist) ? (config.mcpAllowlist as string[]) : [];
     if (list.includes(CURSOR_ALLOWLIST_PATTERN)) return;
+    // Refresh path: if argent was never on (or was removed from) the list, do
+    // not re-add it. Init keeps the default createIfMissing:true.
+    if (!createIfMissing) return;
     editJsoncFile(permPath, ["mcpAllowlist"], [...list, CURSOR_ALLOWLIST_PATTERN]);
   },
 

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -138,6 +138,7 @@ export function resolveUpdatePackageAction(
 export async function update(args: string[]): Promise<void> {
   const nonInteractive = args.includes("--yes") || args.includes("-y");
   const noTelemetry = args.includes("--no-telemetry");
+  const noAllowlist = args.includes("--no-allowlist");
   const requestedVersion = getRequestedVersion(args);
   const trigger = getUpdateTriggerFromEnv();
   telemetryInit("installer");
@@ -741,18 +742,23 @@ export async function update(args: string[]): Promise<void> {
         );
       }
 
-      // Refresh allowlists only for scopes that already had argent configured —
-      // matches the editor list above.
+    // Refresh allowlists only for scopes that already had argent configured —
+    // matches the editor list above. Pass createIfMissing:false so a user who
+    // cleared Cursor's permissions.json (allow-all / Run Everything) is not
+    // shoved back into a partial mcpAllowlist on every update. --no-allowlist
+    // skips the refresh entirely.
+    if (!noAllowlist) {
       for (const [scope, adapters] of adaptersByScope) {
         for (const adapter of adapters) {
           if (!adapter.addAllowlist) continue;
           try {
-            adapter.addAllowlist(projectRoot, scope);
+            adapter.addAllowlist(projectRoot, scope, { createIfMissing: false });
           } catch {
             // non-fatal
           }
         }
       }
+    }
 
       // Refresh rules/agents the same way: per-scope, only for adapters the user
       // opted into in that scope.

--- a/packages/argent-installer/test/init-args.test.ts
+++ b/packages/argent-installer/test/init-args.test.ts
@@ -3,12 +3,24 @@ import { parseInitArgs } from "../src/init-args.js";
 
 describe("parseInitArgs", () => {
   it("parses the full known flag set", () => {
-    const parsed = parseInitArgs(["--yes", "--no-telemetry", "--local", "--from", "./argent.tgz"]);
+    const parsed = parseInitArgs([
+      "--yes",
+      "--no-telemetry",
+      "--no-allowlist",
+      "--local",
+      "--from",
+      "./argent.tgz",
+    ]);
     expect(parsed.nonInteractive).toBe(true);
     expect(parsed.noTelemetry).toBe(true);
+    expect(parsed.noAllowlist).toBe(true);
     expect(parsed.wantsLocal).toBe(true);
     expect(parsed.wantsGlobal).toBe(false);
     expect(parsed.fromTar).toBe("./argent.tgz");
+  });
+
+  it("defaults noAllowlist to false", () => {
+    expect(parseInitArgs(["-y"]).noAllowlist).toBe(false);
   });
 
   it("accepts -y and --global", () => {

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -2288,6 +2288,28 @@ describe("installer preserves foreign MCP config", () => {
     fs.rmSync(homedirOverride, { recursive: true, force: true });
   });
 
+  it("Cursor addAllowlist with createIfMissing:false does not recreate a deleted permissions.json", () => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    // Simulate update after the user deleted the file for Cursor allow-all.
+    expect(fs.existsSync(permPath)).toBe(false);
+    cursor.addAllowlist!(tmpDir, "global", { createIfMissing: false });
+    expect(fs.existsSync(permPath)).toBe(false);
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
+  it("Cursor addAllowlist with createIfMissing:false does not re-add argent after opt-out", () => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    fs.mkdirSync(path.dirname(permPath), { recursive: true });
+    fs.writeFileSync(permPath, JSON.stringify({ mcpAllowlist: ["other:*"] }));
+    cursor.addAllowlist!(tmpDir, "global", { createIfMissing: false });
+    expect(readJsoncFile(permPath).mcpAllowlist).toEqual(["other:*"]);
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
   it("addClaudePermission preserves a comment and foreign permissions in settings.json", () => {
     const settingsPath = path.join(tmpDir, ".claude", "settings.json");
     fs.mkdirSync(path.dirname(settingsPath), { recursive: true });


### PR DESCRIPTION
## Summary

- Cursor's `~/.cursor/permissions.json` with only `argent:*` enables **MCP allowlist mode**. Other MCP servers (Expo, PostHog, etc.) then prompt on every tool call — which fights users who set Cursor to **allow all / Run Everything**.
- `argent update` was unconditionally calling `addAllowlist`, which **recreated** that file even after the user deleted it or cleared `argent:*`.
- This PR:
  - refreshes allowlists with `{ createIfMissing: false }` so a deleted/cleared Cursor allowlist is treated as a durable opt-out
  - adds `--no-allowlist` for `init` and `update`
  - warns Cursor users during the init allowlist prompt

## Workaround today (until this lands)

```bash
rm ~/.cursor/permissions.json
# Prefer: argent update --no-allowlist   (after this PR)
# Or decline the allowlist prompt on interactive init
```

Keep Cursor on **Agent → Auto-run / Run Everything**. Do not re-enable the Argent-only MCP allowlist unless you want allowlist mode.

## Test plan

- [x] `vitest run packages/argent-installer/test/mcp-configs.test.ts packages/argent-installer/test/init-args.test.ts` (250 passed)
- [ ] Manual: `argent init` with Cursor selected shows the Cursor allow-all note; answering No leaves `permissions.json` absent
- [ ] Manual: create `permissions.json` with `argent:*`, delete it, run `argent update` — file stays deleted
- [ ] Manual: `argent init -y --no-allowlist` does not write Cursor allowlist
- [ ] Manual: `argent update --no-allowlist` skips allowlist refresh


Made with [Cursor](https://cursor.com)