### PR TITLE
docs(skills): condense the flow skills without dropping rules

### DIFF
--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -76,7 +76,7 @@ Decision order:
 - Interaction tools (`gesture-tap`, `gesture-swipe`, `gesture-pinch`, `gesture-rotate`, `gesture-custom`, `launch-app`, etc.) return a screenshot automatically.
   Call `screenshot` separately only for a baseline before any action or after a delay.
 - Always open apps with `launch-app` or `open-url` — never tap home screen icons.
-- If there is any chance the task ends in a recorded flow or QA test, do not interact with the app first: load `argent-create-flow` and start the recorder before the first launch or in-app action. A path already walked cannot be recorded retroactively.
+- If a task can require a saved flow, choose `argent-create-flow` or `argent-qa-flows` before the first launch or in-app action. Start the recorder before walking the path; recording is not retroactive.
 - Always use `run-sequence` when performing multiple sequential device actions where you don't need to observe the screen between steps. More in `argent-device-interact` skill.
 - When the session ends or the user says they are done: call `stop-all-simulator-servers` with `devices: [...]`
   naming the devices this session actually used. One tool-server is shared by every other agent using this
@@ -133,7 +133,7 @@ When: Explicit visual regression, screenshot diff, compare screenshots, before/a
 
 SCREEN RECORDING (VIDEO CAPTURE)
 Skill: `argent-screen-recording`
-When: The user wants a video of the device screen — recording a flow, interaction, animation, or bug reproduction as a clip, or documenting app behavior beyond what a still screenshot shows. Covers the start → interact → stop lifecycle, the reminder discipline that keeps a recording from being left running, and retrieving the mp4 artifact. Not for a replayable saved sequence: route that meaning of "record a flow" to `argent-create-flow`.
+When: The user wants an mp4 of an interaction, animation, or bug reproduction. Use `argent-create-flow` instead for a replayable sequence.
 Prompt keywords: record, recording, screen recording, video, capture video, clip, mp4
 
 RUNNING / BUILDING / DEBUGGING REACT NATIVE APP
@@ -158,18 +158,18 @@ When: App feels slow, user asks to optimize, reducing bundle size, improving sta
 
 INTERACTIVE UI TESTING (ONE-OFF, NOT SAVED)
 Skill: `argent-test-ui-flow`
-When: Verifying complete user flows, running interact → screenshot → verify loops, testing features by using the app, executing manual QA steps, or validating visible UI changes or visual behavior after implementation. Not for a test that must be saved and re-run — see GENERATED QA REGRESSION TESTS below.
+When: Running a one-off interact → screenshot → verify check with no saved regression artifact.
 
 RECORDING & REPLAYING FLOWS
 Use skill: `argent-create-flow`
-When: A multi-step interaction sequence needs to be repeated — re-profiling after a fix, A/B comparisons, user says "again" / "run that flow", or you worked through a complex path worth saving. Also use proactively: if you are about to repeat steps you already performed, record first, then replay. For a QA test case, ticket, or acceptance criteria to keep as a regression test, use `argent-qa-flows` (it loads this skill as its engine).
+When: Saving or replaying a repeatable path for profiling, A/B comparison, retry, or reuse. For acceptance-driven regression tests, use `argent-qa-flows`.
 Prompt keywords: flow, repeat, test X times
 
 GENERATED QA REGRESSION TESTS
 Use skill: `argent-qa-flows`
-When: The user gives a test case, ticket, or acceptance criteria to keep as a repeatable test — "generate a QA test", "turn this test case into a flow", "automate this regression check", "make a test that does X and checks Y". Orchestrates `argent-create-flow`, records the first walkthrough live, verifies each requested screen/state with stable evidence, and completes only after the unchanged full flow passes twice consecutively. iOS, Android, Chromium, and Vega (Fire TV — navigation is recorded `tool: tv-remote` steps in place of touch directives); not Apple TV or Android TV.
+When: Saving a test case, ticket, or acceptance criteria as a repeatable regression test. Requires stable evidence and two unchanged full passes. iOS, Android, Chromium, and Vega (D-pad navigation records as `tool: tv-remote` steps); not Apple TV or Android TV.
 Prompt keywords: QA test, regression test, test case, automate this test, automate an e2e test, keep this e2e test, generate a test
-Saved-artifact rule: one-off interactive check → `argent-test-ui-flow`; saved replayable path → `argent-create-flow`; saved test with acceptance criteria and two-pass proof → `argent-qa-flows`.
+Routing: one-off check → `argent-test-ui-flow`; saved path → `argent-create-flow`; saved acceptance test → `argent-qa-flows`.
 
 PROPOSING DESIGN VARIANTS FOR HUMAN SELECTION
 Use skill: `argent-lens`

--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -1,54 +1,49 @@
 ---
 name: argent-create-flow
-description: Create, record, edit, replay, or repair reusable Argent flow YAML files for device interaction. Use when the user asks to create or record a flow, script a repeatable device path, replay the same interaction, preserve a non-trivial path for profiling or A/B comparison, or invoke the authoring engine for argent-qa-flows. Also use proactively before repeating a path of three or more interactions. Do NOT use for a one-off interactive check (use argent-test-ui-flow), a saved QA/regression test driven by acceptance criteria (use argent-qa-flows), or a screen video or bug-reproduction clip (use argent-screen-recording).
+description: Create, record, edit, replay, or repair reusable Argent flow YAML files. Use when the user asks to record or replay a repeatable device path, set up profiling or an A/B comparison, or invoke the authoring engine behind argent-qa-flows. Also use before repeating three or more interactions. For one-off UI checks, acceptance-driven regression tests, or screen video, use argent-test-ui-flow, argent-qa-flows, or argent-screen-recording respectively.
 ---
 
 # Create an Argent flow
 
 An Argent flow is a replayable sequence in `.argent/flows/<name>.yaml`.
 
-**If the request is a QA test case, ticket, or acceptance criteria to keep as a regression test, load `argent-qa-flows` first** — it owns the QA contract (self-contained state, discriminating checks, and two consecutive passes) and uses this skill as its engine.
+For a saved QA test case, ticket, or acceptance criterion, load `argent-qa-flows` first. It adds deterministic setup, acceptance evidence, and two-pass proof.
 
 ## Read the relevant reference
 
