### PR TITLE
refactor(flow): generalize when's block machinery so a second block directive can't miss a site

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -40,7 +40,7 @@ export interface StepReport {
   /** Human-readable step target (selector / snapshot name), set by the runner. */
   target?: string;
   /**
-   * Nesting depth: absent/0 at top level, +1 inside each block directive
+   * Nesting depth: absent/0 at top level, +1 inside each nesting step
    * (`when:` guarded steps, `run:` fragment steps). Renderers indent by it; a
    * pre-depth tool-server sends none and the report renders flat, as before.
    */

--- a/packages/argent-mcp/src/content.ts
+++ b/packages/argent-mcp/src/content.ts
@@ -229,7 +229,7 @@ export type FlowStepResult = {
   /** Human-readable step target (selector / snapshot name), set by the runner. */
   target?: string;
   /**
-   * Nesting depth: absent/0 at top level, +1 inside each block directive
+   * Nesting depth: absent/0 at top level, +1 inside each nesting step
    * (`when:` guarded steps, `run:` fragment steps). The label is indented by
    * it; a pre-depth tool-server sends none and the report renders flat.
    */

--- a/packages/tool-server/src/tools/flows/flow-device.ts
+++ b/packages/tool-server/src/tools/flows/flow-device.ts
@@ -205,7 +205,7 @@ export function stripDeviceKeys(args: Record<string, unknown>): Record<string, u
  *
  * - `when` needs a device whatever its body contains, because the guard itself
  *   reads one — the device's platform, or its view tree. That classifies the
- *   header alone; a block's body is answered by {@link flowRequiresDevice}'s
+ *   header alone; a block's body is left to {@link flowRequiresDevice}'s
  *   walk, not here.
  * - `idle` needs one despite carrying no selector: it reads the device twice
  *   over, the UI tree and a screenshot of it.
@@ -244,10 +244,11 @@ export function stepRequiresDevice(registry: Registry, step: FlowStep): boolean 
 }
 
 /**
- * Whether any step in a flow acts on a device, block children included — each
- * block header's own classification OR, via {@link blockSteps}, the steps it
- * actually CONTAINS. Both halves matter: a `when: { platform: ios }` guard
- * reads the device even over a device-free body.
+ * Whether any step in a flow acts on a device - each block header's own
+ * classification OR, via {@link blockSteps}, the steps it actually CONTAINS.
+ * Today the header half answers every case: `when`, the only block kind,
+ * classifies device-requiring in {@link stepRequiresDevice}, so the child walk
+ * is a no-op until a block kind classifies `false`.
  *
  * Header classification alone is not enough: a block directive whose header
  * reads nothing off the device would naturally be classified `false` in

--- a/packages/tool-server/src/tools/flows/flow-device.ts
+++ b/packages/tool-server/src/tools/flows/flow-device.ts
@@ -2,7 +2,7 @@ import type { DeviceInfo, Registry, ToolContext } from "@argent/registry";
 import { FAILURE_CODES, FailureError } from "@argent/registry";
 import { resolveDevice } from "../../utils/device-info";
 import { invokeSubTool } from "../../utils/sub-invoke";
-import type { FlowStep, WhenPlatform } from "./flow-utils";
+import { blockSteps, type FlowStep, type WhenPlatform } from "./flow-utils";
 
 /**
  * Device resolution + binding for the flow runner. Flows store no device id
@@ -204,7 +204,9 @@ export function stripDeviceKeys(args: Record<string, unknown>): Record<string, u
  * Three of the classifications are worth stating outright:
  *
  * - `when` needs a device whatever its body contains, because the guard itself
- *   reads one — the device's platform, or its view tree.
+ *   reads one — the device's platform, or its view tree. That classifies the
+ *   header alone; a block's body is answered by {@link flowRequiresDevice}'s
+ *   walk, not here.
  * - `idle` needs one despite carrying no selector: it reads the device twice
  *   over, the UI tree and a screenshot of it.
  * - `run` needs one without the fragment being read here. The flow it names is
@@ -241,9 +243,24 @@ export function stepRequiresDevice(registry: Registry, step: FlowStep): boolean 
   }
 }
 
-/** Whether any step in a flow acts on a device. */
+/**
+ * Whether any step in a flow acts on a device, block children included — each
+ * block header's own classification OR, via {@link blockSteps}, the steps it
+ * actually CONTAINS. Both halves matter: a `when: { platform: ios }` guard
+ * reads the device even over a device-free body.
+ *
+ * Header classification alone is not enough: a block directive whose header
+ * reads nothing off the device would naturally be classified `false` in
+ * {@link stepRequiresDevice}, and a flow that is only that block would then
+ * resolve device-free and hard-stop on the first device step in its body. The
+ * exhaustiveness check there forces a new kind to be classified, but not to be
+ * classified `true`; the walk is what makes either answer safe.
+ */
 export function flowRequiresDevice(registry: Registry, steps: FlowStep[]): boolean {
-  return steps.some((step) => stepRequiresDevice(registry, step));
+  return steps.some(
+    (step) =>
+      stepRequiresDevice(registry, step) || flowRequiresDevice(registry, blockSteps(step) ?? [])
+  );
 }
 
 /**

--- a/packages/tool-server/src/tools/flows/flow-device.ts
+++ b/packages/tool-server/src/tools/flows/flow-device.ts
@@ -255,7 +255,8 @@ export function stepRequiresDevice(registry: Registry, step: FlowStep): boolean 
  * {@link stepRequiresDevice}, and a flow that is only that block would then
  * resolve device-free and hard-stop on the first device step in its body. The
  * exhaustiveness check there forces a new kind to be classified, but not to be
- * classified `true`; the walk is what makes either answer safe.
+ * classified `true`; the walk - here and in {@link flowScopesDevice}, the
+ * question the runner asks next - is what makes either answer safe.
  */
 export function flowRequiresDevice(registry: Registry, steps: FlowStep[]): boolean {
   return steps.some(
@@ -273,10 +274,21 @@ export function flowRequiresDevice(registry: Registry, steps: FlowStep[]): boole
  * (keeping the cross-agent protection the scope exists for), or, where no
  * single device is resolvable, run the step's unscoped meaning rather than
  * failing a flow whose whole purpose is to clear the machine.
+ *
+ * Walks a block's body via {@link blockSteps}. The walk answers nothing in a
+ * run today: `when`, the only block kind, classifies device-requiring, so a
+ * flow holding a block is answered by {@link flowRequiresDevice} and never
+ * reaches this question at all. The pair needs both walks - under
+ * a block kind that reads nothing off the device, a `devices` scope in its body
+ * would be invisible here, the run would resolve no device, and the teardown
+ * would execute with its unscoped meaning, the machine-wide sweep the scope
+ * exists to prevent.
  */
 export function flowScopesDevice(registry: Registry, steps: FlowStep[]): boolean {
   return steps.some(
-    (step) => step.kind === "tool" && declaresAny(registry, step.name, DEVICE_BIND_LIST_KEYS)
+    (step) =>
+      (step.kind === "tool" && declaresAny(registry, step.name, DEVICE_BIND_LIST_KEYS)) ||
+      flowScopesDevice(registry, blockSteps(step) ?? [])
   );
 }
 

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1804,11 +1804,11 @@ function describeWhenCondition(cond: WhenCondition): string {
 }
 
 /**
- * Report every step of a `when:` block that will not run as skipped — so a
- * run where the block was skipped (unmet guard, errored guard, hard stop, or
- * cancellation) produces the same report shape (one line per authored step,
- * at the same depth) as a run where it entered, and reports stay comparable
- * run-to-run. Nested block directives expand (their literal steps are known);
+ * Report every step of a block directive that will not run as skipped — so a
+ * run where the block was skipped (a `when:` guard unmet or errored, a hard
+ * stop, a cancellation) produces the same report shape (one line per authored
+ * step, at the same depth) as a run where it entered, and reports stay
+ * comparable run-to-run. Nested blocks expand (their literal steps are known);
  * a `run:` composition stays one line, matching how post-hard-stop skips report
  * a fragment that was never loaded. `scope` is the scope the steps would have
  * executed in — already the block's child scope, not the marker's.

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1710,7 +1710,7 @@ function scopeFlowDir(scope: StepScope): string {
   return path.dirname(scope.runStack[scope.runStack.length - 1]!.canonical);
 }
 
-/** The scope a block directive's children execute in — one level deeper. */
+/** The scope a nesting step's children execute in — one level deeper. */
 function childScope(
   scope: StepScope,
   overrides: Partial<Omit<StepScope, "depth">> = {}
@@ -1719,8 +1719,8 @@ function childScope(
 }
 
 /**
- * The depth stamp for a report — omitted at top level, so a flow with no block
- * directives produces a report byte-identical to the pre-depth shape.
+ * The depth stamp for a report — omitted at top level, so a flow with no
+ * nesting steps produces a report byte-identical to the pre-depth shape.
  */
 function depthOf(scope: StepScope): Pick<StepReport, "depth"> {
   return scope.depth ? { depth: scope.depth } : {};

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -23,6 +23,7 @@ import {
   appIdForPlatform,
   assertSafeFlowName,
   assertValidProjectRoot,
+  blockSteps,
   chromiumLaunchSpec,
   classifyOnDiskSpelling,
   describeSelector,
@@ -1733,9 +1734,10 @@ async function execSteps(state: ExecState, steps: FlowStep[], scope: StepScope):
         // line rather than vanishing — matching reportBlockSkipped.
         ...(step.kind === "echo" ? { message: step.message } : {}),
       });
-      // A when block's literal steps are known — expand them so the report
+      // A block directive's literal steps are known — expand them so the report
       // keeps one line per authored step no matter where the stop landed.
-      if (step.kind === "when") reportBlockSkipped(state, step.steps, childScope(scope));
+      const inner = blockSteps(step);
+      if (inner) reportBlockSkipped(state, inner, childScope(scope));
       continue;
     }
     // The flow was resolved as needing no device, yet a step that acts on one
@@ -1752,7 +1754,8 @@ async function execSteps(state: ExecState, steps: FlowStep[], scope: StepScope):
         ...depthOf(scope),
         reason: `step needs a device but the flow was resolved as device-free — pass an explicit device`,
       });
-      if (step.kind === "when") reportBlockSkipped(state, step.steps, childScope(scope));
+      const inner = blockSteps(step);
+      if (inner) reportBlockSkipped(state, inner, childScope(scope));
       continue;
     }
     if (state.signal?.aborted) {
@@ -1767,9 +1770,8 @@ async function execSteps(state: ExecState, steps: FlowStep[], scope: StepScope):
         ...depthOf(scope),
         ...(step.kind === "echo" ? { message: step.message } : {}),
       });
