### PR TITLE
fix(tools): drop top-level JSON Schema combinators from tool input schemas

### DIFF
--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -237,7 +237,15 @@ export interface ToolDefinition<TParams = void, TResult = unknown> {
   description?: string;
   /** Zod schema for tool input; used for runtime validation. When provided, inputSchema is auto-derived at registration time. */
   zodSchema?: z.ZodObject<any>;
-  /** JSON Schema for tool input; used for listing (GET /tools). Auto-derived from zodSchema if not explicitly set. */
+  /**
+   * JSON Schema for tool input; used for listing (GET /tools). Auto-derived from zodSchema if not
+   * explicitly set — and it should never need to be set. A hand-written schema is how top-level
+   * `oneOf`/`allOf`/`anyOf` reached clients once before (#773): the Anthropic Messages API rejects
+   * those outright with a 400 that fails the WHOLE request, every tool in it. Express a cross-field
+   * rule as a zod `.refine()`/`.superRefine()` plus a sentence in `description` instead. Combinators
+   * nested inside `properties` (e.g. a `z.union` field) are fine.
+   * Enforced by tool-server/test/tool-input-schema-contract.test.ts.
+   */
   inputSchema?: Record<string, unknown>;
   /** Optional hint for adapters (e.g. "image" for MCP to return base64 image content). */
   outputHint?: string;

--- a/packages/tool-server/src/tools/flows/flow-read-prerequisite.ts
+++ b/packages/tool-server/src/tools/flows/flow-read-prerequisite.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import * as fs from "node:fs/promises";
-import { zodObjectToJsonSchema } from "@argent/registry";
 import type { FileInputSpec, ToolContext, ToolDefinition } from "@argent/registry";
 import { parseFlow } from "./flow-utils";
 import { resolveFlowSource } from "./flow-run";
@@ -28,7 +27,7 @@ const zodSchema = z
       .string()
       .optional()
       .describe(
-        "Absolute path to a co-located flow .yaml on the client and tool server's shared filesystem. This must be supplied through the file-input boundary. Pass the same flow source here as to flow-execute, so the prerequisite you read belongs to the flow that will run; for remote reads, pass name + project_root instead."
+        "Omit when name is set. Absolute path to a co-located flow .yaml on the client and tool server's shared filesystem. This must be supplied through the file-input boundary. Pass the same flow source here as to flow-execute, so the prerequisite you read belongs to the flow that will run; for remote reads, pass name + project_root instead."
       ),
   })
   .superRefine((params, ctx) => {
@@ -40,15 +39,6 @@ const zodSchema = z
       });
     }
   });
-
-const inputSchema: Record<string, unknown> = {
-  ...zodObjectToJsonSchema(zodSchema),
-  // Zod's JSON Schema conversion cannot represent superRefine. `oneOf` makes
-  // the same exactly-one source rule visible to MCP and HTTP clients — the
-  // identical addition flow-execute makes, so the pre-flight read advertises
-  // the same contract as the run it precedes.
-  oneOf: [{ required: ["name"] }, { required: ["flow_path"] }],
-};
 
 // Mirror of flow-execute's specs, field for field: the documented pre-flight is
 // "read the prerequisite, then run", so both tools must resolve the same source
@@ -90,9 +80,9 @@ Returns the prerequisite description so you can verify the required state is met
 Use when you need to check what app/simulator state is required before executing a flow; pass the same flow
 source (name or flow_path) you will pass to flow-execute, so the prerequisite you read is the contract of
 the flow that will actually run.
-Fails if the flow file does not exist.`,
+Fails if the flow file does not exist.
+Address the flow exactly as you will address it in flow-execute: name or flow_path, one and only one; supplying both or neither is rejected.`,
   zodSchema,
