### PR TITLE
perf(flows): wait for the launched app to draw instead of sleeping 1.5s

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -73,6 +73,8 @@ import { untrackChromiumPort } from "../../utils/chromium-discovery";
 import { parseChromiumCdpPort, resolveDevice } from "../../utils/device-info";
 import { runSnapshot, DEFAULT_MAX_MISMATCH, type SnapshotArtifacts } from "./flow-visual";
 import { describeVega } from "../describe/platforms/vega";
+import { fetchFlowTree } from "./flow-tree";
+import type { DescribeNode } from "../describe/contract";
 import { pinStatusBar, restoreStatusBar } from "../../utils/status-bar";
 
 const zodSchema = z
@@ -276,12 +278,102 @@ export interface FlowPrerequisiteNotice {
 export const MAX_RUN_DEPTH = 20;
 
 /**
- * Grace period to let a freshly (re)launched app settle before the first step
- * runs. A cold start can outlast the first directive's default auto-wait (e.g. a
- * short-grace `assert`, or a `tap` whose budget is eaten by the launch), so we
- * give the app a head start here rather than inflating every step's timeout.
+ * Longest a freshly (re)launched app is given to put content on screen before
+ * the first step runs. A cold start can outlast the first directive's default
+ * auto-wait (e.g. a short-grace `assert`, or a `tap` whose budget is eaten by
+ * the launch), so we give the app a head start here rather than inflating every
+ * step's timeout.
+ *
+ * This is a BUDGET, not a delay: {@link settleAfterLaunch} stops as soon as the
+ * app has drawn something the flow tree can see. `restart-app` already waits for
+ * the activity to be displayed, so on a warm app the content is usually there on
+ * the first read and the run continues in a fraction of this window; only an app
+ * that is still blank keeps waiting, which is what the budget was for.
  */
 const POST_LAUNCH_SETTLE_MS = 1500;
+
+/**
+ * How often {@link settleAfterLaunch} re-reads the tree while the app is still
+ * blank. Deliberately unhurried: a hierarchy read is served by the inspected
+ * app's own UI thread, which during a cold start is the thing we are waiting
+ * for, so polling it hard would slow the very work being waited on. The read
+ * that matters is the first one — an app that has already drawn is past this
+ * loop before the interval is ever used.
+ */
+const LAUNCH_SETTLE_POLL_MS = 250;
+
+/**
+ * Nodes below which a tree is "the app has not drawn its content yet", for a
+ * screen whose views carry no label at all (see {@link hasDrawnContent}). The
+ * synthetic root counts, so this is "the root plus two views".
+ */
+const LAUNCH_SETTLE_MIN_NODES = 3;
+
+/**
+ * Has the app put something on screen for the flow to act on?
+ *
+ * A freshly launched Android activity reports a tree of exactly one view before
+ * it draws: the window's own content frame, carrying `android:id/content` and
+ * nothing else — no label, no value, no children. Measured on a cold start, that
+ * shell is what the tree holds for the whole settle window, so "the tree is
+ * non-empty" would call a blank screen ready.
+ *
+ * What separates it from a drawn screen is not size but addressability: the
+ * shell has an identifier only, while anything the app itself renders brings a
+ * label or a value. So a single labelled view is enough — an app whose first
+ * screen is one line of text settles as fast as a dense one.
+ *
+ * The node-count arm below is the fallback for a screen that draws real content
+ * with no labels on it at all (icons without a content description, a canvas):
+ * two such views still read as drawn, one does not, and that case simply waits
+ * out the budget.
+ */
+function hasDrawnContent(root: DescribeNode): boolean {
+  let nodes = 0;
+  let addressable = false;
+  const visit = (node: DescribeNode): void => {
+    nodes += 1;
+    if (node !== root && (node.label || node.value)) addressable = true;
+    for (const child of node.children ?? []) visit(child);
+  };
+  visit(root);
+  return addressable || nodes >= LAUNCH_SETTLE_MIN_NODES;
+}
+
+/**
+ * Wait for a freshly launched app to put content on screen, bounded by
+ * {@link POST_LAUNCH_SETTLE_MS}.
+ *
+ * Replaces an unconditional sleep of the whole budget. The condition that sleep
+ * was approximating is observable — the flow's own tree source either shows the
+ * app's content or it doesn't — and reading it costs a fraction of the window on
+ * a warm app while still spending the full budget on a genuinely slow start.
+ *
+ * Deliberately forgiving: a tree that never satisfies {@link hasDrawnContent}
+ * (an app whose first screen is a canvas, a video surface, or anything else
+ * without addressable content) simply uses the whole budget and the run carries
+ * on, exactly as the sleep did. A read that throws is treated the same way —
+ * this is a head start, not a gate, and {@link treeSourceGate} has already
+ * established that the source is up.
+ *
+ * Returns false only when the run was aborted mid-wait.
+ */
+async function settleAfterLaunch(env: ActionEnv): Promise<boolean> {
+  const deadline = Date.now() + POST_LAUNCH_SETTLE_MS;
+  for (;;) {
+    if (env.signal?.aborted) return false;
+    try {
+      const { tree } = await fetchFlowTree(env.registry, env.device);
+      if (hasDrawnContent(tree)) return true;
+    } catch {
+      // Transient read failure — keep waiting out the budget rather than
+      // reporting a launch problem the next step is better placed to describe.
+    }
+    const left = deadline - Date.now();
+    if (left <= 0) return true;
+    if (!(await sleepOrAbort(Math.min(LAUNCH_SETTLE_POLL_MS, left), env.signal))) return false;
+  }
+}
 
 /**
  * Flows resolve selectors against the native UIView tree, served over the
@@ -465,7 +557,6 @@ async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcom
     if (signal?.aborted) return ABORTED_OUTCOME;
     return { ok: false, reason: `restart-app failed: ${errMsg(err)}` };
   }
-  if (!(await sleepOrAbort(POST_LAUNCH_SETTLE_MS, signal))) return ABORTED_OUTCOME;
   const gate = await treeSourceGate(registry, device, bundleId, signal);
   // The gate returns null (ready) on abort — check the signal before trusting
   // it, or a cancelled gate would read as a launch that verified readiness.
@@ -474,8 +565,10 @@ async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcom
   // Remember the launched app for the rest of the RUN (nested `run:` flows
   // share this state, so a nested launch retargets the whole run — see
   // ActionEnv.launchedNativeApp). iOS tree reads use it only when target
-  // auto-resolution times out mid-stall.
+  // auto-resolution times out mid-stall. Recorded before the head start below,
+  // which reads the tree and so is one of those reads.
   state.launchedNativeApp = bundleId;
+  if (!(await settleAfterLaunch(env))) return ABORTED_OUTCOME;
   return { ok: true };
 }
 

--- a/packages/tool-server/test/flows/flow-launch-settle.test.ts
+++ b/packages/tool-server/test/flows/flow-launch-settle.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { DescribeTreeData } from "../../src/tools/describe/contract";
+
+// The launch step's post-launch head start reads the flow tree to decide when
+// the app has drawn, so these tests drive it through the tree source.
+const fetchFlowTree = vi.fn();
+vi.mock("../../src/tools/flows/flow-tree", () => ({
+  fetchFlowTree: (...args: unknown[]) => fetchFlowTree(...(args as [])),
+}));
+
+// Status-bar normalization shells out to `adb` for a real device id, which
+// would put seconds of unrelated I/O inside the elapsed times asserted below.
+vi.mock("../../src/utils/status-bar", () => ({
+  pinStatusBar: async () => true,
+  restoreStatusBar: async () => {},
+}));
+
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+
+const PROJECT_ROOT = path.join(os.tmpdir(), `flow-launch-settle-${process.pid}`);
+const ANDROID_DEVICE = "emulator-5554";
+
+const LAUNCH_FLOW = `steps:
+  - launch: com.example.app
+`;
+
+/** A tree with real content — what a drawn app looks like to the runner. */
+function drawnTree(): DescribeTreeData {
+  return {
+    tree: {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        {
+          role: "Button",
+          label: "Sign in",
+          frame: { x: 0, y: 0, width: 1, height: 0.1 },
+          children: [],
+        },
+        {
+          role: "Text",
+          label: "Welcome",
+          frame: { x: 0, y: 0.2, width: 1, height: 0.1 },
+          children: [],
+        },
+      ],
+    },
+    source: "android-devtools",
+  } as unknown as DescribeTreeData;
+}
+
+/** A tree with nothing in it — the app has not drawn its content yet. */
+function blankTree(): DescribeTreeData {
+  return {
+    tree: { role: "Screen", frame: { x: 0, y: 0, width: 1, height: 1 }, children: [] },
+    source: "android-devtools",
+  } as unknown as DescribeTreeData;
+}
+
+/**
+ * What a freshly launched Android activity actually reports before it draws:
+ * the window's own content frame, identifier and nothing else. Captured from a
+ * cold start on a Pixel 9 emulator — it is the shape a "non-empty tree" check
+ * would wrongly call ready.
+ */
+function undrawnShellTree(): DescribeTreeData {
+  return {
+    tree: {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        {
+          role: "FrameLayout",
+          identifier: "android:id/content",
+          frame: { x: 0, y: 0, width: 1, height: 1 },
+          children: [],
+        },
+      ],
+    },
+    source: "android-devtools",
+  } as unknown as DescribeTreeData;
+}
+
+/** An app whose whole first screen is a single labelled view. */
+function minimalDrawnTree(): DescribeTreeData {
+  return {
+    tree: {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        {
+          role: "Text",
+          label: "Hello",
+          frame: { x: 0, y: 0, width: 1, height: 0.1 },
+          children: [],
+        },
+      ],
+    },
+    source: "android-devtools",
+  } as unknown as DescribeTreeData;
+}
+
+function makeRegistry(): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string) => {
+      if (id === "list-devices") {
+        return {
+          devices: [
+            { platform: "android", id: ANDROID_DEVICE, udid: ANDROID_DEVICE, state: "device" },
+          ],
+        };
+      }
+      return { ok: true, restarted: true };
+    }),
+    getTool: vi.fn(() => undefined),
+    resolveService: vi.fn(async () => ({ isReady: () => true })),
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: string): Promise<string> {
+  const flowsDir = path.join(PROJECT_ROOT, ".argent", "flows");
+  await fs.mkdir(flowsDir, { recursive: true });
+  const file = path.join(flowsDir, `${name}.yaml`);
+  await fs.writeFile(file, yaml, "utf8");
+  return file;
+}
+
+function asRun(r: FlowRunResult | { notice: string }): FlowRunResult {
+  if (!("steps" in r)) throw new Error(`expected a FlowRunResult, got a notice: ${r.notice}`);
+  return r;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  fetchFlowTree.mockReset();
+  await fs.rm(PROJECT_ROOT, { recursive: true, force: true });
+});
+
+describe("post-launch settle", () => {
+  it("continues as soon as the app has drawn instead of sleeping the whole budget", async () => {
+    const flowFile = await writeFlow("launch", LAUNCH_FLOW);
+    fetchFlowTree.mockResolvedValue(drawnTree());
+    const registry = makeRegistry();
+
+    const started = Date.now();
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "launch", project_root: PROJECT_ROOT, flow_file: flowFile, device: ANDROID_DEVICE }
+      )
+    );
+    const elapsed = Date.now() - started;
+
+    expect(result.ok).toBe(true);
+    // The old behaviour slept a flat 1500ms here regardless of the app. One
+    // read is the whole wait now — asserted as a poll count, which does not
+    // move with host load the way an elapsed time does.
+    expect(fetchFlowTree).toHaveBeenCalledTimes(1);
+    expect(elapsed).toBeLessThan(1400);
+  });
+
+  it("keeps waiting while the app is still blank, then carries on", async () => {
+    const flowFile = await writeFlow("launch", LAUNCH_FLOW);
+    // Blank forever: the budget is spent and the launch still succeeds, because
+    // a screen without accessible content is not a launch failure.
+    fetchFlowTree.mockResolvedValue(blankTree());
+    const registry = makeRegistry();
+
+    const started = Date.now();
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "launch", project_root: PROJECT_ROOT, flow_file: flowFile, device: ANDROID_DEVICE }
+      )
+    );
+    const elapsed = Date.now() - started;
+
+    expect(result.ok).toBe(true);
+    expect(elapsed).toBeGreaterThanOrEqual(1400);
+    expect(fetchFlowTree.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("keeps waiting on the undrawn content-frame shell a launching activity reports", async () => {
+    const flowFile = await writeFlow("launch", LAUNCH_FLOW);
+    // Non-empty, but the only view is the window's own content frame: an
+    // identifier with no label, no value, no children. The app has not drawn.
+    fetchFlowTree.mockResolvedValue(undrawnShellTree());
+    const registry = makeRegistry();
+
+    const started = Date.now();
+    await createRunFlowTool(registry).execute(
+      {},
+      { name: "launch", project_root: PROJECT_ROOT, flow_file: flowFile, device: ANDROID_DEVICE }
+    );
+
+    expect(Date.now() - started).toBeGreaterThanOrEqual(1400);
+  });
+
+  it("continues early for an app whose whole first screen is one labelled view", async () => {
+    const flowFile = await writeFlow("launch", LAUNCH_FLOW);
+    fetchFlowTree.mockResolvedValue(minimalDrawnTree());
+    const registry = makeRegistry();
+
+    const started = Date.now();
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "launch", project_root: PROJECT_ROOT, flow_file: flowFile, device: ANDROID_DEVICE }
+      )
+    );
+
+    expect(result.ok).toBe(true);
+    // One view is enough: a minimal screen must not be held for the full budget
+    // just for being small.
+    expect(fetchFlowTree).toHaveBeenCalledTimes(1);
+    expect(Date.now() - started).toBeLessThan(1400);
+  });
+
+  it("does not fail the launch when the tree source throws mid-settle", async () => {
+    const flowFile = await writeFlow("launch", LAUNCH_FLOW);
+    fetchFlowTree.mockRejectedValueOnce(new Error("helper busy")).mockResolvedValue(drawnTree());
+    const registry = makeRegistry();
+
+    const result = asRun(
+      await createRunFlowTool(registry).execute(
+        {},
+        { name: "launch", project_root: PROJECT_ROOT, flow_file: flowFile, device: ANDROID_DEVICE }
+      )
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.steps[0]?.status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## What

Every `launch:` step slept a flat `POST_LAUNCH_SETTLE_MS` (1500ms) before the run's first step, to give a cold start a head start. `restart-app` already waits for the activity to be displayed (`am start -W`), so on any app that is already drawing, that whole window was dead time.

The condition the sleep approximated is observable — the flow's own tree source either shows the app's content or it doesn't. This polls it instead, keeping the same 1500ms as an **upper bound**: a warm app continues after one read, a genuinely slow start still gets the full window.

## What "has drawn" means, and why it isn't just "the tree is non-empty"

Measured on a cold start (Pixel 9 emulator, API 35): a launching Android activity reports a tree of **exactly one view** for the whole settle window —

```
count=2 leaves=[{"role":"FrameLayout","identifier":"android:id/content","children":[]}]
```

— the window's own content frame, with an identifier and nothing else. A "non-empty tree" check would call that blank screen ready. Once the app draws, that shell collapses into real content (the same screen reports 24–53 nodes carrying labels).

So the predicate is **addressability, not size**: one leaf carrying a `label` or `value` is enough. That deliberately includes the case of an app whose entire first screen is a single labelled view — it settles as fast as a dense one, where a plain node-count threshold would have held it for the full budget. The node-count arm (`>= 3`, i.e. the root plus two views) remains only as a fallback for a screen that draws real content with no labels at all — icons without a content description, a canvas.

## Why it can't regress a passing flow

The wait is forgiving in the same places the sleep was silent:

- a tree that never satisfies the predicate spends the whole budget and carries on, exactly as before;
- a tree read that throws is treated the same way;
- `treeSourceGate` still runs first and is still what reports an unusable tree source. This is a head start, not a gate.

The gate now runs *before* the head start rather than after it — reading the tree needs the source to be up, and the gate never depended on the sleep. The poll interval is deliberately unhurried (250ms): a hierarchy read is served by the inspected app's own UI thread, which during a cold start is the thing being waited on.

## Measurements

Android emulator (Pixel 9, API 35), 6-step flow against a fast app. Runs interleaved with the released build, alternating arm by arm, because host load on the measuring machine drifts enough to swamp a sequential A/B:

| run | baseline (1500ms sleep) | this change |
| --- | --- | --- |
| 1 | 6.72s | 5.27s |
| 2 | 6.79s | 5.39s |
| 3 | 6.68s | 5.07s |

**~1.45s saved per launch** — the sleep minus the ~50–100ms the first tree read costs. The saving is per `launch:` step, so a flow that relaunches several times saves a multiple of it. iOS gets the same by construction.

Discovered while profiling why an Android flow run costs ~2.5s more than the equivalent `agent-device` replay on the same device and app; this was the larger of the two fixed overheads. The other is #777.

## Testing

- New `packages/tool-server/test/flows/flow-launch-settle.test.ts`, five cases: continues after a single read once content is present; keeps waiting on an empty tree; **keeps waiting on the real `android:id/content` shell captured above**; continues early for a single-labelled-view screen; survives a throwing tree read. The fast-path assertions are on poll count rather than elapsed time, so they don't move with host load.
- `vitest run test/flows` — 1047 pass. One unrelated failure, `flow-idle-run > settles inside the smallest timeout the parser allows`, is a wall-clock assertion that fails identically on pristine `origin/main` (1052ms vs its <1000ms bound) on this loaded machine.
- `npm run lint`, `npm run knip`, `prettier --check` clean.
- Live-verified on the emulator: 7/7 steps on the real app flow, 6/6 on the micro-benchmark.