### PR TITLE
fix(flows): ride out iOS main-thread stalls instead of failing the step

### DIFF
--- a/packages/tool-server/src/blueprints/native-devtools.ts
+++ b/packages/tool-server/src/blueprints/native-devtools.ts
@@ -478,6 +478,16 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
         );
       }
       const id = nextRpcId++;
+      // The injected handlers hop onto the app's MAIN thread; a heavy cold
+      // start (first Hermes parse, asset decode) can pin it for several
+      // seconds, and the flow runner re-reads the hierarchy through exactly
+      // that window. Give the flows' workhorse read time to ride the stall out
+      // instead of failing the step — mirroring the Android devtools client's
+      // 5s default / 15s getHierarchy tiers. Everything else (including the
+      // per-read Application.getState probe and the interactive point queries)
+      // keeps the 5s ceiling so one-shot agent tools stay snappy on a wedged
+      // app.
+      const timeoutMs = method === "ViewHierarchy.getFullHierarchy" ? 15_000 : 5_000;
       return new Promise((resolve, reject) => {
         pendingRpc.set(id, { resolve, reject });
         conn.socket.write(
@@ -498,7 +508,7 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
               })
             );
           }
-        }, 5000);
+        }, timeoutMs);
       });
     }
 

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -1417,7 +1417,11 @@ async function waitForIdle(
     // backend), so serializing them would double the round without buying
     // anything.
     const [read, frame] = await Promise.all([
-      settleWithin(fetchFlowTree(env.registry, env.device, env.launchedNativeApp), roundBudget, env.signal).then((r) => {
+      settleWithin(
+        fetchFlowTree(env.registry, env.device, env.launchedNativeApp),
+        roundBudget,
+        env.signal
+      ).then((r) => {
         answeredReadMs = Date.now() - roundStartedAt;
         return r;
       }),

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -63,6 +63,17 @@ export interface ActionEnv {
   ctx?: ToolContext;
   device: DeviceInfo;
   signal?: AbortSignal;
+  /**
+   * Bundle id of the last successful native `launch:` in this RUN — nested
+   * `run:` flows share it (ExecState is per-run, so a nested launch updates
+   * the whole run's hint, matching "a nested e2e launch restarts its app").
+   * Cleared by `tool:` steps that can change the foreground app (launch-app,
+   * restart-app, open-url, button, reinstall-app). iOS tree reads use it ONLY
+   * as an arbiter when target auto-resolution itself times out — see
+   * `queryFullHierarchyTree` — so foreground-likeness guards keep firing
+   * whenever the app answers at all.
+   */
+  launchedNativeApp?: string;
 }
 
 /** Outcome of a selector directive: ok, or a machine-readable reason it failed. */
@@ -352,7 +363,7 @@ export async function settleTree(env: ActionEnv): Promise<DescribeNode | undefin
     if (env.signal?.aborted) return undefined;
     let tree: DescribeNode | undefined;
     try {
-      ({ tree } = await fetchFlowTree(env.registry, env.device));
+      ({ tree } = await fetchFlowTree(env.registry, env.device, env.launchedNativeApp));
     } catch (err) {
       // transient describe failure mid-navigation — retry until the deadline
       lastError = err instanceof Error ? err : new Error(String(err));
@@ -481,7 +492,7 @@ async function waitForFocus(
   for (;;) {
     if (env.signal?.aborted) return;
     try {
-      const { tree, source } = await fetchFlowTree(env.registry, env.device);
+      const { tree, source } = await fetchFlowTree(env.registry, env.device, env.launchedNativeApp);
       if (!FOCUS_REPORTING_SOURCES.has(source)) return;
       const target = flowSelectorToFrame(tree, into) ?? tappedFrame;
       if (collectFocused(tree, []).some((n) => framesOverlap(n.frame, target))) return;
@@ -868,7 +879,7 @@ async function runPinch(
  */
 async function fetchScreenAspect(env: ActionEnv): Promise<number | undefined> {
   try {
-    const { screen } = await fetchFlowTree(env.registry, env.device);
+    const { screen } = await fetchFlowTree(env.registry, env.device, env.launchedNativeApp);
     return screen && screen.width > 0 && screen.height > 0
       ? screen.width / screen.height
       : undefined;
@@ -1045,7 +1056,7 @@ async function waitForCondition(
   for (;;) {
     if (env.signal?.aborted) return ABORTED_OUTCOME;
     try {
-      const data = await fetchFlowTree(env.registry, env.device);
+      const data = await fetchFlowTree(env.registry, env.device, env.launchedNativeApp);
       lastMatches = flowFindAll(data.tree, step.selector);
       fetchError = undefined;
       everMatched ||= lastMatches.length > 0;
@@ -1406,7 +1417,7 @@ async function waitForIdle(
     // backend), so serializing them would double the round without buying
     // anything.
     const [read, frame] = await Promise.all([
-      settleWithin(fetchFlowTree(env.registry, env.device), roundBudget, env.signal).then((r) => {
+      settleWithin(fetchFlowTree(env.registry, env.device, env.launchedNativeApp), roundBudget, env.signal).then((r) => {
         answeredReadMs = Date.now() - roundStartedAt;
         return r;
       }),

--- a/packages/tool-server/src/tools/flows/flow-ios-tree.ts
+++ b/packages/tool-server/src/tools/flows/flow-ios-tree.ts
@@ -1,4 +1,4 @@
-import type { DeviceInfo, Registry } from "@argent/registry";
+import { FAILURE_CODES, getFailureSignal, type DeviceInfo, type Registry } from "@argent/registry";
 import { nativeDevtoolsRef, type NativeDevtoolsApi } from "../../blueprints/native-devtools";
 import { resolveNativeTargetApp } from "../../utils/native-target-app";
 import { flattenHoisting, type FlatNode } from "./flow-tree-flatten";
@@ -272,7 +272,8 @@ const FULL_HIERARCHY_FIELDS = [
  */
 export async function queryFullHierarchyTree(
   registry: Registry,
-  device: DeviceInfo
+  device: DeviceInfo,
+  launchedNativeApp?: string
 ): Promise<DescribeTreeData> {
   let nativeApi: NativeDevtoolsApi;
   try {
@@ -285,8 +286,32 @@ export async function queryFullHierarchyTree(
     );
   }
   // resolveNativeTargetApp's own errors (no connected app / ambiguous frontmost)
-  // already carry the actionable next step, so they propagate unwrapped.
-  const target = await resolveNativeTargetApp(nativeApi, undefined);
+  // already carry the actionable next step, so they propagate unwrapped — with
+  // one exception. Auto-resolution's `Application.getState` probe hops onto the
+  // app's MAIN thread; an app whose main thread is momentarily pinned (heavy
+  // cold start: first Hermes parse, Lottie decode) times that probe out even
+  // though it is exactly the app the flow launched and is about to read. When
+  // that happens — and ONLY on the timeout failure — fall back to the app this
+  // run's `launch:` started, provided its devtools connection is still up. A
+  // resolution that ANSWERS (including the deliberate "single app but
+  // backgrounded" error) is always preferred: the arbiter never overrides a
+  // guard that fired, it only rides out a probe the stall made unanswerable.
+  let target: { bundleId: string };
+  try {
+    target = await resolveNativeTargetApp(nativeApi, undefined);
+  } catch (err) {
+    const timedOut =
+      getFailureSignal(err)?.error_code === FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT;
+    if (
+      timedOut &&
+      launchedNativeApp !== undefined &&
+      nativeApi.listConnectedBundleIds().includes(launchedNativeApp)
+    ) {
+      target = { bundleId: launchedNativeApp };
+    } else {
+      throw err;
+    }
+  }
 
   if (await nativeApi.requiresAppRestart(target.bundleId)) {
     throw new Error(

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -293,8 +293,26 @@ const POST_LAUNCH_SETTLE_MS = 1500;
  * start would fail the first directive with a raw tree-source error; gating
  * the launch step reports the problem where it belongs, with a relaunch hint.
  */
-const NATIVE_READY_TIMEOUT_MS = 8000;
+// 15s (was 8s): the injected dylib's connect is gated on the app's main
+// thread, and a heavy first-ever cold start (Hermes first parse, asset
+// decode on a loaded host) can pin it past 8s. Matches the 15s
+// getFullHierarchy RPC tier — both wait out the same class of stall.
+const NATIVE_READY_TIMEOUT_MS = 15000;
 const NATIVE_READY_POLL_MS = 250;
+
+/**
+ * `tool:` steps that can change or relaunch the foreground app — running one
+ * invalidates {@link ActionEnv.launchedNativeApp}. `button` is included for
+ * its `home` case; distinguishing button kinds here would couple this list to
+ * that tool's arg schema for little gain.
+ */
+const FOREGROUND_CHANGING_TOOLS = new Set([
+  "launch-app",
+  "restart-app",
+  "reinstall-app",
+  "open-url",
+  "button",
+]);
 
 /**
  * Poll until native-devtools is connected for `bundleId`. Returns true once
@@ -453,6 +471,11 @@ async function runLaunch(state: ExecState, app: Launch): Promise<DirectiveOutcom
   // it, or a cancelled gate would read as a launch that verified readiness.
   if (signal?.aborted) return ABORTED_OUTCOME;
   if (gate) return { ok: false, reason: gate };
+  // Remember the launched app for the rest of the RUN (nested `run:` flows
+  // share this state, so a nested launch retargets the whole run — see
+  // ActionEnv.launchedNativeApp). iOS tree reads use it only when target
+  // auto-resolution times out mid-stall.
+  state.launchedNativeApp = bundleId;
   return { ok: true };
 }
 
@@ -2209,6 +2232,14 @@ async function execLeafStep(
         return { ...base, status: "skip", tool: step.name, reason: "run aborted during delay" };
       }
       try {
+        // These sub-tools can change (or relaunch) the foreground app, so the
+        // `launch:`-derived hint no longer names what is on screen. Cleared
+        // BEFORE invoking: a tool that throws mid-way may still have switched
+        // apps, and a stale hint is worse than no hint (tree reads fall back
+        // to plain auto-resolution, today's behavior).
+        if (FOREGROUND_CHANGING_TOOLS.has(step.name)) {
+          state.launchedNativeApp = undefined;
+        }
         const result = await invokeSubTool(registry, ctx, step.name, args);
         if (isUnmetUiWaitResult(step.name, result)) {
           const note = (result as { note?: string }).note;

--- a/packages/tool-server/src/tools/flows/flow-tree.ts
+++ b/packages/tool-server/src/tools/flows/flow-tree.ts
@@ -34,10 +34,11 @@ import type { DescribeTreeData } from "../describe/contract";
  */
 export async function fetchFlowTree(
   registry: Registry,
-  device: DeviceInfo
+  device: DeviceInfo,
+  launchedNativeApp?: string
 ): Promise<DescribeTreeData> {
   if (device.platform === "ios") {
-    return queryFullHierarchyTree(registry, device);
+    return queryFullHierarchyTree(registry, device, launchedNativeApp);
   }
   if (device.platform === "android") {
     return queryAndroidFullHierarchy(registry, device);

--- a/packages/tool-server/test/flows/flow-ios-tree-launch-hint.test.ts
+++ b/packages/tool-server/test/flows/flow-ios-tree-launch-hint.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { FAILURE_CODES, FailureError, type DeviceInfo, type Registry } from "@argent/registry";
+import type { NativeAppState, NativeDevtoolsApi } from "../../src/blueprints/native-devtools";
+import { queryFullHierarchyTree } from "../../src/tools/flows/flow-ios-tree";
+
+// The `launch:`-derived hint is a TIMEOUT ARBITER only. Target auto-resolution
+// runs on every read; the hint decides the target solely when that resolution
+// fails with an RPC timeout (the app's main thread is mid-stall) AND the
+// hinted app's devtools connection is still up. Every answered resolution —
+// including the deliberate "single app but backgrounded" error — wins over the
+// hint, so no foreground-likeness guard is ever bypassed by a healthy app.
+
+const IOS_DEVICE = {
+  id: "00000000-0000-0000-0000-0000000000ab",
+  platform: "ios",
+} as unknown as DeviceInfo;
+
+const APP = "com.example.app";
+
+const rpcTimeout = () =>
+  new FailureError("ViewInspector RPC timed out: Application.getState", {
+    error_code: FAILURE_CODES.NATIVE_DEVTOOLS_RPC_TIMEOUT,
+    failure_stage: "native_devtools_rpc_request",
+    failure_area: "tool_server",
+    error_kind: "timeout",
+  });
+
+function windowSpanning() {
+  return {
+    className: "UIWindow",
+    frame: { x: 0, y: 0, width: 400, height: 800 },
+    windowFrame: { x: 0, y: 0, width: 400, height: 800 },
+    children: [],
+  };
+}
+
+function activeState(bundleId: string): NativeAppState {
+  return {
+    bundleId,
+    applicationState: "active",
+    foregroundActiveSceneCount: 1,
+    foregroundInactiveSceneCount: 0,
+    backgroundSceneCount: 0,
+    unattachedSceneCount: 0,
+    isFrontmostCandidate: true,
+  };
+}
+
+function backgroundState(bundleId: string): NativeAppState {
+  return {
+    bundleId,
+    applicationState: "background",
+    foregroundActiveSceneCount: 0,
+    foregroundInactiveSceneCount: 0,
+    backgroundSceneCount: 1,
+    unattachedSceneCount: 0,
+    isFrontmostCandidate: false,
+  };
+}
+
+function api(overrides: Partial<Record<keyof NativeDevtoolsApi, unknown>>): NativeDevtoolsApi {
+  return {
+    listConnectedBundleIds: () => [APP],
+    getAppState: async (id: string) => activeState(id),
+    requiresAppRestart: async () => false,
+    queryViewHierarchy: async (bundleId: string) => ({
+      windows: [windowSpanning()],
+      queried: bundleId,
+    }),
+    ...overrides,
+  } as unknown as NativeDevtoolsApi;
+}
+
+function registryFor(nativeApi: NativeDevtoolsApi): Registry {
+  return { resolveService: async () => nativeApi } as unknown as Registry;
+}
+
+describe("queryFullHierarchyTree launch hint", () => {
+  it("falls back to the hinted app when getState times out and the hint is connected", async () => {
+    const queried: string[] = [];
+    const nativeApi = api({
+      getAppState: async () => {
+        throw rpcTimeout();
+      },
+      queryViewHierarchy: async (bundleId: string) => {
+        queried.push(bundleId);
+        return { windows: [windowSpanning()] };
+      },
+    });
+    const tree = await queryFullHierarchyTree(registryFor(nativeApi), IOS_DEVICE, APP);
+    expect(queried).toEqual([APP]);
+    expect(tree.tree).toBeDefined();
+  });
+
+  it("rethrows the timeout when no hint is provided", async () => {
+    const nativeApi = api({
+      getAppState: async () => {
+        throw rpcTimeout();
+      },
+    });
+    await expect(queryFullHierarchyTree(registryFor(nativeApi), IOS_DEVICE)).rejects.toThrow(
+      /RPC timed out/
+    );
+  });
+
+  it("rethrows the timeout when the hinted app is no longer connected", async () => {
+    const nativeApi = api({
+      listConnectedBundleIds: () => ["com.other.app"],
+      getAppState: async () => {
+        throw rpcTimeout();
+      },
+    });
+    await expect(queryFullHierarchyTree(registryFor(nativeApi), IOS_DEVICE, APP)).rejects.toThrow(
+      /RPC timed out/
+    );
+  });
+
+  it("does not use the hint to bypass an answered backgrounded-app guard", async () => {
+    // Resolution ANSWERS here (single app, backgrounded → deliberate error);
+    // the hint must not override it.
+    const nativeApi = api({
+      getAppState: async (id: string) => backgroundState(id),
+    });
+    await expect(queryFullHierarchyTree(registryFor(nativeApi), IOS_DEVICE, APP)).rejects.toThrow(
+      /not foreground-like/
+    );
+  });
+
+  it("rethrows non-timeout resolution failures even with a connected hint", async () => {
+    const nativeApi = api({
+      getAppState: async () => {
+        throw new FailureError("boom", {
+          error_code: FAILURE_CODES.NATIVE_DEVTOOLS_RPC_ERROR,
+          failure_stage: "native_devtools_rpc_response",
+          failure_area: "tool_server",
+          error_kind: "subprocess",
+        });
+      },
+    });
+    await expect(queryFullHierarchyTree(registryFor(nativeApi), IOS_DEVICE, APP)).rejects.toThrow(
+      /boom/
+    );
+  });
+
+  it("prefers the resolved frontmost app over a stale hint when resolution answers", async () => {
+    // Two connected apps, resolution succeeds and picks the frontmost (B);
+    // the hint (A) must not shadow it.
+    const A = "com.example.app";
+    const B = "com.example.other";
+    const queried: string[] = [];
+    const nativeApi = api({
+      listConnectedBundleIds: () => [A, B],
+      getAppState: async (id: string) => (id === B ? activeState(id) : backgroundState(id)),
+      queryViewHierarchy: async (bundleId: string) => {
+        queried.push(bundleId);
+        return { windows: [windowSpanning()] };
+      },
+    });
+    await queryFullHierarchyTree(registryFor(nativeApi), IOS_DEVICE, A);
+    expect(queried).toEqual([B]);
+  });
+});


### PR DESCRIPTION
## Problem

iOS flows against a heavy app (Expensify NewDot, release sim build) intermittently error with

```
✗  4 tap "Continue" — ViewInspector RPC timed out: Application.getState
```

The only known mitigation was enabling **Reduce Motion** on the simulator — which shouldn't be a functional requirement, and (as the investigation showed) wasn't actually the mechanism.

## Root cause

The injected ViewInspector handlers hop onto the app's **main thread** (`dispatch_sync` in `DevtoolsConnection.m`). During a heavy first-launch cold start (first Hermes parse, asset decode, on a loaded host) the main thread can be pinned past the flat **5s** RPC timeout, and the flow layer turns one timed-out read into a step error:

- every iOS tree read first runs target auto-resolution → an `Application.getState` probe per connected app, per read — the cheap probe is the first to hit the stall;
- `settleTree`'s 3s window < the 5s RPC timeout, so an action step's **first** stalled read exhausts the window and throws;
- a default `await` (7.5s) gets ~1 stalled attempt;
- the flow launch readiness gate (8s) sits below the same stall ceiling, because the dylib's connect is also main-thread-gated.

Steady-state RPCs are fast (instrumented: `getState` p50 0ms / max 402ms, `getFullHierarchy` p50 9–12ms — even with animations on and a 14-core CPU load). Only the stall window is the problem; Reduce Motion merely shortened it below the cliff (and correlated with cache warming from repeated relaunches).

Error-code note: these failures are `NATIVE_DEVTOOLS_RPC_TIMEOUT` on an **established** connection — distinct from the multi-server socket-contention family (#775), which surfaces as `could not connect to native devtools` at launch.

## Fix (three coordinated changes, tool-server only)

1. **`getFullHierarchy` RPC timeout 5s → 15s** — mirrors the Android devtools client's 5s default / 15s `getHierarchy` tiers. Every other method (incl. `getState` and the interactive point queries) keeps 5s, so one-shot agent tools stay snappy on a wedged app.
2. **Flows remember the launched app** (`launchedNativeApp` on the run state, threaded to iOS tree reads; invalidated by `launch-app`/`restart-app`/`reinstall-app`/`open-url`/`button` `tool:` steps; shared with nested `run:` flows). It is a **timeout arbiter only**: auto-resolution still runs on every read, and any *answered* resolution — including the deliberate "single app but backgrounded" guard — wins. The hint decides the target only when the resolution probe itself dies of an RPC timeout and the hinted app's devtools connection is still up.
3. **Launch readiness gate 8s → 15s** — same stall class, same budget.

Accepted trade-offs (from adversarial design review): a persistent outage now takes longer to report (a dead-but-connected app fails an `await` after up to ~2 slow reads instead of three 5s ones), and a stall that clears right at a settle deadline can act on a single post-stall read (previously a hard error). Both were judged worth the removal of the false-failure class; the review also killed an earlier variant of this fix that would have bypassed the backgrounded-app guard.

## Verification

- **Fault injection**: a DYLD-inserted dylib pins the app's main thread on demand (12s). Pre-fix, deterministically reproduces both historical signatures — mid-flow stall → `tap error: ViewInspector RPC timed out: Application.getState`; launch-window stall → `launch error: could not connect`. Post-fix: **5/5 green** across both stall placements ×2 + no-stall control.
- **Android regression**: the same sign-in flow on the Android emulator through the patched server — green (the hint is iOS-only by construction; Android/Chromium tree paths unchanged).
- **Unit tests**: new `flow-ios-tree-launch-hint.test.ts` (6 cases: timeout fallback, no-hint rethrow, disconnected-hint rethrow, backgrounded-guard preserved, non-timeout rethrow, answered-resolution-beats-hint); existing `flow-ios-tree-no-windows` and `native-target-app` suites green. Full tool-server suite: 3875 passed; the 7 failures in `bind-failure/startup/lens-telemetry` tests fail identically on pristine `origin/main` sources in this environment (pre-existing, unrelated).

Related: #775 (multi-server devtools socket contention, filed from the same investigation), #774 (sim keyboard shift wedge, unrelated mechanism ruled out during triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