-  inputSchema,
   fileInputs,
   services: () => ({}),
   async execute(_services, params, ctx?: ToolContext) {

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -8,7 +8,6 @@ import {
   getFailureSignal,
   isLiveServiceState,
   wrapFailure,
-  zodObjectToJsonSchema,
 } from "@argent/registry";
 import type {
   DeviceInfo,
@@ -98,7 +97,7 @@ const zodSchema = z
       .string()
       .optional()
       .describe(
-        "Absolute path to a co-located flow .yaml on the client and tool server's shared filesystem. This must be supplied through the file-input boundary. For remote execution, pass name + project_root instead."
+        "Omit when name is set. Absolute path to a co-located flow .yaml on the client and tool server's shared filesystem. This must be supplied through the file-input boundary. For remote execution, pass name + project_root instead."
       ),
     device: z
       .string()
@@ -136,15 +135,6 @@ const zodSchema = z
   });
 
 type Params = z.infer<typeof zodSchema>;
-
-const inputSchema: Record<string, unknown> = {
-  ...zodObjectToJsonSchema(zodSchema),
-  // Zod's JSON Schema conversion cannot represent superRefine. `oneOf` makes
-  // the same exactly-one source rule visible to MCP and HTTP clients: neither
-  // branch matches when both fields are absent, and both branches match (which
-  // is invalid for oneOf) when both fields are present.
-  oneOf: [{ required: ["name"] }, { required: ["flow_path"] }],
-};
 
 // A dual-source call (name + flow_path) must be diagnosed by the schema's
 // exactly-one rule, not by whether either unused file happens to exist — in
