### PR TITLE
fix(network): report UTF-8 response byte size

### DIFF
--- a/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
@@ -20,6 +20,32 @@ export const NETWORK_INTERCEPTOR_SCRIPT = `(function() {
   var MAX_ENTRIES = 2000;
   function genId() { return 'rn-net-' + (nextReqId++); }
   function ts() { return Date.now() / 1000; }
+  function utf8ByteLength(value) {
+    if (typeof TextEncoder !== 'undefined') {
+      return new TextEncoder().encode(value).length;
+    }
+
+    var length = 0;
+    for (var i = 0; i < value.length; i++) {
+      var code = value.charCodeAt(i);
+      if (code <= 0x7f) {
+        length += 1;
+      } else if (code <= 0x7ff) {
+        length += 2;
+      } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < value.length) {
+        var next = value.charCodeAt(i + 1);
+        if (next >= 0xdc00 && next <= 0xdfff) {
+          length += 4;
+          i += 1;
+        } else {
+          length += 3;
+        }
+      } else {
+        length += 3;
+      }
+    }
+    return length;
+  }
 
   function getOrCreate(reqId) {
     if (byId[reqId]) return byId[reqId];
@@ -83,7 +109,7 @@ export const NETWORK_INTERCEPTOR_SCRIPT = `(function() {
         var cloned = response.clone();
         cloned.text().then(function(body) {
           entry.state = 'finished';
-          entry.encodedDataLength = body.length;
+          entry.encodedDataLength = utf8ByteLength(body);
           entry.durationMs = Math.round((ts() - t) * 1000);
           entry.responseBody = body;
         }).catch(function() {

--- a/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
@@ -20,56 +20,6 @@ export const NETWORK_INTERCEPTOR_SCRIPT = `(function() {
   var MAX_ENTRIES = 2000;
   function genId() { return 'rn-net-' + (nextReqId++); }
   function ts() { return Date.now() / 1000; }
-  function utf8ByteLength(value) {
-    if (typeof TextEncoder !== 'undefined') {
-      return new TextEncoder().encode(value).length;
-    }
-
-    var length = 0;
-    for (var i = 0; i < value.length; i++) {
-      var code = value.charCodeAt(i);
-      if (code <= 0x7f) {
-        length += 1;
-      } else if (code <= 0x7ff) {
-        length += 2;
-      } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < value.length) {
-        var next = value.charCodeAt(i + 1);
-        if (next >= 0xdc00 && next <= 0xdfff) {
-          length += 4;
-          i += 1;
-        } else {
-          length += 3;
-        }
-      } else {
-        length += 3;
-      }
-    }
-    return length;
-  }
-
-  function responseByteLength(body, mimeType, headers) {
-    var keys = Object.keys(headers);
-    for (var i = 0; i < keys.length; i++) {
-      if (keys[i].toLowerCase() !== 'content-length') continue;
-
-      var value = String(headers[keys[i]]).trim();
-      if (/^\\d+$/.test(value)) return Number(value);
-    }
-
-    if (typeof body !== 'string') return 0;
-
-    var textual = mimeType.indexOf('text/') === 0
-      || mimeType === 'application/json'
-      || mimeType.slice(-5) === '+json'
-      || mimeType === 'application/xml'
-      || mimeType.slice(-4) === '+xml'
-      || mimeType === 'application/javascript'
-      || mimeType === 'application/x-javascript'
-      || mimeType === 'application/graphql'
-      || mimeType === 'application/x-www-form-urlencoded';
-
-    return textual ? utf8ByteLength(body) : body.length;
-  }
 
   function getOrCreate(reqId) {
     if (byId[reqId]) return byId[reqId];
@@ -130,15 +80,28 @@ export const NETWORK_INTERCEPTOR_SCRIPT = `(function() {
           mimeType: mimeType
         };
 
-        var cloned = response.clone();
-        cloned.text().then(function(body) {
+        // Read the cloned response as a Blob to preserve the decoded entity's
+        // byte length across text charsets and binary responses. Content-Length
+        // cannot be used here: HEAD/304 responses may advertise a body that was
+        // not sent, and compression headers describe a different measurement.
+        var sizeClone = response.clone();
+        var bodyClone = response.clone();
+        var sizePromise = typeof sizeClone.blob === 'function'
+          ? sizeClone.blob().then(function(blob) {
+              return blob && typeof blob.size === 'number' ? blob.size : undefined;
+            }).catch(function() { return undefined; })
+          : Promise.resolve(undefined);
+        var bodyPromise = bodyClone.text().catch(function() { return undefined; });
+
+        Promise.all([sizePromise, bodyPromise]).then(function(values) {
+          var byteLength = values[0];
+          var body = values[1];
           entry.state = 'finished';
-          entry.encodedDataLength = responseByteLength(body, mimeType, respHeaders);
+          if (typeof byteLength === 'number') entry.encodedDataLength = byteLength;
           entry.durationMs = Math.round((ts() - t) * 1000);
-          entry.responseBody = body;
+          if (typeof body === 'string') entry.responseBody = body;
         }).catch(function() {
           entry.state = 'finished';
-          entry.encodedDataLength = 0;
           entry.durationMs = Math.round((ts() - t) * 1000);
         });
 

--- a/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
+++ b/packages/tool-server/src/utils/debugger/scripts/network-interceptor.ts
@@ -47,6 +47,30 @@ export const NETWORK_INTERCEPTOR_SCRIPT = `(function() {
     return length;
   }
 
+  function responseByteLength(body, mimeType, headers) {
+    var keys = Object.keys(headers);
+    for (var i = 0; i < keys.length; i++) {
+      if (keys[i].toLowerCase() !== 'content-length') continue;
+
+      var value = String(headers[keys[i]]).trim();
+      if (/^\\d+$/.test(value)) return Number(value);
+    }
+
+    if (typeof body !== 'string') return 0;
+
+    var textual = mimeType.indexOf('text/') === 0
+      || mimeType === 'application/json'
+      || mimeType.slice(-5) === '+json'
+      || mimeType === 'application/xml'
+      || mimeType.slice(-4) === '+xml'
+      || mimeType === 'application/javascript'
+      || mimeType === 'application/x-javascript'
+      || mimeType === 'application/graphql'
+      || mimeType === 'application/x-www-form-urlencoded';
+
+    return textual ? utf8ByteLength(body) : body.length;
+  }
+
   function getOrCreate(reqId) {
     if (byId[reqId]) return byId[reqId];
     var entry = {
@@ -109,7 +133,7 @@ export const NETWORK_INTERCEPTOR_SCRIPT = `(function() {
         var cloned = response.clone();
         cloned.text().then(function(body) {
           entry.state = 'finished';
-          entry.encodedDataLength = utf8ByteLength(body);
+          entry.encodedDataLength = responseByteLength(body, mimeType, respHeaders);
           entry.durationMs = Math.round((ts() - t) * 1000);
           entry.responseBody = body;
         }).catch(function() {

--- a/packages/tool-server/test/network/network-interceptor.test.ts
+++ b/packages/tool-server/test/network/network-interceptor.test.ts
@@ -1,8 +1,38 @@
+import { runInNewContext } from "node:vm";
 import { describe, it, expect } from "vitest";
 import {
+  NETWORK_INTERCEPTOR_SCRIPT,
   makeNetworkLogReadScript,
   makeNetworkDetailReadScript,
 } from "../../src/utils/debugger/scripts/network-interceptor";
+
+describe("NETWORK_INTERCEPTOR_SCRIPT", () => {
+  it.each([
+    ["TextEncoder", TextEncoder],
+    ["the legacy fallback", undefined],
+  ])("records UTF-8 response bytes with %s", async (_label, textEncoder) => {
+    const body = JSON.stringify({ message: "你好 👋" });
+    const response = {
+      url: "https://example.test/unicode",
+      status: 200,
+      statusText: "OK",
+      headers: { forEach: () => {} },
+      clone: () => ({ text: async () => body }),
+    };
+    const sandbox: Record<string, unknown> = {
+      TextEncoder: textEncoder,
+      fetch: async () => response,
+    };
+
+    runInNewContext(NETWORK_INTERCEPTOR_SCRIPT, sandbox);
+    await (sandbox.fetch as () => Promise<unknown>)();
+    await Promise.resolve();
+
+    const entries = sandbox.__argent_network_log as Array<{ encodedDataLength: number }>;
+    expect(entries[0]?.encodedDataLength).toBe(Buffer.byteLength(body, "utf8"));
+    expect(entries[0]?.encodedDataLength).not.toBe(body.length);
+  });
+});
 
 describe("makeNetworkLogReadScript", () => {
   it("returns a string containing the start and limit values", () => {

--- a/packages/tool-server/test/network/network-interceptor.test.ts
+++ b/packages/tool-server/test/network/network-interceptor.test.ts
@@ -7,16 +7,27 @@ import {
 } from "../../src/utils/debugger/scripts/network-interceptor";
 
 describe("NETWORK_INTERCEPTOR_SCRIPT", () => {
-  it.each([
-    ["TextEncoder", TextEncoder],
-    ["the legacy fallback", undefined],
-  ])("records UTF-8 response bytes with %s", async (_label, textEncoder) => {
-    const body = JSON.stringify({ message: "你好 👋" });
+  async function interceptResponse({
+    body,
+    mimeType,
+    contentLength,
+    textEncoder = TextEncoder,
+  }: {
+    body: string | undefined;
+    mimeType: string;
+    contentLength?: number;
+    textEncoder?: typeof TextEncoder | undefined;
+  }) {
     const response = {
-      url: "https://example.test/unicode",
+      url: "https://example.test/data",
       status: 200,
       statusText: "OK",
-      headers: { forEach: () => {} },
+      headers: {
+        forEach: (callback: (value: string, key: string) => void) => {
+          callback(mimeType, "content-type");
+          if (contentLength !== undefined) callback(String(contentLength), "content-length");
+        },
+      },
       clone: () => ({ text: async () => body }),
     };
     const sandbox: Record<string, unknown> = {
@@ -28,9 +39,42 @@ describe("NETWORK_INTERCEPTOR_SCRIPT", () => {
     await (sandbox.fetch as () => Promise<unknown>)();
     await Promise.resolve();
 
-    const entries = sandbox.__argent_network_log as Array<{ encodedDataLength: number }>;
-    expect(entries[0]?.encodedDataLength).toBe(Buffer.byteLength(body, "utf8"));
-    expect(entries[0]?.encodedDataLength).not.toBe(body.length);
+    return (sandbox.__argent_network_log as Array<{ encodedDataLength: number }>)[0];
+  }
+
+  it.each([
+    ["TextEncoder", TextEncoder],
+    ["the legacy fallback", undefined],
+  ])("records UTF-8 response bytes with %s", async (_label, textEncoder) => {
+    const body = JSON.stringify({ message: "你好 👋" });
+    const entry = await interceptResponse({ body, mimeType: "application/json", textEncoder });
+
+    expect(entry?.encodedDataLength).toBe(Buffer.byteLength(body, "utf8"));
+    expect(entry?.encodedDataLength).not.toBe(body.length);
+  });
+
+  it("does not re-encode replacement characters from a binary response", async () => {
+    const body = "\uFFFD".repeat(512) + "a".repeat(512);
+    const entry = await interceptResponse({ body, mimeType: "application/octet-stream" });
+
+    expect(entry?.encodedDataLength).toBe(1024);
+    expect(entry?.encodedDataLength).not.toBe(Buffer.byteLength(body, "utf8"));
+  });
+
+  it("prefers a valid Content-Length for binary responses", async () => {
+    const entry = await interceptResponse({
+      body: undefined,
+      mimeType: "image/png",
+      contentLength: 16,
+    });
+
+    expect(entry?.encodedDataLength).toBe(16);
+  });
+
+  it("records zero when a binary body is unavailable", async () => {
+    const entry = await interceptResponse({ body: undefined, mimeType: "image/png" });
+
+    expect(entry?.encodedDataLength).toBe(0);
   });
 });
 

--- a/packages/tool-server/test/network/network-interceptor.test.ts
+++ b/packages/tool-server/test/network/network-interceptor.test.ts
@@ -10,17 +10,23 @@ describe("NETWORK_INTERCEPTOR_SCRIPT", () => {
   async function interceptResponse({
     body,
     mimeType,
+    byteLength,
     contentLength,
-    textEncoder = TextEncoder,
+    method = "GET",
+    status = 200,
+    blobFails = false,
   }: {
     body: string | undefined;
     mimeType: string;
+    byteLength?: number;
     contentLength?: number;
-    textEncoder?: typeof TextEncoder | undefined;
+    method?: string;
+    status?: number;
+    blobFails?: boolean;
   }) {
     const response = {
       url: "https://example.test/data",
-      status: 200,
+      status,
       statusText: "OK",
       headers: {
         forEach: (callback: (value: string, key: string) => void) => {
@@ -28,53 +34,109 @@ describe("NETWORK_INTERCEPTOR_SCRIPT", () => {
           if (contentLength !== undefined) callback(String(contentLength), "content-length");
         },
       },
-      clone: () => ({ text: async () => body }),
+      clone: () => ({
+        text: async () => body,
+        blob: async () => {
+          if (blobFails) throw new Error("Blob unavailable");
+          return { size: byteLength };
+        },
+      }),
     };
     const sandbox: Record<string, unknown> = {
-      TextEncoder: textEncoder,
       fetch: async () => response,
     };
 
     runInNewContext(NETWORK_INTERCEPTOR_SCRIPT, sandbox);
-    await (sandbox.fetch as () => Promise<unknown>)();
-    await Promise.resolve();
+    await (sandbox.fetch as (_input: string, init: { method: string }) => Promise<unknown>)(
+      response.url,
+      { method }
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
-    return (sandbox.__argent_network_log as Array<{ encodedDataLength: number }>)[0];
+    return (
+      sandbox.__argent_network_log as Array<{
+        encodedDataLength?: number;
+        responseBody?: string;
+      }>
+    )[0];
   }
 
-  it.each([
-    ["TextEncoder", TextEncoder],
-    ["the legacy fallback", undefined],
-  ])("records UTF-8 response bytes with %s", async (_label, textEncoder) => {
+  it("records decoded entity bytes instead of JavaScript string length", async () => {
     const body = JSON.stringify({ message: "你好 👋" });
-    const entry = await interceptResponse({ body, mimeType: "application/json", textEncoder });
+    const byteLength = Buffer.byteLength(body, "utf8");
+    const entry = await interceptResponse({ body, byteLength, mimeType: "application/json" });
 
-    expect(entry?.encodedDataLength).toBe(Buffer.byteLength(body, "utf8"));
+    expect(entry?.encodedDataLength).toBe(byteLength);
     expect(entry?.encodedDataLength).not.toBe(body.length);
   });
 
-  it("does not re-encode replacement characters from a binary response", async () => {
-    const body = "\uFFFD".repeat(512) + "a".repeat(512);
-    const entry = await interceptResponse({ body, mimeType: "application/octet-stream" });
+  it("records zero bytes for HEAD even when Content-Length describes a GET body", async () => {
+    const entry = await interceptResponse({
+      body: "",
+      byteLength: 0,
+      contentLength: 524_288_000,
+      method: "HEAD",
+      mimeType: "application/octet-stream",
+    });
 
-    expect(entry?.encodedDataLength).toBe(1024);
+    expect(entry?.encodedDataLength).toBe(0);
+  });
+
+  it("records zero bytes for a 304 cached response", async () => {
+    const entry = await interceptResponse({
+      body: "",
+      byteLength: 0,
+      contentLength: 4096,
+      mimeType: "application/json",
+      status: 304,
+    });
+
+    expect(entry?.encodedDataLength).toBe(0);
+  });
+
+  it("does not re-encode replacement characters from a non-UTF-8 response", async () => {
+    const body = "Caf\uFFFD na\uFFFDve r\uFFFDsum\uFFFD";
+    const entry = await interceptResponse({
+      body,
+      byteLength: 17,
+      mimeType: "text/plain; charset=iso-8859-1",
+    });
+
+    expect(entry?.encodedDataLength).toBe(17);
     expect(entry?.encodedDataLength).not.toBe(Buffer.byteLength(body, "utf8"));
   });
 
-  it("prefers a valid Content-Length for binary responses", async () => {
+  it("uses decoded body bytes instead of compressed Content-Length", async () => {
+    const entry = await interceptResponse({
+      body: "x".repeat(6308),
+      byteLength: 6308,
+      contentLength: 1510,
+      mimeType: "application/json",
+    });
+
+    expect(entry?.encodedDataLength).toBe(6308);
+  });
+
+  it("records binary bytes when no text body is exposed", async () => {
     const entry = await interceptResponse({
       body: undefined,
+      byteLength: 16,
       mimeType: "image/png",
-      contentLength: 16,
     });
 
     expect(entry?.encodedDataLength).toBe(16);
+    expect(entry?.responseBody).toBeUndefined();
   });
 
-  it("records zero when a binary body is unavailable", async () => {
-    const entry = await interceptResponse({ body: undefined, mimeType: "image/png" });
+  it("leaves size unknown when Blob conversion is unavailable", async () => {
+    const entry = await interceptResponse({
+      body: "hello",
+      blobFails: true,
+      mimeType: "text/plain",
+    });
 
-    expect(entry?.encodedDataLength).toBe(0);
+    expect(entry?.encodedDataLength).toBeUndefined();
+    expect(entry?.responseBody).toBe("hello");
   });
 });
 


### PR DESCRIPTION
## Summary

- measure React Native response bodies from a cloned Blob instead of a decoded JavaScript string
- report one consistent metric: decoded response entity bytes
- avoid Content-Length because HEAD/304 and compressed responses give it different semantics
- keep response text capture independent, and leave the size unknown if Blob conversion is unavailable

## Root cause

body.length counts UTF-16 code units. Re-encoding the decoded text as UTF-8 fixes ordinary UTF-8 text, but it overcounts replacement characters from non-UTF-8 and binary responses. Content-Length is also not a safe fallback: it can describe an unsent GET body for HEAD/304 or the compressed wire representation while the response body is decompressed.

Response.blob().size measures the bytes in the decoded entity supplied by the React Native response. The same measurement therefore applies to text, binary, empty, cached, and compressed responses.

## Tests

- network interceptor regression: 23/23 passed
- covers Unicode JSON, HEAD, 304, non-UTF-8 replacement characters, compression, binary bodies, and unavailable Blob conversion
- npm run build
- npm run typecheck:tests -w @argent/tool-server
- targeted ESLint and Prettier checks on both changed files

Fixes #662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reported network response sizes to reflect the actual decoded response data.
  - Corrected size calculations for binary content, compressed responses, and text containing non-ASCII characters.
  - Added reliable handling for `HEAD` and `304` responses, which now report zero size.
  - Prevented failed size calculations from incorrectly reporting a zero-byte response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->