### PR TITLE
fix(flow): floor every settle at two read attempts

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -220,6 +220,20 @@ const FOCUS_REPORTING_SOURCES: ReadonlySet<DescribeSource> = new Set([
 const SETTLE_POLL_MS = 250;
 const SETTLE_TIMEOUT_MS = 3000;
 
+// Read attempts every settle makes before it may conclude anything, enforced
+// even once the window has closed. A read can fail by TIMING OUT, and every
+// tree source's RPC timeout outlasts the 3s window (the shortest is iOS's 5s),
+// so the window fits only one such read: without a floor, "every read in the
+// window failed", which the throw below reports as a tree-source outage, would
+// collapse into "the first read was slow", erroring a step on one transient
+// blip with no retry at all. The second read is not bounded by the window
+// either, and a read is several RPCs deep, each on its own timeout, so a wedged
+// source costs two full reads and tens of seconds, and a source that answers
+// slowly pays a second read where it used to end on one. `await`/`assert` have
+// always had this floor in `waitForCondition`'s final poll; this is the same
+// guarantee for the directives that resolve through a settle.
+const SETTLE_MIN_READS = 2;
+
 // `scroll-to`: a bounded number of momentum-free increments. Each travels half
 // the clip window along the scroll axis (half the screen when no `within`
 // container is named) — < 1 viewport, so consecutive viewports overlap and a
@@ -428,25 +442,26 @@ function readFlowTree(env: ActionEnv): Promise<DescribeTreeData> {
  * from landing mid-deceleration (where a scroll view swallows it) or acting on a
  * frame that has already moved.
  *
- * Throws when EVERY read in the window failed: that is a tree-source outage
+ * Throws when EVERY read attempt failed: that is a tree-source outage
  * (e.g. native devtools disconnected mid-run — `fetchFlowTree` refuses to
  * degrade to a trimmed tree), not a mid-animation blip, and swallowing it would
  * convert the outage into a misleading "element not found" downstream. The
  * throw lands in the step's structured report via `execLeafStep`'s catch.
  *
+ * "Every attempt" is at least {@link SETTLE_MIN_READS} of them: the deadline
+ * bounds the polling, never the number of reads taken, so a read slow enough to
+ * outlast the window on its own is retried rather than treated as the whole
+ * evidence.
+ *
  * `skipProvenOutage` rethrows {@link ActionEnv.treeOutage} instead of buying
  * that window again. Not a shorter budget: a threshold low enough to spare a
  * source serving no tree at all would also abandon the mid-navigation blip the
- * retry above exists for. But the memo is a prediction: one window mints it,
- * nothing re-tests it, and on iOS a window can be one stalled read. The
- * deadline below is only tested after a read RETURNS, and the read a window
- * issues is `ViewHierarchy.getFullHierarchy` on the 15s RPC tier #778 gave it,
- * behind a serial 5s `Application.getState` probe, so a 3000ms window can spend
- * ~20s on the single sample it then mints the verdict from. Being wrong costs a
- * settle, not a step: {@link settleForGesture} swallows the throw - and says
- * so, warning every gesture it spares, so a run whose prediction was wrong
- * reports which greens went out unsettled. Any directive read that comes back
- * retires it, as does a relaunch.
+ * retry above exists for. But the memo is a prediction: one window mints it and
+ * nothing re-tests it. Being wrong costs a settle, not a step:
+ * {@link settleForGesture} swallows the throw - and says so, warning every
+ * gesture it spares, so a run whose prediction was wrong reports which greens
+ * went out unsettled. Any directive read that comes back retires it, as does a
+ * relaunch.
  *
  * What it costs: an outage that lasted a full window, in a run that then never
  * reads the tree again and never relaunches, leaves later gestures unsettled
@@ -463,6 +478,7 @@ export async function settleTree(
   let prevFp: string | undefined;
   let prevTree: DescribeNode | undefined;
   let lastError: Error | undefined;
+  let reads = 0;
   for (;;) {
     if (env.signal?.aborted) return undefined;
     // Inside the loop so the abort above still wins, but only ever true on the
@@ -481,6 +497,7 @@ export async function settleTree(
       // transient describe failure mid-navigation — retry until the deadline
       lastError = read.cause;
     }
+    reads += 1;
     // The abort can land while the read above is in flight (e.g. the HTTP
     // client disconnecting mid-flow trips the run's AbortController). Without
     // this re-check the two-identical-reads return below — or the deadline's
@@ -495,6 +512,10 @@ export async function settleTree(
       prevTree = tree;
     }
     if (Date.now() >= deadline) {
+      // Owed another attempt: retry back-to-back rather than sleeping out a
+      // poll interval the window no longer has (`waitForCondition`'s final
+      // poll does the same). Bounded — `reads` rises on every pass.
+      if (reads < SETTLE_MIN_READS) continue;
       if (prevTree === undefined && lastError !== undefined) {
         if (env.treeOutage) env.treeOutage.proven = { deviceId: env.device.id, error: lastError };
         throw lastError;

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -477,12 +477,12 @@ function readFlowTree(env: ActionEnv): Promise<DescribeTreeData> {
  * reports which greens went out unsettled. Any directive read that comes back
  * retires it, as does a relaunch.
  *
- * What it costs: an outage that lasted a full window, in a run that then never
- * reads the tree again and never relaunches, leaves later gestures unsettled
- * even once it clears. That is a flow of nothing but coordinate gestures giving
- * up a best-effort settle it never had before this directive existed, against
- * every one of those gestures otherwise paying the window for a settle that is
- * not coming.
+ * What it costs: an outage that failed every read attempt, in a run that then
+ * never reads the tree again and never relaunches, leaves later gestures
+ * unsettled even once it clears. That is a flow of nothing but coordinate
+ * gestures giving up a best-effort settle it never had before this directive
+ * existed, against every one of those gestures otherwise paying a whole settle,
+ * window and floor reads alike, for a tree that is not coming.
  */
 export async function settleTree(
   env: ActionEnv,

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -454,7 +454,11 @@ function readFlowTree(env: ActionEnv): Promise<DescribeTreeData> {
  * "Every attempt" is at least {@link SETTLE_MIN_READS} of them: the deadline
  * bounds the polling, never the number of reads taken, so a read slow enough to
  * outlast the window on its own is retried rather than treated as the whole
- * evidence.
+ * evidence. The price lands on the best-effort return: if that retry then
+ * fails, `prevTree` is the first read's tree handed back a read-duration later
+ * (bounded by the tree source's own RPC ceiling), older than what the bare
+ * deadline would have returned. Paid because a single successful read has been
+ * compared against nothing and is no settle at all.
  *
  * `skipProvenOutage` rethrows {@link ActionEnv.treeOutage} instead of buying
  * that whole settle again, window and floor reads alike. Not a shorter budget:

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -464,8 +464,13 @@ function readFlowTree(env: ActionEnv): Promise<DescribeTreeData> {
  * evidence. The price lands on the best-effort return: if that retry then
  * fails, `prevTree` is the first read's tree handed back a read-duration later
  * (bounded by the tree source's own RPC ceiling), older than what the bare
- * deadline would have returned. Paid because a single successful read has been
- * compared against nothing and is no settle at all.
+ * deadline would have returned. Paid for what the retry buys, which differs by
+ * branch. After a failed first read it buys evidence: the outage throw rests on
+ * two failed attempts rather than on one slow read, and a retry that succeeds
+ * there still returns a lone tree matched against nothing. After a successful
+ * first read it buys a fresher sample, since the retry's tree comes back
+ * whether or not the fingerprints match, and with it the settle's only chance
+ * to converge.
  *
  * `skipProvenOutage` rethrows {@link ActionEnv.treeOutage} instead of buying
  * that whole settle again, window and floor reads alike. Not a shorter budget:

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -1135,8 +1135,8 @@ async function runPinch(
  * the tree several times per step, so the extra fetch is noise, and the
  * resolution path every other directive shares stays untouched.
  *
- * The one read {@link ActionEnv.treeOutage} must not spare, unlike the settle
- * window {@link settleForGesture} skips: this answer is DISPATCHED, not waited
+ * The one read {@link ActionEnv.treeOutage} must not spare, unlike the whole
+ * settle {@link settleForGesture} skips: this answer is DISPATCHED, not waited
  * on. A stale verdict would degrade a centre rotate on a phone from the
  * edge-safe vertical placement the real aspect picks (Down points at
  * y = 0.278 / 0.722) to the aspect-1 fallback, which puts both fingers 0.48 off
@@ -1147,9 +1147,11 @@ async function runPinch(
  *
  * A true verdict costs one failed read instead, which the caller degrades past
  * exactly as it degrades past a skip - but not for free: this read carries no
- * budget and no signal, so on iOS it is the 15s hierarchy tier, longer than the
- * 3s window the memo saved. That is the price of never dispatching geometry off
- * a prediction, and it is what every rotate paid before the memo existed.
+ * budget and no signal, so on iOS it is the 15s hierarchy tier. Less than the
+ * whole settle the memo saved - window and floor reads alike, two reads on that
+ * same tier when the source fails by timing out - but still the price of never
+ * dispatching geometry off a prediction, and what every rotate paid before the
+ * memo existed.
  */
 async function fetchScreenAspect(env: ActionEnv): Promise<number | undefined> {
   try {

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -470,7 +470,10 @@ function readFlowTree(env: ActionEnv): Promise<DescribeTreeData> {
  * there still returns a lone tree matched against nothing. After a successful
  * first read it buys a fresher sample, since the retry's tree comes back
  * whether or not the fingerprints match, and with it the settle's only chance
- * to converge.
+ * to converge. The best-effort return also reaches `snapshot: { cropOn }`
+ * through {@link waitForFrame}, where the whole retry widens the gap between
+ * the read the crop rectangle comes from and the capture, so the crop can be
+ * measured against a layout the pixels no longer show.
  *
  * `skipProvenOutage` rethrows {@link ActionEnv.treeOutage} instead of buying
  * that whole settle again, window and floor reads alike. Not a shorter budget:

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -231,9 +231,13 @@ const SETTLE_TIMEOUT_MS = 3000;
 // blip with no retry at all. The second read is not bounded by the window
 // either, so a wedged source costs two full reads and tens of seconds, and a
 // source that answers slowly pays a second read where it used to end on one.
-// `scroll-to` multiplies that: it settles once per round, bounded by
-// `MAX_SCROLL_ITERATIONS` rather than a wall clock, so the added read lands on
-// every round and a slow source turns one step's tens of seconds into minutes.
+// Slower than the window is not the exceptional case: `HUNG_TREE_READ_MS`
+// reasons from 5400ms Android reads, so ending a window on a single read is
+// the ordinary outcome there and the second read an ordinary cost, not a
+// degraded one. `scroll-to` multiplies that: it settles once per round,
+// bounded by `MAX_SCROLL_ITERATIONS` rather than a wall clock, so the added
+// read lands on every round and a slow source turns one step's tens of seconds
+// into minutes.
 // `await`/`assert` have always had this floor in `waitForCondition`'s final
 // poll; this is the same guarantee for the directives that resolve through a
 // settle.

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -229,9 +229,12 @@ const SETTLE_TIMEOUT_MS = 3000;
 // blip with no retry at all. The second read is not bounded by the window
 // either, and a read is several RPCs deep, each on its own timeout, so a wedged
 // source costs two full reads and tens of seconds, and a source that answers
-// slowly pays a second read where it used to end on one. `await`/`assert` have
-// always had this floor in `waitForCondition`'s final poll; this is the same
-// guarantee for the directives that resolve through a settle.
+// slowly pays a second read where it used to end on one. `scroll-to` multiplies
+// that: it settles once per round, bounded by `MAX_SCROLL_ITERATIONS` rather
+// than a wall clock, so the added read lands on every round and a slow source
+// turns one step's tens of seconds into minutes. `await`/`assert` have always
+// had this floor in `waitForCondition`'s final poll; this is the same guarantee
+// for the directives that resolve through a settle.
 const SETTLE_MIN_READS = 2;
 
 // `scroll-to`: a bounded number of momentum-free increments. Each travels half

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -76,7 +76,7 @@ export interface ActionEnv {
   launchedNativeApp?: string;
   /**
    * Run-scoped memo of a tree source that answered nothing: set by a
-   * {@link settleTree} whose whole window failed, cleared by the next
+   * {@link settleTree} that failed every read attempt, cleared by the next
    * DIRECTIVE read that comes back. One holder per run (built in flow-run's
    * ExecState and shared by every `deviceEnv`), so the evidence one step
    * gathered is the evidence the next one acts on.
@@ -89,17 +89,17 @@ export interface ActionEnv {
    * ordered against the step that is running: `idle` hands its read to
    * `settleWithin` and stops waiting at the round budget, so that read can land
    * during a later step and retire a verdict minted after it was issued. Safe
-   * direction - that only ever costs a later gesture a window it would have
+   * direction - that only ever costs a later gesture a settle it would have
    * skipped - but it is a clear by arrival, not by sequence.
    *
-   * Only {@link settleForGesture} READS it, and only to skip a window it has
+   * Only {@link settleForGesture} READS it, and only to skip a settle it has
    * already been shown is unaffordable - never a read whose answer is
    * dispatched rather than waited on, which is why {@link fetchScreenAspect}
    * does not consult it. The skip is not silent: the gesture warns its step
    * report that it dispatched unsettled, so the memo never makes an outage
    * cheaper to miss than it was to prove. It is written by the one place that
-   * can prove a source dead (a {@link settleTree} whose whole window failed),
-   * whichever directive asked for that window. `waitForFrame` and
+   * can prove a source dead (a {@link settleTree} that failed every read
+   * attempt), whichever directive asked for that settle. `waitForFrame` and
    * `scrollToVisible` error the step on it, so a verdict of theirs is never
    * spent; `runSnapshot` is the one producer whose step then passes reporting
    * nothing, since it captures pixels regardless and has no warning to carry.
@@ -120,7 +120,7 @@ export interface ActionEnv {
    * move is behind `runLaunch`, which clears the verdict first - but it keeps
    * the property from resting on where that clear sits in another file. The
    * clear is deliberately NOT keyed: it only ever costs a later gesture a
-   * window it would otherwise have skipped, and that is the side to err on.
+   * settle it would otherwise have skipped, and that is the side to err on.
    */
   treeOutage?: { proven?: { deviceId: string; error: Error } };
 }
@@ -457,14 +457,14 @@ function readFlowTree(env: ActionEnv): Promise<DescribeTreeData> {
  * evidence.
  *
  * `skipProvenOutage` rethrows {@link ActionEnv.treeOutage} instead of buying
- * that window again. Not a shorter budget: a threshold low enough to spare a
- * source serving no tree at all would also abandon the mid-navigation blip the
- * retry above exists for. But the memo is a prediction: one window mints it and
- * nothing re-tests it. Being wrong costs a settle, not a step:
- * {@link settleForGesture} swallows the throw - and says so, warning every
- * gesture it spares, so a run whose prediction was wrong reports which greens
- * went out unsettled. Any directive read that comes back retires it, as does a
- * relaunch.
+ * that whole settle again, window and floor reads alike. Not a shorter budget:
+ * a threshold low enough to spare a source serving no tree at all would also
+ * abandon the mid-navigation blip the retry above exists for. But the memo is a
+ * prediction: one settle mints it and nothing re-tests it. Being wrong costs a
+ * settle, not a step: {@link settleForGesture} swallows the throw - and says
+ * so, warning every gesture it spares, so a run whose prediction was wrong
+ * reports which greens went out unsettled. Any directive read that comes back
+ * retires it, as does a relaunch.
  *
  * What it costs: an outage that lasted a full window, in a run that then never
  * reads the tree again and never relaunches, leaves later gestures unsettled

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -232,7 +232,13 @@ const FOCUS_REPORTING_SOURCES: ReadonlySet<DescribeSource> = new Set([
 // Settle detection: re-read the tree until two consecutive reads match, so a tap
 // never lands mid-fling and a resolved frame can't go stale before we act.
 const SETTLE_POLL_MS = 250;
-const SETTLE_TIMEOUT_MS = 3000;
+/**
+ * How long that re-reading gets. Exported for flow-settle-min-reads.test.ts,
+ * which sizes its slow reads past this window: a hand-copied number there would
+ * survive this one being raised above it, and the read counts it prices would
+ * quietly stop measuring the floor below.
+ */
+export const SETTLE_TIMEOUT_MS = 3000;
 
 // Read attempts every settle makes before it may conclude anything, enforced
 // even once the window has closed. A read can fail by TIMING OUT, and every

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -222,19 +222,21 @@ const SETTLE_TIMEOUT_MS = 3000;
 
 // Read attempts every settle makes before it may conclude anything, enforced
 // even once the window has closed. A read can fail by TIMING OUT, and every
-// tree source's RPC timeout outlasts the 3s window (the shortest is iOS's 5s),
-// so the window fits only one such read: without a floor, "every read in the
-// window failed", which the throw below reports as a tree-source outage, would
+// tree source's RPC timeout outlasts the 3s window: 5s is the shortest tier any
+// of them allows, and a whole read chains several of those (an iOS read spends
+// up to 5s resolving the target app before a 15s `getFullHierarchy`), so the
+// window fits only one such read. Without a floor, "every read in the window
+// failed", which the throw below reports as a tree-source outage, would
 // collapse into "the first read was slow", erroring a step on one transient
 // blip with no retry at all. The second read is not bounded by the window
-// either, and a read is several RPCs deep, each on its own timeout, so a wedged
-// source costs two full reads and tens of seconds, and a source that answers
-// slowly pays a second read where it used to end on one. `scroll-to` multiplies
-// that: it settles once per round, bounded by `MAX_SCROLL_ITERATIONS` rather
-// than a wall clock, so the added read lands on every round and a slow source
-// turns one step's tens of seconds into minutes. `await`/`assert` have always
-// had this floor in `waitForCondition`'s final poll; this is the same guarantee
-// for the directives that resolve through a settle.
+// either, so a wedged source costs two full reads and tens of seconds, and a
+// source that answers slowly pays a second read where it used to end on one.
+// `scroll-to` multiplies that: it settles once per round, bounded by
+// `MAX_SCROLL_ITERATIONS` rather than a wall clock, so the added read lands on
+// every round and a slow source turns one step's tens of seconds into minutes.
+// `await`/`assert` have always had this floor in `waitForCondition`'s final
+// poll; this is the same guarantee for the directives that resolve through a
+// settle.
 const SETTLE_MIN_READS = 2;
 
 // `scroll-to`: a bounded number of momentum-free increments. Each travels half

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -101,32 +101,31 @@ export interface ActionEnv {
    * can prove a source dead (a {@link settleTree} that failed every read
    * attempt), whichever directive asked for that settle. `waitForFrame` and
    * `scrollToVisible` error the step on it, so a verdict of theirs is never
-   * spent; `runSnapshot` is the one producer whose step then passes reporting
-   * nothing, since it captures pixels regardless and has no warning to carry.
-   * Deliberate, but it means a snapshot's outage is heard about on the gesture
-   * that spends the verdict, or not at all if no gesture follows. It is cleared
-   * by {@link readFlowTree}, which every directive's reads go through, since a
-   * read that came back is evidence of health whichever directive asked for it.
-   * A relaunch clears it too, whether spelled `launch` or as one of flow-run's
-   * `FOREGROUND_CHANGING_TOOLS`: it is the repair the commonest of these errors
-   * asks for, and no read need follow it before a gesture does. So does a
-   * nested orchestrator step, which can do either out of this holder's sight.
-   * Absent for a caller that builds an `ActionEnv` by hand, which simply leaves
-   * every settle on its own budget.
+   * spent; `runSnapshot` captures pixels regardless and `VisualOutcome` has
+   * no `warning` field, so its step passes in silence: the outage surfaces on
+   * the gesture that spends the verdict, or not at all if none follows.
    *
-   * `runSnapshot` is the third caller {@link fetchFlowTree} names as swallowing
-   * such an outage, and it deliberately does NOT read the memo: a capture taken
-   * unsettled is one taken mid-animation, and it lands as a pixel mismatch on a
-   * step whose report has no `warning` to carry the caveat, so being wrong
-   * there would cost a step rather than a settle. Snapshots pay the full price
-   * for that: on a source that fails by timing out, every snapshot step re-buys
-   * the whole settle, window and floor reads alike, two reads where the window
-   * alone ended on one. That price buys something back. The settle reads
-   * through {@link readFlowTree}, so a snapshot re-tests the verdict rather
-   * than trusting it, and in a flow of nothing but snapshots and coordinate
-   * gestures - where the gesture settle skips itself while one stands - it is,
-   * with a rotate's {@link fetchScreenAspect}, one of the two reads left that
-   * can retire a wrong one.
+   * That same silence keeps `runSnapshot` deliberately off the reading side,
+   * though not on {@link fetchScreenAspect}'s grounds, since a snapshot's
+   * settle IS waited on. A capture taken on a stale verdict lands as a
+   * mid-animation pixel mismatch that reads as a visual regression, with
+   * nothing to say the screen was never settled: being wrong there costs a
+   * step, where the gesture risks only a settle. The price is that on a source
+   * failing by timeout, every snapshot step re-buys the whole settle, window
+   * and floor reads alike, two reads where the window alone ended on one. In
+   * exchange the settle reads through {@link readFlowTree}, so a snapshot
+   * re-tests the verdict instead of trusting it, and with a rotate's
+   * {@link fetchScreenAspect} it is one of the two reads left that can retire a
+   * wrong one in a flow of nothing but snapshots and coordinate gestures.
+   *
+   * It is cleared by {@link readFlowTree}, which every directive's reads go
+   * through, since a read that came back is evidence of health whichever
+   * directive asked for it. A relaunch clears it too, whether spelled `launch`
+   * or as one of flow-run's `FOREGROUND_CHANGING_TOOLS`: it is the repair the
+   * commonest of these errors asks for, and no read need follow it before a
+   * gesture does. So does a nested orchestrator step, which can do either out
+   * of this holder's sight. Absent for a caller that builds an `ActionEnv` by
+   * hand, which simply leaves every settle on its own budget.
    *
    * The write carries the device it was proven against: a verdict about a
    * device the run has left says nothing about the one it moved onto (a

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -114,6 +114,20 @@ export interface ActionEnv {
    * Absent for a caller that builds an `ActionEnv` by hand, which simply leaves
    * every settle on its own budget.
    *
+   * `runSnapshot` is the third caller {@link fetchFlowTree} names as swallowing
+   * such an outage, and it deliberately does NOT read the memo: a capture taken
+   * unsettled is one taken mid-animation, and it lands as a pixel mismatch on a
+   * step whose report has no `warning` to carry the caveat, so being wrong
+   * there would cost a step rather than a settle. Snapshots pay the full price
+   * for that: on a source that fails by timing out, every snapshot step re-buys
+   * the whole settle, window and floor reads alike, two reads where the window
+   * alone ended on one. That price buys something back. The settle reads
+   * through {@link readFlowTree}, so a snapshot re-tests the verdict rather
+   * than trusting it, and in a flow of nothing but snapshots and coordinate
+   * gestures - where the gesture settle skips itself while one stands - it is,
+   * with a rotate's {@link fetchScreenAspect}, one of the two reads left that
+   * can retire a wrong one.
+   *
    * The write carries the device it was proven against: a verdict about a
    * device the run has left says nothing about the one it moved onto (a
    * chromium `launch` boots its own). Belt-and-braces today - the one mid-run

--- a/packages/tool-server/src/tools/flows/flow-actions.ts
+++ b/packages/tool-server/src/tools/flows/flow-actions.ts
@@ -238,9 +238,10 @@ const SETTLE_TIMEOUT_MS = 3000;
 // bounded by `MAX_SCROLL_ITERATIONS` rather than a wall clock, so the added
 // read lands on every round and a slow source turns one step's tens of seconds
 // into minutes.
-// `await`/`assert` have always had this floor in `waitForCondition`'s final
-// poll; this is the same guarantee for the directives that resolve through a
-// settle.
+// `await`/`assert` never had this hole: `waitForCondition` takes a poll at its
+// deadline unconditionally, however many reads preceded it. The floor here is
+// narrower, firing only when the window closed on fewer than two reads, but it
+// covers the same case: a first read that outlasts the window on its own.
 const SETTLE_MIN_READS = 2;
 
 // `scroll-to`: a bounded number of momentum-free increments. Each travels half

--- a/packages/tool-server/test/flows/flow-gesture-settle.test.ts
+++ b/packages/tool-server/test/flows/flow-gesture-settle.test.ts
@@ -848,9 +848,10 @@ describe("a proven outage is spent only on the device that proved it", () => {
 });
 
 // The settle's deadline is tested only after a read RETURNS, so the window
-// bounds how many reads it issues and never how long it waits on one. That is
-// deliberate: budgeting the read to what is left of the window would put a 3s
-// cap on `ViewHierarchy.getFullHierarchy`, which #778 raised to a 15s RPC tier
+// bounds how many reads it issues - never how long it waits on one, and never
+// below the SETTLE_MIN_READS floor. That is deliberate: budgeting the read to
+// what is left of the window would put a 3s cap on
+// `ViewHierarchy.getFullHierarchy`, which #778 raised to a 15s RPC tier
 // precisely so an iOS cold-start stall is ridden out instead of failed. The
 // abort in the block below is the one thing that does cut such a read short.
 describe("the settle window bounds its retries, not the read in flight", () => {
@@ -859,7 +860,7 @@ describe("the settle window bounds its retries, not the read in flight", () => {
   // so the margin is the only part of this test's cost there is to keep down.
   const SLOW_READ_MS = 3_500;
 
-  it("waits out a read slower than the whole window", async () => {
+  it("waits out every read slower than the whole window", async () => {
     readDelayMs = SLOW_READ_MS;
     await writeFlow("tap-slow-read", {
       executionPrerequisite: "",
@@ -871,13 +872,14 @@ describe("the settle window bounds its retries, not the read in flight", () => {
     const elapsed = Date.now() - startedAt;
 
     expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["tap:pass"]);
-    // Exactly one read: it answered past the deadline, so the window ended on
-    // it and issued no second. A read cut off at the deadline would leave that
-    // count identical - the wait is what separates the two.
-    expect(readsBeforeFirstGesture()).toBe(1);
-    expect(elapsed).toBeGreaterThanOrEqual(SLOW_READ_MS);
-    // The gesture goes out on a tree that converged on nothing, but a read did
-    // come back, so this is no outage and the step is not warned about one.
+    // Two reads, neither cut short: the first answered past the deadline, and
+    // the floor owes a second even though the window is spent. Reads cut off at
+    // the deadline would leave that count identical - the elapsed time is what
+    // separates the two, and it covers BOTH reads.
+    expect(readsBeforeFirstGesture()).toBe(2);
+    expect(elapsed).toBeGreaterThanOrEqual(2 * SLOW_READ_MS);
+    // The floor read is what the settle converges on here, and a read did come
+    // back, so this is no outage and the step is not warned about one.
     expect(gestures()[0]).toMatchObject({ tool: "gesture-tap", args: { x: 0.4, y: 0.6 } });
     expect(result.steps[0].warning).toBeUndefined();
   }, 15_000);

--- a/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
@@ -100,7 +100,7 @@ describe("settleTree takes at least two read attempts", () => {
         await sleep(SLOW_READ_MS);
         throw new Error("ui tree RPC timed out");
       }
-      return tree();
+      return tree("Continue", MOVED_BUTTON_FRAME);
     };
     await writeTap("tap-slow-blip");
 
@@ -109,8 +109,12 @@ describe("settleTree takes at least two read attempts", () => {
     // One slow blip is not an outage: the retry read the screen, so the tap
     // resolved and went out instead of erroring the step.
     expect(result.ok).toBe(true);
-    expect(reads).toBeGreaterThanOrEqual(2);
-    expect(result.calls.map((c) => c.tool)).toEqual(["gesture-tap"]);
+    // The slow failure buys one retry, not an open-ended wait for a good read.
+    expect(reads).toBe(2);
+    // Centre of the MOVED frame, a point only the retry's tree can produce.
+    expect(result.calls).toEqual([
+      { tool: "gesture-tap", args: { udid: DEVICE, x: 0.5, y: 0.75 } },
+    ]);
   }, 20_000);
 
   it("settles against the retry when the only read so far succeeded slowly", async () => {

--- a/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
@@ -168,13 +168,13 @@ describe("settleTree takes at least two read attempts", () => {
     expect(reads).toBeGreaterThan(2);
   }, 20_000);
 
-  it("does not spend a second read when the first one settles the screen", async () => {
+  it("adds no third read when the first two reads matched inside the window", async () => {
     await writeTap("tap-healthy");
 
     const result = await run("tap-healthy");
 
     expect(result.ok).toBe(true);
-    // Two reads are what a settle costs a healthy run — the floor adds none.
+    // Two reads are what a settle has always cost a healthy run.
     expect(reads).toBe(2);
   });
 });

--- a/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
@@ -48,10 +48,15 @@ function tree(label = "Continue", frame?: DescribeFrame): DescribeTreeData {
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+// Set when a scroll increment goes out, so a fixture can reveal the target the
+// way a real scroll does rather than on a read count it is there to measure.
+let swiped = false;
+
 function mockRegistry(calls: Array<{ tool: string; args: Record<string, unknown> }>): Registry {
   return {
     invokeTool: vi.fn(async (id: string, args: Record<string, unknown>) => {
       if (id === "list-devices") return { devices: [] };
+      if (id === "gesture-swipe") swiped = true;
       calls.push({ tool: id, args });
       return { ok: true };
     }),
@@ -87,6 +92,7 @@ async function writeTap(name: string): Promise<void> {
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-settle-reads-"));
   reads = 0;
+  swiped = false;
   onRead = async () => tree();
 });
 afterEach(async () => {
@@ -205,4 +211,32 @@ describe("settleTree takes at least two read attempts", () => {
     // Two reads are what a settle has always cost a healthy run.
     expect(reads).toBe(2);
   });
+});
+
+describe("the settle floor is paid on every `scroll-to` round", () => {
+  it("spends two reads a round against a source slower than the window", async () => {
+    // Every read outlasts the window, so every round's settle closes it on the
+    // first read and pays the floor's retry. The button drifts between reads so
+    // no settle exits early on two matching fingerprints, which would cost two
+    // reads whatever the floor is set to.
+    onRead = async (attempt) => {
+      await sleep(SLOW_READ_MS);
+      const frame = attempt % 2 === 0 ? MOVED_BUTTON_FRAME : BUTTON_FRAME;
+      return tree(swiped ? "Order #1234" : "Top", frame);
+    };
+    await writeFlow("scroll-slow", {
+      executionPrerequisite: "",
+      steps: [{ kind: "scroll-to", target: { text: "Order #1234" }, direction: "down" }],
+    });
+
+    const result = await run("scroll-slow");
+
+    expect(result.ok).toBe(true);
+    // One increment, so the pass took exactly two rounds.
+    expect(result.calls.map((c) => c.tool)).toEqual(["gesture-swipe"]);
+    // Two per round where the pre-floor cost was one. The loop is bounded by
+    // MAX_SCROLL_ITERATIONS rather than a clock, so two pinned rounds stand in
+    // for the 25 it can run.
+    expect(reads).toBe(4);
+  }, 30_000);
 });

--- a/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
@@ -142,6 +142,30 @@ describe("settleTree takes at least two read attempts", () => {
     ]);
   }, 20_000);
 
+  it("settles against the slow first read when the retry then fails", async () => {
+    onRead = async (attempt) => {
+      if (attempt === 1) {
+        await sleep(SLOW_READ_MS);
+        return tree();
+      }
+      throw new Error("ui tree RPC timed out");
+    };
+    await writeTap("tap-slow-then-blip");
+
+    const result = await run("tap-slow-then-blip");
+
+    // A read did come back, so this is no outage: the step passes, and the
+    // branch that would mint the outage memo is the one that throws.
+    expect(result.ok).toBe(true);
+    // The floor buys one retry; its failure is not grounds for a third read.
+    expect(reads).toBe(2);
+    // The first read's frame, handed back a read later than the bare deadline
+    // would have returned it rather than discarded over one blip.
+    expect(result.calls).toEqual([
+      { tool: "gesture-tap", args: { udid: DEVICE, x: 0.5, y: 0.45 } },
+    ]);
+  }, 20_000);
+
   it("still calls a sustained outage an outage, on the read after the slow one", async () => {
     onRead = async (attempt) => {
       if (attempt === 1) await sleep(SLOW_READ_MS);

--- a/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
@@ -23,12 +23,16 @@ vi.mock("../../src/tools/flows/flow-tree", () => ({
   }),
 }));
 
+import { SETTLE_TIMEOUT_MS } from "../../src/tools/flows/flow-actions";
 import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
 import { serializeFlow } from "../../src/tools/flows/flow-utils";
 
 const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
-// Comfortably past the 3000ms settle window, the way a tree RPC's own timeout is.
-const SLOW_READ_MS = 3200;
+// Outlasts the settle window on its own, the way a tree RPC's own timeout does.
+// Derived rather than copied: a window raised past a pinned number would move
+// these cases onto the ordinary poll path, where the scroll-to round cost still
+// comes out at four reads and stops pricing the floor.
+const SLOW_READ_MS = SETTLE_TIMEOUT_MS + 200;
 const BUTTON_FRAME: DescribeFrame = { x: 0.2, y: 0.4, width: 0.6, height: 0.1 };
 // The same button a scroll further down, i.e. a screen still in motion.
 const MOVED_BUTTON_FRAME: DescribeFrame = { ...BUTTON_FRAME, y: 0.7 };

--- a/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
@@ -3,12 +3,17 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Registry } from "@argent/registry";
-import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
+import type {
+  DescribeFrame,
+  DescribeNode,
+  DescribeTreeData,
+} from "../../src/tools/describe/contract";
 
-// Reads are driven per attempt, so a test can make the FIRST one fail slowly —
+// Reads are driven per attempt, so a test can make the FIRST one answer slowly —
 // the shape that matters here. A tree RPC allows itself ~5s, more than the 3s
-// settle window, so one such failure used to be the only read a settle ever
-// took, and the "every read failed" throw fired on a single transient blip.
+// settle window, so one such read used to be the only read a settle ever took:
+// the "every read failed" throw fired on a single transient blip, and a read
+// that came back was returned having been compared against nothing.
 let reads = 0;
 let onRead: (attempt: number) => Promise<DescribeTreeData>;
 vi.mock("../../src/tools/flows/flow-tree", () => ({
@@ -23,21 +28,22 @@ import { serializeFlow } from "../../src/tools/flows/flow-utils";
 
 const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
 // Comfortably past the 3000ms settle window, the way a tree RPC's own timeout is.
-const SLOW_FAILURE_MS = 3200;
+const SLOW_READ_MS = 3200;
+const BUTTON_FRAME: DescribeFrame = { x: 0.2, y: 0.4, width: 0.6, height: 0.1 };
+// The same button a scroll further down, i.e. a screen still in motion.
+const MOVED_BUTTON_FRAME: DescribeFrame = { ...BUTTON_FRAME, y: 0.7 };
 let tmpDir: string;
 
-function screenWith(label: string): DescribeNode {
+function screenWith(label: string, frame: DescribeFrame = BUTTON_FRAME): DescribeNode {
   return {
     role: "AXWindow",
     frame: { x: 0, y: 0, width: 1, height: 1 },
-    children: [
-      { role: "AXButton", label, frame: { x: 0.2, y: 0.4, width: 0.6, height: 0.1 }, children: [] },
-    ],
+    children: [{ role: "AXButton", label, frame, children: [] }],
   };
 }
 
-function tree(label = "Continue"): DescribeTreeData {
-  return { tree: screenWith(label), source: "native-devtools" };
+function tree(label = "Continue", frame?: DescribeFrame): DescribeTreeData {
+  return { tree: screenWith(label, frame), source: "native-devtools" };
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -91,7 +97,7 @@ describe("settleTree takes at least two read attempts", () => {
   it("retries past the window when the only read so far failed slowly", async () => {
     onRead = async (attempt) => {
       if (attempt === 1) {
-        await sleep(SLOW_FAILURE_MS);
+        await sleep(SLOW_READ_MS);
         throw new Error("ui tree RPC timed out");
       }
       return tree();
@@ -107,9 +113,34 @@ describe("settleTree takes at least two read attempts", () => {
     expect(result.calls.map((c) => c.tool)).toEqual(["gesture-tap"]);
   }, 20_000);
 
+  it("settles against the retry when the only read so far succeeded slowly", async () => {
+    // The button moves between the two reads, so the dispatched point tells us
+    // which read the gesture actually acted on.
+    onRead = async (attempt) => {
+      if (attempt === 1) {
+        await sleep(SLOW_READ_MS);
+        return tree();
+      }
+      return tree("Continue", MOVED_BUTTON_FRAME);
+    };
+    await writeTap("tap-slow-settle");
+
+    const result = await run("tap-slow-settle");
+
+    expect(result.ok).toBe(true);
+    // A lone read has been compared against nothing and is no settle at all, so
+    // the window being spent does not excuse skipping the retry.
+    expect(reads).toBe(2);
+    // Centre of the MOVED frame (0.45 would be the first read's): the tap lands
+    // where the second read saw the button, not on the stale pre-deadline one.
+    expect(result.calls).toEqual([
+      { tool: "gesture-tap", args: { udid: DEVICE, x: 0.5, y: 0.75 } },
+    ]);
+  }, 20_000);
+
   it("still calls a sustained outage an outage, on the read after the slow one", async () => {
     onRead = async (attempt) => {
-      if (attempt === 1) await sleep(SLOW_FAILURE_MS);
+      if (attempt === 1) await sleep(SLOW_READ_MS);
       throw new Error("native devtools is unavailable");
     };
     await writeTap("tap-outage");

--- a/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
+
+// Reads are driven per attempt, so a test can make the FIRST one fail slowly —
+// the shape that matters here. A tree RPC allows itself ~5s, more than the 3s
+// settle window, so one such failure used to be the only read a settle ever
+// took, and the "every read failed" throw fired on a single transient blip.
+let reads = 0;
+let onRead: (attempt: number) => Promise<DescribeTreeData>;
+vi.mock("../../src/tools/flows/flow-tree", () => ({
+  fetchFlowTree: vi.fn(async (): Promise<DescribeTreeData> => {
+    reads += 1;
+    return onRead(reads);
+  }),
+}));
+
+import { createRunFlowTool, type FlowRunResult } from "../../src/tools/flows/flow-run";
+import { serializeFlow } from "../../src/tools/flows/flow-utils";
+
+const DEVICE = "00000000-0000-0000-0000-0000000000ab"; // iOS UDID shape
+// Comfortably past the 3000ms settle window, the way a tree RPC's own timeout is.
+const SLOW_FAILURE_MS = 3200;
+let tmpDir: string;
+
+function screenWith(label: string): DescribeNode {
+  return {
+    role: "AXWindow",
+    frame: { x: 0, y: 0, width: 1, height: 1 },
+    children: [
+      { role: "AXButton", label, frame: { x: 0.2, y: 0.4, width: 0.6, height: 0.1 }, children: [] },
+    ],
+  };
+}
+
+function tree(label = "Continue"): DescribeTreeData {
+  return { tree: screenWith(label), source: "native-devtools" };
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function mockRegistry(calls: Array<{ tool: string; args: Record<string, unknown> }>): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string, args: Record<string, unknown>) => {
+      if (id === "list-devices") return { devices: [] };
+      calls.push({ tool: id, args });
+      return { ok: true };
+    }),
+    getTool: vi.fn(() => ({ inputSchema: { properties: { udid: {} } } })),
+  } as unknown as Registry;
+}
+
+async function writeFlow(name: string, yaml: Parameters<typeof serializeFlow>[0]): Promise<void> {
+  const dir = path.join(tmpDir, ".argent", "flows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.yaml`), serializeFlow(yaml), "utf8");
+}
+
+async function run(
+  name: string
+): Promise<FlowRunResult & { calls: Array<{ tool: string; args: Record<string, unknown> }> }> {
+  const calls: Array<{ tool: string; args: Record<string, unknown> }> = [];
+  const r = await createRunFlowTool(mockRegistry(calls)).execute(
+    {},
+    { name, project_root: tmpDir, device: DEVICE }
+  );
+  if (!("steps" in r)) throw new Error(`expected a run result, got notice: ${r.notice}`);
+  return Object.assign(r, { calls });
+}
+
+async function writeTap(name: string): Promise<void> {
+  await writeFlow(name, {
+    executionPrerequisite: "",
+    steps: [{ kind: "tap", selector: { text: "Continue", loose: true } }],
+  });
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-settle-reads-"));
+  reads = 0;
+  onRead = async () => tree();
+});
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("settleTree takes at least two read attempts", () => {
+  it("retries past the window when the only read so far failed slowly", async () => {
+    onRead = async (attempt) => {
+      if (attempt === 1) {
+        await sleep(SLOW_FAILURE_MS);
+        throw new Error("ui tree RPC timed out");
+      }
+      return tree();
+    };
+    await writeTap("tap-slow-blip");
+
+    const result = await run("tap-slow-blip");
+
+    // One slow blip is not an outage: the retry read the screen, so the tap
+    // resolved and went out instead of erroring the step.
+    expect(result.ok).toBe(true);
+    expect(reads).toBeGreaterThanOrEqual(2);
+    expect(result.calls.map((c) => c.tool)).toEqual(["gesture-tap"]);
+  }, 20_000);
+
+  it("still calls a sustained outage an outage, on the read after the slow one", async () => {
+    onRead = async (attempt) => {
+      if (attempt === 1) await sleep(SLOW_FAILURE_MS);
+      throw new Error("native devtools is unavailable");
+    };
+    await writeTap("tap-outage");
+
+    const result = await run("tap-outage");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].reason).toMatch(/native devtools is unavailable/);
+    // The floor is a floor, not an open-ended retry: the second failure settles it.
+    expect(reads).toBe(2);
+    expect(result.calls).toHaveLength(0);
+  }, 20_000);
+
+  it("leaves a fast-failing outage on its existing budget", async () => {
+    onRead = async () => {
+      throw new Error("native devtools is unavailable");
+    };
+    await writeTap("tap-dead");
+
+    const result = await run("tap-dead");
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].reason).toMatch(/native devtools is unavailable/);
+    // Reads that fail fast still fill the window, so the floor changes nothing.
+    expect(reads).toBeGreaterThan(2);
+  }, 20_000);
+
+  it("does not spend a second read when the first one settles the screen", async () => {
+    await writeTap("tap-healthy");
+
+    const result = await run("tap-healthy");
+
+    expect(result.ok).toBe(true);
+    // Two reads are what a settle costs a healthy run — the floor adds none.
+    expect(reads).toBe(2);
+  });
+});

--- a/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
+++ b/packages/tool-server/test/flows/flow-settle-min-reads.test.ts
@@ -75,12 +75,15 @@ async function writeFlow(name: string, yaml: Parameters<typeof serializeFlow>[0]
 }
 
 async function run(
-  name: string
+  name: string,
+  signal?: AbortSignal
 ): Promise<FlowRunResult & { calls: Array<{ tool: string; args: Record<string, unknown> }> }> {
   const calls: Array<{ tool: string; args: Record<string, unknown> }> = [];
+  const ctx = signal ? ({ signal } as never) : undefined;
   const r = await createRunFlowTool(mockRegistry(calls)).execute(
     {},
-    { name, project_root: tmpDir, device: DEVICE }
+    { name, project_root: tmpDir, device: DEVICE },
+    ctx
   );
   if (!("steps" in r)) throw new Error(`expected a run result, got notice: ${r.notice}`);
   return Object.assign(r, { calls });
@@ -215,6 +218,50 @@ describe("settleTree takes at least two read attempts", () => {
     // Two reads are what a settle has always cost a healthy run.
     expect(reads).toBe(2);
   });
+
+  it("ends a run cancelled while the floor's retry is in flight", async () => {
+    // The floor's read is the one cancelled here, not the first: read 1 answers
+    // past the window, so the deadline closes on a lone read and the retry goes
+    // out back-to-back with no poll sleep between them. Read 2 then never
+    // answers, and carries no budget of its own - the read keeps its own RPC
+    // tier so a slow cold start is ridden out - so the signal is all that ends
+    // the wait.
+    let retryStarted!: () => void;
+    const retryInFlight = new Promise<void>((resolve) => {
+      retryStarted = resolve;
+    });
+    onRead = async (attempt) => {
+      if (attempt === 1) {
+        await sleep(SLOW_READ_MS);
+        return tree();
+      }
+      retryStarted();
+      return new Promise<never>(() => {});
+    };
+    await writeTap("tap-cancelled-retry");
+
+    const controller = new AbortController();
+    const running = run("tap-cancelled-retry", controller.signal);
+    // Racing the run itself: a settle that never issued the retry fails on the
+    // assertions below rather than hanging here until this test's own timeout.
+    await Promise.race([retryInFlight, running]);
+    const abortedAt = Date.now();
+    controller.abort();
+    const result = await running;
+
+    // Nothing but the signal could have ended a read that never answers.
+    expect(Date.now() - abortedAt).toBeLessThan(2_000);
+    // The cancelled settle hands back no tree at all, not the pre-deadline one
+    // it already holds: that best-effort return would resolve a frame and land
+    // a tap after cancellation, reported as a pass rather than this skip.
+    expect(result.steps.map((s) => `${s.kind}:${s.status}`)).toEqual(["tap:skip"]);
+    expect(result.steps[0].reason).toBe("run aborted");
+    expect(result.calls).toHaveLength(0);
+    // And the retry really was in flight: an abort on read 1 is a different
+    // moment, already covered by flow-gesture-settle.test.ts, which hangs the
+    // first read instead.
+    expect(reads).toBe(2);
+  }, 20_000);
 });
 
 describe("the settle floor is paid on every `scroll-to` round", () => {

--- a/packages/tool-server/test/flows/flow-visual.test.ts
+++ b/packages/tool-server/test/flows/flow-visual.test.ts
@@ -333,7 +333,7 @@ describe("runSnapshot cross-app key collision", () => {
 
 describe("runSnapshot settle", () => {
   it("proceeds to capture when the tree source is down", async () => {
-    // settleTree throws when every read in its window failed (native devtools
+    // settleTree throws when every read attempt failed (native devtools
     // disconnected). The capture reads pixels, not the tree — the snapshot
     // must still capture and compare instead of reporting an error.
     vi.mocked(settleTree).mockRejectedValueOnce(new Error("native devtools is unavailable"));


### PR DESCRIPTION
`settleTree` bounded its polling by a 3s window but never bounded the number of reads it took, and a tree read can fail by TIMING OUT. Every tree source's RPC timeout outlasts that window, the shortest being iOS's 5s, so the window fit exactly one such read: "every read in the window failed", the condition the throw reports as a tree-source outage, collapsed into "the first read was slow", erroring a tap/type/scroll step on one transient blip with no retry at all.

The floor makes the deadline stop deciding how much evidence an outage verdict is drawn from. `await`/`assert` have never had this flaw, since `waitForCondition`'s final poll already guarantees a second attempt, so this is the same guarantee given to the directives that resolve through a settle.

A run whose reads answer inside the window pays nothing: two reads are what a settle already costs there. A run whose reads outlast it pays a second read, and gets a settle it never actually got before, since past the deadline the old code returned its single tree having compared it against nothing. A wedged source costs two full reads rather than one, and a read is several RPCs deep with each hop on its own timeout, so that is tens of seconds on a step that used to fail in one read. The alternative is the step failing on evidence the window was too short to gather.