@@ -985,10 +975,10 @@ off <id>\`, or \`retired <id> (same app relaunched)\` when the instance it left 
 a relaunch that retired an older owned instance names both.
 
 If a fragment has an execution prerequisite and prerequisiteAcknowledged is not set to true, the tool
-returns a notice with the prerequisite instead of running.`,
+returns a notice with the prerequisite instead of running.
+Pass exactly one flow source: name for a saved flow under project_root, or flow_path for an explicit YAML — both together, or neither, fails the call.`,
     longRunning: true,
     zodSchema,
-    inputSchema,
     fileInputs,
     services: () => ({}),
     async execute(_services, params, ctx?: ToolContext) {

--- a/packages/tool-server/src/tools/gesture-rotate/index.ts
+++ b/packages/tool-server/src/tools/gesture-rotate/index.ts
@@ -1,10 +1,5 @@
 import { z } from "zod";
-import {
-  zodObjectToJsonSchema,
-  type ToolCapability,
-  type ToolContext,
-  type ToolDefinition,
-} from "@argent/registry";
+import { type ToolCapability, type ToolContext, type ToolDefinition } from "@argent/registry";
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { resolveDevice } from "../../utils/device-info";
 import { sendTouchEvent } from "../../utils/gesture-utils";
@@ -62,20 +57,6 @@ const zodSchema = z
     message: "Pass radius, or both radiusX and radiusY.",
   });
 
-// Explicit because the auto-derived JSON Schema loses the .refine() cross-field
-// rules — the anyOf re-encodes both: the per-axis pair together, or radius with
-// neither half of the pair.
-const inputSchema = {
-  ...zodObjectToJsonSchema(zodSchema),
-  anyOf: [
-    { required: ["radiusX", "radiusY"] },
-    {
-      required: ["radius"],
-      not: { anyOf: [{ required: ["radiusX"] }, { required: ["radiusY"] }] },
-    },
-  ],
-};
-
 type Params = z.infer<typeof zodSchema>;
 
 interface Result {
@@ -108,9 +89,9 @@ export const gestureRotateTool: ToolDefinition<Params, Result> = {
 endAngle > startAngle = clockwise rotation. Typical values: radius 0.15, startAngle 0, endAngle 90 for a 90° clockwise turn. A single radius applies to both axes, so on a non-square screen it traces a physical ellipse (finger separation varies through the turn); pass radiusX+radiusY (fractions of width/height with radiusX·width = radiusY·height) for a physically circular orbit instead.
 Auto-generates interpolated frames at ~60fps.
 Unlike gesture-pinch which moves fingers linearly to zoom, this orbits fingers in an arc to change orientation.
-Use when you need to rotate a map, image picker, or any rotateable UI element. Returns { rotated: true, timestampMs }. Fails if the simulator-server / emulator backend is not reachable for the given device.`,
+Use when you need to rotate a map, image picker, or any rotateable UI element. Returns { rotated: true, timestampMs }. Fails if the simulator-server / emulator backend is not reachable for the given device.
+Size the orbit with radius, or with radiusX and radiusY together (the pair overrides radius); one half of the pair alone, or none of the three, is rejected.`,
   zodSchema,
-  inputSchema,
   capability,
   services: (params) => ({
     simulatorServer: simulatorServerRef(resolveDevice(params.udid)),

--- a/packages/tool-server/test/flows/flow-remote-recording.test.ts
+++ b/packages/tool-server/test/flows/flow-remote-recording.test.ts
@@ -8,6 +8,7 @@ import {
   CLIENT_FILE_MARKER,
   FAILURE_CODES,
   getFailureSignal,
+  zodObjectToJsonSchema,
 } from "@argent/registry";
 
 import { flowStartRecordingTool } from "../../src/tools/flows/flow-start-recording";
@@ -498,15 +499,21 @@ describe("flow replay with a boundary-resolved flow_file", () => {
 describe("flow replay with an explicit boundary-resolved flow_path", () => {
   it("advertises exactly one of name and flow_path as the flow source", () => {
     const runFlow = createRunFlowTool(createMockRegistry());
+    const schema = zodObjectToJsonSchema(runFlow.zodSchema!);
 
-    expect(runFlow.inputSchema).toMatchObject({
+    expect(schema).toMatchObject({
       type: "object",
       properties: {
         name: { type: "string" },
         flow_path: { type: "string" },
       },
-      oneOf: [{ required: ["name"] }, { required: ["flow_path"] }],
     });
+    // Neither source may be `required`: the exactly-one rule cannot be a
+    // top-level oneOf (tool-input-schema-contract.test.ts), so the zod
+    // superRefine enforces it and the description states it.
+    expect(schema.required as string[]).not.toContain("name");
+    expect(schema.required as string[]).not.toContain("flow_path");
+    expect(runFlow.description).toMatch(/exactly one flow source/i);
   });
 
   it("states the absolute-path requirement in the flow_path description", () => {
@@ -515,7 +522,7 @@ describe("flow replay with an explicit boundary-resolved flow_path", () => {
     // An agent reading only the schema is the caller that gets this wrong —
     // `argent flow list` hands it a relative path — so the requirement has to
     // be legible before the call, the way project_root's description states it.
-    expect(runFlow.inputSchema).toMatchObject({
+    expect(zodObjectToJsonSchema(runFlow.zodSchema!)).toMatchObject({
       properties: { flow_path: { description: expect.stringMatching(/absolute/i) } },
     });
   });
@@ -527,7 +534,7 @@ describe("flow replay with an explicit boundary-resolved flow_path", () => {
     // resolve beside the YAML — project_root locates nothing there — so the
     // description must not promise `.argent/flows/<name>.yaml` lives under it
     // (`name` is exactly what that branch forbids).
-    expect(runFlow.inputSchema).toMatchObject({
+    expect(zodObjectToJsonSchema(runFlow.zodSchema!)).toMatchObject({
       properties: {
         project_root: {
           description: expect.stringMatching(/with flow_path.*beside the YAML/i),

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -2607,14 +2607,20 @@ describe("flow-read-prerequisite", () => {
     // The pre-flight must offer the same source contract as the run it
     // precedes — a schema still requiring `name` would leave flow_path flows
     // unaddressable and silently answer for a saved flow of the same stem.
-    expect(flowReadPrerequisiteTool.inputSchema).toMatchObject({
+    const schema = zodObjectToJsonSchema(flowReadPrerequisiteTool.zodSchema!);
+    expect(schema).toMatchObject({
       type: "object",
       properties: {
         name: { type: "string" },
         flow_path: { type: "string" },
       },
-      oneOf: [{ required: ["name"] }, { required: ["flow_path"] }],
     });
+    // Neither source may be `required`: the exactly-one rule cannot be a
+    // top-level oneOf (tool-input-schema-contract.test.ts), so the zod
+    // superRefine enforces it and the description states it.
+    expect(schema.required as string[]).not.toContain("name");
+    expect(schema.required as string[]).not.toContain("flow_path");
+    expect(flowReadPrerequisiteTool.description).toMatch(/one and only one/i);
   });
 
   it("reads a boundary-verified flow_path's prerequisite, not the saved flow of the same stem", async () => {

--- a/packages/tool-server/test/gesture-rotate-radius.test.ts
+++ b/packages/tool-server/test/gesture-rotate-radius.test.ts
@@ -7,6 +7,7 @@ vi.mock("../src/utils/simulator-client", async (importOriginal) => ({
   sendCommand: vi.fn(),
 }));
 
+import { zodObjectToJsonSchema } from "@argent/registry";
 import { gestureRotateTool } from "../src/tools/gesture-rotate";
 import { sendCommand } from "../src/utils/simulator-client";
 
@@ -92,25 +93,9 @@ describe("gesture-rotate radiusX/radiusY", () => {
   });
 });
 
-// Minimal evaluator for the presence-only JSON Schema subset the anyOf uses
-// (required / anyOf / not), so the advertised schema can be checked semantically
-// without pulling in a full validator.
-interface PresenceConstraint {
-  required?: string[];
-  anyOf?: PresenceConstraint[];
-  not?: PresenceConstraint;
-}
-
-function satisfies(params: Record<string, unknown>, c: PresenceConstraint): boolean {
-  if (c.required && !c.required.every((key) => key in params)) return false;
-  if (c.anyOf && !c.anyOf.some((branch) => satisfies(params, branch))) return false;
-  if (c.not && satisfies(params, c.not)) return false;
-  return true;
-}
-
 describe("gesture-rotate inputSchema", () => {
-  it("keeps the radius trio optional at the top level, constrained only by the anyOf", () => {
-    const schema = gestureRotateTool.inputSchema!;
+  it("keeps the radius trio optional at the top level", () => {
+    const schema = zodObjectToJsonSchema(gestureRotateTool.zodSchema!);
     expect(schema.type).toBe("object");
     const required = schema.required as string[];
     expect(required).toEqual(
@@ -120,10 +105,12 @@ describe("gesture-rotate inputSchema", () => {
     expect(required).not.toContain("radiusX");
     expect(required).not.toContain("radiusY");
     expect(schema).not.toHaveProperty("$schema");
+    // The cross-field rule cannot live in the schema a client may receive (see
+    // tool-input-schema-contract.test.ts), so the description has to carry it.
+    expect(gestureRotateTool.description).toMatch(/one half of the pair alone/i);
   });
 
-  it("advertises exactly the radius shapes the zod refinements accept at runtime", () => {
-    const anyOf = gestureRotateTool.inputSchema!.anyOf as PresenceConstraint[];
+  it("the zod refinements accept exactly the documented radius shapes", () => {
     const base = { udid, centerX: 0.5, centerY: 0.5, startAngle: 0, endAngle: 90 };
     const shapes: Array<[radii: Record<string, number>, valid: boolean]> = [
       [{ radius: 0.15 }, true],
@@ -137,9 +124,6 @@ describe("gesture-rotate inputSchema", () => {
     ];
     for (const [radii, valid] of shapes) {
       const params = { ...base, ...radii };
-      expect(satisfies(params, { anyOf }), `advertised schema on ${JSON.stringify(radii)}`).toBe(
-        valid
-      );
       expect(
         gestureRotateTool.zodSchema!.safeParse(params).success,
         `zod schema on ${JSON.stringify(radii)}`

--- a/packages/tool-server/test/helpers/catalog.ts
+++ b/packages/tool-server/test/helpers/catalog.ts
@@ -1,0 +1,67 @@
+import { zodObjectToJsonSchema, type Registry, type ToolDefinition } from "@argent/registry";
+import { pasteTool } from "../../src/tools/paste";
+import { createProposeVariantTool } from "../../src/tools/variants/propose-variant";
+import { awaitUserSelectionTool } from "../../src/tools/variants/await-user-selection";
+
+/** Every tool argent can serve. Bump deliberately when a tool is added or removed. */
+export const EXPECTED_TOOL_COUNT = 76;
+
+/**
+ * The full catalog, keyed by id. Two groups never reach `registry.registerTool`
+ * on every platform, so they are added by hand and CI covers one catalog
+ * everywhere: the Lens tools register only on macOS, and `paste` is not
+ * registered at all.
+ */
+export function definitionsById(registry: Registry): Map<string, ToolDefinition<any, any>> {
+  const definitions = new Map<string, ToolDefinition<any, any>>();
+  for (const id of registry.getSnapshot().tools) {
+    definitions.set(id, registry.getTool(id)!);
+  }
+
+  definitions.set("propose_variant", createProposeVariantTool(registry));
+  definitions.set("await_user_selection", awaitUserSelectionTool);
+
+  // This definition intentionally exists outside createRegistry.
+  definitions.set("paste", pasteTool);
+  return definitions;
+}
+
+/**
+ * The schema a client actually receives: the explicit one if a definition
+ * carries it, else the one `Registry.registerTool` derives. Null when a
+ * definition declares neither, so the caller can report that as its own
+ * failure rather than dereferencing undefined.
+ */
+export function advertisedSchema(def: ToolDefinition<any, any>): Record<string, unknown> | null {
+  if (def.inputSchema) return def.inputSchema;
+  return def.zodSchema ? zodObjectToJsonSchema(def.zodSchema) : null;
+}
+
+/**
+ * JSON Schema keywords that must never appear at the TOP LEVEL of a tool's
+ * input_schema.
+ *
+ * Rejected outright by the Anthropic Messages API — "input_schema does not
+ * support oneOf, allOf, or anyOf at the top level", HTTP 400. The 400 fails the
+ * WHOLE request, every tool in it, so a single offending schema bricks any
+ * client that forwards ours verbatim (issue #773):
+ *   oneOf, allOf, anyOf
+ *
+ * Blocked pre-emptively, not rejected by the API — they are the natural way to
+ * re-encode a rejected combinator, and no model reads them anyway:
+ *   not, if, then, else, $ref, $schema
+ *
+ * TOP LEVEL ONLY. A combinator nested inside `properties` is legal and in use:
+ * tv-remote's `button` is a z.union.
+ */
+export const CLIENT_UNSAFE_TOP_LEVEL_KEYWORDS = [
+  "oneOf",
+  "allOf",
+  "anyOf",
+  "not",
+  "if",
+  "then",
+  "else",
+  "$ref",
+  "$schema",
+] as const;

--- a/packages/tool-server/test/interaction-messages.test.ts
+++ b/packages/tool-server/test/interaction-messages.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, it } from "vitest";
-import {
-  FAILURE_CODES,
-  type FailureSignal,
-  type Registry,
-  type ToolDefinition,
-} from "@argent/registry";
+import { FAILURE_CODES, type FailureSignal } from "@argent/registry";
 import { createRegistry } from "../src/utils/setup-registry";
-import { pasteTool } from "../src/tools/paste";
-import { createProposeVariantTool } from "../src/tools/variants/propose-variant";
-import { awaitUserSelectionTool } from "../src/tools/variants/await-user-selection";
+import { definitionsById, EXPECTED_TOOL_COUNT } from "./helpers/catalog";
 
 const failureSignal: FailureSignal = {
   error_code: FAILURE_CODES.ARGENT_UNCLASSIFIED_FAILURE,
@@ -17,26 +10,10 @@ const failureSignal: FailureSignal = {
   error_kind: "unknown",
 };
 
-function definitionsById(registry: Registry): Map<string, ToolDefinition<any, any>> {
-  const definitions = new Map<string, ToolDefinition<any, any>>();
-  for (const id of registry.getSnapshot().tools) {
-    definitions.set(id, registry.getTool(id)!);
-  }
-
-  // Lens tools are only registered on macOS; add them explicitly so this test
-  // covers the same catalog on every CI platform.
-  definitions.set("propose_variant", createProposeVariantTool(registry));
-  definitions.set("await_user_selection", awaitUserSelectionTool);
-
-  // This definition intentionally exists outside createRegistry.
-  definitions.set("paste", pasteTool);
-  return definitions;
-}
-
 describe("tool interaction messages", () => {
   it("defines all three formatters for every tool", () => {
     const definitions = definitionsById(createRegistry());
-    expect(definitions.size).toBe(76);
+    expect(definitions.size).toBe(EXPECTED_TOOL_COUNT);
 
     for (const [id, definition] of definitions) {
       expect(definition.interaction?.startedMsg, `${id}.startedMsg`).toBeTypeOf("function");

--- a/packages/tool-server/test/tool-input-schema-contract.test.ts
+++ b/packages/tool-server/test/tool-input-schema-contract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createRegistry } from "../src/utils/setup-registry";
+import {
+  advertisedSchema,
+  definitionsById,
+  CLIENT_UNSAFE_TOP_LEVEL_KEYWORDS,
+  EXPECTED_TOOL_COUNT,
+} from "./helpers/catalog";
+
+// Three tools once shipped a hand-written inputSchema that spread a top-level
+// oneOf/anyOf onto the derived schema, to express a cross-field rule zod cannot
+// represent in JSON Schema. The Anthropic Messages API rejects that with a 400
+// that fails the whole request — every tool in it — so the tools were unusable
+// through any client forwarding our schemas verbatim (issue #773). Claude Code
+// happens to strip the keyword before sending, which is why our own QA never
+// saw it; this test is what does see it.
+//
+// This is a denylist, deliberately not an allowlist of permitted top-level
+// keys: `additionalProperties` legitimately appears at the top level on the
+// schemas derived from `.strict()` objects (screenshot-diff,
+// stop-all-simulator-servers), and `required` is absent entirely on a schema
+// with no required fields.
+describe("advertised tool input schemas", () => {
+  const definitions = definitionsById(createRegistry());
+
+  it("covers the whole catalog", () => {
+    expect(definitions.size).toBe(EXPECTED_TOOL_COUNT);
+  });
+
+  for (const [id, definition] of definitions) {
+    it(`${id}: is a plain object schema with no top-level combinator`, () => {
+      const schema = advertisedSchema(definition);
+      expect(schema, `${id} declares neither zodSchema nor inputSchema`).not.toBeNull();
+
+      const offending = CLIENT_UNSAFE_TOP_LEVEL_KEYWORDS.filter((keyword) => keyword in schema!);
+      expect(offending, `${id} declares top-level ${offending.join("/")}`).toEqual([]);
+
+      expect(schema!.type, `${id}.type`).toBe("object");
+      expect(typeof schema!.properties, `${id}.properties`).toBe("object");
+    });
+  }
+});


### PR DESCRIPTION
Fixes #773.

## The bug

`gesture-rotate` (`anyOf`), `flow-execute` and `flow-read-prerequisite` (`oneOf`) hand-write an `inputSchema` that spreads a top-level combinator onto the derived schema. The Anthropic Messages API rejects that outright:

```
tools.N.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

