### PR TITLE
feat(dist): ship the package as an Agent Plugins 1.0.0 plugin root

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,33 @@ project already opted into local mode (a committed `.argent/install.json`, or
 > x64, and Windows x64; other targets (Linux arm64, Windows arm) compile from source
 > and need a C/C++ toolchain.
 
+#### Install as an Agent Plugin
+
+`argent init` above is the supported path and stays the default — it detects your
+editor, writes the MCP config it actually reads, and copies skills, rules and agent
+definitions into your workspace. Nothing about it changes.
+
+For clients that implement [Agent Plugins 1.0.0](https://agent-plugins.org), the
+published npm package doubles as a plugin root: it carries a `plugin.json`, an
+`mcp.json`, and the `skills/` directory at the locations the spec fixes. Point such
+a client at an installed copy — for example, in VS Code:
+
+```jsonc
+// .vscode/settings.json
+{ "chat.pluginLocations": ["./node_modules/@swmansion/argent"] }
+```
+
+The plugin's MCP server launches via `npx -y @swmansion/argent@<version> mcp`, pinned
+to the same release the plugin ships, so a plugin copied away from its `node_modules`
+still starts the matching server. The first launch downloads the package (~36 MB of
+platform binaries) if it isn't cached.
+
+> **What a plugin cannot carry.** The spec defines only two portable component
+> types — Agent Skills and MCP servers. Argent's editor rules (`rules/argent.md`)
+> and the `argent-environment-inspector` subagent are not among them, and neither
+> are the per-client touches `init` applies (Windsurf's `alwaysAllow`, Cursor's
+> allowlist, stale-config cleanup). Run `argent init` to get those.
+
 ## CLI Reference
 
 | Command            | Description                                                                                                                                                                                               |

--- a/packages/argent/mcp.json
+++ b/packages/argent/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "argent": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@swmansion/argent@0.19.0", "mcp"]
+    }
+  }
+}

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -40,7 +40,9 @@
     "skills/",
     "agents/",
     "rules/",
-    "assets/"
+    "assets/",
+    "plugin.json",
+    "mcp.json"
   ],
   "dependencies": {
     "@fails-components/webtransport": "^1.6.3",

--- a/packages/argent/plugin.json
+++ b/packages/argent/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "argent",
+  "version": "0.19.0",
+  "description": "iOS Simulator, Android Emulator, Fire TV and Chromium app control for coding agents",
+  "author": {
+    "name": "Software Mansion",
+    "url": "https://swmansion.com"
+  },
+  "homepage": "https://github.com/software-mansion/argent",
+  "repository": "https://github.com/software-mansion/argent",
+  "license": "Apache-2.0",
+  "keywords": [
+    "ios",
+    "android",
+    "simulator",
+    "emulator",
+    "react-native",
+    "electron",
+    "mobile",
+    "testing"
+  ]
+}

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -9,6 +9,13 @@
 // bump that sweeps the workspace leaves it behind — and the registry then
 // rejects the publish, either because `packages[].version` names a version npm
 // has never seen or because `name` doesn't match the tarball's `mcpName`.
