### PR TITLE
fix(profiler): stop exporting component-name types nothing imports

### DIFF
--- a/packages/tool-server/src/utils/react-profiler/component-names.ts
+++ b/packages/tool-server/src/utils/react-profiler/component-names.ts
@@ -22,7 +22,7 @@ const WRAPPER_PATTERNS = [/^Forget\((.+)\)$/, /^Memo\((.+)\)$/, /^ForwardRef\((.
  */
 const MAX_WRAPPER_DEPTH = 4;
 
-export interface StrippedName {
+interface StrippedName {
   baseName: string;
   hasForget: boolean;
   hasMemo: boolean;
@@ -47,7 +47,7 @@ export function stripComponentWrappers(raw: string): StrippedName {
   return { baseName: name, hasForget, hasMemo, hasForwardRef };
 }
 
-export interface ComponentAnnotation {
+interface ComponentAnnotation {
   displayName: string;
   tag: string;
   rawName: string;
@@ -70,7 +70,7 @@ export function annotateComponentName(raw: string): ComponentAnnotation {
   return { displayName: baseName, tag, rawName: raw };
 }
 
-export type ComponentNameResolution =
+type ComponentNameResolution =
   | { kind: "exact"; rawName: string; alsoMatching: string[] }
   | { kind: "display"; rawName: string; query: string }
   | { kind: "ambiguous"; query: string; candidates: string[] }


### PR DESCRIPTION
## The problem

The Dead Code job has been red on `main` since f136c02 ([run 31483379660](https://github.com/software-mansion/argent/actions/runs/31483379660)). It is not a first-pass finding — the only sections printed are the parked ones, which is the shape `knip.yml`'s "Explain the failure" step describes: the second pass exceeded `--max-issues 215`.

Counted the way `knip.jsonc` requires, against a tree with no build output:

| commit | unused exports | unused exported types | unused exported class members | total | `npm run knip` |
| --- | --- | --- | --- | --- | --- |
| 4a11317 (parent) | 47 | 156 | 12 | **215** | exit 0 |
| f136c02 (`main`) | 47 | **159** | 12 | **218** | exit 1 |

The three added issues are the three types `f136c02` exported from the new `component-names.ts`:

```
StrippedName             interface  .../react-profiler/component-names.ts:25:18
ComponentAnnotation      interface  .../react-profiler/component-names.ts:50:18
ComponentNameResolution  type       .../react-profiler/component-names.ts:73:13
```

Nothing outside the module imports any of them. All five consumers — `profiler-commit-query.ts`, `profiler-cpu-query.ts`, `react-profiler-analyze.ts`, `react-profiler-component-source.ts`, `05-render.ts` — and the test file import functions only.

## The fix

Drop `export` from those three declarations. They stay exactly where they are and keep annotating the same signatures; they are simply no longer part of the module's public surface, which is what knip was reporting. This is the gate working as intended rather than a ceiling bump: `knip.jsonc` states the parked backlog is bounded and that paying off one parked export licences a new one, so the total returns to the 215 the ceiling was set against.

Declaration emit is unaffected — `tsc --build` writes the interfaces into `component-names.d.ts` as local declarations and the exported functions keep referencing them:

```ts
interface StrippedName { ... }
export declare function stripComponentWrappers(raw: string): StrippedName;
```

Callers were already relying on inference (`resolveComponentName(...)` narrowed by `kind` and passed straight into `describeResolution` / `renderComponentNameMiss`), so no call site changes.

## Verification

Everything below was run against a clean worktree with no build output, matching how CI counts:

- `npm run knip` — **exit 0** on this commit; second pass back to 47 + 156 + 12 = 215. Both passes green, no config hints. The same command on f136c02 exits 1 at 218, and on 4a11317 exits 0 at 215.
- `npm run build` (`tsc --build`) — clean; the emitted `component-names.js` is byte-identical to the pre-change build (`diff` reports no output), which is the proof this cannot move runtime behaviour.
- `npm run typecheck:tests --workspaces` — clean across all four workspaces that define it.
- `npm test --workspaces` — tool-server 329 files / 3857 passed, 1 skipped; registry, telemetry and update-core green.
- `npm run lint` (`eslint . --max-warnings 0`) — clean.
- `prettier --check` — clean.