The 400 fails the **whole request — every tool in it** — so any client forwarding our schemas verbatim as `custom` tools is bricked entirely, not just for these three tools. Reported from opencode.

## Why we never hit it

**Claude Code silently repairs it before sending.** Verified live: it strips the combinator and re-expresses the rule as a prose line prepended to the description. All of our E2E/QA runs through Claude Code, so the defect was invisible from inside our own test loop.

Secondary reasons: the code is recent (#546, 2026-07-24 for `gesture-rotate`; #568, 2026-08-05 for the two flow tools — before late July no argent tool had a top-level combinator), and nothing in CI asserted the shape of any tool's `inputSchema`.

## Why removing it is safe

The combinators never enforced anything. Nothing in argent validates against the JSON Schema — the zod `.refine()`/`.superRefine()` does all the rejecting, on every dispatch path (HTTP 400, MCP `isError`, CLI flag error, internal registry dispatch), and always did. #546's stated rationale was "to keep invalid calls rejected at the schema layer", but that layer does not exist; the only JSON Schema evaluator in the repo was a 5-line helper inside that PR's own test.

Verified equivalence before deleting: the removed `anyOf` accepts exactly the same 8 radius shapes as the two refinements, and `oneOf` the same 4 source combinations as the superRefine.

## What changed

- The three hand-written `inputSchema` consts are gone. No tool hand-writes one now, so `Registry.registerTool` is the single emission point for all 76 schemas.
- Each rule moves into the tool description, **worded differently per tool** — `tool-description-quality.yml` triggers on these paths and scores `disambiguation_score` (W=1.5), so identical prose on two tools would work against the gate.
- `ToolDefinition.inputSchema` documents why it should stay underived.
- New per-tool contract test over the whole catalog: no top-level `oneOf`/`allOf`/`anyOf` (API-rejected) and no top-level `not`/`if`/`then`/`else`/`$ref`/`$schema` (blocked pre-emptively — the natural way to re-encode a rejected combinator). Nested combinators stay legal and in use: `tv-remote`'s `button` is a `z.union`.
- Catalog walk + expected count extracted to `test/helpers/catalog.ts`, shared with `interaction-messages` so a new tool needs the count bumped once, not twice.
- Six existing tests read `.inputSchema` off unregistered definitions (populated only at registration) and now derive it.

## Not done by design

**No throw in `registerTool`.** `createRegistry()` runs at tool-server bootstrap (`index.ts:182`), where a throw becomes an uncaught exception → `crashShutdown` → `exit 1`: a total outage, and `update-argent` is itself a tool so it could not run to repair it. The catalog is static and compiled in, so the contract test catches the same regressions before merge — and it also covers `paste` and the Lens tools, which never pass through `registerTool` at all.

**Deliberately a denylist, not an allowlist** of permitted top-level keys: `additionalProperties` legitimately appears on schemas derived from `.strict()` objects (`screenshot-diff`, `stop-all-simulator-servers`).

## Follow-up left out

`gesture-rotate`'s refinements carry `path: []`, and `deriveInvalidParams` drops empty-path issues — so every cross-field rejection is telemetered with an empty `invalid_params`. Fixing it changes CLI wording and starts populating that field, so it is not riding in this PR.

## Verification

- 75 registered tools probed live: **zero** top-level combinators; the three now advertise `type, properties, required` only.
- Negative test: re-introducing an `anyOf` fails the gate with `gesture-rotate declares top-level anyOf`.
- `packages/registry` 90/90 pass; `packages/tool-server` 3952 pass with **7 pre-existing failures** in `bind-failure-telemetry`, `lens-relay-telemetry`, `startup-telemetry` and `tool-fail-invalid-params-emission` — all failing identically on pristine `fe5976857` (they die in `attachRegistryEventLogger`, unrelated to schemas).
- Build, eslint, prettier clean; knip identical to baseline (60 unused exports / 187 unused exported types both before and after).

Reaches users on the next npm publish; current version is 0.20.0.