-- **Required before creating or changing a flow:** read [Live authoring](references/live-authoring.md) completely for the recorder workflow, polish pass, and final audit.
-- **When writing or reviewing YAML by hand:** [Flow YAML](references/flow-yaml.md) — flow types, directives, conditions, composition, and runner syntax. For Vega, read its [Composition and platform limits](references/flow-yaml.md#composition-and-platform-limits) before recording remote/keyboard tools.
-- **On a capture warning or a replay failure:** [Reliability and recovery](references/reliability-and-recovery.md) — coordinates or raw gestures appear, a transition is mistimed, an overlay may obstruct a target, the target is `com.apple.*`, an iOS app was not Argent-launched, or a platform's tree source is unavailable.
+- Before creating or changing a flow, read [Live authoring](references/live-authoring.md) completely.
+- When polishing, composing, or manually reviewing YAML, read [Flow YAML](references/flow-yaml.md). For Vega, read its platform limits before recording remote or keyboard tools.
+- On capture warnings, raw coordinates, unavailable trees, mistimed transitions, overlays, or replay failures, read [Reliability and recovery](references/reliability-and-recovery.md).
 
 ## Non-negotiable rules
 
-1. **Record the path live.** The first walkthrough _is_ the recording; never rehearse a path and reconstruct it afterward. [Live authoring](references/live-authoring.md) has the per-platform start order and the discover → echo → `flow-add-step` → inspect cycle.
-2. **Record each check when its state appears** — immediately after the transition or outcome it proves, before the next action. A check is recorded live as an `await-ui-element` call, which polish converts into the `await:`/`assert:` directive; an echo or raw `screenshot` is diagnostic context, not an executable verdict. Record absence as a trio in order — `visible` on the selector, the action that removes it, then `hidden` on the same selector; a `hidden` whose selector was never established cannot fail, so it proves nothing.
-3. **Target semantics, not screen positions.** Prefer strict `{ id: ... }`, then a stable `{ text: ... }` or accessibility label; `scroll-to` for an off-screen target. The recorder converts a `gesture-tap` to a selector whenever it can and **warns when it had to keep the raw point** — stop on that warning and fix the target while the screen is still in front of you, rather than at audit time. Keep a coordinate only after the **coordinate fallback gate** in [Reliability and recovery](references/reliability-and-recovery.md#coordinate-fallback-gate), and report each one.
-4. **After every screen change, prove identity, then readiness** — `await:` on an element that exists _only_ on the destination (never a shared tab bar, a source-screen element, or a positional id), then `await: { idle: true }`. Neither implies the other and a successful tap proves neither. They also arrive by different routes: identity is recorded live, readiness is a polish insertion (rule 5). [Live authoring](references/live-authoring.md#record-identity-then-readiness-after-every-navigation) has the procedure; [Flow YAML](references/flow-yaml.md#prove-a-navigation-identity-then-readiness) has why both are needed.
-5. **Polish only what ran.** Rewriting a recorded raw step into an equivalent directive is allowed — a recorded `await-ui-element` becomes `await:`/`assert:`, a focus tap plus `tool: keyboard` becomes `type:`. Everything else must come from a recorded step; return to the live workflow to execute any missing **action** through the recorder.
-
-   Exactly three unrecorded insertions are allowed, each only where you saw the condition live: `snapshot:` for an inherently pixel-level requirement, `await: { idle: true }`, and the Chromium packaging `launch:`. None of the three has a recorder form — see [Live authoring](references/live-authoring.md#finish-and-polish).
-
-6. **Replay the finished file end to end.** A flow is not done because its steps worked separately. `argent-qa-flows` adds the stronger requirement of two consecutive full passes.
+1. **Record the first walkthrough.** Start the recorder before the first launch or in-app action. Do not reconstruct a rehearsed path.
+2. **Record checks when their states appear.** Record `await-ui-element` live, then convert it during polish. An echo records intent or diagnostic context, not app behavior or a verdict. A screenshot is human evidence, not an executable verdict. For absence, record the same selector as `visible`, perform the removing action, then record it as `hidden`.
+3. **Use semantic targets.** Prefer a strict id, then stable text or an accessibility label. Use `scroll-to` for off-screen elements. Resolve every raw-point warning immediately through the [coordinate fallback gate](references/reliability-and-recovery.md#coordinate-fallback-gate).
+4. **Prove every screen change.** Record a destination-only identity check. During polish, follow it with `await: { idle: true }`. Stillness does not prove identity, and `idle` can pass with a warning.
+5. **Polish only executed behavior.** Convert recorded steps without changing their meaning. Record any missing action or structural check live. The only unrecorded insertions are a planned `snapshot:`, a navigation `await: { idle: true }`, and the documented Chromium packaging `launch:`.
+6. **Replay the final YAML end to end.** A normal flow needs one uninterrupted full pass. `argent-qa-flows` requires two consecutive passes.
 
 ### Stable selectors
 
-A selector is **stable** when its value is fixed by the app's code, not by data, locale, time, count, or position — it would survive a content refresh, a different account, and a re-order. IDs such as `save-button`, `settings-screen`, and `logout-action` are stable; `3 unread`, `Today`, `Item 4`, a username, or any data-derived number are not. Treat visible text as stable only when the app's code keeps it identical across every locale and environment the flow supports.
+A stable selector is fixed by app code and survives account, data, time, count, order, and every locale and environment the flow supports. Prefer ids such as `settings-screen`. Do not gate on values such as `Today`, `Item 4`, usernames, counters, or timestamps.
 
 ### Flow-only selector scopes
 
-During YAML polish, use the frame-based `within`, `after`, and `next` scopes to disambiguate repeated elements. Read [Flow YAML: Relational scopes](references/flow-yaml.md#relational-scopes) for syntax, exact semantics, and the traps.
+During polish, use `within`, `after`, and `next` to disambiguate repeated elements. Read [Flow YAML: Relational scopes](references/flow-yaml.md#relational-scopes) for their frame-based semantics and failure cases.
 
 ## Workflow
 
 1. Choose the flow type:
-   - **e2e:** first non-echo step is `launch:`; it controls process start and is suitable as a standalone entry point.
-   - **fragment:** no leading launch; declare a precise `executionPrerequisite` and run against that state.
-2. Work through [Live authoring](references/live-authoring.md) end to end: start the recorder, build and verify one step at a time, finish, polish, run the blocking audit, replay.
-3. Report the flow path, replay command, verification result, prerequisites or side effects, and every accepted coordinate/raw-gesture exception.
+   - **e2e:** the first non-echo step is `launch:`. The flow controls process start.
+   - **fragment:** there is no leading launch. Declare a precise `executionPrerequisite`.
+2. Follow [Live authoring](references/live-authoring.md): start, record one verified step at a time, finish, polish, audit, and replay.
+3. Report the file, replay command, result, prerequisite or side effects, and every coordinate or raw-gesture exception.
 
 ## Proactive recording
 
-Before re-running a path of three or more interactions — re-testing it, comparing a profile, or retrying it — tell the user, start the recorder, and record that run instead of repeating the path by hand. Replay it from then on.
+Before repeating three or more interactions, tell the user and start a recording. Record that run and replay it afterward. A completed path cannot be recorded retroactively.
 
-A path already walked cannot be recorded retroactively: the recorder has to be running during the execution you want to keep, so the decision has to be made before it, not after.
+## Repair
 
-## Flow self-improvement
-
-When a saved flow fails, do not silently discard it or patch around the failed check. Follow [Reliability and recovery](references/reliability-and-recovery.md): classify the failure, inspect the actual screen/tree, repair the smallest justified unit, audit again, and replay the full flow. Stop after two unsuccessful correction cycles and report the remaining blocker.
+When replay fails, follow [Reliability and recovery](references/reliability-and-recovery.md). Inspect the first divergence, correct the smallest justified unit, audit, and replay the full flow. Stop after two unsuccessful correction cycles. Never weaken a requested check to obtain a pass.

--- a/packages/skills/skills/argent-create-flow/references/flow-yaml.md
+++ b/packages/skills/skills/argent-create-flow/references/flow-yaml.md
@@ -1,12 +1,12 @@
 # Flow YAML
 
-Read this reference when polishing, manually reviewing, or composing a flow.
+Read this reference when polishing, composing, or manually reviewing a flow.
 
 - [File shape and flow type](#file-shape-and-flow-type)
 - [Selectors](#selectors)
 - [Directives](#directives)
 - [Verification conditions](#verification-conditions)
-- [Prove a navigation: identity, then readiness](#prove-a-navigation-identity-then-readiness)
+- [Prove a navigation](#prove-a-navigation-identity-then-readiness)
 - [Optional divergences](#optional-divergences)
 - [Composition and platform limits](#composition-and-platform-limits)
 - [Snapshots and standalone runs](#snapshots-and-standalone-runs)
@@ -21,35 +21,35 @@ steps:
   - await: { idle: true }
 ```
 
-An e2e flow's first non-echo step is `launch:`. It must not declare `executionPrerequisite` — the combination is a parse error. Put the named start state in a leading `echo:` instead.
+An e2e flow has a literal `launch:` as its first non-echo step. It cannot declare `executionPrerequisite`. Put the named start state in a leading echo.
 
-A leading `run:` does **not** make a flow e2e by that classification, but the runner still follows the chain to the launch it reaches. On Chromium that launch boots the app before step 1, exactly as a literal leading `launch:` does. On every platform, a flow whose leading `run:` chain reaches a launch is refused an `executionPrerequisite` too — parse accepts the file and the run then rejects it. The one way out is a run pinned to a Chromium instance you brought to the required state yourself (`--device chromium-cdp-<port>`), where the leading launch only attaches.
+A leading `run:` does not classify the outer flow as e2e, but the runner still follows the chain to the launch it reaches, and on Chromium that launch boots the app before step 1. A flow whose `run:` chain reaches a launch is refused an `executionPrerequisite` too: parse accepts the file, then the run rejects it. The one exception is a run pinned to a Chromium instance you brought to the required state yourself (`--device chromium-cdp-<port>`), where that leading launch only attaches.
 
-A fragment reaches no leading launch, by its own step or through a `run:` chain, and may declare:
+A fragment reaches no leading launch, by its own step or through a `run:` chain, and can declare:
 
 ```yaml
 executionPrerequisite: User is signed in and viewing Settings
 steps: []
 ```
 
-Flows never store a device id. The runner binds the selected/booted device. `launch:` restarts the app process; it does **not** clear persisted app, account, or backend data.
+Flows never store a device id. The runner binds the device. `launch:` restarts the process but does not clear app, account, or backend data.
 
 The one exception is a device _scope_ rather than a target: `stop-all-simulator-servers`' `devices` list **is** kept in the YAML, because without it the step means the machine-wide sweep and would tear down devices other agents are mid-session on. Replay rebinds a recorded scope only when you pass `device` explicitly — an auto-detected device would retarget the teardown at a device the flow never named. So the recorded ids are what run when you replay without `device`; on another host they reap nothing and come back in `unmatched`, so re-record the cleanup flow there or pass `device`. A step that recorded no scope is narrowed onto the run's device **only when the run resolved one**. A cleanup flow whose only step is that teardown needs no device, so with none or several booted it resolves none, replays as the machine-wide sweep, and still reports a pass. Record the scope, or pass `device` at replay, whenever the sweep must stay confined.
 
 ## Selectors
 
-Use selector values that meet the [stable-selector definition](../SKILL.md#stable-selectors). Write explicit selector maps:
+Use values that meet the [stable-selector definition](../SKILL.md#stable-selectors). Always write explicit maps:
 
 ```yaml
-{ id: save-button }       # exact testID/accessibilityIdentifier/resource-id
-{ text: Save }            # case-insensitive text/label substring
-{ role: button }          # case-insensitive role substring
-{ id: settings-row, text: Notifications } # fields all must match
+{ id: save-button }
+{ text: Save }
+{ role: button }
+{ id: settings-row, text: Notifications }
 ```
 
-`id` is exact and case-insensitive; an unqualified Android id such as `save-button` also matches `com.example:id/save-button`. `identifier` parses as an alias for `id`, but `id` is canonical and is what the recorder writes. A bare string is loose shorthand that tries id first and then text. Never write a bare string in a flow you author; always write the explicit map.
+All provided fields must match. `id` is exact and case-insensitive. `text` and `role` are case-insensitive substrings. An unqualified Android id also matches its qualified resource id. `identifier` is accepted as an alias, but `id` is canonical. Never author a bare string. It is loose shorthand that tries id before text.
 
-For dynamic native text, use an anchored, case-sensitive regex and single quotes:
+Use single quotes for anchored, case-sensitive regexes:
 
 ```yaml
 { text: { matches: '^Order #\d+$' } }
@@ -57,31 +57,31 @@ For dynamic native text, use an anchored, case-sensitive regex and single quotes
 
 ### The runner tree is not the discovery tree
 
-Flow selectors resolve against the runner's tree. The agent-facing `describe` tool and the live `await-ui-element` tool read a **different** projection of the same screen, and how the two differ is platform-specific — it decides what a missing element means:
+Flow selectors and live discovery use different screen projections:
 
-| Platform | Runner tree                                                                                | `describe` / `await-ui-element`         | How they differ                                                                                                                                                                                                |
-| -------- | ------------------------------------------------------------------------------------------ | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| iOS      | native UIView hierarchy                                                                    | accessibility tree                      | Each holds elements the other lacks; both name roles `AX…`, but the runner derives them from the UIView class name and `describe` from accessibility traits, so one element can carry a different role in each |
-| Android  | full accessibility hierarchy, including not-important views                                | the same dump, trimmed to interactables | Each holds elements the other lacks; the trim drops testID-only containers and merges nodes                                                                                                                    |
-| Chromium | the same DOM walk, keeping only nodes with an id, label, value, clickable or focused state | the whole DOM walk                      | The runner tree is a strict **subset**                                                                                                                                                                         |
-| Vega     | toolkit page source                                                                        | the same source                         | Same elements, re-shaped                                                                                                                                                                                       |
+| Platform | Runner tree                                               | `describe` / `await-ui-element` | Important difference                                                  |
+| -------- | --------------------------------------------------------- | ------------------------------- | --------------------------------------------------------------------- |
+| iOS      | native UIView hierarchy                                   | accessibility tree              | Each contains elements the other lacks; roles are derived differently |
+| Android  | full accessibility hierarchy                              | trimmed interactables           | Discovery can omit testID-only containers or merge nodes              |
+| Chromium | filtered DOM nodes with id, label, value, click, or focus | full DOM walk                   | The runner tree is a strict subset                                    |
+| Vega     | toolkit page source                                       | same source                     | Same elements, different shape                                        |
 
-Two consequences, both load-bearing:
+On iOS and Android, an id absent from `describe` can still resolve in a flow. Prefer the stable id and verify it in a scratch fragment. On Chromium, an element absent from `describe` cannot resolve. Add a test id instead.
 
-- **On iOS and Android**, a missing id in `describe` is not proof that the flow selector cannot resolve: prefer the id and verify it in a scratch fragment. **On Chromium the reverse holds** — what `describe` does not show, no selector can reach, and an element it does show carrying none of those five attributes is invisible to the runner. Give that element a testid instead of hunting for another selector.
-- A live `await-ui-element` check can pass against the tool's tree and mean nothing to the runner. The recorded `tool:` step still replays (that tool reads the tree it passed against); it is the `await:`/`assert:` directive polish converts it into that may not resolve. Replay the flow after polish and treat an unresolved converted wait as a polish-time blocker, not a recording failure.
-- **On iOS, never copy a `role` from `describe` into a flow selector.** A React Native `Pressable` is class `RCTView`, so the runner reads it `AXGroup` while its `button` trait makes it `AXButton` to `describe`; a `{ role: Button }` selector then matches nothing at replay. Confirm the role against the runner's own tree — the recorder derives its selectors from it — or select on `id`/`text` instead.
+A live wait can pass against its tree while the converted directive cannot resolve. Replay after conversion. Treat failure there as a polish blocker, not a recording failure.
 
-When several nodes match, what the runner does with them depends on the directive:
+**On iOS, never copy a `role` from `describe` into a flow selector.** The runner derives iOS roles from the UIView class name and `describe` from accessibility traits, so a React Native `Pressable` (class `RCTView`) is `AXGroup` to the runner and `AXButton` to `describe`. Select on `id`/`text`, or confirm the role against the runner's own tree.
 
-- **Action directives** (`tap`, `long-press`, `type`, `scroll-to`, `pinch`, `rotate`) take the most specific visible match. An exact text/identifier match beats a substring hit — a regex consuming the element's whole text counts as exact — then the smallest frame wins, then reading order.
-- **Conditions** (`await`, `assert`) do not rank. `exists` and `visible` hold when any match qualifies and `hidden` only when none does, so no single element is elected. `text` reads the **first visible match in reading order** (topmost, then leftmost).
+When several nodes match, the directive decides:
 
-An action and a check therefore name different elements wherever a container aggregates a child's text — the everyday iOS `accessible` wrapper. `tap` hits the exact leaf; `text.in` reads the container above it, so `equals` fails against text that is correct on screen. Give the element an `id` or a [relational scope](#relational-scopes) whenever an action and a check must agree on it, and use a stricter map when the ranking could still elect the wrong repeated element.
+- **Actions** (`tap`, `long-press`, `type`, `scroll-to`, `pinch`, `rotate`) take the most specific visible match: exact text/id beats substring, then the smallest frame, then reading order.
+- **Conditions** (`await`, `assert`) do not rank. `exists`/`visible` hold if any match qualifies and `hidden` only if none does; `text` reads the first visible match in reading order.
+
+A container that aggregates a child's text therefore splits them: `tap` hits the leaf while `text.in` reads the container, so `equals` fails against correct UI. Use an `id` or a [relational scope](#relational-scopes) when an action and a check must agree, and a stricter selector when ranking can still choose the wrong element.
 
 ### Relational scopes
 
-Flow YAML selectors also accept geometric, CSS-like relations. They work in every flow selector slot (`tap`, `type.into`, `await`, `assert`, `scroll-to`, `pinch.on`, `rotate.on`, `snapshot.cropOn`, and nested scopes), but not in the live `await-ui-element` tool.
+Flow selectors support frame-based `within`, `after`, and `next` in every selector slot. Live `await-ui-element` does not support them.
 
 ```yaml
 - tap: { text: Delete, within: { id: profile-card } } # inside a container
@@ -89,47 +89,30 @@ Flow YAML selectors also accept geometric, CSS-like relations. They work in ever
 - tap: { role: Switch, next: { text: Wi-Fi } } # nearest matching follower
 ```
 
-The relations are frame-based because platform flow trees are flattened. `within` means visual containment, so a child whose frame spills outside its parent's — an overflowing row, a popover anchored to a card — does not match it, however clearly it is that parent's child in the code. `after` and `next` use top-to-bottom/left-to-right reading order. Every anchor must be distinct; the synthetic screen root never counts.
+`within` means visual frame containment, not source-tree ancestry. Overflowing children and anchored popovers can fall outside it. `after` and `next` use top-to-bottom, left-to-right reading order. A target cannot satisfy its own `within`, `after`, or `next` anchor. The synthetic root never counts.
 
-`next` means the nearest **matching** follower, so it deliberately skips wrappers, spacers, and other non-matches. This differs from literal CSS `+`: if a Wi-Fi row has no switch, `{ role: Switch, next: { text: Wi-Fi } }` may find the next row's switch. Prefer `{ role: Switch, within: { id: wifi-row } }`, or assert that row-local control before acting, whenever the control may be absent.
+`next` finds the nearest matching follower and skips non-matches. It can therefore reach the next row when the intended row lacks a control. Prefer a stable row container with `within`, or assert the row-local control first.
 
-Scopes may combine and nest, with at most six scope keys per selector. Scope the target by a trusted container when a missing row control must fail instead of reaching another row. Use a strict map for an anchor you care about; a bare string keeps the loose identifier-first fallback and can bind to an unrelated id.
+Scopes can combine and nest, with at most six scope keys. Use strict selectors for anchors. Scope through a trusted container when a missing control must fail instead of reaching another row.
 
 ## Directives
 
-Every directive hard-stops the flow on failure; later steps are skipped. The set is `launch`, `tap`, `long-press`, `type`, `scroll-to`, `pinch`, `rotate`, `await`, `assert`, `wait`, `snapshot`, `run`, `when`, `echo`, and `tool`; `flow-execute`'s own tool description spells out each one's shape and options. What follows is only what that description does not say.
+Directives stop the flow on failure and skip later steps. `flow-execute` documents their shapes. The available directives are `launch`, `tap`, `long-press`, `type`, `scroll-to`, `pinch`, `rotate`, `await`, `assert`, `wait`, `snapshot`, `run`, `when`, `echo`, and `tool`.
 
-A bare `launch: com.acme.app` applies to every platform — and on Chromium it is read as the app **path**, so any flow that must run cross-platform needs the map form.
-
-The map takes `native:`, `ios:`, `android:`, `vega:`, and `chromium:`. `native:` is one id shared by iOS, Android, and Vega, and a per-platform key overrides it for that platform. That override is how a flow whose iOS bundle id differs from its Android package spells both:
+Use the launch map for cross-platform flows. A bare launch applies everywhere and becomes an app path on Chromium. The map takes `native:`, `ios:`, `android:`, `vega:`, and `chromium:`. `native:` is one id shared by iOS, Android, and Vega, and a per-platform key overrides it for that platform. `chromium:` accepts a relative or absolute app path. A launch that declares no id for the run's platform is an error, not a cue to switch platforms.
 
 ```yaml
 - launch: { native: com.acme.app, chromium: ../../app }
 - launch: { ios: com.acme.app, android: com.acme.app.android, chromium: ../../app }
 ```
 
-A launch that declares no id for the run's platform is an error, not a cue to switch platforms.
+An Android app that needs a non-launcher activity has no `launch:` form. Record `restart-app` with `activity` and keep the flow as a fragment.
 
-An Android app that must start on a non-launcher activity has no `launch:` form at all; record `restart-app` with its `activity` and accept that the flow is a fragment.
+In a `scroll-to` map, put the selector under `target:`. The map supports `up`, `down`, `left`, and `right` directions. The default is `down`; set it explicitly to reach a target above the viewport or along a horizontal carousel. If the target is already visible, the step is a safe no-op. `tap`, `type`, and `long-press` do not auto-scroll. Add `scroll-to` when the target can be off-screen. Use `within` for a nested scroller.
 
-A `scroll-to` map is always the options form — the target goes under `target:`. Only the bare-string form (`scroll-to: Logout`) omits it, and that spelling is a loose selector.
-
-`tap`, `type`, and `long-press` do not auto-scroll. Add `scroll-to` first whenever the target may be off-screen. Its `direction` is `up`, `down`, `left`, or `right`, and defaults to `down`; set it explicitly to reach a target above the viewport or along a horizontal carousel. `scroll-to` is a no-op if the target is already visible, and needs `within` for a nested scroller.
-
-`type` presses Enter unless `submit: false`. A polished focus-tap + raw keyboard pair normally needs `submit: false`, because the recording did not submit.
-
-Store secrets as `{{secret:APP_PASSWORD}}`, so one flow runs unchanged in CI and locally. The runner reads the first source that defines the name:
-
-1. the `ARGENT_SECRET_APP_PASSWORD` environment variable;
-2. `<project>/.argent/secrets.env`;
-3. `<project>/.env.local`, then `<project>/.env`;
-4. `~/.argent/secrets.env`.
-
-The two dedicated `secrets.env` files accept the bare name `APP_PASSWORD`. The shared dotenv files expose **only** `ARGENT_SECRET_`-prefixed keys, so a bare `APP_PASSWORD=…` in `.env` or `.env.local` is ignored and the placeholder stays unresolved. Use `{{secret:…}}` for any external value, not only sensitive ones — but every resolved value is redacted from output, so never use it for something a report must show.
+`type` presses Enter unless `submit: false`. A polished focus tap plus keyboard call usually needs `submit: false`. Store external values as `{{secret:NAME}}`. The runner uses the first source that defines the name: environment `ARGENT_SECRET_NAME`; project `.argent/secrets.env`; project `.env.local`, then `.env`; then `~/.argent/secrets.env`. The two `secrets.env` files accept the bare `NAME`, but the shared dotenv files expose only `ARGENT_SECRET_`-prefixed keys, so a bare `NAME=…` in `.env` or `.env.local` stays unresolved. The runner redacts every resolved value, so do not use a placeholder for content a report must show.
 
 ## Verification conditions
-
-The condition name is the key and its value is the selector:
 
 ```yaml
 - await: { visible: { id: settings-screen } }
@@ -139,59 +122,55 @@ The condition name is the key and its value is the selector:
 - assert: { text: { in: { id: result-count }, matches: '^\d+ results$' } }
 ```
 
-`text.in` locates one selector and compares its rendered/descendant text with exactly one of `contains` (case-insensitive substring), `equals` (case-insensitive exact match), or `matches` (case-sensitive JS regex). Substring boundaries are not implied: `contains: "Taps: 3"` is also satisfied by `Taps: 30`, so use `equals` or an anchored `matches` pattern when the complete value matters. Use a regex selector under `visible` when only the shape of free-standing text matters.
+`text.in` locates one element. It compares that element's rendered and descendant text with exactly one comparator:
 
-Use `await` for an outcome that may take time and `assert` for settled state. The default `await` wait is 7500 ms; `assert`'s fixed grace is 1000 ms. Add an `await.timeout` only after the 7500 ms default demonstrably expires, and only above it — a value below 7500 shortens the wait. `assert` rejects `timeout`; a timed check is an `await`.
+- `contains`: case-insensitive substring.
+- `equals`: case-insensitive full match.
+- `matches`: case-sensitive JavaScript regex.
 
-A negative condition such as `hidden` only says that no visible match exists in the current tree. It is true before the element ever appears, true if the selector is misspelled, and true on the wrong screen. Establish it positively first: prove the containing screen, and prove the same selector `visible` at some earlier point in the flow. A `hidden` whose selector never matched anywhere in the flow passes on every replay no matter what the app does, so it is not a check at all. When possible also verify a positive replacement or empty state.
+Use `equals` or an anchored regex when boundaries matter. For example, `contains: "Taps: 3"` also matches `Taps: 30`.
+
+Use `await` for an outcome that can take time. Its default is 7500 ms. Add a larger timeout only after the default expires. Use `assert` for settled state. It has a fixed 1000 ms grace and rejects `timeout`.
+
+A negative condition proves only that the current tree has no visible match. It also passes before the element appears, for a typo, or on the wrong screen. First prove the containing screen and the same stable selector as `visible`. Then perform the removing action and check `hidden`. Prefer an additional positive replacement or empty state.
 
 ## Prove a navigation: identity, then readiness
 
-A navigation needs two checks, and no single one covers both:
+Every screen change needs both checks:
 
 ```yaml
-- await: { visible: { id: profile-screen } } # identity: WHICH screen
-- await: { idle: true } # readiness: it stopped moving
+- await: { visible: { id: profile-screen } } # identity
+- await: { idle: true } # readiness
 ```
 
-**They are independent.** A dropped tap leaves the source screen perfectly idle, so readiness never proves identity. A destination element enters the tree while the transition is still animating over it, so identity never proves readiness.
+The identity selector must exist only on the destination. A dropped tap can leave the source screen idle. A destination element can enter the tree before its animation finishes. Therefore neither check replaces the other.
 
-Identity is an element that exists **only** on the destination ([which ones qualify](reliability-and-recovery.md#strong-transition-gates)).
+### `idle` readiness
 
-### `idle` — readiness
-
-The one condition that carries no selector, because stillness is a property of the whole screen. It returns the moment the screen has content and stops moving in **both** the UI tree and the rendered pixels, so the next tap resolves its target against a screen that has stopped rather than one still sliding under it.
+`idle` waits until the screen has content and stops changing in both the UI tree and pixels.
 
 ```yaml
 - await: { idle: true, stableFor: 400, timeout: 9000 }
 ```
 
-The pixel half is why it exists: an iOS push or modal dismissal commits its hierarchy up front and then animates a layer for a few hundred milliseconds, and a cross-fade or scrim moves no node at all. A tree-only wait returns mid-transition.
+`stableFor` (default 250) is how long stillness must hold. `timeout` (default 7500) is the budget for the whole wait, and parse rejects one that cannot contain a settle. A settle spans three reads across two 200ms polls. The floor is the longer of `stableFor` and the 400ms a settle spans, plus the 200ms of budget the closing round needs to start. The hold runs during those polls rather than after them, so only the longer of the two counts: the default 250ms hold needs 600ms and an 800ms hold needs 1000ms. Stillness is measured across intervals, so `stableFor: 0` means the first two agreeing intervals, not the first read. `idle` has no assert form and no `when:` form.
 
-`stableFor` (default 250) is how long stillness must hold. `timeout` (default 7500) is the budget for the whole wait, and the parser rejects one that cannot contain a settle. A settle spans three reads across two 200ms polls. The floor is the longer of `stableFor` and the 400ms a settle spans, plus the 200ms of budget the closing round needs to start. The hold runs **during** those polls rather than after them, so the two costs overlap and only the longer one counts: the default 250ms hold needs 600ms and an 800ms hold needs 1000ms.
+It **never fails a run.** Every outcome short of a clean settle passes with a warning, because readiness is not an acceptance criterion. Read that warning rather than stepping over it:
 
-Stillness is measured across intervals, so a settle takes at least three reads: `stableFor: 0` means "the first two agreeing intervals", not "the first read".
+- **the screen never held still** — it spent the timeout and was still moving on the last interval. A video, shimmer, carousel, or live text stays healthy while moving, and a load that never finished looks identical.
+- **a small part of it was still changing** — a spinner, caret, or progress dot moved through the hold. Too small to count as the screen moving, so the settle completed anyway.
+- **the screen was still for the last Nms** — the wait ran out mid-hold, so no settle was confirmed. It names the term that was short: a second agreeing interval, or the rest of `stableFor`. Raise this step's `timeout:`, because the wait was too short rather than the screen too busy.
+- **the tree stayed empty** — the screen rendered no accessible content: a canvas or video surface, or a screen that never arrived.
+- **settled on the UI tree alone** — no screenshot pair could be read, so presentation-layer animation was never waited out.
+- **too few reads** — a settle needs three reads across two intervals and this step got fewer, so it ended with no evidence either way.
 
-It has no `assert` form — waiting is the whole point — and no `when:` form. Prefer it over `wait:` for any transition with no element to gate on.
+Only a tree source that cannot be read stops the run, as an errored step — one still failing when the wait ends, one that wedges after answering, one that answers with an empty tree it flags as degraded (an unattached Vega toolkit, an AX service asking to be relaunched), or one that never answers (raise `timeout` before suspecting the app). The run is then not ok and every later step is skipped. A single failed read is not that: the hold restarts from the next good read.
 
-It **never fails a run.** Readiness is not an acceptance criterion, so every outcome short of a clean settle passes carrying a `warning` on the step. Read it rather than stepping over it:
-
-- **the screen never held still** — it spent the timeout and went ahead, and was still moving on the last interval. Healthy screens often never stop (a video, a shimmer, a carousel, live-updating text, which on Android moves the tree as well as the pixels), and a screen that never finished loading looks exactly the same from here.
-- **a small part of it was still changing** — a spinner, a caret, a progress dot, moving through the stretch of stillness the step settled on. Too small to be the screen moving, so the settle completed anyway; if it is a loading spinner, the screen was still loading when this step returned.
-- **the screen was still for the last Nms** — the wait ran out mid-hold, so the settle was never confirmed. The warning names the term that was short: a second agreeing interval, because one alone can be two samples either side of an animation's turning point, or the rest of `stableFor`. Raise this step's `timeout:` — here the wait was too short, not the screen too busy.
-- **the tree stayed empty** — the screen rendered no accessible content. Sometimes the app (a canvas, a video surface), sometimes a screen that never arrived.
-- **settled on the UI tree alone** — no screenshot could be read often enough to compare a pair, so the hierarchy held still but presentation-layer motion above it (a push, a fade, a dismissing modal) was never waited out.
-- **too few reads** — a settle needs three of them spanning two intervals, and this step got fewer, so it ended without evidence either way. A slow tree source, or a window blank for most of the wait.
-
-Only a tree source that cannot be read stops the run, as an `errored` step — one that is still failing when the wait ends, one that answers and then wedges, one that answers with an empty tree it flags as degraded (an unattached Vega toolkit, an AX service asking to be relaunched), or one that never answers within the step (that last may simply be slow: raise `timeout` before suspecting the app). That is a broken window, not a verdict about the app: the run is not ok and every later step is skipped. A single failed read is not that window: the hold restarts from the next good one, and a read that fails at the very end of the wait is named in the warning rather than stopping the run.
-
-One more limit: it says nothing about **which** screen settled, so it never replaces the identity gate.
-
-Add one during polish after each screen change, not after every step: it is a directive with no live tool behind it, and each costs roughly 0.5-1.5 s warm — more on the first capture of a run.
+`idle` proves readiness only and never identifies the screen, so it cannot serve as acceptance evidence or replace the identity gate. Gate the next action on a stable element. Add `idle` during polish after each screen change, not after every step.
 
 ## Optional divergences
 
-Use `when:` only for a one-sided optional path such as a coach mark:
+Use `when:` only for optional setup or an interstitial that reconverges:
 
 ```yaml
 - when: { visible: { text: Got it } }
@@ -199,40 +178,28 @@ Use `when:` only for a one-sided optional path such as a coach mark:
     - tap: { text: Got it }
 ```
 
-The guard may be one `exists`/`visible`/`hidden`/`text` condition or `{ platform: ios|android|chromium|vega }`. It uses the short assert grace. There is no `else` and no per-step `optional`; separate behavioral paths belong in separate flows. A skipped optional block is not a failure, but a required acceptance check must never live behind a condition that may skip it.
+The guard accepts one `exists`, `visible`, `hidden`, or `text` condition, or `{ platform: ios|android|chromium|vega }`. UI guards use the short assert grace and reject `timeout`. There is no `else` or per-step `optional`. Put separate behavioral paths in separate flows. Never place a required acceptance check inside `when:`.
 
 ## Composition and platform limits
 
-A `run:` target is a YAML path resolved against the directory of the flow file that contains the step, so `../shared/login.yaml` reaches a sibling directory rather than the project root. The `.yaml` suffix is optional: `run: login` and `run: login.yaml` both name `login.yaml` beside the flow.
+A `run:` target is a YAML path resolved against the directory of the flow file containing the step, so `../shared/login.yaml` reaches a sibling directory rather than the project root. The `.yaml` suffix is optional: `run: login` and `run: login.yaml` both name `login.yaml` beside the flow.
 
-- iOS/Android e2e flows may run fragments or other e2e flows inline; a nested e2e launch restarts its app.
-- Chromium boots one instance per launch **step**, not one per run. The leading launch — the flow's own, or the one its leading `run:` chain reaches — boots before step 1, unless you pinned the run with an explicit `device`, in which case that first launch only attaches to the instance you pinned. Every later launch boots a fresh instance, moves the run onto it, and tears down the instance the run already owned for that app path. Nesting a Chromium e2e flow with its own launch is therefore the supported way to give a sub-scenario its own app restart. `pinch` and `rotate` are rejected there — drive the app's own zoom or rotate controls instead.
-- Vega is remote-driven. The touch directives (`tap`, `long-press`, `type`, `scroll-to`, `pinch`, `rotate`) are unsupported; record `tool: tv-remote` and raw `tool: keyboard`, then gate every focus/navigation result with `await`.
+- iOS and Android can run fragments or e2e flows inline. A nested e2e launch restarts its app.
+- Chromium boots one instance per launch **step**, not one per run. The leading launch — the flow's own, or the one its leading `run:` chain reaches — boots before step 1, unless you pinned the run with an explicit `device`, where it only attaches. Every later launch boots a fresh instance, moves the run onto it, and tears down the instance the run already owned for that app path. Nesting a Chromium e2e flow with its own launch is therefore the supported way to give a sub-scenario its own restart. Chromium rejects `pinch` and `rotate`. Use the app's own zoom or rotate controls.
+- Vega uses `tool: tv-remote` and raw `tool: keyboard`. The touch directives (`tap`, `long-press`, `type`, `scroll-to`, `pinch`, `rotate`) are unsupported. Gate focus and navigation results with `await`.
 
 ## Snapshots and standalone runs
 
 `argent flow run <name> [--device <id>] [--platform ios|android|chromium|vega] [--update-baselines] [--output <dir>] [--json]` runs without an LLM and exits non-zero on failure.
 
-A raw `screenshot` captures evidence but never compares or fails on visual drift. Keep it for live inspection, diagnosis, or a human-reviewed before/after result. A `snapshot:` directive is executable verification: it compares the current pixels with a stored baseline and hard-fails on a missing baseline, excessive mismatch, or (for `cropOn`) region-size drift.
+A screenshot is human evidence. A `snapshot:` is executable visual verification. A missing baseline or excessive mismatch fails. A `cropOn` size change also fails. Use snapshots for color, layout, size, spacing, typography, clipping, overflow, images, icons, or stable component appearance. Use full screen for global changes and `cropOn` for one component.
 
-Use a snapshot when pixels are part of the requirement and structural selectors cannot prove the rendering:
+Do not use a snapshot as the only proof of navigation, persistence, data, accessibility state, logs, or network behavior. Avoid unstable timestamps, live data, ads, animation, and device drift. First establish deterministic state, identity, and readiness.
 
-- light/dark theme or other global color-mode changes;
-- layout, position, size, spacing, typography, clipping, overflow, image, or icon rendering;
-- a stable component whose appearance matters beyond its accessibility state.
+Baselines live under `.argent/flows/__baselines__/<flow>/` and are keyed by platform and full-capture geometry; `cropOn` also contributes its selector. Seed from a known-good state with `--update-baselines`. Inspect every baseline and require user review. Do not commit it yourself. Baseline creation or update is not a test pass. Never update a baseline only to make a diff pass. The default `maxMismatch` is 0.5 percent.
 
-Pair visual and structural evidence when the requirement is mixed. Use a full-screen snapshot for a global theme/layout and `cropOn` for one stable component to reduce unrelated noise.
-
-Do not use a snapshot as the only proof of navigation, persistence, data correctness, accessibility state, logs, or network behavior. Avoid it when timestamps, random/live data, ads, uncontrolled animation, or device drift make the pixels unstable. First make the screen deterministic and gate its identity/readiness with `await:` or `assert:`.
-
-Snapshot baselines live under `.argent/flows/__baselines__/<flow>/`, keyed by platform and full-capture resolution; `cropOn` also keys by selector. A `snapshot:` step fails when no baseline exists for the run's device class. Seed from a known-good state with `--update-baselines`, inspect every generated baseline against the requirement, tell the user it requires review, and do not commit it yourself. Baseline creation or update is not a test pass. Never update a baseline merely to make a failing diff green. The default `maxMismatch` is `0.5` percent.
-
-For iOS, Android, or Vega, record the seeding run's `--platform` and `--device` values and pass the same flags in CI so the device class stays pinned. For Chromium the class is the window's own pixel size, which the app sets and no launch argument changes: run with `--platform chromium` and omit `--device` so the runner boots the declared app path, rather than attaching to a running window of some other size. A window sized from host or session state produces a key CI cannot reproduce, and the step then fails for a missing baseline. The runner pins the iOS/Android status bar during a run to keep clock, battery, and signal changes out of full-screen visual diffs.
-
-`--output <dir>` writes failed snapshot baseline/current/diff images under `<dir>/<flow>/`, a stable directory for CI artifact upload.
+Pin `--platform` and `--device` for iOS, Android, or Vega. For Chromium the device class is the window's own pixel size, which the app sets and no launch argument changes: pass `--platform chromium` and omit `--device` so the runner boots the declared app path instead of attaching to a running window of another size. A window sized from host or session state produces a key CI cannot reproduce, and the step fails for a missing baseline. The runner pins mobile status bars during visual runs. `--output <dir>` writes failed baseline, current, and diff images under `<dir>/<flow>/` for CI artifact upload.
 
 ## YAML safety
 
-Quote strings containing `#`, `:`, or quotes. A bare `true`/`false` or a number in a text slot is rejected at parse, so quote those too; `yes`/`no`/`on`/`off` parse as plain strings. Use single quotes for regex containing backslashes.
-
-Parse failures include invalid directives, selector shapes, regexes, `else`, unsupported options, and an e2e flow that combines a leading `launch:` with `executionPrerequisite`.
+Quote strings containing `#`, `:`, or quotes. Quote numbers and `true` or `false` in text slots. Use single quotes for regexes with backslashes. Parsing rejects invalid directives, selectors, regexes, `else`, unsupported options, and e2e flows that also declare `executionPrerequisite`.

--- a/packages/skills/skills/argent-create-flow/references/live-authoring.md
+++ b/packages/skills/skills/argent-create-flow/references/live-authoring.md
@@ -1,8 +1,8 @@
 # Live authoring
 
-Read this file before creating or changing a flow. The saved path must be exercised through the recorder as it is discovered; only the final syntax cleanup happens afterward.
+Read this file before creating or changing a flow. Exercise the saved path through the recorder. Perform syntax cleanup only after finishing.
 
-- [Recorder tools](#recorder-tools)
+- [Recorder contract](#recorder-contract)
 - [Start in the correct order](#start-in-the-correct-order)
 - [Record the first walkthrough](#record-the-first-walkthrough)
 - [Finish and polish](#finish-and-polish)
@@ -10,46 +10,46 @@ Read this file before creating or changing a flow. The saved path must be exerci
 - [Blocking audit](#blocking-audit)
 - [Replay](#replay)
 
-## Recorder tools
+## Recorder contract
 
-`flow-add-step`'s `command` parameter takes an MCP tool name. Its `args` value is a JSON **string**, not an object, and is omitted for a no-argument tool:
+`flow-add-step.command` is an MCP tool name. `args` is a JSON string, not an object. Omit `args` for a no-argument tool.
 
 ```text
 command: "gesture-tap"
 args: "{\"udid\":\"DEVICE\",\"x\":0.5,\"y\":0.35}"
 ```
 
-Recording a `flow-execute` carries **two** flow names: the top-level `name` is the recording being appended to, `args.name` is the sibling being run (captured as a `run:` step).
+A recorded `flow-execute` has two names. The top-level `name` identifies the recording. `args.name` identifies the sibling flow captured as `run:`.
 
-### Recording contract
+Obey these lifecycle rules:
 
-- **Every recording tool takes `name` + `project_root`.** `flow-add-step`, `flow-add-echo`, and `flow-finish-recording` each name the recording they address, repeating the `name` and the absolute `project_root` (an error is returned if the path is not absolute) given to `flow-start-recording`. Nothing is carried over between calls.
-- **Recording _state_ is isolated; the device is not.** A recording is keyed by its output file, `<project_root>/.argent/flows/<name>.yaml`, so several can be open at once — different names, different projects — and one recording's steps never land in another's file. Nothing is isolated on the device: every step runs live, so two recordings driving one device interleave real UI actions, and one flow's recorded `restart-app` resets the app under the other. Give each concurrent recording its own device.
-- **Starting always truncates the `.yaml`.** `flow-start-recording` resets `<project_root>/.argent/flows/<name>.yaml` to an empty flow on every call — including a name that is only a saved file with no recording in progress, so starting under the name of a committed flow wipes it. `restarted: true` is reported only when a LIVE recording of that flow was discarded, so its **absence does not mean nothing was overwritten**. `discardedSteps` (in the return value) counts the discarded take, but can be absent even on a restart. Starting a _different_ flow abandons nothing.
-- **Pick a name unique to your task.** `(project_root, name)` has no ownership check, so another agent starting the same pair silently takes it over and your later appends land in _their_ recording, reporting success. If a call ever reports the recording is no longer active, restart under a fresh name rather than re-adding the step. A name that only _resolves_ to the same file counts as the same pair — a differently-cased one on macOS/Windows, or a flow (or `.argent/flows`) symlinked into a shared vault from two projects — because the key is the file the filesystem resolves to, not the spelling you passed. That collision is reported rather than silent: the second start says `restarted` with a `discardedSteps` count, and the first recording's next call fails with `… are the same file on this filesystem …` naming both spellings.
-- **Start before adding.** Adding to or finishing a flow with no recording in progress returns `No active recording for flow ...`, listing the flows live under the `project_root` you passed. Do not answer it with `flow-start-recording`: you get the same error when your take was finished or dropped by the concurrent-recording cap, and on those branches the `.yaml` is fully populated, so starting truncates a take you wanted. Copy the file aside or record under a fresh name. (A takeover by another agent does not reach this error at all — it resolves to _their_ recording and succeeds, per the previous bullet.)
-- **A call that errors records nothing. A call that merely reports failure still records.** When the tool being recorded throws, `flow-add-step` returns the error and appends nothing — fix the issue and try again. When it returns normally while reporting an unmet condition, the step **is** appended, and `message` still says the step was added; `await-ui-element` is the case that turns up in practice (see [Live waits and checks](#live-waits-and-checks)). Every recording tool returns the current flow file contents, so read them to confirm what actually landed.
-- **Edit mistakes out after finishing.** Remove or reorder steps in the `.yaml` once `flow-finish-recording` has run; editing it while the recording is still active can be overwritten by the in-memory copy.
+1. Pass the same `name` and absolute `project_root` to every recording tool.
+2. Choose a name unique to the task. Another caller can take over the same pair without an ownership check. The pair is keyed by the file the filesystem resolves to, not the spelling you passed, so a differently-cased name or a symlinked `.argent/flows` collides too. That collision is reported: the second start says `restarted`, and the first recording's next call fails naming both spellings.
+3. Give concurrent recordings separate devices. Their files are isolated, but their live device actions are not.
+4. Treat `flow-start-recording` as destructive. It always truncates the named YAML, including a finished or committed flow. `restarted` reports only a displaced live take.
+5. If a call says the recording is inactive, do not restart under that name. The completed take can still be on disk. Copy it aside or record under a fresh name.
+6. Inspect `toolResult`, `message`, and `flowFile` after each call. A call that errors records nothing, but a call that returns normally while reporting an unmet condition **does** append the step, and `message` says the step was added either way. `await-ui-element` is the case that turns up in practice (see [Live waits and checks](#live-waits-and-checks)).
+7. Edit or reorder the YAML only after `flow-finish-recording`. An active remote recording can overwrite mid-recording edits.
 
 ## Start in the correct order
 
 ### iOS, Android, and Vega e2e flows
 
 1. Call `flow-start-recording` before launching or touching the app.
-2. Make the first non-echo recorded action a plain `restart-app` with the device id and app id only. The recorder stores it as `launch:`. Extra restart arguments or a `delayMs` prevent that conversion — an Android `activity` is the case that turns up in practice, and it leaves a raw `tool:` step, so the flow is a fragment rather than e2e.
-3. Immediately record `await-ui-element` for the real first screen. Launch waits for platform automation readiness, not for app-specific loading or splash completion.
+2. Record a plain `restart-app` as the first non-echo action. Pass only the device id and app id. The recorder converts it to `launch:`.
+3. Record `await-ui-element` for the real first screen immediately after restart.
 
-Never build a selector, landmark, or echo reference from splash-screen content; wait for the real first screen and base the recorded path on that state.
+Extra restart arguments prevent `launch:` conversion. An Android `activity`, for example, leaves a raw tool step and therefore a fragment.
 
-On iOS, Argent must launch the app for the full selector tree to exist, and only `restart-app` guarantees that — `launch-app` foregrounds an already-running, uninstrumented process instead. See [Reliability and recovery: iOS selector recovery](reliability-and-recovery.md#ios-selector-recovery).
+Do not use splash content as a selector or landmark. Wait for the first real screen.
+
+On iOS, only `restart-app` guarantees an instrumented launch. `launch-app` can foreground an uninstrumented process. Use [iOS selector recovery](reliability-and-recovery.md#ios-selector-recovery) when the tree is missing.
 
 ### Chromium e2e flows
 
-**The app sets the Chromium window size, and no boot argument overrides it.** Electron ignores `--window-size`: the size comes from the app's own `BrowserWindow` options. Argent passes `electronArgs` straight through and never resizes the window, so there is nothing to request and nothing that can refuse a request.
+**The app sets the window size; no boot argument overrides it.** Electron ignores `--window-size` — the size comes from the app's own `BrowserWindow` options, and Argent never resizes the window. Boot a fresh target with `boot-device` and `electronAppPath`, then take one `screenshot` and record its pixel dimensions: that capture size is the snapshot device class ([Flow YAML: Snapshots](flow-yaml.md#snapshots-and-standalone-runs)) and must match when CI replays. If the app sizes its window from host or session state, say so in the report.
 
-Boot the target with `boot-device` and `electronAppPath`, then take one `screenshot` and record its pixel dimensions. That capture size is the snapshot device class ([Flow YAML: Snapshots](flow-yaml.md#snapshots-and-standalone-runs)), so it must be the same when baselines are seeded and when CI replays. Prefer a fresh boot over an already-running target, whose window may carry a size from an earlier session. If the app sizes its window from host or session state, record that in the report — its snapshots reproduce only where that state repeats.
-
-Call `flow-start-recording` after that boot and before the first in-app action, then record the first-screen wait live. `restart-app` has no Chromium support, so the call errors and records nothing, and a recorded Chromium flow is always a fragment — its launch is written in during polish rather than captured, and any `executionPrerequisite` the recording declared must go with it (a launch-first flow must not carry one). During polish, insert a leading Chromium launch that preserves the same app path and arguments, for example:
+After boot, start the recorder before the first in-app action. Record the first-screen wait. `restart-app` has no Chromium support, so the call errors and records nothing, and a recorded Chromium flow is always a fragment: its launch is written in during polish rather than captured, and any `executionPrerequisite` the recording declared must go with it. A launch-first flow must not carry one. During polish, add the matching launch:
 
 ```yaml
 steps:
@@ -59,212 +59,184 @@ steps:
         args: ["--enable-feature-flag"]
 ```
 
-The path is relative to the flow file's own directory, `.argent/flows/`, so `../../app` means `<project_root>/app`; an absolute path is also accepted. Copy the live boot arguments verbatim, and omit `args` when the boot passed none. This packaging exception represents the same app boot used for the live walkthrough; it is not permission to rehearse the UI path.
+The path is relative to `.argent/flows/`. Copy the live boot arguments verbatim, and omit `args` when the boot passed none. This packaging exception represents the boot already exercised live. It does not permit a rehearsed UI path.
 
 ### Fragments
 
-Stage the documented entry state before recording, then call `flow-start-recording` with a precise `executionPrerequisite`. Describe UI/account/platform state, never a concrete device id. Start recording before the first interaction that belongs to the fragment.
+Stage the entry state before recording. Then start with a precise `executionPrerequisite` that names UI, account, and platform state. Do not store a device id. Start recording before the fragment's first interaction.
 
 ## Record the first walkthrough
 
-For Vega, read [Flow YAML: Composition and platform limits](flow-yaml.md#composition-and-platform-limits) before applying this cycle — it is remote-driven and takes no touch gestures.
+For Vega, first read [Flow YAML: Composition and platform limits](flow-yaml.md#composition-and-platform-limits). Vega is remote-driven and does not use touch gestures.
 
-**Reach every screen by tapping through the app's own UI.** A recorded `open-url` skips the navigation the flow exists to exercise, so a broken entry point still passes. Starting the app is not navigation.
+Reach each screen through the app's UI. Do not replace tested navigation with `open-url`. Starting the app is not navigation.
 
-Repeat this cycle for every action:
+For every action:
 
-1. **Discover without mutating.** Call `describe`, `native-find-views` / `native-describe-screen` (iOS only), `debugger-component-tree` (React Native), or `screenshot` directly. These calls are intentionally not recorded. Never record a `debugger-*` step: `port` is not a device-bind key, so a recorded one replays against whatever Metro owns that port.
-2. **Choose a durable target.** Prefer an id, then a text/accessibility label meeting the [stable-selector definition](../SKILL.md#stable-selectors). For iOS ids, use `native-find-views` / `native-describe-screen`; the trimmed accessibility description may omit them.
-3. **Narrate before failure can occur.** Add an echo naming the current state, intended action, and expected destination/outcome.
-4. **Execute and record immediately.** Call `flow-add-step`; inspect `toolResult`, the `message`, and the returned flow file before moving on.
-5. **Verify immediately.** After navigation, prove identity then readiness (below) — the identity check is recorded live, the readiness gate is added during polish. Record requested outcome checks when the state first appears.
+1. **Discover without mutation.** Use `describe`, iOS native discovery, `debugger-component-tree`, or `screenshot`. Do not record discovery or `debugger-*` calls: `port` is not a device-bind key, so a recorded one replays against whatever Metro owns that port.
+2. **Choose a durable target.** Prefer a stable id, then stable text or an accessibility label. On iOS, use native discovery for ids that trimmed accessibility output omits.
+3. **Add an echo.** Name the current state, action, and expected outcome before the action can fail.
+4. **Execute through `flow-add-step`.** Inspect the result and returned YAML immediately.
+5. **Verify immediately.** Record outcome checks when their states first appear. After navigation, prove identity then readiness: record the identity check live, and add the readiness gate during polish.
 
 ### Record identity, then readiness, after every navigation
 
-On the destination screen, in this order:
+1. Record `await-ui-element visible` on an element unique to the destination.
+2. If a specific control marks application readiness, record another visible wait on that control before the next action.
+3. During polish, add `await: { idle: true }` after the identity check.
 
-1. **Identity.** Record `await-ui-element` `visible` on an element that exists **only** on the destination — its root id, or a control no other screen in the flow shows. Anything the source screen also has passes without the navigation happening, so it proves nothing.
-2. **Readiness.** Add `- await: { idle: true }` during polish, and name in the preceding echo what it is waiting out. It is a directive, not a tool, so it cannot be recorded live — do not persist `await-screen-idle` instead, which reads only the tree and returns while a transition is still animating over it.
+A shared tab bar, source element, or positional id does not prove navigation. `idle` cannot identify the screen or prove application data is ready. Keep the control wait because asynchronous loading can continue after stillness. If the screen intentionally moves, disclose it and gate the next action on a stable element. Read [Flow YAML: Prove a navigation](flow-yaml.md#prove-a-navigation-identity-then-readiness) for the directive semantics.
 
-   It never fails; a screen that never settles passes with a `warning` on the step. **If you saw something moving on this screen — a video, a shimmer, a carousel, a spinner — expect that warning**, say so in the echo, and make sure the next action is gated on a stable element rather than on stillness.
+### Record absence in three steps
 
-   Where a specific control marks the screen usable, record an `await-ui-element` on that control as well — but it does not replace the `idle` gate, which is what waits out motion the tree cannot see.
+Use the same stable selector for both checks:
 
-[What qualifies as destination-only](reliability-and-recovery.md#strong-transition-gates).
+1. Record it as `visible`.
+2. Record the action that removes it.
+3. Record it as `hidden`.
 
-### Record absence in three steps, in this order
-
-A `hidden` wait whose selector never matched anywhere in the flow can never fail — it passes just as happily on a typo'd selector or the wrong screen. Record the trio:
-
-1. `await-ui-element` `visible` on the selector, while the element is on screen;
-2. the action that removes it;
-3. `await-ui-element` `hidden` on the same selector.
-
-Step 1 is what makes step 3 falsifiable, so it must carry the **same** selector — an id or spelling that drifts between the two leaves the absence check proving nothing. A step-1 locator with no identity term of its own (a regex `text` match, a role-only selector) is no evidence either.
+Without step 1, `hidden` also passes for a typo or an element that never existed. A role-only or regex-only first locator does not establish a specific element.
 
 ### Taps
 
-`flow-add-step` cannot receive a flow selector directly. Locate the element by id/text first, then record `gesture-tap` at the center of its discovered frame. The live coordinates are transport for the gesture, not an acceptable final locator.
-
-The recorder reads the **pre-tap** tree and derives the selector in a fixed order — `id`, then `text`, then the element's `role` — which gives three outcomes. Only two of them warn, so read the returned flow file after every recorded tap:
+`flow-add-step` cannot receive a flow selector directly. Discover the element first, then record `gesture-tap` at its frame center; the live coordinates are transport for the gesture, not a final locator. The recorder reads the pre-tap tree and derives the selector in a fixed order — `id`, then `text`, then `role` — giving three outcomes. Read the returned flow file after every tap, because only two of them warn:
 
 1. **`tap: { id: ... }` or `tap: { text: ... }`** — the good case.
-2. **`tap: { role: ... }`, appended with no warning at all.** An icon-only button carrying neither id nor visible label lands here. `role` matches as a case-insensitive substring, so a replay screen holding a second control of that role can win the [ranking](flow-yaml.md#the-runner-tree-is-not-the-discovery-tree), and the tap lands on the wrong control and reports a pass. Treat it exactly like a kept coordinate: re-record against an id/text target, or clear it through the coordinate fallback gate.
-3. **A kept raw point**, appended with a **warning naming the reason and the retarget**.
+2. **`tap: { role: ... }`, appended with no warning.** An icon-only button with neither id nor visible label lands here. `role` matches as a case-insensitive substring, so a replay screen holding a second control of that role can win the [ranking](flow-yaml.md#the-runner-tree-is-not-the-discovery-tree) and the tap reports a pass on the wrong control.
+3. **A kept raw point**, with a warning naming the reason and the retarget.
 
-Act on outcome 2 or 3 before the next action: return to the screen the tap started from — with direct MCP calls, never through `flow-add-step` — record the corrected tap, and delete the weak step after `flow-finish-recording`. Do not leave both. Keep a point or a bare role only after the **coordinate fallback gate** in [Reliability and recovery](reliability-and-recovery.md#coordinate-fallback-gate).
+Treat outcomes 2 and 3 alike. Restore the source screen with direct MCP calls, record a corrected tap, then remove the weak step after finishing. Keep a point or a bare role only through the [coordinate fallback gate](reliability-and-recovery.md#coordinate-fallback-gate).
 
-**Never record a tap on the on-screen keyboard.** Some platforms expose the whole keyboard as ONE addressable node, so a tap on a key records a selector for the keyboard and replays at its centre — a different key, reported as a pass. The recorder cannot tell that node from a legitimate large control. Type with `keyboard`, which polish folds into `type:`.
+Never tap the on-screen keyboard through the recorder. Some platforms expose it as one large node, so replay can tap the wrong key while reporting success. Record text with `keyboard`.
 
 ### Typing
 
-Record the focus tap, then record `keyboard`. Use `describe` or an app validation marker to confirm the complete value appeared. If characters were lost, restore the field with direct MCP tool calls (never through `flow-add-step`). Do not record a duplicate typing step.
+Record the focus tap, then record `keyboard`. Verify the complete value with `describe` or an app validation marker.
 
-**Never `describe` or `screenshot` a non-secure field you just filled from `{{secret:…}}`.** Only a password field is redacted; a plain text input hands the resolved value straight back into your context, and an API key, token, or licence code typed into one is the ordinary case. Submit or navigate away first, then verify the resulting screen.
+**Never `describe` or `screenshot` a non-secure field you just filled from `{{secret:…}}`.** Only a password field is redacted; a plain text input hands the resolved value back into your context, and an API key or token typed into one is the ordinary case. Submit or navigate away first, then verify the resulting screen.
 
-**`describe` reports focus on Chromium only.** iOS and Android leave the field unset — it is a Vega/D-pad signal there — so no live pre-typing focus check exists on those two platforms, and confirming the value afterwards is what proves the keys landed in the intended field. On Chromium, read `focused` before recording `keyboard`.
+**`describe` reports focus on Chromium only.** iOS and Android leave it unset — it is a Vega/D-pad signal there — so those platforms have no live pre-typing focus check, and the value check afterwards is what proves the keys landed. On Chromium, read `focused` before recording `keyboard`.
 
-Polish folds the focus tap and keyboard step into `type:`, which at replay re-taps the field and waits for it to take focus before injecting keys. That replay wait reads the runner's own tree, which **does** report focus on iOS, Android, and Chromium. It is still best effort: an unconfirmed poll falls through to typing when its budget runs out rather than failing the step. So keys can go wherever focus actually is, which is why the value is verified after typing.
-
-Never record a credential literal. Use `{{secret:NAME}}`, resolved at run time from `ARGENT_SECRET_NAME` or a secrets file — see the `keyboard` section of `argent-device-interact` for the full source order.
+If characters are lost, restore the field with direct calls. Do not record a duplicate typing step. Polish the valid pair into `type:`. Its replay focus wait reads the runner's own tree, which does report focus on iOS, Android, and Chromium, but an unconfirmed poll falls through to typing rather than failing — so retain the committed-value check. Store credentials as `{{secret:NAME}}`. Never record a literal credential.
 
 ### Scrolling and swiping
 
-During the live walkthrough, record `gesture-swipe` or Chromium `gesture-scroll` when movement is required. During polish:
+Record the required live gesture. During polish:
 
-- movement whose purpose is to reveal an element becomes selector-targeted `scroll-to`;
-- a raw swipe survives only when the gesture itself is under test, such as swipe-to-dismiss, edge-back, or reveal-row-actions.
+- Convert element-seeking movement to selector-based `scroll-to`.
+- Retain a raw swipe only when the gesture itself is under test.
 
-For every retained raw gesture, add an echo naming the gesture target and record an `await-ui-element` condition that proves its result; polish that condition to `await:` or `assert:`.
+For every retained raw gesture, add an echo and a recorded result check.
 
 ### Live waits and checks
 
 Record `await-ui-element` through `flow-add-step`. An unmet condition is not an error: the tool returns normally, `message` reports the step was added, and the only sign of failure is `toolResult.success: false` with a `note`. **The step is in the flow file.** Read `toolResult.success` after every recorded check.
 
-When it is `false`, fix the selector or justified timeout, record the check again, and delete the failed step after `flow-finish-recording`. Do not leave both. A stale `hidden` whose selector matches nothing replays as a silent pass, which is exactly the unfalsifiable gate that [Record absence in three steps](#record-absence-in-three-steps-in-this-order) exists to prevent. Never proceed as though the gate passed. Read the `await-ui-element` section of `argent-device-interact` for the complete live condition and selector reference.
+When it is false, fix the selector or justified timeout, record the check again, and delete the failed step after `flow-finish-recording`. Do not leave both. A stale `hidden` whose selector matches nothing replays as a silent pass — the unfalsifiable gate that [Record absence in three steps](#record-absence-in-three-steps) exists to prevent. Never proceed as though the gate passed. See the `await-ui-element` section of `argent-device-interact` for the full live condition and selector reference.
 
-**A wait that passes live can still be unconvertible**, because the tool and the runner read different projections of the screen ([per-platform table](flow-yaml.md#the-runner-tree-is-not-the-discovery-tree)). The raw step replays fine either way; it is the `await:`/`assert:` conversion that can fail to resolve. Check each converted wait at polish by replaying the flow, and either re-record it with a selector present in both trees or keep the step raw on purpose.
-
-The live wait tool spells an identifier selector as `identifier`; polished flow YAML uses canonical `id`.
+The live tool and flow runner use different trees. A live wait can pass while its converted directive cannot resolve. Replay every conversion. Keep the raw tool only when its `pollIntervalMs` or `bundleId` is required. Live tools use `identifier`. Flow YAML uses `id`.
 
 ### Wrong turns
 
-Stop immediately. Restore the last valid screen with direct MCP tool calls — invoked normally, never through `flow-add-step`, so nothing is appended to the flow — note the bad recorded step, and continue only from verified state. Do not edit a flow file while its recording is in progress: remote/client recording may keep an authoritative in-memory copy. Remove the bad step after `flow-finish-recording`; if recovery changed or skipped meaningful behavior, re-record that portion live instead of fabricating it.
+Stop immediately. Restore the last valid screen with direct MCP calls, not `flow-add-step`. Continue only from verified state. Remove the bad step after finishing. If recovery changed or skipped meaningful behavior, re-record that portion live.
 
 ## Finish and polish
 
-Call `flow-finish-recording`, then read the saved YAML. For recorded steps, apply only semantics-preserving conversions:
+Call `flow-finish-recording`, then read the saved YAML. Apply only meaning-preserving conversions:
 
-| Recorded form                             | Finished form                                                       |
-| ----------------------------------------- | ------------------------------------------------------------------- |
-| focus `tap` + `tool: keyboard`            | `type: { into: <selector>, text: ..., submit: false }`              |
-| keyboard text ending in Enter             | `type:` without `submit: false`; remove Enter from `text`           |
-| `tool: await-ui-element` transition/check | `await:` or `assert:`                                               |
-| element-seeking swipe/scroll              | `scroll-to:` with target selector, direction, and optional `within` |
-| coordinate `tap`/`long-press`             | strict id/text selector after the coordinate fallback gate          |
-| `tool: gesture-pinch`                     | `pinch: { on: <selector>, scale: endDistance / startDistance }`     |
-| `tool: gesture-rotate`                    | `rotate: { on: <selector>, by: endAngle - startAngle }`             |
-| generic `tool: flow-execute` of a sibling | recorder-captured `run:` directive                                  |
+| Recorded form                | Finished form                                                      |
+| ---------------------------- | ------------------------------------------------------------------ |
+| focus tap + `tool: keyboard` | `type:`                                                            |
+| keyboard ending in Enter     | submitted `type:` without Enter in its text                        |
+| `tool: await-ui-element`     | `await:` or `assert:`                                              |
+| element-seeking movement     | `scroll-to:`                                                       |
+| coordinate tap or long-press | strict selector after the fallback gate                            |
+| `tool: gesture-pinch`        | selector-based `pinch:` with `scale = endDistance / startDistance` |
+| `tool: gesture-rotate`       | selector-based `rotate:` with `by = endAngle - startAngle`         |
+| sibling `tool: flow-execute` | recorder-captured `run:`                                           |
 
-Only three unrecorded insertions are allowed during polish, each where you saw the condition live:
+Only these unrecorded insertions are allowed, at states observed live:
 
-- `snapshot:`, which captures state without performing a new app action. Follow [Flow YAML: Snapshots and standalone runs](flow-yaml.md#snapshots-and-standalone-runs) for baseline handling.
-- `await: { idle: true }` as the readiness half of a navigation, named by the preceding echo.
-- The documented leading Chromium `launch:` that packages the same app path and arguments used by the live `boot-device` call.
+- A planned `snapshot:` for pixel-level evidence.
+- `await: { idle: true }` after a navigation identity check.
+- The Chromium launch that packages the live boot.
 
-Preserve a raw form only when conversion would change behavior:
+Keep raw forms only when conversion changes behavior. Examples include point-anchored or panning pinch, velocity-sensitive swipe, or rotation with a tested start angle, radius, pivot, duration, or speed. Keep screenshots for human evidence. Use `snapshot:` for automated visual comparison. Read [Flow YAML](flow-yaml.md) for syntax.
 
-- Keep `tool: await-ui-element` only when its `pollIntervalMs` or `bundleId` is required. It is unrelated to the fixed `wait:` directive.
-- Keep a raw swipe only for a semantic or velocity-sensitive gesture.
-- For a pinch, derive `scale` from the recorded distances and target the selector under its center.
-- Keep `tool: gesture-pinch` only when it is point-anchored inside a large element or deliberately pans with `endCenterX`/`endCenterY`; the directive would recenter it. Keep `tool: gesture-rotate` only when its explicit radius, start angle, or duration is part of the gesture under test; `rotate:` derives all three from the target and the screen edges.
-- Keep raw screenshots for useful human-reviewed before/after or diagnostic evidence. For automated visual verification, add `snapshot:` according to [Flow YAML](flow-yaml.md#snapshots-and-standalone-runs).
-
-See [Flow YAML](flow-yaml.md) for exact syntax.
-
-If polish reveals a missing action or acceptance check, the flow is incomplete. Restore its preceding state and execute the missing behavior through the recorder, or re-record; do not append remembered behavior directly to YAML.
+If polish reveals a missing action or structural check, restore its preceding state and record it. Do not add remembered behavior directly to YAML.
 
 ## Worked example
 
-This session records a third-party app path; the comments show what the recorder captures before polish:
-
-`FLOW` below abbreviates `name: "open-settings", project_root: "/Users/dev/AcmeNotes"` — every call repeats it verbatim.
+`FLOW` below abbreviates `name: "open-settings", project_root: "/Users/dev/AcmeNotes"`. Repeat both fields in every call.
 
 ```text
-flow-start-recording { name: "open-settings", project_root: "/Users/dev/AcmeNotes" }
-flow-add-echo { FLOW, message: "Restart Acme Notes; expect the real Home screen" }
+flow-start-recording { FLOW }
+flow-add-echo { FLOW, message: "Restart Acme Notes; expect Home" }
 flow-add-step { FLOW, command: "restart-app", args: "{\"udid\":\"ABC\",\"bundleId\":\"com.acme.notes\"}" }
 # captured as: - launch: com.acme.notes
 flow-add-step { FLOW, command: "await-ui-element", args: "{\"udid\":\"ABC\",\"condition\":\"visible\",\"selector\":{\"identifier\":\"home-screen\"}}" }
-flow-add-echo { FLOW, message: "On Home; open Settings and expect the Settings screen" }
+flow-add-echo { FLOW, message: "On Home; open Settings" }
 flow-add-step { FLOW, command: "gesture-tap", args: "{\"udid\":\"ABC\",\"x\":0.91,\"y\":0.94}" }
-# pre-tap capture resolves the point to: - tap: { id: settings-tab }
+# pre-tap capture resolves to: - tap: { id: settings-tab }
 flow-add-step { FLOW, command: "await-ui-element", args: "{\"udid\":\"ABC\",\"condition\":\"visible\",\"selector\":{\"identifier\":\"settings-screen\"}}" }
 flow-finish-recording { FLOW }
 ```
 
-After converting the recorded `await-ui-element` tools to directives, the finished flow is:
+After meaning-preserving conversion:
 
 ```yaml
 steps:
-  - echo: Restart Acme Notes; expect the real Home screen
+  - echo: Restart Acme Notes. Expect Home
   - launch: com.acme.notes
-  - await: { visible: { id: home-screen } } # identity: which screen
-  - await: { idle: true } # readiness: it stopped moving
-  - echo: On Home; open Settings and expect the Settings screen
+  - await: { visible: { id: home-screen } }
+  - await: { idle: true }
+  - echo: On Home. Open Settings
   - tap: { id: settings-tab }
-  - await: { visible: { id: settings-screen } } # identity: which screen
-  - await: { idle: true } # readiness: it stopped moving
+  - await: { visible: { id: settings-screen } }
+  - await: { idle: true }
 ```
-
-Both screen changes carry the pair. Each `idle` gate is added during polish — it is a directive with no live tool to record.
 
 ## Blocking audit
 
-Review the file before replay. Run all four greps and resolve every hit.
+Run these checks before replay:
 
 ```text
-# 1. Weak targets: coordinates, raw gestures, and role selectors
+# Weak targets: coordinates, raw gestures, role-only selectors
 rg -n '(\{ *x:|^ +(x|centerX|fromX|toX):|gesture-(tap|swipe|scroll|drag|pinch|rotate|custom))' .argent/flows/<name>.yaml
 rg -n -B2 '^ +role:' .argent/flows/<name>.yaml
-
-# 2. Stored device ids
+# Stored device ids
 rg -n '(udid|device_id)' .argent/flows/<name>.yaml
-
-# 3. Unstable gate values: positional ids, and bare (loose) selectors in a condition
+# Positional ids and loose condition selectors
 rg -n '(-selector-\d+|selector-\d+\b)' .argent/flows/<name>.yaml
 rg -n '(visible|hidden|exists) *: *["'"'"'A-Za-z0-9]' .argent/flows/<name>.yaml
-
-# 4. Fixed sleeps, and navigation that skipped the UI
-rg -n '^\s*- wait:' .argent/flows/<name>.yaml
-rg -n 'open-url' .argent/flows/<name>.yaml
+# Fixed waits and skipped navigation
+rg -n '^\s*- wait:|open-url' .argent/flows/<name>.yaml
 ```
 
-- Convert every element-targeting point to a selector. Each coordinate `tap:` warned you when it was recorded; this grep is the second chance, not the first, so every remaining hit has to defend itself.
-- **A `role:` that is the only key under a `tap:`/`long-press:` is the recorder's silent fallback** — it warned you about nothing. Replace it with an id/text selector, or clear it through the coordinate fallback gate. A `role:` sitting beside another field or a scope (`within`, `after`, `next`) is a deliberate selector and needs no defence.
-- Convert every raw gesture used only to find an element to `scroll-to`.
-- For each remaining point/raw gesture, require the exception evidence and expected-result check from the **coordinate fallback gate** in [Reliability and recovery](reliability-and-recovery.md).
-- Require zero stored device ids and zero literal credentials.
-- **Reject every positional id in a gate.** Replace with a stable destination-only root or control id.
-- **Rewrite every bare-selector condition into an explicit map.** Grep 3's second pattern lists them: it matches a condition key with a scalar after it — `visible: Save` — and not `visible:` opening a map. It covers `when:` guards too, which take the same loose fallback.
-- **Reject data-derived gate values** — a counter, count, username, timestamp, or any number the app computes. Read every `text:` gate and confirm its value is fixed by the app's code; use an anchored `{ matches: '^…$' }` when the full value matters.
-- **Every `wait:` must justify itself** — a preceding echo and a following `await:`/`assert:` that proves the state. Prefer replacing it with `await: { idle: true }`.
-- **Reject every `open-url` that stands in for a navigation** — restore the source screen and record the tap path live.
-- Confirm every added `snapshot:` is intentional, non-mutating, and ready for reviewed baseline creation.
-- Confirm the first non-echo e2e step is `launch:` and the next functional step gates the real first screen. If either is missing on mobile/Vega, record it live; only the documented Chromium packaging launch may be inserted during polish.
-- **Confirm every navigation has identity and readiness proof** — walk the file top to bottom and, for each action that changes screens, name the two gates that follow it. The two are repaired differently: a missing identity gate must be recorded live, so restore that screen and record the `await-ui-element` check, while a missing readiness gate is added in YAML, because `await: { idle: true }` is one of the three polish insertions with no recorder form.
-- Confirm every `hidden` gate is preceded by the **same selector** proved `visible` earlier in the flow. A proven containing screen is not a substitute — it is no evidence that the selector string itself ever resolved. Without that leg the `hidden` check passes on every replay whatever the app does.
+The condition grep matches a condition key with a scalar after it — `visible: Save` — and not `visible:` opening a map. Recorder output is always block style, so both forms are one line below their `await:`/`assert:`. It covers `when:` guards too, which take the same loose fallback.
+
+Resolve every hit and confirm:
+
+- Every element action uses a stable selector unless the fallback gate cleared and documented it.
+- **No `role:` stands as the only key under a `tap:`/`long-press:`.** That is the recorder's silent fallback, which warned about nothing. Replace it, or clear it through the fallback gate. A `role:` beside another field or a scope (`within`, `after`, `next`) is deliberate and needs no defence.
+- Every element-seeking gesture became `scroll-to`.
+- No device id or literal credential remains.
+- Every selector-bearing condition uses an explicit selector map without positional or data-derived values.
+- Every fixed wait has an echo and a following hard check. Prefer a condition or `idle`.
+- No `open-url` replaces tested navigation.
+- Every snapshot is intentional, deterministic, non-mutating, and ready for reviewed baseline creation.
+- The e2e launch and real first-screen gate are present. Only Chromium permits an inserted launch.
+- Every screen change has a destination-only identity check and an `idle` readiness check. The two are repaired differently: record a missing identity check live on the restored screen, but add a missing readiness gate in YAML, because `await: { idle: true }` has no recorder form.
+- Every `hidden` check follows a `visible` check on the same stable selector and the removing action. A proven containing screen is not a substitute, because it is no evidence the selector itself ever resolved.
 
 ## Replay
 
-Run `flow-execute` on the complete polished flow with the absolute project root. For a fragment, verify its prerequisite and rerun with `prerequisiteAcknowledged: true` when requested. A replay you rescued by hand is not a pass: if you tapped, waited, or reset anything to get the run through, the pass does not count.
+Run `flow-execute` on the complete YAML with the absolute project root. For a fragment, verify its prerequisite before setting `prerequisiteAcknowledged: true`.
 
-`flow-execute` takes exactly one flow source: `name`, for a flow saved under `.argent/flows/`, or `flow_path`, an absolute path to any flow `.yaml`. A flow's `run:` targets and baselines resolve on the **tool server's** filesystem, beside the YAML it actually reads. `flow_path` therefore requires the agent and the tool server to share a filesystem and is refused when they do not; `name` still runs there, but a remote call reaches the server as an upload of that one YAML into a fresh temp directory, so a `run:` target fails as a missing fragment and a `snapshot` fails for a missing baseline. Replay self-contained flows remotely; one that composes or snapshots needs both on one filesystem.
+`flow-execute` takes exactly one flow source: `name`, for a flow saved under `.argent/flows/`, or `flow_path`, an absolute path to any flow `.yaml`. `run:` targets and baselines resolve on the tool server's filesystem, beside the YAML it actually reads. `flow_path` therefore requires the agent and the tool server to share a filesystem and is refused when they do not. `name` still runs remotely, but the server receives only that one YAML in a fresh temp directory, so a `run:` target fails as a missing fragment and a `snapshot` fails for a missing baseline. Replay self-contained flows remotely; a composing or snapshotting flow needs one shared filesystem.
 
-An `errored` step is not a failed one: it was never evaluated. The cases are an `await: { idle: true }` whose tree source could not be read, a step that threw, a `run:` target that does not resolve, and a `launch:` that did not start the app. Fix what the reason names and rerun; a step that could not be evaluated never counts for or against a pass.
+Manual rescue invalidates the pass. An `errored` step was never evaluated: an `idle` wait whose tree source could not be read, a step that threw, an unresolvable `run:` target, or a `launch:` that did not start the app. Read the reason — most name the environment, but a failed `launch:` is a verdict about the app. Unconfirmed focus is not in this class at all: the replay focus poll has no failure return, so a `type:` step whose focus was never confirmed is scored a **pass**, and only the value check after typing catches it.
 
-Unconfirmed focus is **not** one of them. The replay-side focus poll has no failure return — a source that cannot report focus returns at once, and an unconfirmed poll falls through to typing when its budget runs out — so the `type:` step is scored a **pass**. Keys landing outside the intended field show up in the value check after typing, nowhere else.
+**A passing step that carries a `warning` is a finding, not noise.** `await: { idle: true }` raises [six different warnings](flow-yaml.md#idle-readiness) and they do not share one meaning. Two say the screen was moving; one says the wait ran out mid-hold and is repaired by raising the step's `timeout:`; one says the tree stayed empty; one says the tree did hold still and only the screenshot pairs were missing, so the capture path is what to check; one says the step ended with no evidence either way. No report separates intended motion from a load that never finished. Read which one it is, look at that screen, disclose what you found, and confirm the following step targets a stable element rather than stillness.
 
-**A passing step that carries a `warning` is a finding, not noise.** `await: { idle: true }` raises [six different warnings](flow-yaml.md#idle--readiness), and they do not share one meaning: the screen never held still, a small part of it kept changing, the screen was still but the wait ran out mid-hold, the tree stayed empty, the settle saw the tree alone, or there were too few reads. Read which one it is. Only the first two say the screen was moving; the third says the wait was too short and is repaired by raising the step's `timeout:`; the fourth says the screen rendered no accessible content; the fifth says the tree did hold still and only the screenshot pairs were missing, so the capture path is what to check; the sixth says the step ended with no evidence either way. No report distinguishes intended motion from a load that never finished. Go and look at that screen, disclose what you found, and confirm the following step targets a stable element rather than stillness.
-
-The base create-flow gate is one uninterrupted full pass of the finished YAML. Return to the invoking skill for any stronger completion rule: `argent-qa-flows` requires two consecutive full passes of the unchanged flow. For CI, use `argent flow run <name> [--platform ...]`; it exits non-zero on failure.
+One uninterrupted full pass completes a normal flow. `argent-qa-flows` requires two consecutive passes of unchanged YAML. For CI, use `argent flow run <name> [--platform ...]`; it exits non-zero on failure.

--- a/packages/skills/skills/argent-create-flow/references/reliability-and-recovery.md
+++ b/packages/skills/skills/argent-create-flow/references/reliability-and-recovery.md
@@ -1,155 +1,149 @@
 # Reliability and recovery
 
-Read this file when selector capture warns, a finished file contains coordinates/raw scrolling, a transition or overlay can swallow an action, the platform's flow tree source is unavailable (iOS native devtools, the Android helper, a Chromium CDP session, the Vega toolkit), or a replay fails.
+Read this file for selector warnings, raw coordinates, unavailable trees, swallowed actions, overlays, or replay failures.
 
 - [Coordinate fallback gate](#coordinate-fallback-gate)
 - [iOS selector recovery](#ios-selector-recovery)
-- [Tree source recovery on Android, Chromium, and Vega](#tree-source-recovery-on-android-chromium-and-vega)
+- [Other tree sources](#tree-source-recovery-on-android-chromium-and-vega)
 - [Strong transition gates](#strong-transition-gates)
-- [Obscured targets and persistent overlays](#obscured-targets-and-persistent-overlays)
-- [Diagnose a replay failure](#diagnose-a-replay-failure)
-- [Correct the smallest justified unit](#correct-the-smallest-justified-unit)
+- [Obscured targets](#obscured-targets-and-persistent-overlays)
+- [Replay diagnosis](#diagnose-a-replay-failure)
+- [Corrections](#correct-the-smallest-justified-unit)
 
 ## Coordinate fallback gate
 
-Use this order for every element-targeting action, applying the [stable-selector definition](../SKILL.md#stable-selectors):
+Use this target order:
 
-1. strict `{ id: ... }`;
-2. narrow, stable `{ text: ... }` or accessibility label;
-3. stable role only when it uniquely identifies the element;
-4. `scroll-to` plus one of those selectors for an off-screen target;
-5. raw coordinates only after completing this gate.
+1. A strict stable id.
+2. Narrow, stable text or accessibility label.
+3. A stable role only when it is unique.
+4. `scroll-to` plus one of those selectors for an off-screen target.
+5. Raw coordinates only after the checks below.
 
-An element-seeking swipe follows the same rule: if its purpose is to reveal a target, replace it with `scroll-to`. Keep a coordinate swipe only when the gesture itself is the intended UI action — for example, testing or invoking a real swipe-to-dismiss interaction — and no selector-based directive expresses it.
+Convert element-seeking swipes to `scroll-to`. Keep a coordinate swipe only when the gesture itself is the tested action and no directive expresses it.
 
-### Run the gate on the warning, not at audit time
+### Run the gate when capture warns
 
-Work this gate the moment `flow-add-step` warns that it kept a raw point — and equally when it silently recorded a role-only selector, which warns about nothing — while the screen that produced it is still on the device:
+Work this gate as soon as capture warns that it kept a raw point — and equally when it silently recorded a role-only selector, which warns about nothing. Keep the source screen available and do these checks:
 
-1. On iOS, make an evidenced full-tree probe before keeping the point: query each plausible id/label with `native-find-views`; when there is no useful query term, call `native-full-hierarchy` with narrow `fields` and `maxDepth: 100`. Record the relevant match or no-match result with the exception evidence. `describe` and the leaf-only `native-describe-screen` are accessibility projections and are never sufficient evidence that no flow selector exists. A recorder warning only proves automatic derivation failed; it does not rule out a sibling or child label that can safely receive the tap.
-2. On other platforms, inspect the deepest available app tree: `debugger-component-tree` for React Native, otherwise `describe`. On Android no tool exposes the runner's tree at all, so step 3 is the only way to confirm a candidate there. Prefer an id on iOS and Android even when trimmed discovery omits it; on Chromium the runner's tree is a [subset of `describe`](flow-yaml.md#the-runner-tree-is-not-the-discovery-tree), so an element absent there has no selector at all.
-3. Verify candidates in a scratch fragment containing `assert: { visible: <candidate> }`, executed on the valid target screen. If one passes, replace the point. If it fails, inspect the exact reason and try a better id, label, target app, or container; do not assume a visible miss is depth truncation.
-4. If no candidate resolves and you have the app's source, read it for the element's `testID` / `accessibilityIdentifier` / `resource-id` — the code is the one projection no discovery tool trims, and it names ids the others can drop. If the element has none, tell the user which element needs a stable test id and report that as the real fix; a kept coordinate is the workaround.
+1. **iOS:** query plausible ids or labels with `native-find-views`. If no term is useful, call `native-full-hierarchy` with narrow fields and `maxDepth: 100`. `describe` and `native-describe-screen` are accessibility projections. They cannot prove that no flow selector exists.
+2. **Other platforms:** use `debugger-component-tree` for React Native, otherwise `describe`. Android has no agent view of the runner tree, so verify candidates in step 3. On Chromium, an element absent from `describe` has no runner selector.
+3. Test each candidate in a scratch fragment with `assert: { visible: <candidate> }` on the valid screen. Inspect every failure before trying a better id, label, app, or container.
+4. If source is available, inspect its `testID`, `accessibilityIdentifier`, or `resource-id`. If none exists, report the missing stable id as the real fix.
 
-A tree-unavailable error makes the candidate run **void** — on iOS an error containing `native devtools is unavailable` or `No native-devtools-connected apps are available`, on Android a failure to reach the devtools helper, on Chromium an unreachable CDP session, on Vega a missing page source. It proves the tree was absent, not that the selector failed, and never authorizes coordinates — and it is the same reason the recorder quotes back in its `selector capture failed` warning, so read that warning before treating it as a verdict about the element.
+An unavailable tree makes the candidate test void. It proves the tree was absent, not that the selector failed, so it never authorizes coordinates. Relevant failures include `native devtools is unavailable` or `No native-devtools-connected apps are available` on iOS, an unreachable Android helper, an unreachable Chromium CDP session, or missing Vega page source. The recorder quotes the same reason back in its `selector capture failed` warning, so read that warning before treating it as a verdict about the element. Restore the tree and repeat the test.
 
-Coordinates may remain only when the target is genuinely unlabeled (no id/text/label in available discovery) or all plausible labeled candidates failed against a working flow tree. Precede the kept point with an echo naming the target, and follow it with an `await:`/`assert:` on the **outcome** — the destination screen, the changed state, the element that disappeared. The target itself has no selector to check, so what makes the step falsifiable is proof that the tap landed, not proof that the target exists. Report the evidence. Anything the gate did not clear gets re-recorded against a selector, not annotated. A QA flow may keep such a step only for a genuinely unlabeled target, and every kept coordinate must appear in the report with its evidence; any other kept coordinate is a blocking defect.
+Keep coordinates only for a genuinely unlabeled target or after all plausible labeled candidates fail against a working flow tree. Add an echo naming the target and a hard check on the action's outcome. Report the point, discovery results, and candidate failures. Re-record every uncleared point.
+
+QA flows are stricter. They can keep a coordinate only for a genuinely unlabeled target. Failed selector candidates alone are insufficient.
 
 ## iOS selector recovery
 
-The full iOS flow tree exists only for an app Argent launched with instrumentation.
+The full iOS flow tree exists only for an app launched by Argent with instrumentation.
 
-1. If the app came from Metro/Expo, Xcode, its icon, or an earlier uninstrumented launch, call `restart-app`, restore the screen, and retry. `launch-app` does not terminate the app first: when the app is already running, the launch only foregrounds that existing, uninstrumented process. Only `restart-app` (terminate + relaunch) guarantees an instrumented launch.
-2. Tap capture does **not** wait for that connection: it makes one tree read and turns any failure straight into the kept-coordinates warning. A recording-time `restart-app` returns before the devtools connection opens, so a missing-tree warning on the first tap after a restart can be transient. Re-record that tap once before escalating. Only a warning that survives the retry is evidence of a real fault.
-3. Call `native-devtools-status` with the same explicit simulator UDID and bundle id. If `requiresRestart` is true, restart once and check again.
-4. If the app is injectable but still disconnected, call `stop-all-simulator-servers` once, **scoped to `devices: [<this simulator's UDID>]`** — the UDID step 3 already has in hand. One tool-server serves every agent using this Argent install, so an unscoped call tears down their devices too. Then call `restart-app` and `native-devtools-status` again. This recreates the current Argent transport and devtools services; it does not change app/account data.
-5. If it remains disconnected, report an Argent server/instrumentation environment blocker. Do not call the app non-injectable or replace selector actions with coordinates in a QA flow.
+1. If Metro, Expo, Xcode, an icon, or a prior process launched the app, call `restart-app`. Restore the source screen and retry capture. `launch-app` can only foreground the existing process.
+2. Tap capture does **not** wait for that connection. It makes one tree read and turns any failure straight into the kept-coordinates warning. A recording-time `restart-app` returns before the devtools connection opens, so the first tap after a restart can warn transiently. Re-record that tap once before escalating; only a warning that survives the retry is evidence of a real fault.
+3. If the warning survives, call `native-devtools-status` with the same UDID and bundle id. If `requiresRestart` is true, restart once and check again.
+4. If an injectable app remains disconnected, call `stop-all-simulator-servers` once, **scoped to `devices: [<this simulator's UDID>]`**. One tool-server serves every agent on this Argent install, so an unscoped call tears down their devices too. This does not change app or account data. Then restart and check status again.
+5. If it still fails, report an instrumentation blocker. Do not replace selectors with coordinates in a QA flow.
 
-More than one booted simulator is not itself an injection fault: native services are keyed by UDID. Use the same explicit UDID throughout; when standalone flow device selection reports ambiguity, pass `--device <udid>`.
-
-Android, Chromium, and Vega never inject anything, so none of this applies to them — their tree sources fail differently, see [Tree source recovery on Android, Chromium, and Vega](#tree-source-recovery-on-android-chromium-and-vega).
+Use the same explicit UDID throughout. Multiple booted simulators are not an injection fault. Pass `--device <udid>` when standalone selection is ambiguous.
 
 ### Terminally non-injectable iOS apps
 
-**Scope gate: this section applies only to `com.apple.*` system apps. A connection failure in any other app never authorizes this fallback.**
+This fallback applies only to `com.apple.*` system apps. A connection failure in another app never authorizes it.
 
-Apple system apps (`com.apple.*`) cannot load the instrumentation, and nothing in the launch path exempts them. A `launch:` step on iOS always waits for the devtools connection, so for one of these apps it spends that budget, fails, and every later step is skipped.
+Apple system apps cannot load the instrumentation, and nothing in the launch path exempts them. A `launch:` step on iOS always waits for the devtools connection, so for one of these apps it spends that budget, fails, and every later step is skipped.
 
-**Never give such a flow a `launch:` step.** Start it with a raw `tool: restart-app`, which performs the same terminate-and-relaunch without the readiness gate. Accept that the result is a **fragment**: its first non-echo step is not `launch:`, so the runner never classifies it as e2e. The rest of the injection-free form:
+**Never give such a flow a `launch:` step.** Start it with a raw `tool: restart-app`, which terminates and relaunches without the readiness gate. Accept that the result is a **fragment**: its first non-echo step is not `launch:`, so the runner never classifies it as e2e. The rest of the injection-free form:
 
-- raw `tool: await-ui-element` checks against the accessibility tree;
-- point `tap:` / `long-press:` actions derived from `describe`, each named by an echo;
-- point focus tap plus raw `tool: keyboard` with `delayMs: 500`;
-- raw `gesture-swipe` calls with `settle: true` (momentum-free, so the scroll lands where the finger lifts and the following coordinate taps stay valid) because `scroll-to` needs the missing flow tree.
+- Raw `tool: await-ui-element` accessibility checks.
+- Point taps or long-presses derived from `describe`, each named by an echo.
+- A point focus tap plus raw keyboard with `delayMs: 500`.
+- Raw swipes with `settle: true` because `scroll-to` needs the missing flow tree. Momentum-free scrolling keeps later coordinate taps valid.
 
-Disclose that the whole flow is injection-free. Do not pretend its coordinates are portable.
+Report that the flow is injection-free and its coordinates are not portable. It cannot satisfy the QA contract. Report the artifact and platform blocker instead.
 
-An injection-free flow is a valid generic flow but never a QA-contract-satisfying one: report it as an injection-free artifact plus the platform blocker, not as a completed QA test. Disclose it in the final report.
-
-The same fragment fallback covers a normally injectable app that is broken in the environment: raw `tool: restart-app` in place of `launch:` still makes a self-resetting flow. Either way the flow cannot satisfy the `argent-qa-flows` e2e contract, which requires a leading `launch:`. Report the blocker rather than labeling that fallback a completed QA test.
+The same fragment fallback covers a normally injectable app that is broken in the environment: raw `restart-app` in place of `launch:` still makes a self-resetting flow. Either way it is not e2e and cannot complete `argent-qa-flows`, which requires a leading `launch:`. Report the blocker rather than labeling that fallback a completed QA test.
 
 ## Tree source recovery on Android, Chromium, and Vega
 
-No injection is involved, but each platform has one source the runner cannot do without. While it is down, selector directives fail and every recorded tap keeps its raw point — a void run, never a coordinates case. Restore the source, re-record the affected taps, and delete the points that outage produced.
+While the required source is down, selector failures and raw-point capture are void. Restore the source and re-record affected taps.
 
-| Platform | Symptom                                                          | Cause and fix                                                                                                      |
-| -------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Android  | `launch:` reports it could not reach the Android devtools helper | The helper could not be installed or started — unlock the device, allow `adb install -t`, re-run                   |
-| Chromium | a step reports no reachable CDP session                          | The Electron target died or was started without remote debugging — re-boot it with `boot-device`/`electronAppPath` |
-| Vega     | `launch:` reports the toolkit served no page source              | The toolkit attaches at app launch — re-run to relaunch; the app must be built with automation support             |
+| Platform | Symptom                          | Recovery                                               |
+| -------- | -------------------------------- | ------------------------------------------------------ |
+| Android  | Cannot reach the devtools helper | Unlock the device, allow `adb install -t`, and rerun   |
+| Chromium | No reachable CDP session         | Boot again with `electronAppPath` and remote debugging |
+| Vega     | Toolkit returns no page source   | Relaunch an app built with automation support          |
 
-**On Android, a healthy `describe` is not evidence that the flow tree is available.** `describe` falls back to a legacy `uiautomator dump` when the helper is missing; the flow tree refuses that fallback, because a trimmed tree silently changes what selectors match instead of failing. Discovery therefore looks perfect while every flow selector fails.
+On Android, healthy `describe` output does not prove the flow tree is available. It can fall back to legacy `uiautomator`, while the runner refuses that trimmed fallback.
 
 ## Strong transition gates
 
-Every navigation carries identity then readiness ([why](flow-yaml.md#prove-a-navigation-identity-then-readiness)). **Never prove a screen** with a shared header, a persistent tab bar, a source element, a positional id (`…-selector-1` encodes how many siblings exist), or a data-derived value (a counter, a count, a username, a timestamp).
+Every navigation needs destination identity followed by readiness. Do not identify a screen with a shared header, persistent tab bar, source element, positional id, counter, username, timestamp, or other data-derived value.
 
-### Leave a screen by a fixed destination, not by popping the stack
-
-A back button, a swipe-back, and a post-save `goBack()` all pop **one** stack entry, so where they land depends on how many entries the run happened to push. A flow that reached the same screen twice has a different stack depth than the walkthrough did, and the identity gate after the back tap then fails on the wrong destination.
-
-Prefer an action whose destination is fixed regardless of history: tapping the already-active bottom-tab pops to that tab's root, and a Home/Close affordance goes to a known screen.
-
-Reach for back only when the back navigation _is_ the behavior under test. Gate it on identity like any other navigation, and expect the destination to depend on the path taken to get there.
+Prefer navigation with a fixed destination. A back button or swipe pops one stack entry, so repeated visits can change its destination. Use back only when back navigation is under test, and gate its result like any other screen change.
 
 ## Obscured targets and persistent overlays
 
-A selector tap resolves an element and dispatches at its coordinates; it does not prove that element is the topmost hit-test target. A toast, snackbar, banner, sheet, or other overlay can absorb the touch while the step reports success, producing a silent misfire that surfaces later.
+A selector tap can resolve the intended element while an overlay receives the touch.
 
-- After a mutating action raises an overlay that intersects the next target, first establish its selector **while it is visible**, then dismiss it and record `await: { hidden: <overlay selector> }` before touching that region — the trio in order, so the absence check can actually fail. Do not rely on an auto-dismiss timer; automation or backgrounded rendering can pause it.
-- Prefer an app-provided e2e build affordance that disables or shortens transient overlays. Otherwise record the real dismissal interaction.
-- On iOS, use the `native-user-interactable-view-at-point` tool for live diagnosis of which view would receive a candidate touch. Android and Chromium have no hit-test tool, so there the recorded `visible` → dismiss → `hidden` trio is the only proof the overlay is gone.
-- Keep a dismissal swipe only when the UI really supports swipe-to-dismiss. Treat it as the intended semantic action, not as element-seeking movement; put it through the coordinate fallback gate and hard-check that the overlay became hidden.
+When an overlay intersects the next target:
+
+1. Record the overlay as `visible` while it exists.
+2. Record its real dismissal action.
+3. Record the same selector as `hidden`.
+4. Only then touch the covered region.
+
+Do not rely on auto-dismiss timers. Prefer an app e2e affordance that disables transient overlays. On iOS, use `native-user-interactable-view-at-point` for hit-test diagnosis. Other platforms rely on the recorded visibility trio.
+
+Keep a dismissal swipe only when the UI supports it. Pass it through the coordinate gate and hard-check that the overlay disappeared.
 
 ## Diagnose a replay failure
 
-Classify the result before editing:
+Classify before editing:
 
-| Outcome              | Evidence                                                                                            | Next step                                                                                                                                                                                                                                                                                                     |
-| -------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Hard error           | A step reports error/fail and later steps skip                                                      | Inspect that step and actual state                                                                                                                                                                                                                                                                            |
-| Environment, not app | The reason says the check could not run — an unreadable tree, a `run:` target that does not resolve | Fix the environment and rerun; it is not a verdict about the app and never counts toward or against a pass streak. A failed `launch:` is `errored` too but **is** a verdict — treat it as a hard error                                                                                                        |
-| Silent misfire       | Run reports success but expected final state is wrong                                               | Restore the screen where the state should have changed and record the missing gate live; do not add it in YAML                                                                                                                                                                                                |
-| Partial divergence   | An intermediate screenshot/tree disagrees with its echo                                             | Find the first divergent transition                                                                                                                                                                                                                                                                           |
-| Acceptance failure   | Navigation/actions passed but a requested check fails                                               | Preserve the check; investigate app/data behavior                                                                                                                                                                                                                                                             |
-| No clean settle      | A step passed carrying a `warning` from `await: { idle: true }`                                     | Read [which of the six warnings](flow-yaml.md#idle--readiness) it is — the screen moved, the wait ran out mid-hold, the screen rendered nothing, the tree held still but no screenshot pair was compared, or the step got no evidence — then look at that screen and gate the next action on a stable element |
+| Outcome            | Meaning                                        | Response                                                                                                                                                |
+| ------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hard failure       | A step fails and later steps skip              | Inspect that step and actual state                                                                                                                      |
+| Environment error  | The reason says the check could not run        | Repair the environment and rerun; it is no verdict about the app. A failed `launch:` is `errored` too but **is** a verdict — treat it as a hard failure |
+| Silent misfire     | The run passes but final state is wrong        | Restore the first wrong screen and record a stronger gate                                                                                               |
+| Partial divergence | An intermediate result disagrees with its echo | Find the first divergent transition                                                                                                                     |
+| Acceptance failure | Actions pass but a requested check fails       | Preserve the check and investigate behavior                                                                                                             |
+| Idle warning       | A readiness step passes without settling       | Read [which of the six warnings](flow-yaml.md#idle-readiness) it is, then gate the next action on a stable element                                      |
 
 Then:
 
-1. Note the first failure/divergence index and message.
-2. Call `screenshot` and `describe`; when deeper evidence is needed, call `native-find-views` / `native-describe-screen` (iOS only) or `debugger-component-tree` (React Native).
+1. Record the first failure or divergence index and message.
+2. Capture `screenshot` and `describe`. Use native or React Native discovery when needed.
 3. Compare actual state with the preceding echo and expected destination.
-4. Classify the cause: wrong selector, wrong screen, missing element, timing/readiness, stale prerequisite/data, optional interstitial, or real product behavior.
-5. State the diagnosis in one sentence before correcting anything.
+4. Classify the cause: selector, screen, missing element, readiness, stale data, optional interstitial, or product behavior.
+5. State the diagnosis in one sentence before correcting it.
 
 ## Correct the smallest justified unit
 
-- **Parameter/selector error in one step:** edit the YAML, preferring a stable selector over a new coordinate.
-- **Timing/readiness failure:** repair the transition gate, then audit every step of the same shape in the flow — especially taps after a launch, screen push, drawer/sheet open, or mutating action. A fixed delay at only the observed failure leaves the same race at the other sites.
-- **Identity failure (a silent misfire, or arrival on the wrong screen):** run the same same-shape audit. Every navigation gated the same weak way has the same defect, whether or not it has surfaced yet.
-- **One new/missing transition or two to three structural steps:** reset to entry state and re-record the working prefix and changed portion live.
-- **Four or more broken steps, unclear state, or comparison/profiling flow:** fully re-record so every action is exercised consistently.
+- For one parameter or selector error, edit the YAML and prefer a stable selector.
+- For readiness or identity failure, repair that gate and audit every transition with the same shape.
+- For one missing transition or two to three structural steps, copy the working prefix and re-record the affected span live.
+- For four or more broken steps, unclear state, or a comparison or profiling flow, fully re-record.
+- Treat manual recovery as diagnosis only. It never counts as a replay pass.
 
-  Either re-record restarts under the same `name` + `project_root`, and `flow-start-recording` truncates that `.yaml` before you can read it — copy the working prefix out first.
+Starting again under the same name truncates the YAML. Copy any working prefix before re-recording.
 
-- **Transient manual recovery:** useful for diagnosis only; it does not fix the flow and cannot count as a replay pass.
+### Make every replacement gate stronger
 
-### A replacement gate must be strictly stronger
+| Weak gate                     | Do not use     | Add the missing proof                     |
+| ----------------------------- | -------------- | ----------------------------------------- |
+| Shared or positional identity | Longer timeout | Destination-only root or control          |
+| Tap lost during motion        | Fixed wait     | `idle` after destination identity         |
+| Toast absorbs tap             | Retry          | Verified overlay dismissal                |
+| `hidden` never established    | Longer timeout | Same-selector `visible`, action, `hidden` |
+| Typed value is wrong          | Retype         | Assert the committed value                |
 
-A gate that let a misfire through is not repaired by a longer timeout — that keeps the same unfalsifiable check and only waits longer for it. The replacement must add the missing leg:
+State the added proof before rerunning.
 
-| The gate that failed             | Not this         | This                                                                                                                    |
-| -------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Shared header / positional id    | Longer `timeout` | A destination-only root or control id                                                                                   |
-| Next tap lost to a moving screen | `wait: 2000`     | Add `await: { idle: true }` after the identity gate                                                                     |
-| Tap absorbed by a toast          | Retry the tap    | `await: { hidden: <overlay> }` before the tap                                                                           |
-| `hidden` that never matched      | Longer `timeout` | Record the `visible` check first, then the `hidden` one                                                                 |
-| Typed value wrong or truncated   | Retype it        | Assert the committed value after `type:`; a bare retype hides whether the field was covered, unfocused, or not an input |
+### Correction limit
 
-State which leg you added before rerunning.
+After each correction, audit and replay from the declared start. Stop after two unsuccessful correction cycles and report the remaining blocker. If failures move while the flow grows, re-record the affected span instead of adding more patches.
 
-### The correction budget is a stop, not a guideline
-
-After any correction, rerun the entire polished flow from its declared start. Count every correction cycle. **After two unsuccessful cycles, stop editing** and report the remaining failure with the recommended human decision. A flow that fails at a different index each run while its step count grows is accumulating gates around an unproven path: re-record the affected span live instead of patching.
-
-Never weaken, remove, hide behind `when:`, or replace a requested check merely to make the run green. If the product behavior is wrong, retain the strong test and report it as an unproven regression artifact; the invoking skill decides whether that satisfies its task. QA does not call it complete until its two-pass gate succeeds.
+Never weaken, remove, or hide a requested check to obtain a pass. Keep a failing product check and report the flow as an unproven regression artifact. QA remains incomplete until its two-pass gate succeeds.

--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -214,7 +214,7 @@ Instead of polling `screenshot`/`describe` in a loop, use `await-ui-element` to 
 - `selector`: `{ text?, identifier?, role? }` — every provided field must match. `text` matches the element's label or value and `role` its element role (e.g. `AXButton`, `button`, `TextView`, `StaticText`), both as case-insensitive substrings; `identifier` matches its accessibility id / resource-id / testID **exactly** (case-insensitive), also accepting the unqualified Android resource-id name (`submit` matches `com.example.app:id/submit`). The synthetic `ROOT` container `describe` prints is never matched, so a `role` like `AXGroup`/`html` won't trivially "match the screen".
 - Prefer a **specific** selector. A loose substring can match several elements, and the tool may then key off one you didn't mean: `text` reads the first **visible** match in **reading order** (top-to-bottom, left-to-right — the same order `describe` lists them, so it's the one you saw first; when no match is visible, the first match overall), while `visible`/`exists` are satisfied by **any** match. Disambiguate with a longer or more exact string, an `identifier`, or a `role` (e.g. pin to a text role like `StaticText` to skip a same-named button). On a `text` timeout the `note` quotes the matched element's text, so you can see which one it landed on.
 - `text` condition also needs `expectedText` (substring the matched element must contain).
-- `hidden` treats a selector that matches **nothing** as already-hidden, so a typo'd selector returns an instant (false) success. The result `note` flags when the selector never matched any element; treat that note as a failed check, not a pass, and find the real selector before continuing — a gate that cannot fail proves nothing on replay. (On iOS, if the accessibility backend is down the tree comes back empty; the tool will **not** report `hidden` success off such a degraded read and the `note` surfaces the boot hint instead.)
+- `hidden` passes when the selector matches nothing. If `note` says it never matched, treat the check as failed and fix the selector. On iOS, a degraded empty tree does not report `hidden` success; the note gives the recovery hint.
 - Optional `timeoutMs` (default 5000) and `pollIntervalMs` (default 400).
 
 Returns `{ success, elapsed }`; on a timeout `success` is `false` and a `note` explains what was seen.
@@ -227,9 +227,9 @@ Use after launch/navigation and before a raw tap, when an early-painted element 
 { "udid": "<UDID>", "timeoutMs": 3000, "minStableMs": 250 }
 ```
 
-Local iOS, Android, and Chromium. It polls the same tree as `describe` until a non-empty one stops changing, and reports a timeout as a soft `settled: false` rather than throwing — so continue only on `settled: true`. An idle wrong screen is still wrong: pair it with `await-ui-element` on a destination-specific element.
+On local iOS, Android, and Chromium, the tool waits for a non-empty `describe` tree to stop changing. Continue only when `settled: true`. Pair it with a destination-specific `await-ui-element`; stillness does not identify a screen.
 
-Live diagnosis only. Do not persist it in a flow and do not nest it in `run-sequence`. A flow's persistable equivalent is `await: { idle: true }`, which also compares screenshots — this tool reads the tree alone, so it returns while a transition is still animating over it.
+Use it only for live diagnosis. Do not record it or put it in `run-sequence`. Flows use `await: { idle: true }`, which also compares pixels. This live tool can return during a presentation-layer animation.
 
 ---
 

--- a/packages/skills/skills/argent-qa-flows/SKILL.md
+++ b/packages/skills/skills/argent-qa-flows/SKILL.md
@@ -1,126 +1,123 @@
 ---
 name: argent-qa-flows
-description: Create repeatable QA regression E2E tests as Argent flows from natural-language test cases, tickets, or acceptance criteria. Use when the user asks to generate a QA test, automate a regression or E2E scenario, or preserve described actions and expected outcomes as a test. Orchestrates argent-create-flow, records the first walkthrough live, requires stable targets and explicit structural or visual checks, and completes only after two consecutive full passing runs. Do NOT use for a one-off interactive check that produces no saved test artifact (use argent-test-ui-flow), or for a replayable path with no acceptance criteria to prove (use argent-create-flow). iOS, Android, Chromium, and Vega (Fire TV); not Apple TV or Android TV.
+description: Create repeatable QA regression E2E tests as Argent flows from test cases, tickets, or acceptance criteria. Use when the user asks to generate or preserve an automated regression scenario, with deterministic setup, stable targets, executable structural or visual evidence, and two consecutive full passes. For one-off UI checks or replayable paths without acceptance criteria, use argent-test-ui-flow or argent-create-flow. Supports iOS, Android, Chromium, and Vega (Fire TV), where recorded tv-remote steps replace touch directives. Apple TV and Android TV are unsupported; use argent-tv-interact there and report the limitation.
 ---
 
 # Create a QA regression flow
 
-Use `argent-create-flow` as the authoring engine. Load that skill now, then follow the references it marks required for the current task. It owns recorder/tool syntax, selectors, polish, platform exceptions, and repair. This skill adds only the QA contract and completion gates.
+Load `argent-create-flow` as the authoring engine. Follow its required references for recorder syntax, selectors, polish, platform exceptions, and repair. This skill adds the QA contract and completion gate.
 
-## Definition of done
-
-On **Vega** every item below holds — `launch: { vega: ... }`, `await:`/`assert:` selectors, `snapshot:`, and `idle` all run there. Only the touch directives are missing, because Vega is remote-driven: navigate with recorded `tool: tv-remote` steps and type with `tool: keyboard`, which leaves item 5 with nothing to govern. A D-pad path is relative to where focus already is, so follow every move with the identity gate of item 4 rather than assuming the cursor landed. Read `argent-tv-interact` for focus reading and remote navigation.
+**Vega** supports every item below: `launch: { vega: ... }`, `await:`/`assert:` selectors, `snapshot:`, and `idle` all run there. Only the touch directives are missing, because Vega is remote-driven. Navigate with recorded `tool: tv-remote` steps and type with `tool: keyboard`, which leaves item 5 with nothing to govern. A D-pad path is relative to where focus already is, so gate every move with item 4's identity check rather than assuming the cursor landed. Read `argent-tv-interact` for focus reading and remote navigation.
 
 **Apple TV and Android TV are out of scope.** The runner does not reject touch directives there, so they fail at the gesture layer instead of with authoring guidance. Use `argent-tv-interact` and report the limitation.
 
-A QA flow is complete only when every item holds:
+## Definition of done
 
-1. **Self-contained, idempotent state:** the first non-echo step is `launch:`; setup establishes and hard-checks the required data baseline before the first scenario mutation; and repeated runs do not accumulate artifacts or require manual cleanup. Launch resets the process, not persisted app/account/backend data.
-2. **Recorded live:** the first walkthrough — not a later reconstruction — produced every action and check, with the recorder started in `argent-create-flow`'s platform-specific order.
-3. **Every requirement is executable proof:** each requested outcome maps to a hard `await:`, `assert:`, or reviewed `snapshot:` baseline comparison. A raw `screenshot` and an echo never count as unattended regression verdicts.
-4. **Correct-screen proof:** every navigation is followed by an identity gate then a readiness gate, before the next action or negative check, per [`argent-create-flow` rule 4](../argent-create-flow/SKILL.md#non-negotiable-rules).
-5. **Stable interaction:** targets follow `argent-create-flow`'s selector order and its **coordinate fallback gate**. QA is stricter about what the gate may clear: a coordinate is retained only for a genuinely unlabeled target, and failed selector candidates alone do not qualify. Vacuous on Vega, which has no coordinate targets.
-6. **Fresh-service/warm consecutive passes:** the exact final YAML passes two uninterrupted full executions with the same runner and no edit or manual state recovery between them; the first mobile pass starts from freshly recycled Argent device services, and the second follows immediately.
+A QA flow is complete only when:
 
-## 1. Turn the request into a test contract
+1. The first non-echo step is `launch:`. In-flow setup proves a deterministic data baseline. Repeated runs do not accumulate artifacts or require manual cleanup.
+2. The first walkthrough recorded every action and live structural check. Only the three documented polish insertions are unrecorded.
+3. Every requirement maps to a hard `await:`, `assert:`, or reviewed `snapshot:`. Echoes and screenshots are not verdicts. A negative check needs the same stable selector established as visible earlier.
+4. Every screen change has destination identity followed by `idle` readiness.
+5. Targets satisfy the stable-selector and coordinate-fallback rules. QA keeps coordinates only for genuinely unlabeled targets. Vacuous on Vega, which has no coordinate targets.
+6. The unchanged YAML passes twice with the same runner. Pass 1 starts with fresh mobile Argent services, and pass 2 follows immediately.
 
-Before touching the app, write the test contract as a compact Markdown table in your reply, and restate it in the final report. Include:
+## 1. Define the test contract
 
-- the app/platform and named start state;
-- ordered user actions;
-- one row per `verify`, `check`, `should`, persistence, or absence clause;
-- the concrete stable executable evidence for each row;
-- required data and side effects.
+Before touching the app, write a compact table. Restate it in the final report. Include:
 
-Choose evidence per outcome: use `await:`/`assert:` for semantic state, `snapshot:` for pixel rendering the tree cannot prove, and both for mixed requirements.
+- App, platform, and named start state.
+- Ordered user actions.
+- One row for each expected outcome, persistence rule, or absence claim.
+- Stable executable evidence for each row.
+- Required data and side effects.
 
-One behavioral scenario becomes one `qa-<area>-<behavior>` flow. Do not invent a material test value or weaken an ambiguous expected outcome to keep moving; choose the strongest UI-verifiable reading and report it, or ask when the choice changes test meaning.
+Use structural checks for semantic state, snapshots for pixels, and both for mixed requirements. One behavioral scenario becomes one `qa-<area>-<behavior>` flow.
+
+Do not invent a material value or weaken ambiguity. Choose the strongest UI-verifiable reading and report it. Ask when the choice changes test meaning.
 
 Make repeated runs deterministic:
 
-- Inspect the required baseline with read-only discovery before recording the scenario. If the account is already dirty, do not author the scenario from that state. Record a dedicated reset/seed flow first, or include safe normalization in the main flow's setup.
-- Gate the normalized baseline early and hard. After launch, required non-mutating navigation, and any recorded reset/seed setup, add an echo that names the baseline and an `assert:` that proves it before the first scenario mutation. A destination-unique `await:` may serve as that hard gate only when it completely proves the named baseline. A dirty baseline must fail in setup, not many steps later on an unrelated check.
-- Preferably restore the same data state at the end, so run N and run N+1 start from the same place.
+1. Inspect the required baseline without mutation.
+2. If the account is dirty, record a safe reset or seed flow. Alternatively, include safe normalization in setup.
+3. After setup navigation, echo the named baseline and hard-check it before the first scenario mutation. Use `assert:` or a destination `await:` that fully proves the baseline.
+4. Prefer to restore the baseline at the end.
 
-Use `run:` for a dedicated reset/seed flow recorded under the same live-authoring rules — there is no other fixture mechanism. If safe cleanup is unspecified and would create/delete meaningful user data beyond the test, ask before recording.
+Use `run:` for a separately recorded reset or seed flow. No other fixture mechanism exists. Ask before cleanup that creates or deletes meaningful user data outside the request.
 
-### Worked example
+### Compact example
 
-Ticket: "On iOS in `com.acme.shop`, from signed-in Home, select the Dark theme in Settings and verify that Settings renders in dark mode, Dark is selected, and Light is not."
+Ticket: select Dark in Settings. Verify Dark is selected, Light is absent, and the screen renders in dark mode.
 
-| Contract row              | Action                                              | Stable executable evidence                    | Data / side effect                                 |
-| ------------------------- | --------------------------------------------------- | --------------------------------------------- | -------------------------------------------------- |
-| App and named start state | Restart iOS app `com.acme.shop` from signed-in Home | `home-screen` visible, then `idle`            | Existing signed-in account                         |
-| Reach Settings            | Tap `settings-tab`                                  | `settings-screen` visible, then `idle`        | None                                               |
-| Normalized theme baseline | Inspect the settled Settings screen                 | `assert:` `theme-light-selected` is visible   | Fails in setup if an earlier run left Dark         |
-| Select Dark               | Tap `theme-dark-option`                             | `theme-dark-selected` is visible              | Theme becomes Dark                                 |
-| Exclude old state         | Inspect the settled Settings screen                 | `theme-light-selected` is hidden              | None                                               |
-| Render dark appearance    | Compare the stable Settings screen                  | `settings-dark` matches its reviewed snapshot | Dark palette is visible across the screen          |
-| Restore the baseline      | Tap `theme-light-option`                            | `theme-light-selected` is visible             | Theme back to Light, so run N+1 starts where N did |
+| Contract row          | Action                   | Evidence                                                                    | State effect          |
+| --------------------- | ------------------------ | --------------------------------------------------------------------------- | --------------------- |
+| Signed-in Home        | Launch                   | `await: { visible: { id: home-screen } }`, then `await: { idle: true }`     | Existing account      |
+| Open Settings         | Tap `settings-tab`       | `await: { visible: { id: settings-screen } }`, then `await: { idle: true }` | None                  |
+| Prove Light selected  | Inspect Settings         | `assert: { visible: { id: theme-light-selected } }`                         | Fails if already Dark |
+| Prove Dark selected   | Tap `theme-dark-option`  | `await: { visible: { id: theme-dark-selected } }`                           | Theme becomes Dark    |
+| Prove Light absent    | Inspect settled screen   | `assert: { hidden: { id: theme-light-selected } }`                          | None                  |
+| Verify dark rendering | Inspect settled screen   | `snapshot: settings-dark`                                                   | None                  |
+| Restore baseline      | Tap `theme-light-option` | `await: { visible: { id: theme-light-selected } }`                          | Next run starts clean |
 
-Three rows carry more weight than they look. `home-screen` proves the named baseline because it exists only in the signed-in state. The Light-selected `assert:` does double duty: it fails in setup if a previous run left the app Dark, and it establishes `theme-light-selected` so the later `hidden` check is a verdict rather than an unfalsifiable pass. The closing restore is what keeps that baseline true — without it run 2 starts Dark, the tap changes nothing, and every check below it still passes, so the second consecutive pass proves nothing the first did.
+The initial Light check establishes the selector used by the later `hidden` check. The final restore makes pass 2 independent.
 
-## 2. Record under the QA contract
+## 2. Record the scenario
 
-Follow `argent-create-flow`'s **Start in the correct order** and **Record the first walkthrough** sections for every recorder call and first-screen gate.
+Follow `argent-create-flow`'s start order and live-authoring cycle. Record each structural contract check when its state appears.
 
-Record each structural contract verification as soon as its state appears. A `snapshot:` has no recorder form: inspect the stable visual state during the live walkthrough, then add the planned snapshot during polish as the documented non-mutating exception. If the walkthrough requires direct state-changing recovery, follow `argent-create-flow`'s wrong-turn procedure; recovered behavior is not proof unless the saved path still exercises it faithfully.
+A snapshot has no recorder form. Inspect its stable state during the walkthrough, then add the planned snapshot during polish. If direct recovery changes state, re-record the affected behavior. A recovered walkthrough is not proof.
 
-## 3. Make each verification discriminating
+## 3. Make evidence discriminating
 
-- **State change:** prove the new state and that the old state is absent when both could otherwise match.
-- **Cancel/persistence:** cross the commit boundary — leave the screen, re-enter it, then verify the stored state.
-- **Absence/removal:** first prove the correct containing screen/list loaded, then record the trio in order (`visible` → action → `hidden`). Nothing enforces the order for you: a `hidden` whose selector never matched records as a clean pass, flagged only by a note in the tool result. Prefer a positive replacement/empty state alongside. In a scrollable collection `hidden` proves only the loaded/visible tree: use seeded data that fixes the expected row position, a section count/empty state, or other collection-wide evidence instead of claiming global absence from one viewport.
-- **Overlays over the next target:** a `visible` check on the target passes while a toast eats the tap — follow `argent-create-flow`'s [obscured-targets procedure](../argent-create-flow/references/reliability-and-recovery.md#obscured-targets-and-persistent-overlays) whenever a save/follow/delete raises one over the next target.
-- **Repeated controls and section/list membership:** prefer a stable target id; otherwise bind the target/check to its row or card with flow-only [`within`](../argent-create-flow/references/flow-yaml.md#relational-scopes), whose containment is geometric. Use `text.in` on a stable container to prove rendered membership, not merely that the same name exists somewhere on screen.
-- **Dynamic content:** assert app chrome or state the flow controls. Use a structural/regex check for unavoidable dynamic values, and disclose any accepted live-data dependency.
-- **Visual appearance:** follow [Flow YAML: Snapshots](../argent-create-flow/references/flow-yaml.md#snapshots-and-standalone-runs). Snapshot only a correct, settled, deterministic state; use full-screen comparison for global changes and `cropOn` for a component.
+- **State change:** prove the new state and the old state's absence when both can otherwise match.
+- **Cancel/persistence:** cross the commit boundary. After cancel or save, leave, re-enter, then verify the stored state: unchanged after cancel or updated after save.
+- **Absence:** prove the containing screen and record the same stable selector as `visible`, then the action, then `hidden`. Do not add an unestablished `hidden` check only to strengthen a positive baseline. In a collection, viewport absence is not global absence. Use fixed seeded position, count, empty state, or other collection-wide evidence.
+- **Overlays:** use the create-flow [obscured-target procedure](../argent-create-flow/references/reliability-and-recovery.md#obscured-targets-and-persistent-overlays).
+- **Repeated controls:** prefer an id. Otherwise use flow-only `within` with a stable container. Use `text.in` to prove rendered membership inside that container.
+- **Dynamic content:** assert controlled state or stable app chrome. Use anchored structure for unavoidable dynamic values and disclose the dependency.
+- **Visual state:** snapshot only a correct, settled, deterministic screen. Use full screen for global changes and `cropOn` for one component.
 
-Never put an acceptance check inside a `when:` block that may skip it. `when:` is only for optional setup or interstitial handling that reconverges to the same required path.
+Never put acceptance evidence inside `when:`. Use `when:` only for optional setup that reconverges to the required path.
 
-## 4. Finish, polish, and audit
+## 4. Finish and audit
 
-Use `argent-create-flow` to finish and perform its full polish and blocking audit. Then compare the final YAML with the QA contract:
+Complete the create-flow polish and blocking audit. Then:
 
-- map every contract row to an executed action or hard `await:`/`assert:`/`snapshot:` check;
-- build a navigation table and include it in the report — one row per screen change, with the identity gate and the readiness gate named. A row missing either is a blocking defect, and the two are repaired differently: record a missing identity gate live on the restored screen, and add a missing readiness gate in YAML, because `await: { idle: true }` has no recorder form and is one of `argent-create-flow`'s three permitted polish insertions.
+1. Map every contract row to an executed action or hard check.
+2. Build a navigation table with one row per screen change, naming both the identity gate and the readiness gate. A row missing either is a blocking defect.
+3. Confirm setup and end state permit an immediate second run.
 
-  | Action             | Expected destination | Identity gate                               | Readiness gate          |
-  | ------------------ | -------------------- | ------------------------------------------- | ----------------------- |
-  | Tap `settings-tab` | Settings             | `await: { visible: {id: settings-screen} }` | `await: { idle: true }` |
+| Action             | Destination | Identity                  | Readiness |
+| ------------------ | ----------- | ------------------------- | --------- |
+| Tap `settings-tab` | Settings    | `settings-screen` visible | `idle`    |
 
-- confirm the setup and end state allow an immediate independent second run.
+The two are repaired differently. A missing identity check must be recorded live on the restored screen. A missing `idle` check is added in YAML, because `await: { idle: true }` has no recorder form and is one of `argent-create-flow`'s three permitted polish insertions. Re-record any missing action or other structural check.
 
-If the audit finds a missing action/check, record it live or re-record the affected path. Adding it only in YAML violates the contract and cannot enter proof.
+## 5. Prove two consecutive passes
 
-## 5. Require two consecutive full passes
+After the last edit and audit, set the streak to zero:
 
-After the last edit and audit, set the pass streak to zero:
+1. Choose one runner for both passes. Use `flow-execute` locally or `argent flow run <name> --platform <platform>` for CI. Switching runners resets the streak.
+2. Seed, review, and freeze snapshot baselines. Baseline updates do not count as passes.
+3. Before mobile pass 1, recycle Argent services for this flow's device: two warm passes are correlated evidence, because a fixed timing margin can pass twice simply because environment speed did not change. Scope `stop-all-simulator-servers` to `devices: [<device>]`. Never omit the scope — a bare call is the machine-wide sweep, and step 7 restarts this proof often enough to reap every other agent's devices repeatedly. Use the MCP call for `flow-execute`, or `argent run stop-all-simulator-servers --devices <device>` from the standalone runner's install. The reset must not change app or account data. For Chromium, let the runner boot the declared app and omit `device`. Vega owns no recyclable Argent services, so the teardown is a no-op there and both passes are warm.
+4. Run from the flow's launch and setup without baseline-update mode. Count a pass only when `ok: true` and every acceptance check executed. A false `when:` can skip optional setup only. An errored step does not advance the streak, and the count mixes two kinds — read each reason. One that could not run (an unreadable tree under `idle`, an unresolvable `run:` target) is environment: fix it and rerun. **A failed `launch:` also scores `errored`, and it is a verdict about the app** — an app that no longer installs or starts is the regression this test exists to catch, so report it instead of rerunning.
+5. Resolve every passing-step warning before completion. `await: { idle: true }` raises [six different warnings](../argent-create-flow/references/flow-yaml.md#idle-readiness), so read which one it is first. Two say the screen was moving. One says the wait ran out mid-hold and needs a larger `timeout:`. One says the tree stayed empty. One — **settled on the UI tree alone** — says the hierarchy did hold still and only the screenshot pairs were missing, so inspect the capture path rather than the app's rendering. One says the step ended with no evidence either way. Inspect the screen, disclose the cause, and verify that surrounding acceptance checks use stable elements rather than stillness.
+6. Run the same YAML again immediately with the same runner. Do not manually reset app or account data.
+7. Reset the streak after any failure, edit, re-recording, baseline update, or state-changing manual recovery. Repair through `argent-create-flow`, audit again, and restart with fresh services.
 
-1. Choose the runner the test will actually use for both passes: `flow-execute` for a local-only flow, or `argent flow run <name> --platform <platform>` for CI. Switching runners resets the streak.
-2. If the flow contains snapshots, seed, review, and freeze their baselines according to `argent-create-flow`. A baseline update does not count as a pass; never use one to dismiss an unexplained diff.
-3. Make the first trial fresh, through the same Argent server as the chosen runner — two warm passes are correlated evidence, because a fixed timing margin can pass twice simply because environment speed did not change. Recycle the services with `stop-all-simulator-servers`, scoped to this flow's device so a shared tool-server's other agents keep theirs: `devices: [<this flow's device>]` through that MCP connection before two `flow-execute` passes, or `argent run stop-all-simulator-servers --devices <this flow's device>` from the same Argent install before two standalone passes. Never omit the scope — a bare call is the machine-wide sweep, and step 6 restarts this proof often enough to reap every other agent's devices repeatedly. Nothing needs reconnecting: the run establishes its own device and debugger connections, and the reset does not alter app/account data. For Chromium, let the runner boot the declared app path without an explicit `device` pin. Vega owns no recyclable Argent services, so the teardown is a no-op there and both passes are warm.
-4. Run the entire flow from its own launch and in-flow setup, without baseline-update mode. Increment the streak only when the run reports `ok: true` and every required acceptance check — including each snapshot comparison — executed. A false `when:` may skip optional setup/interstitial steps only. A run with `errored > 0` was not fully evaluated. Read each reason before classifying it, because the count mixes two kinds. A reason naming something that could not run — an unreadable tree under `await: { idle: true }`, a `run:` target that does not resolve — is environment: fix it, rerun, and do not report it as a regression. **A failed `launch:` scores `errored` as well, and it is a verdict about the app** — an app that no longer installs or starts is the regression this test exists to catch, so report it instead of rerunning.
+Finish only when the streak reaches two. If the intended runner is unavailable, report proof as blocked. If product behavior fails, keep the strong check and report the regression. Never weaken it to obtain green output.
 
-   A passing step that carries a `warning` does not block the streak, but it must be resolved before you finish. `await: { idle: true }` raises [six different warnings](../argent-create-flow/references/flow-yaml.md#idle--readiness), so read which one it is before deciding what to do. Two of them say the screen was moving, and nothing in the report distinguishes intended motion from a load that never completed. One — the screen was still, but the wait ran out before the hold completed — says the step's `timeout:` is too short rather than the screen too busy. The last three each say something different: the tree stayed empty means the screen rendered no accessible content; **settled on the UI tree alone** means the hierarchy did hold still and only the screenshot pairs were missing, so the capture path is what to check, not the app's rendering; too few reads means the step ended with no evidence either way. In every case, inspect the screen, disclose the cause, and confirm the acceptance checks around it rest on stable elements rather than on stillness.
-
-5. Run the same unchanged flow again immediately with the same runner. Do not manually reset app/account data between passing runs; the flow must make run 2 valid.
-6. On any failure, YAML edit, re-recording, baseline update, or manual state-changing recovery, reset the streak to zero. Diagnose and repair through `argent-create-flow`, audit, and restart proof from step 1, including the fresh-service setup.
-7. Finish only when the streak reaches two.
-
-Record the runner and fresh-service setup used. If the intended runner is unavailable, report proof as blocked instead of substituting another runner.
-
-If intended product behavior fails, keep the strong check and report the regression plus the unproven flow artifact — never weaken the test to reach a green run.
+Record the runner and fresh-service setup used.
 
 ## 6. Report
 
 Report:
 
-- flow name, file path, platform, and the standalone command (`argent flow run <name> --platform <platform>`);
-- the test-contract table, restated with its requirement-to-step/check mapping and any interpretation chosen;
-- the navigation table from the audit;
-- how the persistent baseline and end state are established;
-- both consecutive passing run results, runner used, and fresh-service setup before pass 1, plus every step `warning` either run raised and what you found behind it;
-- every snapshot name/scope, reviewed baseline status, and justified mismatch tolerance;
-- coordinate/raw-gesture exceptions and accepted live-data dependencies;
-- any remaining manual judgment or blocker.
+- Flow name, path, platform, and standalone command.
+- Contract rows mapped to actions and checks.
+- Navigation table.
+- Baseline setup, end-state restoration, and accepted data dependencies.
+- Both pass results, runner, fresh-service setup, and resolved warnings.
+- Snapshot scope, reviewed baseline status, and mismatch tolerance.
+- Coordinate or raw-gesture exceptions.
+- Remaining manual judgment or blocker.

--- a/packages/tool-server/test/flows/flow-skill-docs.test.ts
+++ b/packages/tool-server/test/flows/flow-skill-docs.test.ts
@@ -124,7 +124,11 @@ describe("create-flow idle docs", () => {
     ];
     expect(spelled, `no spelling for ${listed} warnings`).toBeDefined();
     for (const file of WARNING_COUNT_CITATIONS) {
-      const quoted = readFileSync(file, "utf8").match(/(\w+) (?:different )?warnings/);
+      // Anchored on the linked citation, not on any "… warnings" phrase: these
+      // files also say things like "Read this file for selector warnings".
+      const quoted = readFileSync(file, "utf8").match(
+        /\[(?:which of the )?(\w+) (?:different )?warnings\]\(/
+      );
       expect(quoted, `${file} no longer cites the idle warning count`).not.toBeNull();
       expect(quoted![1], file).toBe(spelled);
     }


### PR DESCRIPTION
> Stacked on #730. Everything here is a rewrite of the files that PR introduces or restructures — review it on top of that base.

The prose landing in #730 states each rule twice: once as the rule, once as the argument for it. That reads well in review and costs on every invocation, because the whole skill loads whether the task is replaying a two-step fragment or authoring a regression test.

This PR rewrites the same content as directives — one statement per rule — and keeps the reasoning only where it changes what the agent does.

## Size

| File | Words | |
| --- | --- | --- |
| `argent-create-flow/SKILL.md` | 988 → 557 | **-43%** |
| `argent-qa-flows/SKILL.md` | 2,082 → 1,325 | **-36%** |
| `references/live-authoring.md` | 3,660 → 1,980 | **-45%** |
| `references/reliability-and-recovery.md` | 2,593 → 1,411 | **-45%** |
| `references/flow-yaml.md` | 3,058 → 2,077 | **-32%** |
| `rules/argent.md` | 2,273 → 2,069 | -8% |
| `argent-device-interact/SKILL.md` | 3,708 → 3,626 | -2% |
| | **18,362 → 13,045** | **-28%** |

The two files an agent loads before it can do anything — the core skill and the QA contract — take the largest cut.

## What was preserved

Every gate, threshold, tool name, platform exception, and cross-reference. Nothing became optional and no rule was merged into another:

- the six non-negotiable rules, the coordinate fallback gate and its four discovery steps, the stable-selector definition, the three permitted unrecorded polish insertions;
- the QA definition of done, the two-consecutive-pass protocol including the fresh-service reset and the streak resets, the discriminating-evidence list;
- the iOS instrumentation recovery ladder, the `com.apple.*` scope gate, the per-platform tree-source table, the replay-failure classification and the two-cycle correction budget.

## What was cut

Repetition, not content. Each rule keeps its rationale only where the rationale is itself operative — the cases where an agent that knows only the rule would still do the wrong thing:

- `idle` cannot identify a screen, so identity and readiness are two checks and not one;
- a `hidden` whose selector never matched records as a clean pass, so absence needs the `visible` → action → `hidden` trio;
- pass 2 proves nothing unless the flow restores its own baseline;
- a longer timeout does not repair a gate that let a misfire through.

What went are the second and third restatements of a rule already given, the "not this / this" framing where the rule alone is unambiguous, and the extended worked example in `argent-qa-flows` — replaced by a compact table carrying the same seven contract rows and the two sentences that made it worth reading.

Routing entries in `rules/argent.md` shed their justification prose and keep the decision. Two paragraphs in `argent-device-interact` covering `await-ui-element`'s `hidden` and `await-screen-idle` were tightened for consistency with the reference they point at; the rest of that skill is untouched.

## Verification

- `packages/argent-installer/test/skills-frontmatter.test.ts` and `packages/tool-server/test/flows/flow-skill-docs.test.ts` — 21 tests pass, so the trimmed `idle` prose still matches the constants the parser enforces and the tool description.
- All 42 internal links and heading anchors across `packages/skills` resolve, including the ones whose TOC labels were shortened while the target headings stayed put.
- `prettier --check packages/skills` clean.