-      if (step.kind === "when") {
-        reportBlockSkipped(state, step.steps, childScope(scope), "run aborted");
-      }
+      const inner = blockSteps(step);
+      if (inner) reportBlockSkipped(state, inner, childScope(scope), "run aborted");
       continue;
     }
 
@@ -1799,8 +1801,8 @@ function describeWhenCondition(cond: WhenCondition): string {
  * run where the block was skipped (unmet guard, errored guard, hard stop, or
  * cancellation) produces the same report shape (one line per authored step,
  * at the same depth) as a run where it entered, and reports stay comparable
- * run-to-run. Nested when blocks expand (their literal steps are known); a
- * `run:` composition stays one line, matching how post-hard-stop skips report
+ * run-to-run. Nested block directives expand (their literal steps are known);
+ * a `run:` composition stays one line, matching how post-hard-stop skips report
  * a fragment that was never loaded. `scope` is the scope the steps would have
  * executed in — already the block's child scope, not the marker's.
  */
@@ -1821,7 +1823,8 @@ function reportBlockSkipped(
       ...depthOf(scope),
       ...(step.kind === "echo" ? { message: step.message } : {}),
     });
-    if (step.kind === "when") reportBlockSkipped(state, step.steps, childScope(scope), reason);
+    const inner = blockSteps(step);
+    if (inner) reportBlockSkipped(state, inner, childScope(scope), reason);
   }
 }
 

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -29,8 +29,10 @@ import {
   describeSelector,
   describeTextExpectation,
   getFlowPath,
+  isBlockStep,
   parseFlow,
   runTargetName,
+  type BlockStep,
   type FlowFile,
   type FlowSelector,
   type FlowStep,
@@ -1791,8 +1793,8 @@ async function execSteps(state: ExecState, steps: FlowStep[], scope: StepScope):
       await execRunStep(state, step, scope);
       continue;
     }
-    if (step.kind === "when") {
-      await execWhenStep(state, step, scope);
+    if (isBlockStep(step)) {
+      await execBlockStep(state, step, scope);
       continue;
     }
 
@@ -1837,6 +1839,26 @@ function reportBlockSkipped(
     });
     const inner = blockSteps(step);
     if (inner) reportBlockSkipped(state, inner, childScope(scope), reason);
+  }
+}
+
+/**
+ * Dispatch a block directive to its executor. The `never` default arm is the
+ * run-time site a kind registered in BLOCK_DIRECTIVE_KEYS cannot miss: an
+ * unhandled registered kind fails tsc here instead of falling through to
+ * execLeafStep as an "unsupported step kind" error that skips the block's
+ * children without a report. Binds `step.kind` rather than `step` - while the
+ * registry has one entry BlockStep is not a union, so only the discriminant
+ * narrows to `never`.
+ */
+async function execBlockStep(state: ExecState, step: BlockStep, scope: StepScope): Promise<void> {
+  switch (step.kind) {
+    case "when":
+      return execWhenStep(state, step, scope);
+    default: {
+      const unhandled: never = step.kind;
+      void unhandled;
+    }
   }
 }
 

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1750,6 +1750,11 @@ async function execSteps(state: ExecState, steps: FlowStep[], scope: StepScope):
     // The flow was resolved as needing no device, yet a step that acts on one
     // reached execution — the two decisions disagree. Report it as this step's
     // error and stop, rather than letting it fail obscurely further in.
