### PR TITLE
perf(flows): only normalize the status bar for runs that can snapshot

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -873,6 +873,27 @@ function displayFlowName(params: { name?: string; flow_path?: string }): string 
   return params.name || stem || params.flow_path || "(unspecified)";
 }
 
+/**
+ * Whether this run can produce a `snapshot` comparison, and therefore needs the
+ * status bar normalized before step 1.
+ *
+ * Pinning it is a device-level override that costs a round of shell calls per
+ * run (on Android, a `settings put` plus five demo-mode broadcasts, and the
+ * same again to restore) — worth paying for a run whose baselines would
+ * otherwise diff on the clock, wasted on one that never captures.
+ *
+ * Conservative by construction: a `run:` step's target is a separate file
+ * resolved during execution, so anything a composed flow might do counts as
+ * "might snapshot" and keeps the pin. Only a self-contained flow with no
+ * snapshot step at all skips it.
+ */
+function mayCapture(flow: FlowFile): boolean {
+  for (const step of walkSteps(flow.steps)) {
+    if (step.kind === "snapshot" || step.kind === "run") return true;
+  }
+  return false;
+}
+
 /** Yield every parsed step, recursing into `when:` blocks (the parser's only nesting). */
 function* walkSteps(steps: FlowStep[]): Generator<FlowStep> {
   for (const step of steps) {
@@ -1088,9 +1109,11 @@ returns a notice with the prerequisite instead of running.`,
       // never drives a snapshot diff and every screenshot is consistent. Pinned
       // before step 1 — it's a device-level override independent of the app, so
       // an e2e flow's leading launch step (relaunch + settle) doubles as
-      // propagation headroom before anything is captured. No-op (returns false)
+      // propagation headroom before anything is captured. Skipped entirely for a
+      // run that cannot capture (see {@link mayCapture}), whose screenshots are
+      // failure evidence rather than something diffed. No-op (returns false)
       // on chromium/vega; restored on teardown.
-      const statusBarPinned = device !== null && (await pinStatusBar(device));
+      const statusBarPinned = device !== null && mayCapture(flow) && (await pinStatusBar(device));
 
       // The chromium equivalent of that normalization: front the page so a
       // backgrounded window doesn't throttle rendering — wheel-event acks

--- a/packages/tool-server/test/flows/flow-status-bar-pin.test.ts
+++ b/packages/tool-server/test/flows/flow-status-bar-pin.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { DescribeTreeData } from "../../src/tools/describe/contract";
+
+// The status bar is normalized so a `snapshot` diff never turns on the clock.
+// These tests pin WHEN that normalization is worth its shell calls.
+const pinStatusBar = vi.fn(async () => true);
+const restoreStatusBar = vi.fn(async () => {});
+vi.mock("../../src/utils/status-bar", () => ({
+  pinStatusBar: (...args: unknown[]) => pinStatusBar(...(args as [])),
+  restoreStatusBar: (...args: unknown[]) => restoreStatusBar(...(args as [])),
+}));
+
+const fetchFlowTree = vi.fn(
+  async (): Promise<DescribeTreeData> =>
+    ({
+      tree: {
+        role: "Screen",
+        frame: { x: 0, y: 0, width: 1, height: 1 },
+        children: [
+          {
+            role: "Button",
+            label: "Go",
+            frame: { x: 0, y: 0, width: 1, height: 0.1 },
+            children: [],
+          },
+          {
+            role: "Text",
+            label: "Hi",
+            frame: { x: 0, y: 0.2, width: 1, height: 0.1 },
+            children: [],
+          },
+        ],
+      },
+      source: "android-devtools",
+    }) as unknown as DescribeTreeData
+);
+vi.mock("../../src/tools/flows/flow-tree", () => ({
+  fetchFlowTree: (...args: unknown[]) => fetchFlowTree(...(args as [])),
+}));
+
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+
+const PROJECT_ROOT = path.join(os.tmpdir(), `flow-status-bar-${process.pid}`);
+const DEVICE = "emulator-5554";
+
+function makeRegistry(): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string) => {
+      if (id === "list-devices") {
+        return { devices: [{ platform: "android", id: DEVICE, udid: DEVICE, state: "device" }] };
+      }
+      return { ok: true, restarted: true, tapped: true };
+    }),
+    getTool: vi.fn(() => undefined),
+    resolveService: vi.fn(async () => ({ isReady: () => true })),
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: string): Promise<string> {
+  const flowsDir = path.join(PROJECT_ROOT, ".argent", "flows");
+  await fs.mkdir(flowsDir, { recursive: true });
+  const file = path.join(flowsDir, `${name}.yaml`);
+  await fs.writeFile(file, yaml, "utf8");
+  return file;
+}
+
+async function run(name: string, yaml: string): Promise<FlowRunResult> {
+  const flowFile = await writeFlow(name, yaml);
+  const r = await createRunFlowTool(makeRegistry()).execute(
+    {},
+    { name, project_root: PROJECT_ROOT, flow_file: flowFile, device: DEVICE }
+  );
+  if (!("steps" in r)) throw new Error("expected a FlowRunResult");
+  return r;
+}
+
+afterEach(async () => {
+  pinStatusBar.mockClear();
+  restoreStatusBar.mockClear();
+  await fs.rm(PROJECT_ROOT, { recursive: true, force: true });
+});
+
+describe("status-bar normalization", () => {
+  it("is skipped for a run that never captures", async () => {
+    const result = await run("plain", `steps:\n  - launch: com.example.app\n`);
+    expect(result.ok).toBe(true);
+    expect(pinStatusBar).not.toHaveBeenCalled();
+    // Nothing was pinned, so nothing is restored on teardown either.
+    expect(restoreStatusBar).not.toHaveBeenCalled();
+  });
+
+  it("is applied for a flow with a snapshot step", async () => {
+    await run("shot", `steps:\n  - launch: com.example.app\n  - snapshot: home\n`);
+    expect(pinStatusBar).toHaveBeenCalledTimes(1);
+    expect(restoreStatusBar).toHaveBeenCalledTimes(1);
+  });
+
+  it("is applied for a snapshot nested in a when: block", async () => {
+    await run(
+      "guarded",
+      `steps:
+  - launch: com.example.app
+  - when: { visible: { text: Got it } }
+    steps:
+      - snapshot: promo
+`
+    );
+    expect(pinStatusBar).toHaveBeenCalledTimes(1);
+  });
+
+  it("is applied for a composing flow, whose run: target may snapshot", async () => {
+    await writeFlow("child", `steps:\n  - snapshot: inner\n`);
+    await run("parent", `steps:\n  - launch: com.example.app\n  - run: child\n`);
+    expect(pinStatusBar).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Every flow run pinned the device status bar (clock/battery/signal) before step 1 and restored it on teardown, so a `snapshot` diff could never turn on the clock. A run with **no snapshot step** captures nothing to diff — its screenshots are failure evidence — so it paid those shell calls for nothing.

This skips the normalization (and, symmetrically, the teardown restore) for runs that cannot capture.

## Cost being removed

On Android it is seven adb round-trips per run — `settings put global sysui_demo_allowed 1` plus five `am broadcast` demo-mode commands, then exit + `settings put` to restore. Timed on an idle Pixel 9 emulator:

```
pin sequence:      0.44s
restore sequence:  0.25s
```

~0.69s per run idle, and ~1s when the device is loaded (each broadcast is a separate `adb shell` round-trip). On iOS it is two `simctl status_bar` invocations.

## Why it is safe

Conservative by construction. A `run:` step's target is a separate file resolved during execution, so **any composing flow still pins** — the check treats `run:` as "might snapshot" rather than trying to resolve the chain ahead of time. Only a self-contained flow with no snapshot step anywhere (including inside `when:` blocks, which `walkSteps` already recurses into) skips it. Since nothing was pinned in that case, `state.pinned` stays false and teardown skips the restore on its own.

What a skipping run loses is a normalized clock in the screenshots attached to a failure — evidence, never something diffed.

## Testing

- New `packages/tool-server/test/flows/flow-status-bar-pin.test.ts`: skipped for a plain run (and not restored), applied for a snapshot step, for a snapshot nested in `when:`, and for a composing `run:` flow.
- `vitest run test/flows` — 44 files / 1047 tests pass.
- `npm run lint` clean.

Found while profiling why an Android flow run costs ~2.5s more than the equivalent `agent-device` replay on the same device and app. The other half is #776.