### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6788,7 +6788,7 @@
     },
     "packages/archive": {
       "name": "@argent/archive",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6797,7 +6797,7 @@
     },
     "packages/argent": {
       "name": "@swmansion/argent",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fails-components/webtransport": "^1.6.3",
@@ -6836,7 +6836,7 @@
     },
     "packages/argent-cli": {
       "name": "@argent/cli",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/registry": "file:../registry",
@@ -6853,7 +6853,7 @@
     },
     "packages/argent-installer": {
       "name": "@argent/installer",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@argent/registry": "file:../registry",
         "@argent/telemetry": "file:../telemetry",
@@ -6888,7 +6888,7 @@
     },
     "packages/argent-mcp": {
       "name": "@argent/mcp",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/telemetry": "file:../telemetry",
@@ -6903,7 +6903,7 @@
     },
     "packages/argent-tools-client": {
       "name": "@argent/tools-client",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@argent/archive": "file:../archive",
         "@argent/configuration-core": "file:../configuration-core",
@@ -6917,7 +6917,7 @@
     },
     "packages/configuration-core": {
       "name": "@argent/configuration-core",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "dotenv": "^17.4.2"
       },
@@ -6929,7 +6929,7 @@
     },
     "packages/native-devtools-android": {
       "name": "@argent/native-devtools-android",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6938,7 +6938,7 @@
     },
     "packages/native-devtools-ios": {
       "name": "@argent/native-devtools-ios",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "typescript": "^6.0.3",
@@ -6947,7 +6947,7 @@
     },
     "packages/preview-window": {
       "name": "@argent/preview-window",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "devDependencies": {
         "@types/node": "^26.0.1",
         "electron": "^42.5.0",
@@ -6956,7 +6956,7 @@
     },
     "packages/registry": {
       "name": "@argent/registry",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "zod": "^4.0.0"
       },
@@ -6967,14 +6967,14 @@
     },
     "packages/skills": {
       "name": "@argent/skills",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "bin": {
         "argent-skills": "scripts/install.js"
       }
     },
     "packages/telemetry": {
       "name": "@argent/telemetry",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@argent/configuration-core": "file:../configuration-core",
         "@argent/native-devtools-ios": "file:../native-devtools-ios",
@@ -6990,7 +6990,7 @@
     },
     "packages/tool-server": {
       "name": "@argent/tool-server",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@argent/archive": "file:../archive",
         "@argent/configuration-core": "file:../configuration-core",
@@ -7038,11 +7038,11 @@
     },
     "packages/ui": {
       "name": "@argent/ui",
-      "version": "0.20.0"
+      "version": "0.21.0"
     },
     "packages/update-core": {
       "name": "@argent/update-core",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "semver": "^7.8.5"
       },

--- a/packages/archive/package.json
+++ b/packages/archive/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/archive",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Shared tar.gz helpers for the file boundary: create an archive of a path and extract one back to its top-level member.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-cli/package.json
+++ b/packages/argent-cli/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Shell CLI commands for argent: tools, run, server, enable, disable, flags",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/installer",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Workspace setup logic for argent: init, update, uninstall",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-mcp/package.json
+++ b/packages/argent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/mcp",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "MCP stdio protocol adapter — talks to the argent tool-server and forwards calls",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent-tools-client/package.json
+++ b/packages/argent-tools-client/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tools-client",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Spawn-and-talk client for the argent tool-server (used by MCP and CLI)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/argent/package.json
+++ b/packages/argent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swmansion/argent",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "mcpName": "io.github.software-mansion/argent",
   "description": "MCP server for iOS Simulator and Android Emulator control",
   "license": "Apache-2.0",

--- a/packages/configuration-core/package.json
+++ b/packages/configuration-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/configuration-core",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Source of truth for argent feature flags: registry, JSON storage, and isFlagEnabled",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/native-devtools-android/package.json
+++ b/packages/native-devtools-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-android",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/native-devtools-ios/package.json
+++ b/packages/native-devtools-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/native-devtools-ios",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/preview-window/package.json
+++ b/packages/preview-window/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/preview-window",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "description": "Electron host for Argent Lens — the variant preview & selection UI.",
   "main": "dist/main.js",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/registry",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Dependency-aware service lifecycle manager with stateless tool invocation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/skills",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "module",
   "description": "Claude Code skills for iOS simulator and Android emulator interaction via argent",
   "scripts": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/telemetry",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Opt-out telemetry client for Argent CLI / installer / tool-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/tool-server/package.json
+++ b/packages/tool-server/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/tool-server",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Framework-agnostic tool registry for iOS simulator and Android emulator control",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/ui",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Simple browser UI that streams a simulator and forwards taps/gestures directly to the argent simulator-server.",
   "files": [
     "index.html"

--- a/packages/update-core/package.json
+++ b/packages/update-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@argent/update-core",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Shared npm release-age detection and installable-target resolution for argent updates",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "id": "1164885639"
   },
   "websiteUrl": "https://argent.swmansion.com",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@swmansion/argent",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Bumps the monorepo from 0.20.0 to 0.21.0 across the full 18-file set:

- all 16 `packages/*/package.json` (via `npm version --workspaces`)
- `package-lock.json` regenerated with `npm install --package-lock-only --ignore-scripts` on Node 24 / npm 11 (version-only diff, matching the lockfile CI job)
- `server.json` — both the top-level `version` and `packages[0].version`

`npm run check:versions` passes: all workspace packages and server.json are at 0.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)