+//
+// packages/argent/plugin.json + mcp.json (the Agent Plugins manifest pair, which
+// makes the published tarball a loadable plugin root) are checked for the same
+// reason: plugin.json carries its own `version`, and mcp.json pins the exact npm
+// version its stdio server runs. Both are inert at build time, so nothing else
+// notices when a bump leaves them behind — the plugin would just keep launching
+// the previous release, next to skills shipped from this one.
 import { readFileSync, readdirSync, realpathSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,6 +26,22 @@ const repoRoot = join(dirname(selfPath), "..");
 const packagesDir = join(repoRoot, "packages");
 const argentManifestPath = join(packagesDir, "argent", "package.json");
 const serverJsonPath = join(repoRoot, "server.json");
+const pluginManifestPath = join(packagesDir, "argent", "plugin.json");
+const pluginMcpPath = join(packagesDir, "argent", "mcp.json");
+
+// The Agent Plugins spec version the manifest pair targets. Both files declare
+// it, and the spec requires them to agree — a mismatch invalidates the MCP
+// component while leaving the rest of the plugin loadable, which is exactly the
+// half-broken state this check exists to prevent.
+const PLUGIN_SPEC_VERSION = "1.0.0";
+const PLUGIN_SCHEMA = `https://agent-plugins.org/schemas/${PLUGIN_SPEC_VERSION}/plugin.schema.json`;
+const PLUGIN_MCP_SCHEMA = `https://agent-plugins.org/schemas/${PLUGIN_SPEC_VERSION}/mcp.schema.json`;
+
+// Same key `argent init` writes into every editor config (MCP_SERVER_KEY in
+// packages/argent-installer). Clients namespace a plugin server's tools by this
+// id, so renaming it here would rename every `mcp__argent__*` tool the bundled
+// skills call for by name.
+const PLUGIN_MCP_SERVER_KEY = "argent";
 
 /**
  * Everything server.json has to keep in step with the npm package it points at,
@@ -96,6 +119,88 @@ export function serverJsonMismatches(publishedVersion, argentPkg, server) {
         `server.json packages[${i}].identifier (${pkg.identifier}) != published package name (${argentPkg.name})`
       );
     }
+  }
+
+  return mismatches;
+}
+
+/**
+ * Everything the Agent Plugins manifest pair has to keep in step with the npm
+ * package it ships inside, as one human-readable line per problem. Pure, like
+ * serverJsonMismatches() above, so the whole matrix is unit-testable.
+ * @param {string | undefined} publishedVersion the version packages/argent/package.json carries
+ * @param {{ name?: string, files?: string[] }} argentPkg packages/argent/package.json
+ * @param {{ $schema?: string, name?: string, version?: string }} plugin packages/argent/plugin.json
+ * @param {{ $schema?: string, mcpServers?: Record<string, { type?: string, command?: string, args?: string[] }> }} mcp packages/argent/mcp.json
+ * @returns {string[]} empty when in sync
+ */
+export function pluginManifestMismatches(publishedVersion, argentPkg, plugin, mcp) {
+  const mismatches = [];
+
+  // Mirrors the publishedVersion guard in serverJsonMismatches: with no version
+  // to compare against, every check below would pass on undefined === undefined.
+  if (!publishedVersion) {
+    mismatches.push(
+      "packages/argent/package.json has no version — nothing for plugin.json to be checked against"
+    );
+  } else if (plugin.version !== publishedVersion) {
+    mismatches.push(
+      `plugin.json version is ${plugin.version}, packages/argent/package.json is ${publishedVersion}`
+    );
+  }
+
+  if (plugin.$schema !== PLUGIN_SCHEMA) {
+    mismatches.push(`plugin.json $schema is ${plugin.$schema}, expected ${PLUGIN_SCHEMA}`);
+  }
+  if (mcp.$schema !== PLUGIN_MCP_SCHEMA) {
+    mismatches.push(`mcp.json $schema is ${mcp.$schema}, expected ${PLUGIN_MCP_SCHEMA}`);
+  }
+
+  // Both files ship inside the tarball, but only if `files` names them — npm
+  // includes package.json, README and LICENSE implicitly and nothing else. A
+  // plugin root missing either file is not a plugin at all.
+  const files = Array.isArray(argentPkg.files) ? argentPkg.files : [];
+  for (const entry of ["plugin.json", "mcp.json"]) {
+    if (!files.includes(entry)) {
+      mismatches.push(
+        `packages/argent/package.json "files" does not list ${entry} — it would not ship in the tarball`
+      );
+    }
+  }
+
+  // Absent and non-object both mean the plugin declares no MCP server, and
+  // reading through the latter would throw rather than report.
+  const servers = mcp.mcpServers;
+  if (typeof servers !== "object" || servers === null || Array.isArray(servers)) {
+    mismatches.push("mcp.json has no mcpServers object — the plugin would expose no tools");
+    return mismatches;
+  }
+
+  const keys = Object.keys(servers);
+  if (!keys.includes(PLUGIN_MCP_SERVER_KEY)) {
+    mismatches.push(
+      `mcp.json declares no "${PLUGIN_MCP_SERVER_KEY}" server (found: ${keys.join(", ") || "none"}) — ` +
+        `plugin tools would not be named mcp__${PLUGIN_MCP_SERVER_KEY}__*, which the bundled skills call for`
+    );
+    return mismatches;
+  }
+
+  const entry = servers[PLUGIN_MCP_SERVER_KEY];
+  if (entry.type !== "stdio") {
+    mismatches.push(`mcp.json ${PLUGIN_MCP_SERVER_KEY}.type is ${entry.type}, expected stdio`);
+  }
+
+  // The npx form is deliberate: a plugin directory can reach a client by a route
+  // that never runs `npm install` (a git clone, a marketplace copy), so the
+  // server cannot be assumed to be resolvable next to the manifest. The pin is
+  // what keeps the launched server on the same release as the skills sitting
+  // beside it in the same plugin.
+  const pin = `${argentPkg.name}@${publishedVersion}`;
+  const args = Array.isArray(entry.args) ? entry.args : [];
+  if (publishedVersion && argentPkg.name && !args.includes(pin)) {
+    mismatches.push(
+      `mcp.json ${PLUGIN_MCP_SERVER_KEY}.args does not pin ${pin} (found: ${args.join(" ") || "none"})`
+    );
   }
 
   return mismatches;
@@ -182,6 +287,8 @@ function main() {
   // though — a manifest missing its version is caught as a mismatch below.
   const argentPkg = readTrackedJson(argentManifestPath);
   const server = readTrackedJson(serverJsonPath);
+  const plugin = readTrackedJson(pluginManifestPath);
+  const pluginMcp = readTrackedJson(pluginMcpPath);
 
   // server.json names the npm coordinates of packages/argent, so that manifest
   // is what it has to agree with. Reported even when packages/* disagree, so a
@@ -197,9 +304,26 @@ function main() {
     failed = true;
   }
 
+  // Reported alongside the server.json result rather than instead of it, for the
+  // same reason: one run should list every file a half-finished bump left behind.
+  const pluginProblems = pluginManifestMismatches(argentPkg.version, argentPkg, plugin, pluginMcp);
+  if (pluginProblems.length > 0) {
+    console.error(
+      "packages/argent/plugin.json + mcp.json are out of sync with packages/argent/package.json:"
+    );
+    for (const line of pluginProblems) console.error(`  ${line}`);
+    console.error(
+      "\nThe Agent Plugins manifest pair carries its own version and pins the npm version its\n" +
+        "server runs, so a workspace bump leaves both behind — edit them by hand to match."
+    );
+    failed = true;
+  }
+
   if (failed) process.exit(1);
 
-  console.log(`All workspace packages and server.json are at ${argentPkg.version}.`);
+  console.log(
+    `All workspace packages, server.json and the plugin manifest are at ${argentPkg.version}.`
+  );
 }
 
 // Run only when invoked directly, not when imported by the test. Both sides are

--- a/scripts/check-workspace-versions.test.mjs
+++ b/scripts/check-workspace-versions.test.mjs
@@ -27,19 +27,48 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { serverJsonMismatches } from "./check-workspace-versions.mjs";
+import { pluginManifestMismatches, serverJsonMismatches } from "./check-workspace-versions.mjs";
 
 const VERSION = "0.18.0";
-const ARGENT_PKG = { name: "@swmansion/argent", mcpName: "io.github.software-mansion/argent" };
+const ARGENT_PKG = {
+  name: "@swmansion/argent",
+  mcpName: "io.github.software-mansion/argent",
+  files: ["dist/", "skills/", "plugin.json", "mcp.json"],
+};
 const SERVER = {
   name: "io.github.software-mansion/argent",
   version: VERSION,
   packages: [{ identifier: "@swmansion/argent", version: VERSION }],
 };
+const PLUGIN = {
+  $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  name: "argent",
+  version: VERSION,
+};
+const PLUGIN_MCP = {
+  $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  mcpServers: {
+    argent: { type: "stdio", command: "npx", args: ["-y", `@swmansion/argent@${VERSION}`, "mcp"] },
+  },
+};
 
 /** @param {(s: typeof SERVER) => void} mutate */
 function server(mutate) {
   const copy = structuredClone(SERVER);
+  mutate(copy);
+  return copy;
+}
+
+/** @param {(p: typeof PLUGIN) => void} mutate */
+function plugin(mutate) {
+  const copy = structuredClone(PLUGIN);
+  mutate(copy);
+  return copy;
+}
+
+/** @param {(m: typeof PLUGIN_MCP) => void} mutate */
+function pluginMcp(mutate) {
+  const copy = structuredClone(PLUGIN_MCP);
   mutate(copy);
   return copy;
 }
@@ -219,6 +248,159 @@ test("every problem is reported at once, not just the first", () => {
   assert.equal(problems.length, 4);
 });
 
+// --- the Agent Plugins manifest pair ----------------------------------------
+// plugin.json and mcp.json are read by plugin-aware clients, never by our build,
+// so nothing in the repo exercises them — these are the only thing standing
+// between a bump and a plugin that ships this release's skills next to a server
+// pinned to the previous one.
+
+test("an in-sync manifest pair reports nothing", () => {
+  assert.deepEqual(pluginManifestMismatches(VERSION, ARGENT_PKG, PLUGIN, PLUGIN_MCP), []);
+});
+
+test("a plugin.json version left behind by a bump is caught", () => {
+  const problems = pluginManifestMismatches(
+    VERSION,
+    ARGENT_PKG,
+    plugin((p) => (p.version = "0.17.0")),
+    PLUGIN_MCP
+  );
+  assert.deepEqual(problems, [
+    "plugin.json version is 0.17.0, packages/argent/package.json is 0.18.0",
+  ]);
+});
+
+// The failure this pair exists to prevent: the manifest says 0.18.0 while the
+// server it launches is the previous release, so the skills and the tools they
+// name come from different versions.
+test("an npx pin left behind by a bump is caught", () => {
+  const problems = pluginManifestMismatches(
+    VERSION,
+    ARGENT_PKG,
+    PLUGIN,
+    pluginMcp((m) => (m.mcpServers.argent.args = ["-y", "@swmansion/argent@0.17.0", "mcp"]))
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /does not pin @swmansion\/argent@0\.18\.0/);
+});
+
+// An unpinned `@latest` (or a bare name) passes every other check here while
+// silently decoupling the server from the plugin it ships in.
+test("an unpinned npx arg is caught", () => {
+  for (const spec of ["@swmansion/argent", "@swmansion/argent@latest"]) {
+    const problems = pluginManifestMismatches(
+      VERSION,
+      ARGENT_PKG,
+      PLUGIN,
+      pluginMcp((m) => (m.mcpServers.argent.args = ["-y", spec, "mcp"]))
+    );
+    assert.equal(problems.length, 1, `expected ${spec} to be caught`);
+    assert.match(problems[0], /does not pin/);
+  }
+});
+
+// The spec requires both $schema values to name the same spec version; a
+// mismatch invalidates the MCP component while the rest of the plugin still
+// loads, which is worse than failing outright.
+test("either $schema drifting from the targeted spec version is caught", () => {
+  const bumped = pluginManifestMismatches(
+    VERSION,
+    ARGENT_PKG,
+    plugin((p) => (p.$schema = "https://agent-plugins.org/schemas/1.1.0/plugin.schema.json")),
+    PLUGIN_MCP
+  );
+  assert.equal(bumped.length, 1);
+  assert.match(bumped[0], /plugin\.json \$schema is/);
+
+  const mcpBumped = pluginManifestMismatches(
+    VERSION,
+    ARGENT_PKG,
+    PLUGIN,
+    pluginMcp((m) => (m.$schema = "https://agent-plugins.org/schemas/1.1.0/mcp.schema.json"))
+  );
+  assert.equal(mcpBumped.length, 1);
+  assert.match(mcpBumped[0], /mcp\.json \$schema is/);
+});
+
+// npm ships package.json, README and LICENSE implicitly and nothing else, so a
+// `files` array that forgets either file publishes a tarball that is not a
+// plugin root at all — and every other check here would still pass.
+test("a files array that would not ship the pair is caught", () => {
+  const problems = pluginManifestMismatches(
+    VERSION,
+    { ...ARGENT_PKG, files: ["dist/", "skills/"] },
+    PLUGIN,
+    PLUGIN_MCP
+  );
+  assert.deepEqual(problems, [
+    'packages/argent/package.json "files" does not list plugin.json — it would not ship in the tarball',
+    'packages/argent/package.json "files" does not list mcp.json — it would not ship in the tarball',
+  ]);
+});
+
+// Clients namespace a plugin server's tools by its mcp.json key, so renaming it
+// renames every mcp__argent__* tool the bundled skills call for by name.
+test("renaming the server key away from argent is caught", () => {
+  const problems = pluginManifestMismatches(
+    VERSION,
+    ARGENT_PKG,
+    PLUGIN,
+    pluginMcp((m) => {
+      m.mcpServers = /** @type {any} */ ({ "swm-argent": m.mcpServers.argent });
+    })
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /declares no "argent" server \(found: swm-argent\)/);
+});
+
+// Absent, null and array all leave the plugin exposing no tools, and reading
+// through the last two would throw rather than report.
+test("an mcp.json with no usable mcpServers object is caught", () => {
+  const unusable = [
+    pluginMcp((m) => delete (/** @type {any} */ (m).mcpServers)),
+    pluginMcp((m) => (m.mcpServers = /** @type {any} */ (null))),
+    pluginMcp((m) => (m.mcpServers = /** @type {any} */ ([]))),
+  ];
+  for (const broken of unusable) {
+    const problems = pluginManifestMismatches(VERSION, ARGENT_PKG, PLUGIN, broken);
+    assert.deepEqual(problems, [
+      "mcp.json has no mcpServers object — the plugin would expose no tools",
+    ]);
+  }
+});
+
+// A transport the client cannot launch from a plugin directory, e.g. a hand-edit
+// to an http URL that nothing in this repo serves.
+test("a non-stdio transport is caught", () => {
+  const problems = pluginManifestMismatches(
+    VERSION,
+    ARGENT_PKG,
+    PLUGIN,
+    pluginMcp((m) => (m.mcpServers.argent.type = "streamable-http"))
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /argent\.type is streamable-http, expected stdio/);
+});
+
+// Same vacuous-pass shape serverJsonMismatches guards: with no version to
+// compare against, the version check and the pin check both compare undefined.
+test("a version-less manifest fails instead of passing vacuously", () => {
+  const problems = pluginManifestMismatches(undefined, ARGENT_PKG, PLUGIN, PLUGIN_MCP);
+  assert.deepEqual(problems, [
+    "packages/argent/package.json has no version — nothing for plugin.json to be checked against",
+  ]);
+});
+
+test("every problem is reported at once, not just the first", () => {
+  const problems = pluginManifestMismatches(
+    VERSION,
+    { ...ARGENT_PKG, files: ["dist/"] },
+    plugin((p) => (p.version = "0.17.0")),
+    pluginMcp((m) => (m.mcpServers.argent.args = ["-y", "@swmansion/argent@0.17.0", "mcp"]))
+  );
+  assert.equal(problems.length, 4);
+});
+
 // --- the real script, spawned -----------------------------------------------
 // main() is what repo-hygiene.yml runs and none of the above touches it, so a
 // fail-open edit there (an exit(0) on the failure path, a guard that skips
@@ -234,16 +416,24 @@ const SCRIPT_PATH = fileURLToPath(new URL("./check-workspace-versions.mjs", impo
  * symlink test then reintroduces deliberately.
  * @param {import("node:test").TestContext} t
  * @param {{ argentVersion?: string | null, otherVersion?: string, serverJson?: unknown,
- *   extraPackages?: Record<string, unknown> }} [options]
- *   serverJson: an object to write as JSON, a string to write verbatim, or null
- *   to leave the file out entirely. argentVersion: null omits the version key.
- *   extraPackages: further packages/<dir> entries, a null value creating the
- *   directory with no package.json in it.
+ *   pluginJson?: unknown, pluginMcpJson?: unknown, extraPackages?: Record<string, unknown> }} [options]
+ *   serverJson / pluginJson / pluginMcpJson: an object to write as JSON, a
+ *   string to write verbatim, or null to leave the file out entirely.
+ *   argentVersion: null omits the version key. extraPackages: further
+ *   packages/<dir> entries, a null value creating the directory with no
+ *   package.json in it.
  * @returns {string} the repo root
  */
 function fixtureRepo(
   t,
-  { argentVersion = VERSION, otherVersion = VERSION, serverJson, extraPackages = {} } = {}
+  {
+    argentVersion = VERSION,
+    otherVersion = VERSION,
+    serverJson,
+    pluginJson,
+    pluginMcpJson,
+    extraPackages = {},
+  } = {}
 ) {
   const root = realpathSync(mkdtempSync(join(tmpdir(), "check-workspace-versions-")));
   t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -269,6 +459,12 @@ function fixtureRepo(
     if (manifest !== null) write(join(root, "packages", dir, "package.json"), manifest);
   }
   if (serverJson !== null) write(join(root, "server.json"), serverJson ?? SERVER);
+  if (pluginJson !== null) {
+    write(join(root, "packages", "argent", "plugin.json"), pluginJson ?? PLUGIN);
+  }
+  if (pluginMcpJson !== null) {
+    write(join(root, "packages", "argent", "mcp.json"), pluginMcpJson ?? PLUGIN_MCP);
+  }
 
   return root;
 }
@@ -289,7 +485,51 @@ test("[script] an in-sync repo passes quietly", (t) => {
   const result = runScript(fixtureRepo(t));
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stderr, "");
-  assert.match(result.stdout, /All workspace packages and server\.json are at 0\.18\.0\./);
+  assert.match(
+    result.stdout,
+    /All workspace packages, server\.json and the plugin manifest are at 0\.18\.0\./
+  );
+});
+
+test("[script] plugin manifest drift alone exits 1", (t) => {
+  const root = fixtureRepo(t, { pluginJson: plugin((p) => (p.version = "0.17.0")) });
+  const result = runScript(root);
+  assert.equal(result.status, 1, `expected a failure, got:\n${result.stdout}${result.stderr}`);
+  assert.match(result.stderr, /plugin\.json version is 0\.17\.0/);
+  // Nothing else disagrees, so this is the only thing that could have failed it.
+  assert.doesNotMatch(result.stderr, /server\.json is out of sync/);
+  assert.doesNotMatch(result.stderr, /Workspace package versions are out of sync/);
+});
+
+test("[script] a half-finished bump reports server.json and the plugin pair in one run", (t) => {
+  const root = fixtureRepo(t, {
+    serverJson: server((s) => {
+      s.version = "0.17.0";
+      s.packages[0].version = "0.17.0";
+    }),
+    pluginMcpJson: pluginMcp(
+      (m) => (m.mcpServers.argent.args = ["-y", "@swmansion/argent@0.17.0", "mcp"])
+    ),
+  });
+  const result = runScript(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /server\.json version is 0\.17\.0/);
+  assert.match(result.stderr, /does not pin @swmansion\/argent@0\.18\.0/);
+});
+
+test("[script] a missing plugin.json fails on-message", (t) => {
+  const result = runScript(fixtureRepo(t, { pluginJson: null }));
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Cannot read packages\/argent\/plugin\.json: /);
+  assert.match(result.stderr, /git checkout -- packages\/argent\/plugin\.json/);
+  assertNoStackTrace(result.stderr);
+});
+
+test("[script] a malformed mcp.json fails on-message", (t) => {
+  const result = runScript(fixtureRepo(t, { pluginMcpJson: "{ not json" }));
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /packages\/argent\/mcp\.json is not valid JSON: /);
+  assertNoStackTrace(result.stderr);
 });
 
 test("[script] server.json drift alone exits 1", (t) => {


### PR DESCRIPTION
## What

Adds two files — `packages/argent/plugin.json` and `packages/argent/mcp.json` — so the published npm tarball doubles as a loadable [Agent Plugins 1.0.0](https://agent-plugins.org/specification) plugin root. The spec fixes `plugin.json`, `mcp.json` and `skills/` at the plugin root, and `skills/` already lands there at build time (`bundle-tools.cjs` copies `packages/skills/skills` → `packages/argent/skills`), so the layout is a two-file gap, not a restructure.

```
@swmansion/argent/          ← plugin root
├── plugin.json             ← new
├── mcp.json                ← new
├── skills/                 ← already there
└── dist/, bin/, dylibs/, …
```

## What this does NOT change

**`argent init` is untouched and stays the default.** Zero lines change under `packages/argent-installer/` — editor detection, the MCP entries written into all ten supported clients, global vs. `--local` committable mode, rules and agent copying, stale-config cleanup, allowlists, telemetry all behave exactly as before. This is an additional way in for clients that implement the standard, not a replacement.

The README section says so explicitly, and lists what a plugin structurally *cannot* carry (the spec has only two portable component types — Agent Skills and MCP servers): `rules/argent.md`, the `argent-environment-inspector` subagent, and the per-client touches `init` applies.

## Why npx, and why pinned

```json
{ "type": "stdio", "command": "npx", "args": ["-y", "@swmansion/argent@0.19.0", "mcp"] }
```

A plugin directory can reach a client by a route that never runs `npm install` — a git clone, a marketplace copy — so the server can't be assumed to sit next to the manifest, which rules out the `${PLUGIN_ROOT}/dist/cli.js` form. The version pin keeps the launched server on the same release as the skills shipped beside it in the same plugin; an unpinned `@latest` would silently decouple them.

Trade-off worth knowing: the first launch downloads the package (~36 MB of platform binaries) unless it's already in the npx cache. Documented in the README.

The server key stays `argent`, matching `MCP_SERVER_KEY` in the installer — clients namespace a plugin server's tools by that id, so renaming it would rename every `mcp__argent__*` tool the bundled skills call for by name.

## Keeping it from rotting

Both files are inert at build time, so nothing in the repo would notice a release bump leaving them behind — the plugin would keep launching the previous release next to this release's skills. `scripts/check-workspace-versions.mjs` (already run by `repo-hygiene.yml`) now holds them to `packages/argent/package.json` the same way it holds `server.json`, via a new pure `pluginManifestMismatches()`:

- `plugin.json` version == the workspace version
- the npx arg pins `@swmansion/argent@<that version>` (an unpinned or stale spec fails)
- both `$schema` values name spec 1.0.0 and agree with each other
- `mcp.json` declares an `argent` stdio server
- `files` lists both filenames — npm ships `package.json`/README/LICENSE implicitly and nothing else, so forgetting either one publishes a tarball that isn't a plugin root while every other check still passes

**Note for the next release:** `plugin.json`'s `version` and `mcp.json`'s npx pin join the version-bump file set. Getting either wrong now fails CI rather than shipping quietly.

## Testing

- `node --test scripts/check-workspace-versions.test.mjs` — 42 pass (17 new: the `pluginManifestMismatches()` matrix plus spawned-script runs for plugin drift, a combined half-finished bump, and missing/malformed file handling)
- `node scripts/check-workspace-versions.mjs` against this branch → in sync at 0.19.0
- Both manifests validated with ajv against the **published** schemas fetched from `agent-plugins.org/schemas/1.0.0/` → VALID
- `npm pack --dry-run -w @swmansion/argent` → `plugin.json` and `mcp.json` present in the tarball contents
- `tsc -p tsconfig.scripts.json`, `eslint scripts/`, `prettier --check` all clean

## Follow-ups (not in this PR)

- Marketplace listings (VS Code discovers from `copilot-plugins`/`awesome-copilot`-style repos; each client has its own route)
- A `com.anthropic.claude-code/` extension namespace dir if we want the rule and subagent to travel with the plugin for Claude Code
- Live verification in VS Code / Copilot CLI once we decide on a distribution route

🤖 Generated with [Claude Code](https://claude.com/claude-code)