### PR TITLE
fix(installer): never create Cursor's permissions.json (it turns off Run Everything)

### DIFF
--- a/packages/argent-installer/src/init-allowlist.ts
+++ b/packages/argent-installer/src/init-allowlist.ts
@@ -54,8 +54,12 @@ export async function configureAllowlist(args: {
       continue;
     }
     try {
-      adapter.addAllowlist!(effectiveRoot, scope);
-      lines.push(`${pc.green("+")} ${adapter.name}`);
+      const note = adapter.addAllowlist!(effectiveRoot, scope);
+      lines.push(
+        note
+          ? `${pc.yellow("-")} ${adapter.name} ${pc.dim(`(${note})`)}`
+          : `${pc.green("+")} ${adapter.name}`
+      );
     } catch (err) {
       lines.push(`${pc.red("x")} ${adapter.name}: ${pc.dim(String(err))}`);
     }

--- a/packages/argent-installer/src/init-allowlist.ts
+++ b/packages/argent-installer/src/init-allowlist.ts
@@ -14,12 +14,19 @@ export async function configureAllowlist(args: {
   effectiveRoot: string;
   scope: "local" | "global";
   nonInteractive: boolean;
+  /** --no-allowlist: skip the whole step without prompting */
+  noAllowlist: boolean;
 }): Promise<AllowlistResult> {
-  const { adapters, effectiveRoot, scope, nonInteractive } = args;
+  const { adapters, effectiveRoot, scope, nonInteractive, noAllowlist } = args;
   const adaptersWithAllowlist = adapters.filter((a) => a.addAllowlist);
   const adaptersWithoutAllowlist = adapters.filter((a) => !a.addAllowlist);
 
   let enabled = false;
+
+  if (noAllowlist) {
+    p.log.info(pc.dim("Skipping editor auto-approve allowlists (--no-allowlist)."));
+    return { enabled, lines: [] };
+  }
 
   if (adaptersWithAllowlist.length > 0) {
     p.log.info(

--- a/packages/argent-installer/src/init-allowlist.ts
+++ b/packages/argent-installer/src/init-allowlist.ts
@@ -5,6 +5,8 @@ import { InitCancelled } from "./init-args.js";
 
 interface AllowlistResult {
   enabled: boolean;
+  /** How `enabled` was reached: --no-allowlist, the -y default, or an answer. */
+  decidedBy: "flag" | "default" | "prompt";
   lines: string[];
 }
 
@@ -22,10 +24,11 @@ export async function configureAllowlist(args: {
   const adaptersWithoutAllowlist = adapters.filter((a) => !a.addAllowlist);
 
   let enabled = false;
+  let decidedBy: AllowlistResult["decidedBy"] = "default";
 
   if (noAllowlist) {
     p.log.info(pc.dim("Skipping editor auto-approve allowlists (--no-allowlist)."));
-    return { enabled, lines: [] };
+    return { enabled, decidedBy: "flag", lines: [] };
   }
 
   if (adaptersWithAllowlist.length > 0) {
@@ -47,10 +50,11 @@ export async function configureAllowlist(args: {
 
       if (p.isCancel(allowlistChoice)) throw new InitCancelled("allowlist");
       enabled = allowlistChoice as boolean;
+      decidedBy = "prompt";
     }
   }
 
-  if (!enabled) return { enabled, lines: [] };
+  if (!enabled) return { enabled, decidedBy, lines: [] };
 
   const lines: string[] = [];
 
@@ -78,5 +82,5 @@ export async function configureAllowlist(args: {
     );
   }
 
-  return { enabled, lines };
+  return { enabled, decidedBy, lines };
 }

--- a/packages/argent-installer/src/init-args.ts
+++ b/packages/argent-installer/src/init-args.ts
@@ -6,6 +6,8 @@ interface InitArgs {
   nonInteractive: boolean;
   /** --no-telemetry */
   noTelemetry: boolean;
+  /** --no-allowlist  skip the editor auto-approve allowlist step */
+  noAllowlist: boolean;
   /** --from <path>: reinstall from a local tarball (developer flow) */
   fromTar: string | null;
   /** --local: the devDependency install mode */
@@ -28,6 +30,7 @@ export function parseInitArgs(args: string[]): InitArgs {
   return {
     nonInteractive: args.includes("--yes") || args.includes("-y"),
     noTelemetry: args.includes("--no-telemetry"),
+    noAllowlist: args.includes("--no-allowlist"),
     fromTar,
     wantsLocal: args.includes("--local"),
     wantsGlobal: args.includes("--global"),

--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -246,7 +246,10 @@ export async function init(args: string[]): Promise<void> {
       nonInteractive: parsed.nonInteractive,
       noAllowlist: parsed.noAllowlist,
     });
-    track("installation:allowlist_decision", { is_enabled: allowlist.enabled });
+    track("installation:allowlist_decision", {
+      is_enabled: allowlist.enabled,
+      decided_by: allowlist.decidedBy,
+    });
     if (allowlist.enabled && allowlist.lines.length > 0) {
       p.note(allowlist.lines.join("\n"), "Tool Auto-Approval");
     }

--- a/packages/argent-installer/src/init.ts
+++ b/packages/argent-installer/src/init.ts
@@ -244,6 +244,7 @@ export async function init(args: string[]): Promise<void> {
       effectiveRoot,
       scope: normalizedScope,
       nonInteractive: parsed.nonInteractive,
+      noAllowlist: parsed.noAllowlist,
     });
     track("installation:allowlist_decision", { is_enabled: allowlist.enabled });
     if (allowlist.enabled && allowlist.lines.length > 0) {

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -42,6 +42,28 @@ function getAvailableToolIds(): string[] {
 
 // The exact opted-in shape Windsurf's alwaysAllow / Kiro's autoApprove get:
 // anything else there is a value the user narrowed since.
+// `update` rewrites the argent MCP entry on every run (to repair drift), but
+// only command/args/env are argent's to author. Editors keep state INSIDE the
+// entry too — Gemini's `trust`, Kiro's `autoApprove`, Windsurf's `alwaysAllow`,
+// Codex's `tools` table, a user-set `timeout`/`disabled` — and a wholesale
+// replace drops all of it. Dropping the opt-in keys used to be masked by the
+// unconditional allowlist re-add that followed; update's refresh guard has
+// retired that re-add, so the rewrite itself must carry them over.
+function mergeServerEntry(existing: unknown, entry: McpServerEntry): Record<string, unknown> {
+  const kept: Record<string, unknown> = {};
+  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+    for (const [key, value] of Object.entries(existing as Record<string, unknown>)) {
+      if (key !== "command" && key !== "args" && key !== "env") kept[key] = value;
+    }
+  }
+  return {
+    command: entry.command,
+    args: entry.args,
+    ...(hasEnv(entry) ? { env: entry.env } : {}),
+    ...kept,
+  };
+}
+
 function isWildcardOnly(value: unknown): boolean {
   return Array.isArray(value) && value.length === 1 && value[0] === "*";
 }
@@ -1093,11 +1115,10 @@ const windsurfAdapter: McpConfigAdapter = {
 
   // JSONC-safe writes (see the Cursor adapter).
   write(configPath: string, entry: McpServerEntry): void {
-    editJsoncFile(configPath, ["mcpServers", MCP_SERVER_KEY], {
-      command: entry.command,
-      args: entry.args,
-      ...(hasEnv(entry) ? { env: entry.env } : {}),
-    });
+    const existing = (readJsonc(configPath).mcpServers as Record<string, unknown> | undefined)?.[
+      MCP_SERVER_KEY
+    ];
+    editJsoncFile(configPath, ["mcpServers", MCP_SERVER_KEY], mergeServerEntry(existing, entry));
   },
 
   remove(configPath: string): boolean {
@@ -1280,11 +1301,10 @@ const geminiAdapter: McpConfigAdapter = {
 
   // JSONC-safe writes (see the Cursor adapter).
   write(configPath: string, entry: McpServerEntry): void {
-    editJsoncFile(configPath, ["mcpServers", MCP_SERVER_KEY], {
-      command: entry.command,
-      args: entry.args,
-      ...(hasEnv(entry) ? { env: entry.env } : {}),
-    });
+    const existing = (readJsonc(configPath).mcpServers as Record<string, unknown> | undefined)?.[
+      MCP_SERVER_KEY
+    ];
+    editJsoncFile(configPath, ["mcpServers", MCP_SERVER_KEY], mergeServerEntry(existing, entry));
   },
 
   remove(configPath: string): boolean {
@@ -1371,11 +1391,7 @@ const codexAdapter: McpConfigAdapter = {
   write(configPath: string, entry: McpServerEntry): void {
     const config = readToml(configPath);
     const servers = (config.mcp_servers ?? {}) as Record<string, unknown>;
-    servers[MCP_SERVER_KEY] = {
-      command: entry.command,
-      args: entry.args,
-      ...(hasEnv(entry) ? { env: entry.env } : {}),
-    };
+    servers[MCP_SERVER_KEY] = mergeServerEntry(servers[MCP_SERVER_KEY], entry);
     config.mcp_servers = servers;
     writeToml(configPath, config);
   },
@@ -1660,11 +1676,10 @@ const kiroAdapter: McpConfigAdapter = {
   // Read and written as JSONC through readJsonc / editJsoncFile so comments and
   // foreign servers survive (see the Cursor adapter).
   write(configPath: string, entry: McpServerEntry): void {
-    editJsoncFile(configPath, ["mcpServers", MCP_SERVER_KEY], {
-      command: entry.command,
-      args: entry.args,
-      ...(hasEnv(entry) ? { env: entry.env } : {}),
-    });
+    const existing = (readJsonc(configPath).mcpServers as Record<string, unknown> | undefined)?.[
+      MCP_SERVER_KEY
+    ];
+    editJsoncFile(configPath, ["mcpServers", MCP_SERVER_KEY], mergeServerEntry(existing, entry));
   },
 
   remove(configPath: string): boolean {

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -89,10 +89,13 @@ export interface McpConfigAdapter {
   // say so instead of claiming a write.
   //
   // `refresh: true` marks update's periodic re-run, as opposed to init's
-  // explicit opt-in. An adapter whose rule has side effects beyond argent may
-  // treat a rule missing from an existing allowlist as a deliberate removal
-  // and decline to re-add it on refresh. Only Cursor does today; the other
-  // adapters re-add on both paths.
+  // explicit opt-in. An adapter whose write can override a choice the user
+  // made since init — Cursor's file allowlist, Zed's global tool_permissions
+  // default, Codex's per-tool approval modes — declines to re-impose it on
+  // refresh; adapters whose entries are argent-scoped and inert keep re-adding
+  // on both paths. Absence-based checks cannot tell "removed on purpose" from
+  // "never added" (no consent is persisted anywhere), so refresh errs toward
+  // not writing; `argent init` is the explicit (re-)opt-in path.
   addAllowlist?(
     root: string,
     scope: "local" | "global",
@@ -729,11 +732,13 @@ const cursorAdapter: McpConfigAdapter = {
       return `skipped - an mcpAllowlist here would turn off Cursor's "Run Everything" mode and override its in-app allowlist`;
     }
     if (list.includes(CURSOR_ALLOWLIST_PATTERN)) return;
-    // On update's refresh, argent:* missing from a list the user maintains is
-    // a deliberate removal — re-adding it would override that choice on every
-    // update. Re-opting in is `argent init`'s allowlist step.
+    // On update's refresh, argent:* missing from a list the user maintains
+    // usually means they removed it — re-adding would override that choice on
+    // every update. (It can also mean they never opted in; absence cannot tell
+    // the two apart, so refresh errs toward not writing.) Opting in is
+    // `argent init`'s allowlist step.
     if (options?.refresh) {
-      return `skipped - argent:* was removed from this allowlist; re-add it via argent init`;
+      return `skipped - argent:* is not on this allowlist; opt in via argent init`;
     }
     editJsoncFile(permPath, ["mcpAllowlist"], [...list, CURSOR_ALLOWLIST_PATTERN]);
   },
@@ -1170,13 +1175,30 @@ const zedAdapter: McpConfigAdapter = {
     return this.getArgentEntry(configPath) !== null;
   },
 
-  // Zed has no server-level wildcard for MCP tools — each tool would need its
-  // own entry — so the global default is set to "allow" instead.
-  addAllowlist(root: string, scope: "local" | "global"): void {
+  // Zed doesn't support server-level wildcards for MCP tools — each tool
+  // would need its own entry.  Setting the global default to "allow" is the
+  // documented opt-in; built-in security rules still protect against
+  // destructive operations.
+  //
+  // That default governs EVERY agent tool in Zed, not just argent's, so
+  // update's refresh never re-imposes it: any other value is a choice the
+  // user made since init (or an opt-in that never happened), and overriding
+  // it on each update would be the Cursor run-mode bug in another skin.
+  addAllowlist(root, scope, options): string | void {
     const settingsPath =
       scope === "global"
         ? path.join(homedir(), ".config", "zed", "settings.json")
         : path.join(root, ".zed", "settings.json");
+    if (options?.refresh) {
+      const config = fs.existsSync(settingsPath) ? readJsonc(settingsPath) : {};
+      const perms = (config.agent as Record<string, unknown>)?.tool_permissions as
+        | Record<string, unknown>
+        | undefined;
+      if (perms?.default !== "allow") {
+        return `skipped - Zed's tool_permissions default is not "allow"; opt in via argent init`;
+      }
+      return;
+    }
     editJsoncFile(settingsPath, ["agent", "tool_permissions", "default"], "allow");
   },
 
@@ -1330,7 +1352,11 @@ const codexAdapter: McpConfigAdapter = {
     return this.getArgentEntry(configPath) !== null;
   },
 
-  addAllowlist(root, scope): void {
+  // On update's refresh the per-tool table is maintained, not re-imposed: ids
+  // a new version added are filled in, but an entry the user restricted keeps
+  // their approval_mode, and a table they emptied or removed stays gone —
+  // rewriting either would override a choice made since init.
+  addAllowlist(root, scope, options): string | void {
     const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
 
     if (!configPath) {
@@ -1339,6 +1365,22 @@ const codexAdapter: McpConfigAdapter = {
 
     const tools = getAvailableToolIds();
     const config = readToml(configPath) as CodexConfig;
+
+    if (options?.refresh) {
+      const toolsConfig = config.mcp_servers?.argent?.tools;
+      if (toolsConfig === undefined || Object.keys(toolsConfig).length === 0) {
+        return `skipped - no argent tools allowlist in config.toml; opt in via argent init`;
+      }
+      let added = false;
+      for (const tool of tools) {
+        if (!(tool in toolsConfig)) {
+          toolsConfig[tool] = { approval_mode: "approve" };
+          added = true;
+        }
+      }
+      if (added) writeToml(configPath, config);
+      return;
+    }
 
     config.mcp_servers ??= {};
     config.mcp_servers.argent ??= {};

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -85,7 +85,9 @@ export interface McpConfigAdapter {
   // Report argent state outside the projectPath/globalPath pair that can keep
   // the entry written at `writtenScope` from taking effect.
   findShadowingConfigs?(root: string, writtenScope: "local" | "global"): ShadowingConfigFinding[];
-  addAllowlist?(root: string, scope: "local" | "global"): void;
+  // Returns a short note when the rule was deliberately NOT added (or an
+  // earlier one was undone) so init can say so instead of claiming a write.
+  addAllowlist?(root: string, scope: "local" | "global"): string | void;
   removeAllowlist?(root: string, scope: "local" | "global"): void;
 }
 
@@ -672,12 +674,50 @@ const cursorAdapter: McpConfigAdapter = {
     return this.getArgentEntry(configPath) !== null;
   },
 
-  // The allowlist lives in a separate ~/.cursor/permissions.json that may carry
-  // the user's own rules, so edit that one key instead of rewriting the file.
-  addAllowlist(): void {
+  // Cursor's allowlist lives in a separate ~/.cursor/permissions.json, which —
+  // like every Cursor config — is JSONC (comments, trailing commas) and may
+  // carry the user's own unrelated rules. Route through readJsonc / editJsoncFile
+  // so a hand-commented or multi-rule permissions.json survives: the old readJson
+  // path ran it through `catch { return {} }` and rewrote the whole file with
+  // only { mcpAllowlist }, dropping every foreign rule and comment. Newly matters
+  // because `hasArgentEntry` now reads mcp.json with readJsonc, so `update`
+  // detects a commented config as configured and calls this.
+  //
+  // APPEND-ONLY, NEVER CREATE. Cursor derives its Run Mode from this file:
+  // `shouldPermissionsFileConstrainUnrestrictedMode()` disables "Run Everything"
+  // whenever a non-empty mcpAllowlist/terminalAllowlist is present and no
+  // approvalMode overrides it, which the UI reports as
+  // `Run Mode (Enforced by ~/.cursor/permissions.json)`. The same non-emptiness
+  // makes the file SUPERSEDE the in-IDE MCP allowlist and freeze its editor
+  // (`getEffectiveMcpAllowlist` ignores composerState.mcpAllowedTools,
+  // `canAddToAllowlistFromIde("mcp")` goes false), so the user's own
+  // "Always allow" entries stop being consulted.
+  //
+  // Creating the file therefore costs a run mode the user chose — and buys
+  // nothing, because under "Run Everything" every tool auto-runs already and
+  // the allowlist is never read. So argent only appends where the user already
+  // keeps a file-based MCP allowlist: there both effects are their own doing
+  // and `argent:*` changes no state. Existing files are never deleted either:
+  // even an argent-only one may be an allowlist the user keeps deliberately.
+  //
+  // Setting `approvalMode: "unrestricted"` to lift the constraint is NOT an
+  // option — Cursor treats a permissions-file approvalMode as authoritative
+  // (`getModeFullAutoRun` returns true for it), so it would force Run
+  // Everything ON for users who chose "Ask every time".
+  addAllowlist(): string | void {
     const permPath = path.join(homedir(), ".cursor", "permissions.json");
+    if (!fs.existsSync(permPath)) {
+      return `skipped - creating ~/.cursor/permissions.json would turn off Cursor's "Run Everything" mode`;
+    }
+    // An existing file is left as the user has it, argent-only shape included:
+    // we cannot tell a file an earlier argent created from one the user keeps
+    // deliberately, and deleting the latter would take away an allowlist they
+    // want. Removing it stays a manual step (or `argent uninstall`).
     const config = readJsonc(permPath);
-    const list = Array.isArray(config.mcpAllowlist) ? (config.mcpAllowlist as string[]) : [];
+    const list = Array.isArray(config.mcpAllowlist) ? (config.mcpAllowlist as string[]) : null;
+    if (list === null || list.length === 0) {
+      return `skipped - an mcpAllowlist here would override Cursor's in-app allowlist`;
+    }
     if (list.includes(CURSOR_ALLOWLIST_PATTERN)) return;
     editJsoncFile(permPath, ["mcpAllowlist"], [...list, CURSOR_ALLOWLIST_PATTERN]);
   },

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -87,7 +87,17 @@ export interface McpConfigAdapter {
   findShadowingConfigs?(root: string, writtenScope: "local" | "global"): ShadowingConfigFinding[];
   // Returns a short note when the rule was deliberately NOT added so init can
   // say so instead of claiming a write.
-  addAllowlist?(root: string, scope: "local" | "global"): string | void;
+  //
+  // `refresh: true` marks update's periodic re-run, as opposed to init's
+  // explicit opt-in. An adapter whose rule has side effects beyond argent may
+  // treat a rule missing from an existing allowlist as a deliberate removal
+  // and decline to re-add it on refresh. Only Cursor does today; the other
+  // adapters re-add on both paths.
+  addAllowlist?(
+    root: string,
+    scope: "local" | "global",
+    options?: { refresh?: boolean }
+  ): string | void;
   removeAllowlist?(root: string, scope: "local" | "global"): void;
 }
 
@@ -704,7 +714,7 @@ const cursorAdapter: McpConfigAdapter = {
   // option — Cursor treats a permissions-file approvalMode as authoritative
   // (`getModeFullAutoRun` returns true for it), so it would force Run
   // Everything ON for users who chose "Ask every time".
-  addAllowlist(): string | void {
+  addAllowlist(_root, _scope, options): string | void {
     const permPath = path.join(homedir(), ".cursor", "permissions.json");
     if (!fs.existsSync(permPath)) {
       return `skipped - creating ~/.cursor/permissions.json would turn off Cursor's "Run Everything" mode`;
@@ -719,6 +729,12 @@ const cursorAdapter: McpConfigAdapter = {
       return `skipped - an mcpAllowlist here would turn off Cursor's "Run Everything" mode and override its in-app allowlist`;
     }
     if (list.includes(CURSOR_ALLOWLIST_PATTERN)) return;
+    // On update's refresh, argent:* missing from a list the user maintains is
+    // a deliberate removal — re-adding it would override that choice on every
+    // update. Re-opting in is `argent init`'s allowlist step.
+    if (options?.refresh) {
+      return `skipped - argent:* was removed from this allowlist; re-add it via argent init`;
+    }
     editJsoncFile(permPath, ["mcpAllowlist"], [...list, CURSOR_ALLOWLIST_PATTERN]);
   },
 

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -85,8 +85,8 @@ export interface McpConfigAdapter {
   // Report argent state outside the projectPath/globalPath pair that can keep
   // the entry written at `writtenScope` from taking effect.
   findShadowingConfigs?(root: string, writtenScope: "local" | "global"): ShadowingConfigFinding[];
-  // Returns a short note when the rule was deliberately NOT added (or an
-  // earlier one was undone) so init can say so instead of claiming a write.
+  // Returns a short note when the rule was deliberately NOT added so init can
+  // say so instead of claiming a write.
   addAllowlist?(root: string, scope: "local" | "global"): string | void;
   removeAllowlist?(root: string, scope: "local" | "global"): void;
 }
@@ -716,7 +716,7 @@ const cursorAdapter: McpConfigAdapter = {
     const config = readJsonc(permPath);
     const list = Array.isArray(config.mcpAllowlist) ? (config.mcpAllowlist as string[]) : null;
     if (list === null || list.length === 0) {
-      return `skipped - an mcpAllowlist here would override Cursor's in-app allowlist`;
+      return `skipped - an mcpAllowlist here would turn off Cursor's "Run Everything" mode and override its in-app allowlist`;
     }
     if (list.includes(CURSOR_ALLOWLIST_PATTERN)) return;
     editJsoncFile(permPath, ["mcpAllowlist"], [...list, CURSOR_ALLOWLIST_PATTERN]);

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -40,6 +40,13 @@ function getAvailableToolIds(): string[] {
   return tools.map((t) => t.id);
 }
 
+// The exact opted-in shape Windsurf's alwaysAllow / Kiro's autoApprove get:
+// anything else there is a value the user narrowed since.
+function isWildcardOnly(value: unknown): boolean {
+  return Array.isArray(value) && value.length === 1 && value[0] === "*";
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 // MARK: Types
 
 export interface McpServerEntry {
@@ -89,13 +96,17 @@ export interface McpConfigAdapter {
   // say so instead of claiming a write.
   //
   // `refresh: true` marks update's periodic re-run, as opposed to init's
-  // explicit opt-in. An adapter whose write can override a choice the user
-  // made since init — Cursor's file allowlist, Zed's global tool_permissions
-  // default, Codex's per-tool approval modes — declines to re-impose it on
-  // refresh; adapters whose entries are argent-scoped and inert keep re-adding
-  // on both paths. Absence-based checks cannot tell "removed on purpose" from
-  // "never added" (no consent is persisted anywhere), so refresh errs toward
-  // not writing; `argent init` is the explicit (re-)opt-in path.
+  // explicit opt-in. Refresh never changes the effective approval state the
+  // user has: when an adapter's opted-in value is absent or was changed since
+  // init, it skips with a note — re-imposing the value would override that
+  // choice (the Cursor run-mode bug in another skin). The one write refresh
+  // still performs is Codex's backfill of tool ids a new version added, for
+  // users whose table shows they are opted in. Absence cannot tell "removed
+  // on purpose" from "never added" (no consent is persisted anywhere), so
+  // refresh errs toward not writing; `argent init` is the explicit
+  // (re-)opt-in path. The option is advisory — an adapter that ignores it
+  // re-adds on both paths — so a new adapter must decide its refresh
+  // behavior explicitly.
   addAllowlist?(
     root: string,
     scope: "local" | "global",
@@ -949,7 +960,15 @@ const claudeAdapter: McpConfigAdapter = {
     return findings;
   },
 
-  addAllowlist(root: string, scope: "local" | "global"): void {
+  // On refresh there is nothing to maintain — the rule is a single
+  // argent-scoped entry — so a missing rule is only reported: re-adding it
+  // (and creating settings.json for a user who declined at init) would
+  // override a removal.
+  addAllowlist(root, scope, options): string | void {
+    if (options?.refresh) {
+      if (hasClaudePermission(root, scope)) return;
+      return `skipped - the argent permission rule is not in settings.json; opt in via argent init`;
+    }
     addClaudePermission(root, scope);
   },
 
@@ -1101,13 +1120,23 @@ const windsurfAdapter: McpConfigAdapter = {
     return this.getArgentEntry(configPath) !== null;
   },
 
-  // Targets just the argent entry's alwaysAllow key, so comments and foreign
-  // servers survive.
-  addAllowlist(): void {
+  // JSONC-safe allowlist edits (see the Cursor adapter): the argent entry lives
+  // in this same mcp_config.json, and `init` runs write() (comment-preserving)
+  // before addAllowlist(). The old readJson path choked on any user comment and
+  // silently skipped the toggle; editJsoncFile targets just the argent entry's
+  // alwaysAllow key so comments and foreign servers survive.
+  addAllowlist(_root, _scope, options): string | void {
     const configPath = path.join(homedir(), ".codeium", "windsurf", "mcp_config.json");
     const config = readJsonc(configPath);
     const servers = config.mcpServers as Record<string, unknown> | undefined;
     if (!servers?.[MCP_SERVER_KEY]) return;
+    // A user-narrowed or removed alwaysAllow is their choice — rewriting it
+    // to ["*"] on refresh would override it.
+    if (options?.refresh) {
+      const entry = servers[MCP_SERVER_KEY] as Record<string, unknown>;
+      if (isWildcardOnly(entry.alwaysAllow)) return;
+      return `skipped - argent's alwaysAllow is not ["*"]; opt in via argent init`;
+    }
     editJsoncFile(configPath, ["mcpServers", MCP_SERVER_KEY, "alwaysAllow"], ["*"]);
   },
 
@@ -1126,6 +1155,17 @@ const windsurfAdapter: McpConfigAdapter = {
 };
 
 // MARK: Zed
+
+// The one place Zed's agent.tool_permissions.default is read, so the opt-in
+// schema can't drift between addAllowlist's refresh guard and removeAllowlist.
+// readJsonc returns {} for a missing file.
+function zedToolPermissionsDefault(settingsPath: string): unknown {
+  const config = readJsonc(settingsPath);
+  const perms = (config.agent as Record<string, unknown>)?.tool_permissions as
+    | Record<string, unknown>
+    | undefined;
+  return perms?.default;
+}
 
 const zedAdapter: McpConfigAdapter = {
   name: "Zed",
@@ -1190,11 +1230,16 @@ const zedAdapter: McpConfigAdapter = {
         ? path.join(homedir(), ".config", "zed", "settings.json")
         : path.join(root, ".zed", "settings.json");
     if (options?.refresh) {
-      const config = fs.existsSync(settingsPath) ? readJsonc(settingsPath) : {};
-      const perms = (config.agent as Record<string, unknown>)?.tool_permissions as
-        | Record<string, unknown>
-        | undefined;
-      if (perms?.default !== "allow") {
+      // Zed merges project settings over global, so a project file with no
+      // agent block inherits the global default — check both before deciding
+      // the user is not opted in.
+      let current = zedToolPermissionsDefault(settingsPath);
+      if (current === undefined && scope === "local") {
+        current = zedToolPermissionsDefault(
+          path.join(homedir(), ".config", "zed", "settings.json")
+        );
+      }
+      if (current !== "allow") {
         return `skipped - Zed's tool_permissions default is not "allow"; opt in via argent init`;
       }
       return;
@@ -1208,11 +1253,7 @@ const zedAdapter: McpConfigAdapter = {
         ? path.join(homedir(), ".config", "zed", "settings.json")
         : path.join(root, ".zed", "settings.json");
     if (!fs.existsSync(settingsPath)) return;
-    const config = readJsonc(settingsPath);
-    const perms = (config.agent as Record<string, unknown>)?.tool_permissions as
-      | Record<string, unknown>
-      | undefined;
-    if (!perms || perms.default !== "allow") return;
+    if (zedToolPermissionsDefault(settingsPath) !== "allow") return;
     editJsoncFile(settingsPath, ["agent", "tool_permissions", "default"], "confirm");
   },
 };
@@ -1266,9 +1307,12 @@ const geminiAdapter: McpConfigAdapter = {
     return this.getArgentEntry(configPath) !== null;
   },
 
-  // Targets just the argent entry's trust key, so comments and foreign servers
-  // survive.
-  addAllowlist(root: string, scope: "local" | "global"): void {
+  // JSONC-safe allowlist edits (see the Cursor adapter): the argent entry lives
+  // in this same settings.json, and `init` runs write() (comment-preserving)
+  // before addAllowlist(). The old readJson path choked on any user comment and
+  // silently skipped the toggle; editJsoncFile targets just the argent entry's
+  // trust key so comments and foreign servers survive.
+  addAllowlist(root, scope, options): string | void {
     const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
 
     if (!configPath) {
@@ -1278,6 +1322,12 @@ const geminiAdapter: McpConfigAdapter = {
     const config = readJsonc(configPath);
     const servers = config.mcpServers as Record<string, unknown> | undefined;
     if (!servers?.[MCP_SERVER_KEY]) return;
+    // trust unset or false on refresh is the user's state, not ours to flip.
+    if (options?.refresh) {
+      const entry = servers[MCP_SERVER_KEY] as Record<string, unknown>;
+      if (entry.trust === true) return;
+      return `skipped - argent's trust flag is not set; opt in via argent init`;
+    }
     editJsoncFile(configPath, ["mcpServers", MCP_SERVER_KEY, "trust"], true);
   },
 
@@ -1354,8 +1404,10 @@ const codexAdapter: McpConfigAdapter = {
 
   // On update's refresh the per-tool table is maintained, not re-imposed: ids
   // a new version added are filled in, but an entry the user restricted keeps
-  // their approval_mode, and a table they emptied or removed stays gone —
-  // rewriting either would override a choice made since init.
+  // their approval_mode, and a table they emptied, removed, or turned
+  // all-"deny" stays theirs — rewriting any of those would override a choice
+  // made since init. Opt-in is read from the values (at least one entry the
+  // user left on "approve"), not mere table presence.
   addAllowlist(root, scope, options): string | void {
     const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
 
@@ -1363,23 +1415,17 @@ const codexAdapter: McpConfigAdapter = {
       return;
     }
 
-    const tools = getAvailableToolIds();
+    const refresh = options?.refresh === true;
     const config = readToml(configPath) as CodexConfig;
 
-    if (options?.refresh) {
-      const toolsConfig = config.mcp_servers?.argent?.tools;
-      if (toolsConfig === undefined || Object.keys(toolsConfig).length === 0) {
-        return `skipped - no argent tools allowlist in config.toml; opt in via argent init`;
+    if (refresh) {
+      const existing = config.mcp_servers?.argent?.tools;
+      const optedIn =
+        existing !== undefined &&
+        Object.values(existing).some((entry) => entry.approval_mode === "approve");
+      if (!optedIn) {
+        return `skipped - no approved argent tools in config.toml; opt in via argent init`;
       }
-      let added = false;
-      for (const tool of tools) {
-        if (!(tool in toolsConfig)) {
-          toolsConfig[tool] = { approval_mode: "approve" };
-          added = true;
-        }
-      }
-      if (added) writeToml(configPath, config);
-      return;
     }
 
     config.mcp_servers ??= {};
@@ -1387,13 +1433,15 @@ const codexAdapter: McpConfigAdapter = {
     config.mcp_servers.argent.tools ??= {};
     const toolsConfig = config.mcp_servers.argent.tools;
 
-    for (const tool of tools) {
-      toolsConfig[tool] = {
-        approval_mode: "approve",
-      };
+    let changed = false;
+    for (const tool of getAvailableToolIds()) {
+      // Refresh only backfills ids the table doesn't know; init's explicit
+      // opt-in (re)writes them all.
+      if (refresh && tool in toolsConfig) continue;
+      toolsConfig[tool] = { approval_mode: "approve" };
+      changed = true;
     }
-
-    writeToml(configPath, config);
+    if (changed) writeToml(configPath, config);
   },
 
   removeAllowlist(root, scope): void {
@@ -1560,9 +1608,15 @@ const openCodeAdapter: McpConfigAdapter = {
     return this.getArgentEntry(configPath) !== null;
   },
 
-  addAllowlist(root: string, scope: "local" | "global"): void {
+  addAllowlist(root, scope, options): string | void {
     const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
     if (!configPath) return;
+    // A removed or falsified tools entry on refresh stays the user's call.
+    if (options?.refresh) {
+      const tools = readJsonc(configPath).tools as Record<string, unknown> | undefined;
+      if (tools?.[OPENCODE_ALLOWLIST_PATTERN] === true) return;
+      return `skipped - the argent tools entry is not enabled; opt in via argent init`;
+    }
     editJsoncFile(configPath, ["tools", OPENCODE_ALLOWLIST_PATTERN], true);
   },
 
@@ -1633,14 +1687,23 @@ const kiroAdapter: McpConfigAdapter = {
     return this.getArgentEntry(configPath) !== null;
   },
 
-  // Targets just the argent entry's autoApprove key, so comments and foreign
-  // servers survive.
-  addAllowlist(root: string, scope: "local" | "global"): void {
+  // JSONC-safe allowlist edits (see the Cursor adapter): .kiro/settings/mcp.json
+  // is JSONC, the argent entry lives in it, and `init` runs write() (comment-
+  // preserving) before addAllowlist(). The old readJson path choked on any user
+  // comment and silently skipped the toggle; editJsoncFile targets just the
+  // argent entry's autoApprove key so comments and foreign servers survive.
+  addAllowlist(root, scope, options): string | void {
     const configPath = scope === "global" ? this.globalPath() : this.projectPath(root);
     if (!configPath) return;
     const config = readJsonc(configPath);
     const servers = config.mcpServers as Record<string, unknown> | undefined;
     if (!servers?.[MCP_SERVER_KEY]) return;
+    // Same rule as Windsurf: a narrowed or removed autoApprove stays theirs.
+    if (options?.refresh) {
+      const entry = servers[MCP_SERVER_KEY] as Record<string, unknown>;
+      if (isWildcardOnly(entry.autoApprove)) return;
+      return `skipped - argent's autoApprove is not ["*"]; opt in via argent init`;
+    }
     editJsoncFile(
       configPath,
       ["mcpServers", MCP_SERVER_KEY, "autoApprove"],
@@ -1717,6 +1780,19 @@ export function findConfiguredAdapterScopes(
     }
   }
   return results;
+}
+
+// ── Claude permissions helpers ────────────────────────────────────────────────
+
+function hasClaudePermission(root: string, scope: "local" | "global"): boolean {
+  const settingsPath =
+    scope === "global"
+      ? path.join(homedir(), ".claude", "settings.json")
+      : path.join(root, ".claude", "settings.json");
+  const config = readJsonc(settingsPath);
+  const permissions = (config.permissions ?? {}) as Record<string, unknown>;
+  const allow = Array.isArray(permissions.allow) ? (permissions.allow as string[]) : [];
+  return allow.includes(PERMISSION_RULE);
 }
 
 export function addClaudePermission(root: string, scope: "local" | "global"): void {

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -726,16 +726,27 @@ export async function update(args: string[]): Promise<void> {
       // matches the editor list above. `refresh: true` lets an adapter treat a
       // rule missing from an existing allowlist as a deliberate removal
       // instead of re-adding it; --no-allowlist skips the refresh entirely.
-      if (!noAllowlist) {
+      // Both skips leave a trace so a missing auto-approve entry after an
+      // update is explainable from the output.
+      if (noAllowlist) {
+        p.log.info(pc.dim("Skipped editor auto-approve allowlist refresh (--no-allowlist)."));
+      } else {
+        // Set-dedup: an adapter configured in both scopes (Cursor's allowlist
+        // is machine-global regardless) would otherwise note twice.
+        const allowlistNotes = new Set<string>();
         for (const [scope, adapters] of adaptersByScope) {
           for (const adapter of adapters) {
             if (!adapter.addAllowlist) continue;
             try {
-              adapter.addAllowlist(projectRoot, scope, { refresh: true });
+              const note = adapter.addAllowlist(projectRoot, scope, { refresh: true });
+              if (note) allowlistNotes.add(`- ${adapter.name}: ${note}`);
             } catch {
               // non-fatal
             }
           }
+        }
+        if (allowlistNotes.size > 0) {
+          p.log.info(pc.dim([...allowlistNotes].join("\n")));
         }
       }
 

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -137,6 +137,7 @@ export function resolveUpdatePackageAction(
 export async function update(args: string[]): Promise<void> {
   const nonInteractive = args.includes("--yes") || args.includes("-y");
   const noTelemetry = args.includes("--no-telemetry");
+  const noAllowlist = args.includes("--no-allowlist");
   const requestedVersion = getRequestedVersion(args);
   const trigger = getUpdateTriggerFromEnv();
   telemetryInit("installer");
@@ -721,14 +722,19 @@ export async function update(args: string[]): Promise<void> {
         );
       }
 
-      // Allowlists only for scopes that already had argent configured.
-      for (const [scope, adapters] of adaptersByScope) {
-        for (const adapter of adapters) {
-          if (!adapter.addAllowlist) continue;
-          try {
-            adapter.addAllowlist(projectRoot, scope);
-          } catch {
-            // non-fatal
+      // Refresh allowlists only for scopes that already had argent configured —
+      // matches the editor list above. `refresh: true` lets an adapter treat a
+      // rule missing from an existing allowlist as a deliberate removal
+      // instead of re-adding it; --no-allowlist skips the refresh entirely.
+      if (!noAllowlist) {
+        for (const [scope, adapters] of adaptersByScope) {
+          for (const adapter of adapters) {
+            if (!adapter.addAllowlist) continue;
+            try {
+              adapter.addAllowlist(projectRoot, scope, { refresh: true });
+            } catch {
+              // non-fatal
+            }
           }
         }
       }

--- a/packages/argent-installer/test/init-args.test.ts
+++ b/packages/argent-installer/test/init-args.test.ts
@@ -3,12 +3,24 @@ import { parseInitArgs } from "../src/init-args.js";
 
 describe("parseInitArgs", () => {
   it("parses the full known flag set", () => {
-    const parsed = parseInitArgs(["--yes", "--no-telemetry", "--local", "--from", "./argent.tgz"]);
+    const parsed = parseInitArgs([
+      "--yes",
+      "--no-telemetry",
+      "--no-allowlist",
+      "--local",
+      "--from",
+      "./argent.tgz",
+    ]);
     expect(parsed.nonInteractive).toBe(true);
     expect(parsed.noTelemetry).toBe(true);
+    expect(parsed.noAllowlist).toBe(true);
     expect(parsed.wantsLocal).toBe(true);
     expect(parsed.wantsGlobal).toBe(false);
     expect(parsed.fromTar).toBe("./argent.tgz");
+  });
+
+  it("defaults noAllowlist to false", () => {
+    expect(parseInitArgs(["-y"]).noAllowlist).toBe(false);
   });
 
   it("accepts -y and --global", () => {

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -2718,6 +2718,93 @@ describe("installer preserves foreign MCP config", () => {
 // "the editor is installed" on later runs (self-fulfilling detection), while
 // anything the user/editor itself put there still must.
 
+describe("update's entry rewrite keeps entry-scoped opt-ins", () => {
+  // `update` runs adapter.write() on every invocation and then
+  // addAllowlist({ refresh: true }), which only re-reads the opt-in. For the
+  // adapters whose opt-in lives INSIDE the argent entry, a wholesale replace
+  // in write() would drop it and the guard would then decline to restore it —
+  // auto-approval silently gone after every update. write() must carry those
+  // keys (and any other user key in the entry) over while still repairing
+  // command/args.
+  const rewritten = { command: "node", args: ["node_modules/@swmansion/argent/dist/x.js", "mcp"] };
+
+  it("Gemini: trust and a user timeout survive the rewrite", () => {
+    const adapter = ALL_ADAPTERS.find((a) => a.name === "Gemini")!;
+    const configPath = path.join(tmpDir, ".gemini", "settings.json");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+    editJsoncFile(configPath, ["mcpServers", "argent", "timeout"], 5000);
+
+    adapter.write(configPath, rewritten);
+
+    const argent = (readJsonFile(configPath).mcpServers as Record<string, Record<string, unknown>>)
+      .argent;
+    expect(argent.command).toBe("node");
+    expect(argent.args).toEqual(rewritten.args);
+    expect(argent.trust).toBe(true);
+    expect(argent.timeout).toBe(5000);
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+  });
+
+  it("Kiro: autoApprove survives the rewrite", () => {
+    const adapter = ALL_ADAPTERS.find((a) => a.name === "Kiro")!;
+    const configPath = path.join(tmpDir, ".kiro", "settings", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+
+    adapter.write(configPath, rewritten);
+
+    const argent = (readJsonFile(configPath).mcpServers as Record<string, Record<string, unknown>>)
+      .argent;
+    expect(argent.command).toBe("node");
+    expect(argent.autoApprove).toEqual(["*"]);
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+  });
+
+  it("Windsurf: alwaysAllow survives the rewrite", () => {
+    const adapter = ALL_ADAPTERS.find((a) => a.name === "Windsurf")!;
+    homedirOverride = path.join(tmpDir, "home");
+    const configPath = path.join(homedirOverride, ".codeium", "windsurf", "mcp_config.json");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "global");
+
+    adapter.write(configPath, rewritten);
+
+    const argent = (readJsonFile(configPath).mcpServers as Record<string, Record<string, unknown>>)
+      .argent;
+    expect(argent.command).toBe("node");
+    expect(argent.alwaysAllow).toEqual(["*"]);
+    expect(adapter.addAllowlist!(tmpDir, "global", { refresh: true })).toBeUndefined();
+  });
+
+  it("Codex: the tools table, a restricted entry and a user key survive the rewrite", () => {
+    const adapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
+    const configPath = path.join(tmpDir, ".codex", "config.toml");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+    let content = fs.readFileSync(configPath, "utf8");
+    content = content.replace(
+      '[mcp_servers.argent.tools.tool-b]\napproval_mode = "approve"',
+      '[mcp_servers.argent.tools.tool-b]\napproval_mode = "prompt"'
+    );
+    content = content.replace(
+      "[mcp_servers.argent]\n",
+      "[mcp_servers.argent]\nstartup_timeout_sec = 30\n"
+    );
+    fs.writeFileSync(configPath, content);
+
+    adapter.write(configPath, rewritten);
+
+    const after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain('command = "node"');
+    expect(after).toContain("startup_timeout_sec = 30");
+    expect(after).toContain('[mcp_servers.argent.tools.tool-a]\napproval_mode = "approve"');
+    expect(after).toContain('[mcp_servers.argent.tools.tool-b]\napproval_mode = "prompt"');
+    expect(after).toContain('[mcp_servers.argent.tools.tool-c]\napproval_mode = "approve"');
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+  });
+});
+
 describe("detection evidence", () => {
   const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
   const codex = ALL_ADAPTERS.find((a) => a.name === "Codex")!;

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -2347,6 +2347,36 @@ describe("installer preserves foreign MCP config", () => {
     fs.rmSync(homedirOverride, { recursive: true, force: true });
   });
 
+  // A list the user maintains that lacks argent:* means they removed it —
+  // update's refresh must not override that choice on every run. Opting back
+  // in is `argent init`'s allowlist step (which does append here).
+  it("Cursor addAllowlist on refresh does not re-add argent:* removed from a user's allowlist", () => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    fs.mkdirSync(path.dirname(permPath), { recursive: true });
+    fs.writeFileSync(permPath, `{\n  "mcpAllowlist": ["other:*"]\n}\n`);
+    const note = cursor.addAllowlist!(tmpDir, "global", { refresh: true });
+    expect(readJsoncFile(permPath).mcpAllowlist).toEqual(["other:*"]);
+    expect(note).toContain("removed");
+    // The same file on init's path (no refresh) still gets the rule.
+    expect(cursor.addAllowlist!(tmpDir, "global")).toBeUndefined();
+    expect(readJsoncFile(permPath).mcpAllowlist).toEqual(["other:*", "argent:*"]);
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
+  it("Cursor addAllowlist on refresh is a byte-level no-op when argent:* is present", () => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    fs.mkdirSync(path.dirname(permPath), { recursive: true });
+    const original = `{\n  // mine\n  "mcpAllowlist": ["argent:*", "other:*"]\n}\n`;
+    fs.writeFileSync(permPath, original);
+    expect(cursor.addAllowlist!(tmpDir, "global", { refresh: true })).toBeUndefined();
+    expect(fs.readFileSync(permPath, "utf8")).toBe(original);
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
   it("addClaudePermission preserves a comment and foreign permissions in settings.json", () => {
     const settingsPath = path.join(tmpDir, ".claude", "settings.json");
     fs.mkdirSync(path.dirname(settingsPath), { recursive: true });

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -17,6 +17,7 @@ import {
   injectCodexRules,
   removeCodexRules,
 } from "../src/mcp-configs.js";
+import { editJsoncFile } from "../src/utils.js";
 
 // ── homedir mock ──────────────────────────────────────────────────────────────
 // Allows individual tests to redirect homedir() to a temp path so that
@@ -466,6 +467,24 @@ describe("Claude Code adapter", () => {
   it("globalPath returns ~/.claude.json", () => {
     expect(adapter.globalPath()).toBe(path.join(os.homedir(), ".claude.json"));
   });
+
+  it("addAllowlist on refresh does not create settings.json or re-add a removed rule", () => {
+    const settingsPath = path.join(tmpDir, ".claude", "settings.json");
+    // Absent file: refresh reports instead of creating it.
+    let note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+    expect(note).toContain("opt in via argent init");
+    expect(fs.existsSync(settingsPath)).toBe(false);
+    // Rule present: refresh is a no-op.
+    adapter.addAllowlist!(tmpDir, "local");
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+    // Rule removed: refresh reports and leaves the file alone.
+    removeClaudePermission(tmpDir, "local");
+    note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+    expect(note).toContain("opt in via argent init");
+    if (fs.existsSync(settingsPath)) {
+      expect(fs.readFileSync(settingsPath, "utf8")).not.toContain("mcp__argent");
+    }
+  });
 });
 
 // ── VS Code adapter ──────────────────────────────────────────────────────────
@@ -555,6 +574,25 @@ describe("Windsurf adapter", () => {
     const servers2 = readJsoncFile(configPath).mcpServers as Record<string, unknown>;
     expect(servers2).toHaveProperty("myserver");
     expect(servers2.argent as Record<string, unknown>).not.toHaveProperty("alwaysAllow");
+  });
+
+  it("addAllowlist on refresh keeps a user-narrowed alwaysAllow", () => {
+    homedirOverride = path.join(tmpDir, "home");
+    const configPath = path.join(homedirOverride, ".codeium", "windsurf", "mcp_config.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "global");
+    // User narrows the wildcard to one tool.
+    editJsoncFile(configPath, ["mcpServers", "argent", "alwaysAllow"], ["screenshot"]);
+
+    const note = adapter.addAllowlist!(tmpDir, "global", { refresh: true });
+
+    expect(note).toContain("opt in via argent init");
+    const servers = readJsoncFile(configPath).mcpServers as Record<string, unknown>;
+    expect((servers.argent as Record<string, unknown>).alwaysAllow).toEqual(["screenshot"]);
+    // Still ["*"]: refresh is a no-op, not a note.
+    editJsoncFile(configPath, ["mcpServers", "argent", "alwaysAllow"], ["*"]);
+    expect(adapter.addAllowlist!(tmpDir, "global", { refresh: true })).toBeUndefined();
   });
 });
 
@@ -700,6 +738,22 @@ describe("Zed adapter", () => {
     expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
     expect(fs.readFileSync(configPath, "utf8")).toBe(afterOptIn);
   });
+
+  // Zed merges project settings over global: a project file with no agent
+  // block inherits the global default, so a local-scope refresh must not
+  // report "not opted in" when the global file carries the opt-in.
+  it("addAllowlist on refresh sees a global opt-in from local scope", () => {
+    homedirOverride = path.join(tmpDir, "home");
+    const globalPath = path.join(homedirOverride, ".config", "zed", "settings.json");
+    fs.mkdirSync(path.dirname(globalPath), { recursive: true });
+    fs.writeFileSync(globalPath, `{ "agent": { "tool_permissions": { "default": "allow" } } }\n`);
+    const localPath = path.join(tmpDir, ".zed", "settings.json");
+    fs.mkdirSync(path.dirname(localPath), { recursive: true });
+    fs.writeFileSync(localPath, `{}\n`);
+
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+    expect(fs.readFileSync(localPath, "utf8")).toBe(`{}\n`);
+  });
 });
 
 // ── Gemini adapter ────────────────────────────────────────────────────────────
@@ -785,6 +839,30 @@ describe("Gemini adapter", () => {
     const config = readJsonFile(configPath);
     const entry = (config.mcpServers as Record<string, unknown>).argent as Record<string, unknown>;
     expect(entry.trust).toBe(true);
+  });
+
+  it("addAllowlist on refresh does not flip a trust flag the user unset", () => {
+    const configPath = path.join(tmpDir, ".gemini", "settings.json");
+    adapter.write(configPath, getMcpEntry());
+    // Never opted in: note, no write.
+    let note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+    expect(note).toContain("opt in via argent init");
+    let entry = (readJsoncFile(configPath).mcpServers as Record<string, unknown>).argent as Record<
+      string,
+      unknown
+    >;
+    expect(entry).not.toHaveProperty("trust");
+    // Opted in: no-op. User sets trust:false: refresh leaves it false.
+    adapter.addAllowlist!(tmpDir, "local");
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+    editJsoncFile(configPath, ["mcpServers", "argent", "trust"], false);
+    note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+    expect(note).toContain("opt in via argent init");
+    entry = (readJsoncFile(configPath).mcpServers as Record<string, unknown>).argent as Record<
+      string,
+      unknown
+    >;
+    expect(entry.trust).toBe(false);
   });
 
   it("addAllowlist sets trust:true on the argent entry (global)", () => {
@@ -1014,6 +1092,23 @@ describe("Codex adapter", () => {
 
     expect(fs.readFileSync(configPath, "utf8")).toBe(before);
     expect(note).toContain("opt in via argent init");
+  });
+
+  // Opt-in is read from the values, not table presence: a table the user
+  // switched entirely to "deny" is non-consent, and new tool ids must not
+  // arrive pre-approved into it.
+  it("addAllowlist on refresh treats an all-deny table as opted out", () => {
+    const configPath = path.join(tmpDir, ".codex", "config.toml");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+    let content = fs.readFileSync(configPath, "utf8");
+    content = content.replaceAll('approval_mode = "approve"', 'approval_mode = "deny"');
+    fs.writeFileSync(configPath, content);
+
+    const note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+
+    expect(note).toContain("opt in via argent init");
+    expect(fs.readFileSync(configPath, "utf8")).toBe(content);
   });
 });
 
@@ -1372,6 +1467,20 @@ describe("opencode adapter", () => {
     expect(tools["argent*"]).toBe(true);
   });
 
+  it("addAllowlist on refresh does not re-add a removed 'argent*' entry", () => {
+    const configPath = path.join(tmpDir, "opencode.json");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+    adapter.removeAllowlist!(tmpDir, "local");
+
+    const note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+
+    expect(note).toContain("opt in via argent init");
+    const tools = readJsoncFile(configPath).tools as Record<string, unknown> | undefined;
+    expect(tools?.["argent*"]).toBeUndefined();
+  });
+
   it("addAllowlist sets 'argent*' wildcard in tools (global)", () => {
     homedirOverride = path.join(tmpDir, "home");
     const configPath = path.join(homedirOverride, ".config", "opencode", "opencode.json");
@@ -1525,6 +1634,21 @@ describe("Kiro adapter", () => {
     const config = readJsonFile(configPath);
     const entry = (config.mcpServers as Record<string, unknown>).argent as Record<string, unknown>;
     expect(entry.autoApprove).toEqual(["*"]);
+  });
+
+  it("addAllowlist on refresh keeps a user-narrowed autoApprove", () => {
+    const configPath = path.join(tmpDir, ".kiro", "settings", "mcp.json");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+    editJsoncFile(configPath, ["mcpServers", "argent", "autoApprove"], ["screenshot"]);
+
+    const note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+
+    expect(note).toContain("opt in via argent init");
+    const entry = (readJsoncFile(configPath).mcpServers as Record<string, unknown>)
+      .argent as Record<string, unknown>;
+    expect(entry.autoApprove).toEqual(["screenshot"]);
   });
 
   it("addAllowlist sets autoApprove: ['*'] on the argent entry (global)", () => {

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -2282,9 +2282,68 @@ describe("installer preserves foreign MCP config", () => {
     const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
     homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
     const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
-    cursor.addAllowlist!(tmpDir, "global"); // fresh create: { mcpAllowlist: ["argent:*"] }
+    fs.mkdirSync(path.dirname(permPath), { recursive: true });
+    // As argent <= 0.20.x created it before addAllowlist stopped creating files.
+    fs.writeFileSync(permPath, JSON.stringify({ mcpAllowlist: ["argent:*"] }));
     cursor.removeAllowlist!(tmpDir, "global");
     expect(fs.existsSync(permPath)).toBe(false);
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
+  // Cursor turns "Run Everything" off whenever permissions.json carries a
+  // non-empty allowlist, and lets that file supersede the in-IDE MCP allowlist.
+  // Creating the file to hold one rule costs the user a run mode they picked
+  // and buys nothing (under Run Everything the allowlist is never consulted).
+  it("Cursor addAllowlist does not create permissions.json, and says so", () => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    const note = cursor.addAllowlist!(tmpDir, "global");
+    expect(fs.existsSync(permPath)).toBe(false);
+    expect(note).toContain("Run Everything");
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
+  it("Cursor addAllowlist leaves a file that has no mcpAllowlist alone", () => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    fs.mkdirSync(path.dirname(permPath), { recursive: true });
+    // A terminalAllowlist already constrains the run mode, but adding an
+    // mcpAllowlist would newly take the in-IDE MCP allowlist over.
+    fs.writeFileSync(permPath, `{\n  "terminalAllowlist": ["git"]\n}\n`);
+    const note = cursor.addAllowlist!(tmpDir, "global");
+    const after = readJsoncFile(permPath);
+    expect(after).not.toHaveProperty("mcpAllowlist");
+    expect(after.terminalAllowlist).toEqual(["git"]);
+    expect(note).toContain("in-app allowlist");
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
+  // An argent-only file may be one the user keeps deliberately - we cannot
+  // tell, so it stays. Removing it is a manual step (or `argent uninstall`).
+  it("Cursor addAllowlist leaves an existing argent-only permissions.json in place", () => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    fs.mkdirSync(path.dirname(permPath), { recursive: true });
+    fs.writeFileSync(permPath, JSON.stringify({ mcpAllowlist: ["argent:*"] }));
+    expect(cursor.addAllowlist!(tmpDir, "global")).toBeUndefined();
+    expect(readJsoncFile(permPath).mcpAllowlist).toEqual(["argent:*"]);
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
+  it("Cursor addAllowlist keeps a user-owned permissions.json intact", () => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    fs.mkdirSync(path.dirname(permPath), { recursive: true });
+    // argent's rule is present but so is the user's own — not argent's file.
+    fs.writeFileSync(permPath, `{\n  // mine\n  "mcpAllowlist": ["argent:*", "other:*"]\n}\n`);
+    expect(cursor.addAllowlist!(tmpDir, "global")).toBeUndefined();
+    const after = readJsoncFile(permPath);
+    expect(after.mcpAllowlist).toEqual(["argent:*", "other:*"]); // untouched
+    expect(fs.readFileSync(permPath, "utf8")).toContain("mine");
     fs.rmSync(homedirOverride, { recursive: true, force: true });
   });
 

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -679,6 +679,27 @@ describe("Zed adapter", () => {
       default: "confirm",
     });
   });
+
+  // Zed's tool_permissions default governs every agent tool, not just
+  // argent's — refresh must not flip a value the user changed back to "allow".
+  it('addAllowlist on refresh does not re-impose default:"allow" the user reverted', () => {
+    const configPath = path.join(tmpDir, ".zed", "settings.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const original = `{\n  "agent": { "tool_permissions": { "default": "confirm" } }\n}\n`;
+    fs.writeFileSync(configPath, original);
+    const note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+    expect(fs.readFileSync(configPath, "utf8")).toBe(original);
+    expect(note).toContain("not");
+    // The non-refresh path (init's explicit opt-in) still sets it.
+    expect(adapter.addAllowlist!(tmpDir, "local")).toBeUndefined();
+    expect((readJsoncFile(configPath).agent as Record<string, unknown>).tool_permissions).toEqual({
+      default: "allow",
+    });
+    // And refresh is a no-op once the value is already "allow".
+    const afterOptIn = fs.readFileSync(configPath, "utf8");
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+    expect(fs.readFileSync(configPath, "utf8")).toBe(afterOptIn);
+  });
 });
 
 // ── Gemini adapter ────────────────────────────────────────────────────────────
@@ -952,6 +973,47 @@ describe("Codex adapter", () => {
     expect(() => adapter.removeAllowlist!(tmpDir, "local")).not.toThrow();
     const content = fs.readFileSync(configPath, "utf8");
     expect(content).toContain('command = "argent"');
+  });
+
+  // Refresh maintains the table (fills in ids a new version added) but never
+  // overrides a choice made since init: a restricted entry keeps its value,
+  // and a table the user removed stays gone.
+  it("addAllowlist on refresh fills missing tools but keeps a user-restricted entry", () => {
+    const configPath = path.join(tmpDir, ".codex", "config.toml");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+    // User restricts one tool and deletes another; a new version adds nothing.
+    let content = fs.readFileSync(configPath, "utf8");
+    content = content.replace(
+      /\[mcp_servers\.argent\.tools\.tool-b\]\napproval_mode = "approve"\n?/,
+      ""
+    );
+    content = content.replace(
+      /(\[mcp_servers\.argent\.tools\.tool-c\]\napproval_mode = )"approve"/,
+      '$1"deny"'
+    );
+    fs.writeFileSync(configPath, content);
+
+    expect(adapter.addAllowlist!(tmpDir, "local", { refresh: true })).toBeUndefined();
+
+    const after = fs.readFileSync(configPath, "utf8");
+    // tool-b was absent → refresh re-fills it (indistinguishable from a tool
+    // added by the update); tool-c keeps the user's restriction.
+    expect(after).toContain("[mcp_servers.argent.tools.tool-b]");
+    expect(after).toMatch(/\[mcp_servers\.argent\.tools\.tool-c\]\napproval_mode = "deny"/);
+  });
+
+  it("addAllowlist on refresh does not recreate a tools table the user removed", () => {
+    const configPath = path.join(tmpDir, ".codex", "config.toml");
+    adapter.write(configPath, getMcpEntry());
+    adapter.addAllowlist!(tmpDir, "local");
+    adapter.removeAllowlist!(tmpDir, "local");
+    const before = fs.readFileSync(configPath, "utf8");
+
+    const note = adapter.addAllowlist!(tmpDir, "local", { refresh: true });
+
+    expect(fs.readFileSync(configPath, "utf8")).toBe(before);
+    expect(note).toContain("opt in via argent init");
   });
 });
 
@@ -2358,7 +2420,7 @@ describe("installer preserves foreign MCP config", () => {
     fs.writeFileSync(permPath, `{\n  "mcpAllowlist": ["other:*"]\n}\n`);
     const note = cursor.addAllowlist!(tmpDir, "global", { refresh: true });
     expect(readJsoncFile(permPath).mcpAllowlist).toEqual(["other:*"]);
-    expect(note).toContain("removed");
+    expect(note).toContain("not on this allowlist");
     // The same file on init's path (no refresh) still gets the rule.
     expect(cursor.addAllowlist!(tmpDir, "global")).toBeUndefined();
     expect(readJsoncFile(permPath).mcpAllowlist).toEqual(["other:*", "argent:*"]);

--- a/packages/argent/src/installer-help.ts
+++ b/packages/argent/src/installer-help.ts
@@ -117,6 +117,8 @@ const NO_TELEMETRY_OPTION: InstallerOption = {
   flag: "--no-telemetry",
   description: "Opt out of anonymous telemetry for this run.",
 };
+// Shared spelling; the description differs per command (add vs refresh).
+const NO_ALLOWLIST_FLAG = "--no-allowlist";
 
 /**
  * Help copy per subcommand. The summary and detail lines are the sole copy, also
@@ -137,7 +139,7 @@ export const INSTALLER_COMMAND_META: Record<InstallerCommand, InstallerCommandMe
       NON_INTERACTIVE_OPTION,
       NO_TELEMETRY_OPTION,
       {
-        flag: "--no-allowlist",
+        flag: NO_ALLOWLIST_FLAG,
         description: "Skip adding argent to editor auto-approve allowlists.",
       },
       {
@@ -171,7 +173,7 @@ export const INSTALLER_COMMAND_META: Record<InstallerCommand, InstallerCommandMe
       NON_INTERACTIVE_OPTION,
       NO_TELEMETRY_OPTION,
       {
-        flag: "--no-allowlist",
+        flag: NO_ALLOWLIST_FLAG,
         description: "Skip the editor auto-approve allowlist refresh.",
       },
       {

--- a/packages/argent/src/installer-help.ts
+++ b/packages/argent/src/installer-help.ts
@@ -137,6 +137,10 @@ export const INSTALLER_COMMAND_META: Record<InstallerCommand, InstallerCommandMe
       NON_INTERACTIVE_OPTION,
       NO_TELEMETRY_OPTION,
       {
+        flag: "--no-allowlist",
+        description: "Skip adding argent to editor auto-approve allowlists.",
+      },
+      {
         flag: "--from <path>",
         description: "Install from a local tarball or package spec instead of the npm release.",
       },
@@ -166,6 +170,10 @@ export const INSTALLER_COMMAND_META: Record<InstallerCommand, InstallerCommandMe
     options: [
       NON_INTERACTIVE_OPTION,
       NO_TELEMETRY_OPTION,
+      {
+        flag: "--no-allowlist",
+        description: "Skip the editor auto-approve allowlist refresh.",
+      },
       {
         flag: "--version <version>",
         description: "Update to a specific version instead of the latest.",

--- a/packages/telemetry/src/events.ts
+++ b/packages/telemetry/src/events.ts
@@ -65,6 +65,8 @@ export interface InstallationEditorsSelectProps {
 
 export interface InstallationAllowlistDecisionProps {
   is_enabled: boolean;
+  /** "flag" = --no-allowlist, "default" = -y accepted defaults, "prompt" = the user answered. */
+  decided_by: "flag" | "default" | "prompt";
 }
 
 // Post-write sweep in init/update: argent config in other scopes that would

--- a/packages/telemetry/src/sanitize.ts
+++ b/packages/telemetry/src/sanitize.ts
@@ -164,6 +164,7 @@ export const ALLOWED: ValidatorMap = {
   },
   "installation:allowlist_decision": {
     is_enabled: bool,
+    decided_by: oneOf(["flag", "default", "prompt"] as const),
   },
   "installation:stale_config_cleanup": {
     removed_count: COUNT,


### PR DESCRIPTION
## The bug

Reported by Magda: with Cursor's run mode set to **Run Everything (unsandboxed)**, running `argent init` silently reverts it to **Allowlist**.

Her diagnosis was exactly right. `argent init` creates `~/.cursor/permissions.json` as `{ "mcpAllowlist": ["argent:*"] }` when the user has no such file, and Cursor derives its Run Mode from that file (verified in the Cursor 3.15.6 bundle):

```js
shouldPermissionsFileConstrainUnrestrictedMode(){
  …
  if (t === "unrestricted") return false;
  if (t === "allowlist" || t === "manual") return true;
  return mcpAllowlist.length > 0 || terminalAllowlist.length > 0;   // ← our write
}
```

The UI then reads `Run Mode (Enforced by ~/.cursor/permissions.json)`. It doesn't matter *what* we write — the file merely being non-empty is enough.

**Second effect, same write:** once the file has an `mcpAllowlist`, it *supersedes* the in-IDE MCP allowlist — `getEffectiveMcpAllowlist` returns the file's list and ignores `composerState.mcpAllowedTools`, and `canAddToAllowlistFromIde("mcp")` goes `false` (editor read-only). A user who had "Always allow"-ed other MCP servers silently stops getting them.

Not to be confused with the *older* clobbering bug (argent rewriting the file and dropping the user's rules) — that one was fixed by the JSONC append path and is covered by existing tests.

## The fix

`addAllowlist` becomes **append-only, never create**:

| `~/.cursor/permissions.json` | before | after |
|---|---|---|
| absent | created → **run mode demoted** | left alone |
| exists, no `mcpAllowlist` | key added → **in-IDE allowlist taken over** | left alone |
| exists with `mcpAllowlist` | `argent:*` appended | `argent:*` appended (unchanged) |

Skipping costs those users nothing: under Run Everything the allowlist is never consulted, so the rule we were adding was already a no-op. Where the user already keeps a file-based allowlist, both effects are their own doing and `argent:*` changes no state — so we still append there.

Existing files are never deleted, argent-only shape included. A file an earlier argent created is indistinguishable from one the user keeps on purpose, and if they like that allowlist it should stay. Removing it is a manual step (or `argent uninstall`, whose `removeAllowlist` already prunes the entry and drops the file when nothing else is left).

`init` now reports the skip instead of claiming it added the rule:

```
- Cursor (skipped - creating ~/.cursor/permissions.json would turn off Cursor's "Run Everything" mode)
```

## Rejected alternative

Writing `"approvalMode": "unrestricted"` alongside the allowlist does silence the constraint — but Cursor treats a permissions-file `approvalMode` as authoritative, not permissive:

```js
getModeFullAutoRun(e){ switch(…){ case "unrestricted": return true;   // forces it ON
```

That would push users who deliberately chose "Ask every time" into Run Everything. Disqualified.

## Scope

IDE only. The `cursor-agent` CLI is unaffected — its permissions-file provider reports `approvalMode: "unrestricted"` and only a provider reporting `"allowlist"` downgrades the merge.

Already-demoted machines are not repaired by this PR: those users delete `~/.cursor/permissions.json` (or drop the `argent:*` rule) once, and Run Everything returns — Cursor evaluates the constraint on read and never writes the demotion back, so nothing needs reconfiguring.

## Test plan

- 4 new cases in `mcp-configs.test.ts`: no file created (+ note), file without `mcpAllowlist` untouched, existing argent-only file left in place, user-owned file with `argent:*` left byte-intact
- Existing Cursor allowlist tests (comment/foreign-rule preservation, remove round-trip, argent-only detection) unchanged and green
- `packages/argent-installer` suite: 558 passed; `tsc --build`, `eslint --max-warnings 0`, both `knip` gates (215/215) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Adopted from #742, generalized

Two ideas from #742 land here in reworked form (credit @softwarebyze):

- **`--no-allowlist`** on `init` and `update` skips the editor auto-approve allowlist step entirely — a scriptable opt-out for CI images and provisioning, where the prompt never runs. Documented in both `--help` outputs (the flags-sync test keeps them honest); `allowlist_decision` telemetry gains `decided_by: flag | default | prompt` so an automated skip is distinguishable from a user declining.

- **Update's allowlist refresh never changes the approval state the user has.** `addAllowlist` takes `refresh: true` on update's re-run; every adapter now declines (with a note) to re-impose its opted-in value when it is absent or was changed since init:
  - Cursor: `argent:*` missing from an existing list is not re-appended
  - Zed: a `tool_permissions.default` the user reset from `"allow"` stays (the guard honors Zed's project-over-global settings merge)
  - Codex: opt-in derives from entry values (≥1 `"approve"`), a restricted entry keeps its mode, an all-deny or removed table stays; the one refresh write left anywhere is backfilling tool ids a new version added, for opted-in tables
  - Claude Code: the permissions rule is not re-added (and `settings.json` not created) on refresh
  - Windsurf/Kiro: a narrowed `alwaysAllow`/`autoApprove` stays narrowed
  - Gemini/opencode: an unset/falsified `trust`/tools toggle stays
  
  Unlike #742's `createIfMissing:false` (which silently made update read-only), the option says what it means, and each skip prints a note (`- Cursor: skipped - argent:* is not on this allowlist; opt in via argent init`) so a missing auto-approve entry after an update is explainable from the output. `argent init` remains the explicit (re-)opt-in path.

## Known limitations (follow-up material)

- No consent bit is persisted anywhere, so refresh infers intent from file shape — it cannot tell "removed on purpose" from "never added" and errs toward not writing.
- The agent-triggered auto-update (`update-argent` tool) spawns `argent update --yes` detached with `stdio: "ignore"`, so the skip notes are not visible on that path and `--no-allowlist` cannot be passed there. The refresh guards themselves do apply, which removes the harmful overrides; durable observability there needs a log file or telemetry from update.

## Test plan (additions)

- 571 installer tests (13 new: per-adapter refresh guards incl. Zed scope-merge and Codex all-deny, `--no-allowlist` parsing), 295 telemetry, 80 argent (flags-sync green)
- Live from a packed tgz in a sandboxed `HOME`: `--help` shows the flag; `init -y --no-allowlist` writes nothing and says so; removed `argent:*` / reverted Zed default / deleted opencode entry all survive `argent update` with notes printed; fully opted-in update prints zero notes and keeps state; `update --no-allowlist` prints its trace line