+    // They cannot disagree today, nor for a future block directive whichever way
+    // stepRequiresDevice classifies it — flowRequiresDevice recurses through
+    // blockSteps, so no nesting hides a step: under `true` a device is resolved
+    // and `!state.device` is false; under `false` this guard's own
+    // stepRequiresDevice conjunct fails. The expansion below stays regardless.
     if (!state.device && stepRequiresDevice(state.registry, step)) {
       state.stopped = true;
       pushReport(state, {

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -874,23 +874,30 @@ function displayFlowName(params: { name?: string; flow_path?: string }): string 
   return params.name || stem || params.flow_path || "(unspecified)";
 }
 
-/** Yield every parsed step, recursing into `when:` blocks (the parser's only nesting). */
+/**
+ * Yield every parsed step, recursing into a block directive's children through
+ * {@link blockSteps} rather than testing one kind: this is the sole feeder of
+ * {@link assertUploadSelfContained}, so a block absent from the recursion would
+ * carry an uploaded flow's nested `run:`/`snapshot` past the preflight and let
+ * an unrunnable flow report green.
+ */
 function* walkSteps(steps: FlowStep[]): Generator<FlowStep> {
   for (const step of steps) {
     yield step;
-    if (step.kind === "when") yield* walkSteps(step.steps);
+    const inner = blockSteps(step);
+    if (inner) yield* walkSteps(inner);
   }
 }
 
 /**
  * Reject an uploaded root flow that is not self-contained — one with a `run:`
- * or `snapshot` step (even inside a `when:` block) — before anything executes:
- * a mid-run or guard-gated error could execute half the flow first, or first
- * surface in CI. Both step kinds anchor at the flow file's real directory,
- * which an uploaded flow does not have: a run: step's referenced files stayed
- * on the client, and snapshot baselines live beside the flow's file — against
- * a per-call temp materialization a plain snapshot can only fail (no baseline)
- * and updateBaselines writes PNGs no later run can find.
+ * or `snapshot` step (at any depth inside a block directive) — before anything
+ * executes: a mid-run or guard-gated error could execute half the flow first,
+ * or first surface in CI. Both step kinds anchor at the flow file's real
+ * directory, which an uploaded flow does not have: a run: step's referenced
+ * files stayed on the client, and snapshot baselines live beside the flow's
+ * file — against a per-call temp materialization a plain snapshot can only fail
+ * (no baseline) and updateBaselines writes PNGs no later run can find.
  */
 function assertUploadSelfContained(flow: FlowFile): void {
   for (const step of walkSteps(flow.steps)) {

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -240,8 +240,8 @@ export interface StepReport {
   /** Snapshot-step artifacts (baseline/current/diff) as materializable handles. */
   artifacts?: SnapshotArtifacts;
   /**
-   * Nesting depth for display: omitted at top level, +1 inside each block
-   * directive's expanded steps (a `when:` block's guarded steps, a `run:`
+   * Nesting depth for display: omitted at top level, +1 inside each nesting
+   * step's expanded steps (a `when:` block's guarded steps, a `run:`
    * fragment's steps). Renderers indent by it without knowing which directives
    * nest — the report is a flat list with no block-end marker, so depth cannot
    * be reconstructed downstream.

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1626,8 +1626,22 @@ function stepTarget(step: FlowStep): string | undefined {
       // The as-written path, so a report line shows exactly what the flow
       // references (`run ../shared/login.yaml`), not just the attribution stem.
       return step.flow;
-    default:
+    case "echo":
+    case "tool":
+      // Each carries its subject in a report field of its own (`message`,
+      // `tool`) that renderers print in the target's place.
       return undefined;
+    case "launch":
+      // A launch's app id may be per-platform (`appIdForPlatform`), and a step
+      // alone does not know the run device.
+      return undefined;
+    case "wait":
+      return undefined;
+    default: {
+      const unclassified: never = step;
+      void unclassified;
+      return undefined;
+    }
   }
 }
 
@@ -1845,11 +1859,12 @@ function reportBlockSkipped(
 /**
  * Dispatch a block directive to its executor. The `never` default arm is the
  * run-time site a kind registered in BLOCK_DIRECTIVE_KEYS cannot miss: an
- * unhandled registered kind fails tsc here instead of falling through to
- * execLeafStep as an "unsupported step kind" error that skips the block's
- * children without a report. Binds `step.kind` rather than `step` - while the
- * registry has one entry BlockStep is not a union, so only the discriminant
- * narrows to `never`.
+ * unhandled registered kind fails tsc here instead of returning silently and
+ * leaving the block out of the report entirely, not even its own marker.
+ * Preventing execLeafStep's "unsupported step kind" error is the isBlockStep
+ * gate's doing, not this arm's - a registered kind never reaches the leaf
+ * switch. Binds `step.kind` rather than `step` - while the registry has one
+ * entry BlockStep is not a union, so only the discriminant narrows to `never`.
  */
 async function execBlockStep(state: ExecState, step: BlockStep, scope: StepScope): Promise<void> {
   switch (step.kind) {

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -729,7 +729,7 @@ export type FlowFile = {
 /**
  * The literal child steps of a block directive, or undefined for a leaf step.
  *
- * The single predicate for "this step has authored children", read at six
+ * The single predicate for "this step has authored children", read at seven
  * sites. Four expand a block that will NOT execute into skip lines, so a report
  * keeps one line per authored step no matter where the run ended: `execSteps`'
  * three gates — a hard stop, a device-free flow, a cancellation — plus
@@ -737,12 +737,12 @@ export type FlowFile = {
  * reaches those same skip lines by another route: `execWhenStep` has the block
  * in hand and passes `step.steps` straight to `reportBlockSkipped`.) The fifth
  * is the upload preflight's walk, where a block it cannot see hides a nested
- * `run:`/`snapshot` from validation. The sixth, `flowRequiresDevice`
- * (flow-device.ts), reads children not to skip them but to resolve the flow's
- * device requirement from a block's body — the guard against a later block
- * directive whose header reads nothing off the device, and a no-op while
- * `when`, whose header already classifies device-requiring, is the only block
- * kind.
+ * `run:`/`snapshot` from validation. The sixth and seventh,
+ * `flowRequiresDevice` and `flowScopesDevice` (flow-device.ts), read children
+ * not to skip them but to resolve the flow's device decisions from a block's
+ * body — the guard against a later block directive whose header reads nothing
+ * off the device, and dead in a run while `when`, whose header already
+ * classifies device-requiring, is the only block kind.
  *
  * Five sites asked `kind === "when"` directly before this existed — the five in
  * the runner; `flowRequiresDevice`'s walk arrived after the predicate and never

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -744,13 +744,13 @@ export type FlowFile = {
  * off the device, and dead in a run while `when`, whose header already
  * classifies device-requiring, is the only block kind.
  *
- * Five sites asked `kind === "when"` directly before this existed — the five in
- * the runner; `flowRequiresDevice`'s walk arrived after the predicate and never
- * had to. A second block directive would have had to remember all five,
- * and a forgotten one drops a whole block from the report — or from the
- * preflight — silently. Now it is one case here — and it is the same case the
- * PARSER exempts from the single-key sibling check, because the kinds come from
- * {@link BLOCK_DIRECTIVE_KEYS} rather than being restated.
+ * Six sites asked `kind === "when"` directly before this existed: five for the
+ * children, one for the dispatch (now {@link isBlockStep}/`execBlockStep`);
+ * `flowRequiresDevice`'s walk arrived after the predicate and never had to. A
+ * second block directive would have had to remember all six; a forgotten one
+ * drops a whole block from the report or preflight silently. Now both are one
+ * case here, the same case the PARSER exempts from the single-key sibling
+ * check: the kinds come from {@link BLOCK_DIRECTIVE_KEYS}, not restated.
  */
 export function blockSteps(step: FlowStep): FlowStep[] | undefined {
   return isBlockStep(step) ? (step.steps satisfies FlowStep[]) : undefined;

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -2064,10 +2064,11 @@ const _everyChildBearingKindIsRegistered: [UnregisteredBlockKind] extends [never
   : UnregisteredBlockKind = true;
 
 /**
- * Is this directive key a block directive? The parser and runner's only read of
- * {@link BLOCK_DIRECTIVE_KEYS}; the widening is the lookup itself — the const
- * tuple's own `includes` accepts only keys already known to be block kinds,
- * which is the question being asked.
+ * Is this directive key a block directive? The parser and runner's only
+ * CLASSIFYING read of {@link BLOCK_DIRECTIVE_KEYS} ({@link assertBlockDepth}
+ * reads it to NAME the keys in its message); the widening is the lookup
+ * itself — the const tuple's own `includes` accepts only keys already known to
+ * be block kinds, which is the question being asked.
  */
 function isBlockDirectiveKey(key: string): key is BlockDirectiveKind {
   return (BLOCK_DIRECTIVE_KEYS as readonly string[]).includes(key);

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -1450,7 +1450,7 @@ const SELECTOR_KEYS: readonly string[] = [
 /**
  * Total number of scopes one selector may carry, counted across its whole
  * relation TREE rather than down a single branch — the selector analog of
- * MAX_WHEN_DEPTH. A size bound, not a depth bound, because each level can open
+ * MAX_BLOCK_DEPTH. A size bound, not a depth bound, because each level can open
  * three branches: capping depth alone still admits 3^depth scopes, and the
  * runner's loose-alternative expansion is exponential in the number of
  * bare-string scopes (`selectorAlternatives`), so a few hundred bytes of YAML

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -1998,10 +1998,13 @@ const STEP_DIRECTIVE_KEYS: readonly string[] = [
  * The directive keys that carry a sibling `steps:` list — the single registry
  * of what a block directive is: {@link blockSteps} reads THIS list rather than
  * restating the kinds, so parse time and run time cannot answer differently.
- * Two constraints keep an entry honest: `satisfies` rejects a key that is not a
- * real step kind, and blockSteps' `Extract` rejects a kind whose step type
- * carries no `steps` (a directive listed here without children is a compile
- * error, not a silent runtime `undefined`).
+ * Three constraints keep an entry honest. Two judge the keys already listed:
+ * `satisfies` rejects a key that is not a real step kind, and blockSteps'
+ * `Extract` rejects a kind whose step type carries no `steps` (a directive
+ * listed here without children is a compile error, not a silent runtime
+ * `undefined`). Neither can force a key IN, which is what
+ * {@link _everyChildBearingKindIsRegistered} does — without it a child-bearing
+ * kind added later is simply absent here, and absent is not an error.
  *
  * At parse time these keys are exempt from the single-key sibling check,
  * because their own parser validates their siblings with pointed messages.
@@ -2010,6 +2013,24 @@ export const BLOCK_DIRECTIVE_KEYS = ["when"] as const satisfies readonly FlowSte
 
 /** The step kinds {@link BLOCK_DIRECTIVE_KEYS} names. */
 type BlockDirectiveKind = (typeof BLOCK_DIRECTIVE_KEYS)[number];
+
+/** The child-bearing step kinds {@link BLOCK_DIRECTIVE_KEYS} fails to list. */
+type UnregisteredBlockKind = Exclude<
+  Extract<FlowStep, { steps: FlowStep[] }>["kind"],
+  BlockDirectiveKind
+>;
+
+/**
+ * Forces a child-bearing kind INTO the registry — the direction the two
+ * constraints on {@link BLOCK_DIRECTIVE_KEYS} cannot cover, since both only
+ * judge kinds already listed. An unlisted one parses like any other step and
+ * then reads as `undefined` from {@link blockSteps}, so every reader listed
+ * there silently misses its children. Spelled as a conditional rather than a
+ * bare `never` so the compile error names the missing kind.
+ */
+const _everyChildBearingKindIsRegistered: [UnregisteredBlockKind] extends [never]
+  ? true
+  : UnregisteredBlockKind = true;
 
 /**
  * Is this directive key a block directive? The parser and runner's only read of

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -737,10 +737,21 @@ export type FlowFile = {
  * nested `run:`/`snapshot` from validation. Five sites asked `kind === "when"`
  * directly before this existed; a second block directive would have had to
  * remember all five, and a forgotten one drops a whole block from the report —
- * or from the preflight — silently. Now it is one case here.
+ * or from the preflight — silently. Now it is one case here — and it is the
+ * same case the PARSER exempts from the single-key sibling check, because the
+ * kinds come from {@link BLOCK_DIRECTIVE_KEYS} rather than being restated.
  */
 export function blockSteps(step: FlowStep): FlowStep[] | undefined {
-  return step.kind === "when" ? step.steps : undefined;
+  return isBlockStep(step) ? step.steps : undefined;
+}
+
+/**
+ * Narrow a step to the kinds {@link BLOCK_DIRECTIVE_KEYS} lists. `Extract` is
+ * what makes the list load-bearing: {@link blockSteps}' `.steps` typechecks
+ * only while EVERY listed kind's step type carries children.
+ */
+function isBlockStep(step: FlowStep): step is Extract<FlowStep, { kind: BlockDirectiveKind }> {
+  return isBlockDirectiveKey(step.kind);
 }
 
 /**
@@ -1984,12 +1995,31 @@ const STEP_DIRECTIVE_KEYS: readonly string[] = [
 ];
 
 /**
- * The directive keys that carry a sibling `steps:` list. Parse-time counterpart
- * to {@link blockSteps} (which answers the same question about an already
- * parsed step): these are exempt from the single-key sibling check, because
- * their own parser validates their siblings with pointed messages.
+ * The directive keys that carry a sibling `steps:` list — the single registry
+ * of what a block directive is: {@link blockSteps} reads THIS list rather than
+ * restating the kinds, so parse time and run time cannot answer differently.
+ * Two constraints keep an entry honest: `satisfies` rejects a key that is not a
+ * real step kind, and blockSteps' `Extract` rejects a kind whose step type
+ * carries no `steps` (a directive listed here without children is a compile
+ * error, not a silent runtime `undefined`).
+ *
+ * At parse time these keys are exempt from the single-key sibling check,
+ * because their own parser validates their siblings with pointed messages.
  */
-const BLOCK_DIRECTIVE_KEYS: readonly string[] = ["when"];
+export const BLOCK_DIRECTIVE_KEYS = ["when"] as const satisfies readonly FlowStep["kind"][];
+
+/** The step kinds {@link BLOCK_DIRECTIVE_KEYS} names. */
+type BlockDirectiveKind = (typeof BLOCK_DIRECTIVE_KEYS)[number];
+
+/**
+ * Is this directive key a block directive? The parser and runner's only read of
+ * {@link BLOCK_DIRECTIVE_KEYS}; the widening is the lookup itself — the const
+ * tuple's own `includes` accepts only keys already known to be block kinds,
+ * which is the question being asked.
+ */
+function isBlockDirectiveKey(key: string): key is BlockDirectiveKind {
+  return (BLOCK_DIRECTIVE_KEYS as readonly string[]).includes(key);
+}
 
 /**
  * Parse `times` on a tap body: an integer tap count dispatched as ONE
@@ -2517,7 +2547,7 @@ function fromYamlStep(raw: YamlStep, blockDepth = 0): FlowStep {
   // it), but its own parser validates them with pointed messages, so the
   // generic check stays out of its way.
   const kind = kinds[0]!;
-  if (!BLOCK_DIRECTIVE_KEYS.includes(kind)) {
+  if (!isBlockDirectiveKey(kind)) {
     const siblings = kind === "tool" ? ["tool", "args", "delayMs"] : [kind];
     const extras = Object.keys(entry).filter((k) => !siblings.includes(k));
     if (extras.length > 0) {

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -2310,7 +2310,9 @@ const MAX_BLOCK_DEPTH = 20;
  * Guard a block directive's recursion depth. Called FIRST in a block's parse —
  * before its own key/shape checks — so a cyclic alias reports as a depth error
  * rather than surfacing whatever the cycle happens to make the shallower checks
- * say.
+ * say. That early call buys the error PRECEDENCE only, not the cap itself:
+ * {@link parseBlockSteps} asserts again before it recurses, so forgetting the
+ * early call costs a directive the precedence and nothing more.
  */
 function assertBlockDepth(raw: unknown, depth: number): void {
   if (depth >= MAX_BLOCK_DEPTH) {
@@ -2327,12 +2329,18 @@ function assertBlockDepth(raw: unknown, depth: number): void {
  * chain. `emptyDetail` is the directive's own message for an absent or empty
  * list — the one part worth phrasing per directive, since it is where an author
  * lands when they wrote the guard but not the body.
+ *
+ * Asserts the depth cap here too, on the one path every block directive must go
+ * through to recurse, so no directive can opt out of the cap by forgetting the
+ * early {@link assertBlockDepth} call. `depth` is unchanged between the two
+ * calls, so for a directive that made the early one this is a no-op.
  */
 function parseBlockSteps(
   raw: Record<string, unknown>,
   depth: number,
   emptyDetail: string
 ): FlowStep[] {
+  assertBlockDepth(raw, depth);
   if (!Array.isArray(raw.steps) || raw.steps.length === 0) badEntry(raw, emptyDetail);
   return (raw.steps as unknown[]).map((s) => {
     if (s !== null && typeof s === "object") return fromYamlStep(s as YamlStep, depth + 1);

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -2385,9 +2385,10 @@ const MAX_BLOCK_DEPTH = 20;
  */
 function assertBlockDepth(raw: unknown, depth: number): void {
   if (depth >= MAX_BLOCK_DEPTH) {
+    const directives = BLOCK_DIRECTIVE_KEYS.map((key) => `\`${key}:\``).join("/");
     badEntry(
       raw,
-      `block directives nest deeper than ${MAX_BLOCK_DEPTH} levels — check for a cyclic YAML alias (\`steps: &s … steps: *s\`)`
+      `${directives} blocks nest deeper than ${MAX_BLOCK_DEPTH} levels — check for a cyclic YAML alias (\`steps: &s … steps: *s\`)`
     );
   }
 }

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -729,17 +729,28 @@ export type FlowFile = {
 /**
  * The literal child steps of a block directive, or undefined for a leaf step.
  *
- * The single predicate for "this step has authored children". The runner reads
- * it wherever a block does NOT execute — a hard stop, a device-free flow, a
- * cancellation, an unmet guard — to expand the block's steps as skip lines, so
- * a report keeps one line per authored step no matter where the run ended, and
- * once more in the upload preflight's walk, where a block it cannot see hides a
- * nested `run:`/`snapshot` from validation. Five sites asked `kind === "when"`
- * directly before this existed; a second block directive would have had to
- * remember all five, and a forgotten one drops a whole block from the report —
- * or from the preflight — silently. Now it is one case here — and it is the
- * same case the PARSER exempts from the single-key sibling check, because the
- * kinds come from {@link BLOCK_DIRECTIVE_KEYS} rather than being restated.
+ * The single predicate for "this step has authored children", read at six
+ * sites. Four expand a block that will NOT execute into skip lines, so a report
+ * keeps one line per authored step no matter where the run ended: `execSteps`'
+ * three gates — a hard stop, a device-free flow, a cancellation — plus
+ * `reportBlockSkipped` recursing into a nested block. (A guard-unmet `when`
+ * reaches those same skip lines by another route: `execWhenStep` has the block
+ * in hand and passes `step.steps` straight to `reportBlockSkipped`.) The fifth
+ * is the upload preflight's walk, where a block it cannot see hides a nested
+ * `run:`/`snapshot` from validation. The sixth, `flowRequiresDevice`
+ * (flow-device.ts), reads children not to skip them but to resolve the flow's
+ * device requirement from a block's body — the guard against a later block
+ * directive whose header reads nothing off the device, and a no-op while
+ * `when`, whose header already classifies device-requiring, is the only block
+ * kind.
+ *
+ * Five sites asked `kind === "when"` directly before this existed — the five in
+ * the runner; `flowRequiresDevice`'s walk arrived after the predicate and never
+ * had to. A second block directive would have had to remember all five,
+ * and a forgotten one drops a whole block from the report — or from the
+ * preflight — silently. Now it is one case here — and it is the same case the
+ * PARSER exempts from the single-key sibling check, because the kinds come from
+ * {@link BLOCK_DIRECTIVE_KEYS} rather than being restated.
  */
 export function blockSteps(step: FlowStep): FlowStep[] | undefined {
   return isBlockStep(step) ? step.steps : undefined;

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -2584,8 +2584,9 @@ function fromYamlStep(raw: YamlStep, blockDepth = 0): FlowStep {
   // directive step is a single-key mapping — its options live INSIDE the
   // value, so a sibling key is a mis-nested or misspelled option. A block
   // directive also carries siblings (`steps`, and whatever it rejects beside
-  // it), but its own parser validates them with pointed messages, so the
-  // generic check stays out of its way.
+  // it), but its own parser validates them with pointed messages - a promise
+  // flow-utils.test.ts pins per registry entry - so the generic check stays
+  // out of its way.
   const kind = kinds[0]!;
   if (!isBlockDirectiveKey(kind)) {
     const siblings = kind === "tool" ? ["tool", "args", "delayMs"] : [kind];

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -2421,7 +2421,9 @@ function assertBlockDepth(raw: unknown, depth: number): void {
  * Asserts the depth cap here too, on the one path every block directive must go
  * through to recurse, so no directive can opt out of the cap by forgetting the
  * early {@link assertBlockDepth} call. `depth` is unchanged between the two
- * calls, so for a directive that made the early one this is a no-op.
+ * calls, so for a directive that made the early one this is a no-op. While
+ * every registered directive makes that call, no input can make THIS assert the
+ * one that fires, so nothing pins it until one skips the early call.
  */
 function parseBlockSteps(
   raw: Record<string, unknown>,

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -727,6 +727,21 @@ export type FlowFile = {
 };
 
 /**
+ * The literal child steps of a block directive, or undefined for a leaf step.
+ *
+ * The single predicate for "this step has authored children". The runner reads
+ * it wherever a block does NOT execute — a hard stop, a device-free flow, a
+ * cancellation, an unmet guard — to expand the block's steps as skip lines, so
+ * a report keeps one line per authored step no matter where the run ended. Four
+ * sites asked `kind === "when"` directly before this existed; a second block
+ * directive would have had to remember all four, and a forgotten one drops a
+ * whole block from the report silently. Now it is one case here.
+ */
+export function blockSteps(step: FlowStep): FlowStep[] | undefined {
+  return step.kind === "when" ? step.steps : undefined;
+}
+
+/**
  * A flow is end-to-end iff it BEGINS by launching an app — its first step
  * (ignoring `echo` narration) is a `launch`. Such a flow controls its own
  * start state, so it is the natural standalone/suite entry point and must not
@@ -1967,6 +1982,14 @@ const STEP_DIRECTIVE_KEYS: readonly string[] = [
 ];
 
 /**
+ * The directive keys that carry a sibling `steps:` list. Parse-time counterpart
+ * to {@link blockSteps} (which answers the same question about an already
+ * parsed step): these are exempt from the single-key sibling check, because
+ * their own parser validates their siblings with pointed messages.
+ */
+const BLOCK_DIRECTIVE_KEYS: readonly string[] = ["when"];
+
+/**
  * Parse `times` on a tap body: an integer tap count dispatched as ONE
  * multi-tap gesture (2 = double-tap; the OS may recognize it as such — N
  * *independent* taps are N tap steps). `times: 1` is the default and
@@ -2270,13 +2293,50 @@ function parseWhenCondition(raw: unknown): WhenCondition {
 }
 
 /**
- * Nesting cap for `when` blocks — the parse-side analog of flow-run's
- * MAX_RUN_DEPTH. `when` is the only step kind whose parse recurses into child
- * steps, and the yaml library happily materializes a cyclic alias
- * (`steps: &s … steps: *s`) as a cyclic object; without a cap that cycle
+ * Nesting cap for block directives — the parse-side analog of flow-run's
+ * MAX_RUN_DEPTH. A block directive is the only kind of step whose parse
+ * recurses into child steps, and the yaml library happily materializes a cyclic
+ * alias (`steps: &s … steps: *s`) as a cyclic object; without a cap that cycle
  * escapes parseFlow as a raw RangeError instead of a structured parse error.
+ *
+ * ONE counter shared by every block directive, deliberately: a per-directive
+ * counter would let an alternating chain evade all of them and reopen the hole.
  */
-const MAX_WHEN_DEPTH = 20;
+const MAX_BLOCK_DEPTH = 20;
+
+/**
+ * Guard a block directive's recursion depth. Called FIRST in a block's parse —
+ * before its own key/shape checks — so a cyclic alias reports as a depth error
+ * rather than surfacing whatever the cycle happens to make the shallower checks
+ * say.
+ */
+function assertBlockDepth(raw: unknown, depth: number): void {
+  if (depth >= MAX_BLOCK_DEPTH) {
+    badEntry(
+      raw,
+      `block directives nest deeper than ${MAX_BLOCK_DEPTH} levels — check for a cyclic YAML alias (\`steps: &s … steps: *s\`)`
+    );
+  }
+}
+
+/**
+ * Parse a block directive's sibling `steps:` list: non-empty, every entry an
+ * object, each parsed one level deeper so the shared depth cap sees the whole
+ * chain. `emptyDetail` is the directive's own message for an absent or empty
+ * list — the one part worth phrasing per directive, since it is where an author
+ * lands when they wrote the guard but not the body.
+ */
+function parseBlockSteps(
+  raw: Record<string, unknown>,
+  depth: number,
+  emptyDetail: string
+): FlowStep[] {
+  if (!Array.isArray(raw.steps) || raw.steps.length === 0) badEntry(raw, emptyDetail);
+  return (raw.steps as unknown[]).map((s) => {
+    if (s !== null && typeof s === "object") return fromYamlStep(s as YamlStep, depth + 1);
+    return badEntry(s, "step must be an object");
+  });
+}
 
 /**
  * Parse a `when` step: `{ when: <condition>, steps: [<step>, …] }` — a guarded
@@ -2285,12 +2345,7 @@ const MAX_WHEN_DEPTH = 20;
  * back on the known path), so paths may only reconverge, never diverge.
  */
 function parseWhenStep(raw: Record<string, unknown>, depth: number): FlowStep {
-  if (depth >= MAX_WHEN_DEPTH) {
-    badEntry(
-      raw,
-      `when blocks nest deeper than ${MAX_WHEN_DEPTH} levels — check for a cyclic YAML alias (\`steps: &s … steps: *s\`)`
-    );
-  }
+  assertBlockDepth(raw, depth);
   if ("else" in raw) {
     badEntry(
       raw,
@@ -2301,13 +2356,7 @@ function parseWhenStep(raw: Record<string, unknown>, depth: number): FlowStep {
     badEntry(raw, "a when step takes exactly { when: <condition>, steps: [...] }");
   }
   const condition = parseWhenCondition(raw.when);
-  if (!Array.isArray(raw.steps) || raw.steps.length === 0) {
-    badEntry(raw, "when needs a non-empty steps list to guard");
-  }
-  const steps = (raw.steps as unknown[]).map((s) => {
-    if (s !== null && typeof s === "object") return fromYamlStep(s as YamlStep, depth + 1);
-    return badEntry(s, "step must be an object");
-  });
+  const steps = parseBlockSteps(raw, depth, "when needs a non-empty steps list to guard");
   return { kind: "when", condition, steps };
 }
 
@@ -2416,7 +2465,7 @@ function completeRunExtension(value: string): string {
   return FLOW_FILE_NAME_PATTERN.test(path.posix.basename(candidate)) ? candidate : value;
 }
 
-function fromYamlStep(raw: YamlStep, whenDepth = 0): FlowStep {
+function fromYamlStep(raw: YamlStep, blockDepth = 0): FlowStep {
   const entry = raw as Record<string, unknown>;
   // There is deliberately no per-step `optional:` — it would have to be
   // re-plumbed into every action directive (and each future gesture
@@ -2453,12 +2502,12 @@ function fromYamlStep(raw: YamlStep, whenDepth = 0): FlowStep {
   }
   // Only a `tool` step carries sibling keys (`args`, `delayMs`); every other
   // directive step is a single-key mapping — its options live INSIDE the
-  // value, so a sibling key is a mis-nested or misspelled option. A `when`
-  // step also carries siblings (`steps`, and the rejected `else`), but
-  // parseWhenStep validates them itself with pointed messages, so the generic
-  // check stays out of its way.
+  // value, so a sibling key is a mis-nested or misspelled option. A block
+  // directive also carries siblings (`steps`, and whatever it rejects beside
+  // it), but its own parser validates them with pointed messages, so the
+  // generic check stays out of its way.
   const kind = kinds[0]!;
-  if (kind !== "when") {
+  if (!BLOCK_DIRECTIVE_KEYS.includes(kind)) {
     const siblings = kind === "tool" ? ["tool", "args", "delayMs"] : [kind];
     const extras = Object.keys(entry).filter((k) => !siblings.includes(k));
     if (extras.length > 0) {
@@ -2475,7 +2524,7 @@ function fromYamlStep(raw: YamlStep, whenDepth = 0): FlowStep {
   if ("echo" in raw) return { kind: "echo", message: String(raw.echo) };
   if ("launch" in raw) return { kind: "launch", app: parseLaunch(raw.launch) };
   if ("run" in raw) return { kind: "run", flow: parseRunTarget(raw, raw.run) };
-  if ("when" in raw) return parseWhenStep(entry, whenDepth);
+  if ("when" in raw) return parseWhenStep(entry, blockDepth);
 
   if ("tap" in raw) return parseTap((raw as { tap: unknown }).tap, raw);
 

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -732,10 +732,12 @@ export type FlowFile = {
  * The single predicate for "this step has authored children". The runner reads
  * it wherever a block does NOT execute — a hard stop, a device-free flow, a
  * cancellation, an unmet guard — to expand the block's steps as skip lines, so
- * a report keeps one line per authored step no matter where the run ended. Four
- * sites asked `kind === "when"` directly before this existed; a second block
- * directive would have had to remember all four, and a forgotten one drops a
- * whole block from the report silently. Now it is one case here.
+ * a report keeps one line per authored step no matter where the run ended, and
+ * once more in the upload preflight's walk, where a block it cannot see hides a
+ * nested `run:`/`snapshot` from validation. Five sites asked `kind === "when"`
+ * directly before this existed; a second block directive would have had to
+ * remember all five, and a forgotten one drops a whole block from the report —
+ * or from the preflight — silently. Now it is one case here.
  */
 export function blockSteps(step: FlowStep): FlowStep[] | undefined {
   return step.kind === "when" ? step.steps : undefined;

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -753,13 +753,16 @@ export type FlowFile = {
  * {@link BLOCK_DIRECTIVE_KEYS} rather than being restated.
  */
 export function blockSteps(step: FlowStep): FlowStep[] | undefined {
-  return isBlockStep(step) ? step.steps : undefined;
+  return isBlockStep(step) ? (step.steps satisfies FlowStep[]) : undefined;
 }
 
 /**
  * Narrow a step to the kinds {@link BLOCK_DIRECTIVE_KEYS} lists. `Extract` is
  * what makes the list load-bearing: {@link blockSteps}' `.steps` typechecks
- * only while EVERY listed kind's step type carries children.
+ * only while EVERY listed kind's step type carries children. The `satisfies`
+ * there pins them to a REQUIRED `steps`; an optional one types as
+ * `FlowStep[] | undefined`, which the return type alone would accept while
+ * every reader sees a childless leaf.
  */
 export function isBlockStep(step: FlowStep): step is BlockStep {
   return isBlockDirectiveKey(step.kind);
@@ -2011,9 +2014,10 @@ const STEP_DIRECTIVE_KEYS: readonly string[] = [
  * restating the kinds, so parse time and run time cannot answer differently.
  * Three constraints keep an entry honest. Two judge the keys already listed:
  * `satisfies` rejects a key that is not a real step kind, and blockSteps'
- * `Extract` rejects a kind whose step type carries no `steps` (a directive
- * listed here without children is a compile error, not a silent runtime
- * `undefined`). Neither can force a key IN, which is what
+ * `.steps` read rejects a kind with no usable `steps` - `Extract` catches a
+ * missing one, its own `satisfies` one that is not a `FlowStep[]`, so a
+ * childless directive listed here is a compile error, not a silent runtime
+ * `undefined`. Neither can force a key IN, which is what
  * {@link _everyChildBearingKindIsRegistered} does — without it a child-bearing
  * kind added later is simply absent here, and absent is not an error.
  *
@@ -2028,19 +2032,32 @@ type BlockDirectiveKind = (typeof BLOCK_DIRECTIVE_KEYS)[number];
 /** The step union those kinds select - what {@link isBlockStep} narrows to. */
 export type BlockStep = Extract<FlowStep, { kind: BlockDirectiveKind }>;
 
+/**
+ * Every step kind whose type carries a `steps` property, whatever its spelling:
+ * optional, `readonly`, any element type. Distributes over the union and asks
+ * `keyof` rather than matching structurally, because the obvious
+ * `Extract<FlowStep, { steps: FlowStep[] }>` misses a `steps?` or a
+ * `readonly FlowStep[]` - anything not both required and assignable to
+ * `FlowStep[]` reads as a childless leaf.
+ */
+type ChildBearingKind<S extends FlowStep = FlowStep> = S extends unknown
+  ? "steps" extends keyof S
+    ? S["kind"]
+    : never
+  : never;
+
 /** The child-bearing step kinds {@link BLOCK_DIRECTIVE_KEYS} fails to list. */
-type UnregisteredBlockKind = Exclude<
-  Extract<FlowStep, { steps: FlowStep[] }>["kind"],
-  BlockDirectiveKind
->;
+type UnregisteredBlockKind = Exclude<ChildBearingKind, BlockDirectiveKind>;
 
 /**
  * Forces a child-bearing kind INTO the registry — the direction the two
  * constraints on {@link BLOCK_DIRECTIVE_KEYS} cannot cover, since both only
  * judge kinds already listed. An unlisted one parses like any other step and
  * then reads as `undefined` from {@link blockSteps}, so every reader listed
- * there silently misses its children. Spelled as a conditional rather than a
- * bare `never` so the compile error names the missing kind.
+ * there silently misses its children. {@link ChildBearingKind} is what makes
+ * this reach every spelling of `steps`, not just the one a structural match
+ * names. Spelled as a conditional rather than a bare `never` so the compile
+ * error names the missing kind.
  */
 const _everyChildBearingKindIsRegistered: [UnregisteredBlockKind] extends [never]
   ? true

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -761,7 +761,7 @@ export function blockSteps(step: FlowStep): FlowStep[] | undefined {
  * what makes the list load-bearing: {@link blockSteps}' `.steps` typechecks
  * only while EVERY listed kind's step type carries children.
  */
-function isBlockStep(step: FlowStep): step is Extract<FlowStep, { kind: BlockDirectiveKind }> {
+export function isBlockStep(step: FlowStep): step is BlockStep {
   return isBlockDirectiveKey(step.kind);
 }
 
@@ -2024,6 +2024,9 @@ export const BLOCK_DIRECTIVE_KEYS = ["when"] as const satisfies readonly FlowSte
 
 /** The step kinds {@link BLOCK_DIRECTIVE_KEYS} names. */
 type BlockDirectiveKind = (typeof BLOCK_DIRECTIVE_KEYS)[number];
+
+/** The step union those kinds select - what {@link isBlockStep} narrows to. */
+export type BlockStep = Extract<FlowStep, { kind: BlockDirectiveKind }>;
 
 /** The child-bearing step kinds {@link BLOCK_DIRECTIVE_KEYS} fails to list. */
 type UnregisteredBlockKind = Exclude<

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -2370,11 +2370,15 @@ const MAX_BLOCK_DEPTH = 20;
 
 /**
  * Guard a block directive's recursion depth. Called FIRST in a block's parse —
- * before its own key/shape checks — so a cyclic alias reports as a depth error
- * rather than surfacing whatever the cycle happens to make the shallower checks
- * say. That early call buys the error PRECEDENCE only, not the cap itself:
- * {@link parseBlockSteps} asserts again before it recurses, so forgetting the
- * early call costs a directive the precedence and nothing more.
+ * before its own key/shape checks — so an entry that has REACHED the cap
+ * reports the depth rather than its second defect: nest `when` to the cap and
+ * give the entry AT it an `else:`, a third sibling key, or an unknown condition
+ * key, and it reports the depth, not that check's message. (A cyclic alias is
+ * NOT that case — the same object repeats at every level, so a shape defect in
+ * it fires at depth 0 and a well-formed cycle reaches the cap with or without
+ * this call.) That early call buys the error PRECEDENCE only, not the cap
+ * itself: {@link parseBlockSteps} asserts again before it recurses, so
+ * forgetting the early call costs a directive the precedence and nothing more.
  */
 function assertBlockDepth(raw: unknown, depth: number): void {
   if (depth >= MAX_BLOCK_DEPTH) {

--- a/packages/tool-server/test/flows/flow-composition.test.ts
+++ b/packages/tool-server/test/flows/flow-composition.test.ts
@@ -2176,7 +2176,7 @@ describe("flow composition (run:)", () => {
 
     // Each run marker sits at its enclosing depth; the fragment it expands runs
     // one deeper. Top-level steps omit the field entirely, so a flow with no
-    // block directives reports byte-identically to the pre-depth shape.
+    // nesting steps reports byte-identically to the pre-depth shape.
     expect(result.steps.map((s) => `${s.kind}:${s.depth ?? 0}`)).toEqual([
       "run:0",
       "tool:1",

--- a/packages/tool-server/test/flows/flow-composition.test.ts
+++ b/packages/tool-server/test/flows/flow-composition.test.ts
@@ -1459,12 +1459,12 @@ describe("flow composition (run:)", () => {
 
   it("rejects an uploaded flow whose run: sits two when: blocks deep", async () => {
     // Pins walkSteps' recursion DEPTH, which the single-level test above
-    // cannot: a one-level peek (`yield* step.steps` in place of
-    // `yield* walkSteps(step.steps)`) still passes that neighbor but never
-    // reaches this run:, so the flow reports ok: true with the run line inside
-    // a block skip — the silent-green CI outcome the preflight exists to
-    // prevent. The parser nests when: to MAX_WHEN_DEPTH (20), so two levels is
-    // ordinary authorable YAML, not an edge case.
+    // cannot: a one-level peek (`yield* inner` in place of
+    // `yield* walkSteps(inner)`) still passes that neighbor but never reaches
+    // this run:, so the flow reports ok: true with the run line inside a block
+    // skip — the silent-green CI outcome the preflight exists to prevent. The
+    // parser nests when: to MAX_BLOCK_DEPTH (20), so two levels is ordinary
+    // authorable YAML, not an edge case.
     const uploadedPath = path.join(tmpDir, "materialized-upload.yaml");
     await fs.writeFile(
       uploadedPath,

--- a/packages/tool-server/test/flows/flow-deviceless.test.ts
+++ b/packages/tool-server/test/flows/flow-deviceless.test.ts
@@ -6,7 +6,7 @@ import type { Registry } from "@argent/registry";
 import { zodObjectToJsonSchema } from "@argent/registry";
 import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
 import { serializeFlow, type FlowStep } from "../../src/tools/flows/flow-utils";
-import { stepRequiresDevice } from "../../src/tools/flows/flow-device";
+import { flowRequiresDevice, stepRequiresDevice } from "../../src/tools/flows/flow-device";
 import { createStopAllSimulatorServersTool } from "../../src/tools/simulator/stop-all-simulator-servers";
 
 const DEVICE = "00000000-0000-0000-0000-0000000000ab";
@@ -324,6 +324,66 @@ describe("stepRequiresDevice", () => {
       stepRequiresDevice(registry, { kind: "tool", name: "stop-all-simulator-servers", args: {} })
     ).toBe(false);
     expect(stepRequiresDevice(registry, { kind: "tool", name: "tap", args: {} })).toBe(true);
+  });
+});
+
+describe("flowRequiresDevice", () => {
+  // These pin the function's ANSWERS. With `when` the only block kind, its
+  // header decides every case - no FlowStep value can exercise the child walk.
+  const whenOver = (steps: FlowStep[]): FlowStep => ({
+    kind: "when",
+    condition: { kind: "platform", platform: "ios" },
+    steps,
+  });
+
+  it("answers false for an empty flow", () => {
+    const { registry } = mockRegistry();
+    expect(flowRequiresDevice(registry, [])).toBe(false);
+  });
+
+  it("answers false for narration and waits alone", () => {
+    const { registry } = mockRegistry();
+    expect(
+      flowRequiresDevice(registry, [
+        { kind: "echo", message: "hi" },
+        { kind: "wait", ms: 1 },
+      ])
+    ).toBe(false);
+  });
+
+  it("answers false for a tool step whose tool takes no device", () => {
+    const { registry } = mockRegistry();
+    expect(
+      flowRequiresDevice(registry, [{ kind: "tool", name: "stop-metro", args: { port: 8081 } }])
+    ).toBe(false);
+  });
+
+  it("answers true for a tool step whose tool declares a device argument", () => {
+    const { registry } = mockRegistry();
+    expect(flowRequiresDevice(registry, [{ kind: "tool", name: "tap", args: {} }])).toBe(true);
+  });
+
+  it("answers true for a when over a device-free body - the guard reads the device", () => {
+    const { registry } = mockRegistry();
+    expect(flowRequiresDevice(registry, [whenOver([{ kind: "echo", message: "quiet" }])])).toBe(
+      true
+    );
+  });
+
+  it("answers true for a when nested three deep", () => {
+    const { registry } = mockRegistry();
+    expect(flowRequiresDevice(registry, [whenOver([whenOver([whenOver([])])])])).toBe(true);
+  });
+
+  it("answers true when only a later step in a mixed list needs a device", () => {
+    const { registry } = mockRegistry();
+    expect(
+      flowRequiresDevice(registry, [
+        { kind: "echo", message: "about to tap" },
+        { kind: "tool", name: "stop-metro", args: { port: 8081 } },
+        { kind: "tap", x: 0.5, y: 0.5 },
+      ])
+    ).toBe(true);
   });
 });
 

--- a/packages/tool-server/test/flows/flow-deviceless.test.ts
+++ b/packages/tool-server/test/flows/flow-deviceless.test.ts
@@ -6,7 +6,11 @@ import type { Registry } from "@argent/registry";
 import { zodObjectToJsonSchema } from "@argent/registry";
 import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
 import { serializeFlow, type FlowStep } from "../../src/tools/flows/flow-utils";
-import { flowRequiresDevice, stepRequiresDevice } from "../../src/tools/flows/flow-device";
+import {
+  flowRequiresDevice,
+  flowScopesDevice,
+  stepRequiresDevice,
+} from "../../src/tools/flows/flow-device";
 import { createStopAllSimulatorServersTool } from "../../src/tools/simulator/stop-all-simulator-servers";
 
 const DEVICE = "00000000-0000-0000-0000-0000000000ab";
@@ -384,6 +388,57 @@ describe("flowRequiresDevice", () => {
         { kind: "tap", x: 0.5, y: 0.5 },
       ])
     ).toBe(true);
+  });
+});
+
+describe("flowScopesDevice", () => {
+  // These pin the function's ANSWERS. The child walk shows in them - unlike
+  // `flowRequiresDevice`, a `when` header scopes nothing itself - but only
+  // under a direct call: a run reaches this question only once
+  // `flowRequiresDevice` said no, and `when`, the only block kind, answers that
+  // one yes for any flow holding a block.
+  const whenOver = (steps: FlowStep[]): FlowStep => ({
+    kind: "when",
+    condition: { kind: "platform", platform: "ios" },
+    steps,
+  });
+  const teardown: FlowStep = { kind: "tool", name: "stop-all-simulator-servers", args: {} };
+
+  it("answers false for an empty flow", () => {
+    const { registry } = mockRegistry();
+    expect(flowScopesDevice(registry, [])).toBe(false);
+  });
+
+  it("answers false for a tool step whose tool declares no device scope", () => {
+    const { registry } = mockRegistry();
+    expect(
+      flowScopesDevice(registry, [
+        { kind: "echo", message: "hi" },
+        { kind: "tool", name: "stop-metro", args: { port: 8081 } },
+      ])
+    ).toBe(false);
+  });
+
+  it("answers false for a device TARGET argument - a target is not a scope", () => {
+    const { registry } = mockRegistry();
+    expect(flowScopesDevice(registry, [{ kind: "tool", name: "tap", args: {} }])).toBe(false);
+  });
+
+  it("answers true for a tool step whose tool declares a device LIST scope", () => {
+    const { registry } = mockRegistry();
+    expect(flowScopesDevice(registry, [teardown])).toBe(true);
+  });
+
+  it("answers false for a when over a body that scopes nothing", () => {
+    const { registry } = mockRegistry();
+    expect(flowScopesDevice(registry, [whenOver([{ kind: "echo", message: "quiet" }])])).toBe(
+      false
+    );
+  });
+
+  it("answers true for a scope inside a when, nested three deep", () => {
+    const { registry } = mockRegistry();
+    expect(flowScopesDevice(registry, [whenOver([whenOver([whenOver([teardown])])])])).toBe(true);
   });
 });
 

--- a/packages/tool-server/test/flows/flow-utils.test.ts
+++ b/packages/tool-server/test/flows/flow-utils.test.ts
@@ -216,14 +216,40 @@ describe("parseFlow", () => {
     expect((thrown as Error).message).toContain("line 1");
   });
 
-  it("throws a validation error (not a TypeError) on a primitive step entry", async () => {
-    const content = 'executionPrerequisite: ""\nsteps:\n  - tap\n';
-    expect(() => parseFlow(content)).toThrow("Unrecognized flow entry");
+  // `step must be an object` is spelled twice — here for a top-level entry, and
+  // in parseBlockSteps for a block directive's own steps: list. Nothing else
+  // asserts either copy, so the two are free to drift apart or be dropped with
+  // nothing noticing; the pair below pins each site independently.
+  const entryRejectionMessage = (content: string): string => {
+    try {
+      parseFlow(content);
+    } catch (err) {
+      // A raw TypeError would carry no signal — this is what makes it structured.
+      expect(getFailureSignal(err)?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
+      return err instanceof Error ? err.message : String(err);
+    }
+    throw new Error("expected the entry to be rejected");
+  };
+
+  it.each([
+    ["a bare string", 'executionPrerequisite: ""\nsteps:\n  - tap\n'],
+    ["a primitive", 'executionPrerequisite: ""\nsteps:\n  - 42\n'],
+    ["a null", 'executionPrerequisite: ""\nsteps:\n  - ~\n'],
+  ])("names the step shape when %s sits in the top-level steps list", (_shape, content) => {
+    expect(entryRejectionMessage(content)).toContain(
+      "Unrecognized flow entry (step must be an object)"
+    );
   });
 
-  it("throws a validation error on a null step entry", async () => {
-    const content = 'executionPrerequisite: ""\nsteps:\n  - ~\n';
-    expect(() => parseFlow(content)).toThrow("Unrecognized flow entry");
+  it.each([
+    ["a primitive", "steps:\n  - when: { visible: Cart }\n    steps: [42]\n"],
+    ["a null", "steps:\n  - when: { visible: Cart }\n    steps: [~]\n"],
+  ])("names the step shape when %s sits in a block's steps list", (_shape, content) => {
+    // `when:` is only the vehicle — it is today's sole block directive, and the
+    // guard it reaches is parseBlockSteps', shared by every block directive.
+    expect(entryRejectionMessage(content)).toContain(
+      "Unrecognized flow entry (step must be an object)"
+    );
   });
 
   it("sugars a bare-string selector into a loose { text } for tap", async () => {

--- a/packages/tool-server/test/flows/flow-utils.test.ts
+++ b/packages/tool-server/test/flows/flow-utils.test.ts
@@ -21,6 +21,8 @@ import {
   appIdForPlatform,
   chromiumLaunchSpec,
   writeNewFlowFile,
+  blockSteps,
+  BLOCK_DIRECTIVE_KEYS,
   type FlowFile,
 } from "../../src/tools/flows/flow-utils";
 
@@ -895,6 +897,48 @@ describe("parseFlow", () => {
     };
     const serialized = serializeFlow(flow);
     expect(parseFlow(serialized)).toEqual(flow);
+  });
+});
+
+// ── block directives ─────────────────────────────────────────────────
+
+// A flow per key in BLOCK_DIRECTIVE_KEYS, with the children its block authors.
+// Deliberately not derived from the key: a fixture that agreed with the parser
+// by construction would test nothing.
+const BLOCK_DIRECTIVE_FLOWS: Partial<
+  Record<(typeof BLOCK_DIRECTIVE_KEYS)[number], { yaml: string; children: FlowFile["steps"] }>
+> = {
+  when: {
+    yaml:
+      [
+        "steps:",
+        "  - when: { visible: Cart }",
+        "    steps:",
+        "      - echo: Guarded",
+        "      - tap: Buy",
+      ].join("\n") + "\n",
+    children: [
+      { kind: "echo", message: "Guarded" },
+      { kind: "tap", selector: { text: "Buy", loose: true } },
+    ],
+  },
+};
+
+// The parser's block list and blockSteps' runtime answer are the same claim
+// asked twice; a directive only one of them knows drops its whole block from
+// every skip expansion and from the upload preflight, silently.
+describe("block directives", () => {
+  it.each(BLOCK_DIRECTIVE_KEYS)("%s parses to its own kind and yields its children", (key) => {
+    const fixture = BLOCK_DIRECTIVE_FLOWS[key];
+    expect(fixture, `no flow fixture for block directive \`${key}\``).toBeDefined();
+    const step = parseFlow(fixture!.yaml).steps[0]!;
+    expect(step.kind).toBe(key);
+    expect(blockSteps(step)).toEqual(fixture!.children);
+  });
+
+  it("returns undefined for a leaf step", () => {
+    const step = parseFlow("steps:\n  - tap: Buy\n").steps[0]!;
+    expect(blockSteps(step)).toBeUndefined();
   });
 });
 

--- a/packages/tool-server/test/flows/flow-utils.test.ts
+++ b/packages/tool-server/test/flows/flow-utils.test.ts
@@ -928,11 +928,13 @@ describe("parseFlow", () => {
 
 // ── block directives ─────────────────────────────────────────────────
 
-// A flow per key in BLOCK_DIRECTIVE_KEYS, with the children its block authors.
-// Deliberately not derived from the key: a fixture that agreed with the parser
-// by construction would test nothing.
-const BLOCK_DIRECTIVE_FLOWS: Partial<
-  Record<(typeof BLOCK_DIRECTIVE_KEYS)[number], { yaml: string; children: FlowFile["steps"] }>
+// A flow per block directive, with the children its block authors. Its key type
+// derives from the registry, so registering a directive without a fixture here
+// is a compile error. The fixture itself is deliberately not derived from the
+// key: one that agreed with the parser by construction would test nothing.
+const BLOCK_DIRECTIVE_FLOWS: Record<
+  (typeof BLOCK_DIRECTIVE_KEYS)[number],
+  { yaml: string; children: FlowFile["steps"] }
 > = {
   when: {
     yaml:
@@ -974,11 +976,10 @@ const BLOCK_DIRECTIVE_SIBLING_REJECTIONS: Record<
 // every skip expansion and from the upload preflight, silently.
 describe("block directives", () => {
   it.each(BLOCK_DIRECTIVE_KEYS)("%s parses to its own kind and yields its children", (key) => {
-    const fixture = BLOCK_DIRECTIVE_FLOWS[key];
-    expect(fixture, `no flow fixture for block directive \`${key}\``).toBeDefined();
-    const step = parseFlow(fixture!.yaml).steps[0]!;
+    const { yaml, children } = BLOCK_DIRECTIVE_FLOWS[key];
+    const step = parseFlow(yaml).steps[0]!;
     expect(step.kind).toBe(key);
-    expect(blockSteps(step)).toEqual(fixture!.children);
+    expect(blockSteps(step)).toEqual(children);
   });
 
   it.each(BLOCK_DIRECTIVE_KEYS)("%s rejects an unknown sibling key with its own message", (key) => {

--- a/packages/tool-server/test/flows/flow-utils.test.ts
+++ b/packages/tool-server/test/flows/flow-utils.test.ts
@@ -950,6 +950,25 @@ const BLOCK_DIRECTIVE_FLOWS: Partial<
   },
 };
 
+// Registering a kind in BLOCK_DIRECTIVE_KEYS exempts it from fromYamlStep's
+// generic unknown-sibling rejection, on the promise that its own parser
+// rejects unknown siblings with a pointed message. This table is what holds a
+// NEW entry to that promise: its key type derives from the registry, so
+// registering a directive without a fixture here is a compile error, and the
+// test proves the fixture's bogus sibling is rejected, not silently accepted.
+const BLOCK_DIRECTIVE_SIBLING_REJECTIONS: Record<
+  (typeof BLOCK_DIRECTIVE_KEYS)[number],
+  { yaml: string; message: string }
+> = {
+  when: {
+    yaml:
+      ["steps:", "  - when: { exists: x }", "    steps:", "      - echo: hi", "    bogus: 1"].join(
+        "\n"
+      ) + "\n",
+    message: "a when step takes exactly { when: <condition>, steps: [...] }",
+  },
+};
+
 // The parser's block list and blockSteps' runtime answer are the same claim
 // asked twice; a directive only one of them knows drops its whole block from
 // every skip expansion and from the upload preflight, silently.
@@ -960,6 +979,19 @@ describe("block directives", () => {
     const step = parseFlow(fixture!.yaml).steps[0]!;
     expect(step.kind).toBe(key);
     expect(blockSteps(step)).toEqual(fixture!.children);
+  });
+
+  it.each(BLOCK_DIRECTIVE_KEYS)("%s rejects an unknown sibling key with its own message", (key) => {
+    const { yaml, message } = BLOCK_DIRECTIVE_SIBLING_REJECTIONS[key];
+    let thrown: unknown;
+    try {
+      parseFlow(yaml);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown, "the unknown sibling was silently accepted").toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain(message);
+    expect(getFailureSignal(thrown)?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
   });
 
   it("returns undefined for a leaf step", () => {

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -186,11 +186,13 @@ describe("when: parse/serialize", () => {
       thrown = err;
     }
     // The whole message is pinned, not only the "nest deeper than" half: the
-    // cap covers every block directive rather than when: alone, and the alias
-    // hint is what points the author at the actual mistake.
+    // prefix names the registered block directives (a literal on purpose - it
+    // must be updated consciously when a new directive registers, not drift
+    // with the source), and the alias hint is what points the author at the
+    // actual mistake.
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toContain(
-      "block directives nest deeper than 20 levels — check for a cyclic YAML alias (`steps: &s … steps: *s`)"
+      "`when:` blocks nest deeper than 20 levels — check for a cyclic YAML alias (`steps: &s … steps: *s`)"
     );
     // A raw RangeError would carry no signal — this is what makes it structured.
     const signal = getFailureSignal(thrown);
@@ -227,7 +229,7 @@ describe("when: parse/serialize", () => {
       thrown = err;
     }
     expect(thrown).toBeInstanceOf(Error); // a raised cap would leave this unset
-    expect((thrown as Error).message).toContain("block directives nest deeper than 20 levels");
+    expect((thrown as Error).message).toContain("`when:` blocks nest deeper than 20 levels");
     expect(getFailureSignal(thrown)?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
   });
 
@@ -258,7 +260,7 @@ describe("when: parse/serialize", () => {
         thrown = err;
       }
       expect(thrown).toBeInstanceOf(Error);
-      expect((thrown as Error).message).toContain("block directives nest deeper than 20 levels");
+      expect((thrown as Error).message).toContain("`when:` blocks nest deeper than 20 levels");
       // Not just "the depth error is in there": the shallower check must not be
       // what answered, which is the whole difference the early call makes.
       expect((thrown as Error).message).not.toContain(shallow);

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Registry } from "@argent/registry";
+import { FAILURE_CODES, getFailureSignal, type Registry } from "@argent/registry";
 import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
 
 // Serve the flow tree directly: flows resolve selectors against the platform's
@@ -179,9 +179,56 @@ describe("when: parse/serialize", () => {
     // The yaml library materializes `steps: *s` as a cyclic object; without
     // the depth cap the parser would recurse forever and escape as a raw
     // RangeError instead of a flow parse error.
-    expect(() => parseFlow("steps: &s\n  - when: { visible: X }\n    steps: *s\n")).toThrow(
-      /nest deeper than 20 levels/i
+    let thrown: unknown;
+    try {
+      parseFlow("steps: &s\n  - when: { visible: X }\n    steps: *s\n");
+    } catch (err) {
+      thrown = err;
+    }
+    // The whole message is pinned, not only the "nest deeper than" half: the
+    // cap covers every block directive rather than when: alone, and the alias
+    // hint is what points the author at the actual mistake.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain(
+      "block directives nest deeper than 20 levels — check for a cyclic YAML alias (`steps: &s … steps: *s`)"
     );
+    // A raw RangeError would carry no signal — this is what makes it structured.
+    const signal = getFailureSignal(thrown);
+    expect(signal?.error_kind).toBe("validation");
+    expect(signal?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
+  });
+
+  it("parses when: nested to the depth cap and rejects one level deeper", () => {
+    // The cyclic-alias test above only proves SOME cap exists; this pins its
+    // value from both sides so it cannot drift in either direction. The literal
+    // 20 IS the pin — reading MAX_BLOCK_DEPTH would move with the constant and
+    // assert nothing.
+    const nestedWhens = (levels: number): string => {
+      let steps = "[{ echo: deepest }]";
+      for (let i = 0; i < levels; i++) steps = `[{ when: { platform: ios }, steps: ${steps} }]`;
+      return `steps: ${steps}\n`;
+    };
+
+    let step = parseFlow(nestedWhens(20)).steps[0];
+    let depth = 0;
+    while (step.kind === "when") {
+      depth++;
+      step = step.steps[0];
+    }
+    expect(depth).toBe(20);
+    expect(step).toEqual({ kind: "echo", message: "deepest" });
+
+    // 21 levels is plain over-deep YAML, not a cycle, so it must still land as
+    // the structured parse error rather than escaping as a RangeError.
+    let thrown: unknown;
+    try {
+      parseFlow(nestedWhens(21));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error); // a raised cap would leave this unset
+    expect((thrown as Error).message).toContain("block directives nest deeper than 20 levels");
+    expect(getFailureSignal(thrown)?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
   });
 
   it("rejects a per-step optional key, pointing at when:", () => {

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -231,6 +231,40 @@ describe("when: parse/serialize", () => {
     expect(getFailureSignal(thrown)?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
   });
 
+  // The only pin on parseWhenStep's EARLY assertBlockDepth call: the cap itself
+  // outlives it (parseBlockSteps asserts again before recursing) and the cyclic
+  // alias above reports the depth error either way, so deleting the early call
+  // leaves the rest of the suite green while exactly these entries — at the cap
+  // and carrying a second defect — flip to the shallower check's message.
+  it.each([
+    ["an else branch", "when: { platform: ios }, else: 1, steps: [{ echo: x }]", "has no else"],
+    [
+      "a third sibling key",
+      "when: { platform: ios }, foo: 1, steps: [{ echo: x }]",
+      "takes exactly { when: <condition>, steps: [...] }",
+    ],
+    ["an unknown condition key", "when: { nope: X }, steps: [{ echo: x }]", "one condition key"],
+  ])(
+    "reports the depth, not %s, for the entry sitting at the cap",
+    (_defect, innermost, shallow) => {
+      // 20 wrappers occupy depths 0-19, so the defective entry is the one at 20.
+      let steps = `[{ ${innermost} }]`;
+      for (let i = 0; i < 20; i++) steps = `[{ when: { platform: ios }, steps: ${steps} }]`;
+
+      let thrown: unknown;
+      try {
+        parseFlow(`steps: ${steps}\n`);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toContain("block directives nest deeper than 20 levels");
+      // Not just "the depth error is in there": the shallower check must not be
+      // what answered, which is the whole difference the early call makes.
+      expect((thrown as Error).message).not.toContain(shallow);
+    }
+  );
+
   it("rejects a per-step optional key, pointing at when:", () => {
     // No silent drop: an ignored `optional: true` would leave a step the
     // author believes can't fail hard-stopping the flow.

--- a/packages/tool-server/test/flows/flow-when.test.ts
+++ b/packages/tool-server/test/flows/flow-when.test.ts
@@ -175,6 +175,12 @@ describe("when: parse/serialize", () => {
     ).toThrow(/no other keys/i);
   });
 
+  // Hand-written, and ONE copy for the three tests below: the prefix names the
+  // registered block directives, so a second one must update this literal
+  // consciously. Deriving it from BLOCK_DIRECTIVE_KEYS would move it with the
+  // source and pin nothing; restating it per test made that three edits to find.
+  const DEPTH_CAP_MESSAGE = "`when:` blocks nest deeper than 20 levels";
+
   it("rejects a cyclic YAML alias on when steps with a structured error", () => {
     // The yaml library materializes `steps: *s` as a cyclic object; without
     // the depth cap the parser would recurse forever and escape as a raw
@@ -185,14 +191,11 @@ describe("when: parse/serialize", () => {
     } catch (err) {
       thrown = err;
     }
-    // The whole message is pinned, not only the "nest deeper than" half: the
-    // prefix names the registered block directives (a literal on purpose - it
-    // must be updated consciously when a new directive registers, not drift
-    // with the source), and the alias hint is what points the author at the
-    // actual mistake.
+    // The only site that pins the whole message: the alias hint is what points
+    // the author at the actual mistake here, so it is part of the contract.
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toContain(
-      "`when:` blocks nest deeper than 20 levels — check for a cyclic YAML alias (`steps: &s … steps: *s`)"
+      `${DEPTH_CAP_MESSAGE} — check for a cyclic YAML alias (\`steps: &s … steps: *s\`)`
     );
     // A raw RangeError would carry no signal — this is what makes it structured.
     const signal = getFailureSignal(thrown);
@@ -229,7 +232,7 @@ describe("when: parse/serialize", () => {
       thrown = err;
     }
     expect(thrown).toBeInstanceOf(Error); // a raised cap would leave this unset
-    expect((thrown as Error).message).toContain("`when:` blocks nest deeper than 20 levels");
+    expect((thrown as Error).message).toContain(DEPTH_CAP_MESSAGE);
     expect(getFailureSignal(thrown)?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
   });
 
@@ -260,7 +263,7 @@ describe("when: parse/serialize", () => {
         thrown = err;
       }
       expect(thrown).toBeInstanceOf(Error);
-      expect((thrown as Error).message).toContain("`when:` blocks nest deeper than 20 levels");
+      expect((thrown as Error).message).toContain(DEPTH_CAP_MESSAGE);
       // Not just "the depth error is in there": the shallower check must not be
       // what answered, which is the whole difference the early call makes.
       expect((thrown as Error).message).not.toContain(shallow);


### PR DESCRIPTION
`when` is the only directive with a sibling `steps:` list, and four runner sites asked `kind === "when"` directly to decide whether a step has authored children to expand as skip lines. A second block directive would have had to remember all four, and a forgotten one silently drops a whole block from the report — exactly the invariant `reportBlockSkipped` exists to hold.

This introduces `blockSteps(step)` as the single runtime predicate and `BLOCK_DIRECTIVE_KEYS` as its parse-time counterpart, and extracts the parse-side block plumbing (`assertBlockDepth`, `parseBlockSteps`) that a second directive must share — notably the depth cap, renamed `MAX_BLOCK_DEPTH`, which has to be ONE counter across directives or an alternating nesting chain evades it and reopens the cyclic-YAML-alias hole it was added to close.

No behavior change, with one deliberate exception: the depth-cap message now reads `block directives nest deeper than 20 levels` where it said `when blocks nest deeper than 20 levels` — the cap stopped being `when`'s the moment it became shared, and a message naming only `when` would misdirect an author who hit it through a different directive. Every other error message, their ordering, and the report shapes are untouched.

559 flow tests pass unchanged.

---

**Stack**

1. **#748 — you are here** · `refactor(flow)`: generalize when's block machinery → `main`
2. #749 · `feat(flow)`: add `repeat:` blocks → #748
