### PR TITLE
fix(ci): stamp the canary version before the bundle bakes it into telemetry

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -153,6 +153,22 @@ jobs:
 
       - run: npx tsc --build
 
+      # Canary version: <patch-bump of highest published>-next.<counter>, where
+      # the counter resets to 0 per base and increments per publish (derived
+      # from the registry). Stamped into package.json so the published build
+      # reports it. Sequenced after `npm ci` (the checked-out lockfile still
+      # matches the original version at install time) and before the bundle
+      # build, which bakes the version into the telemetry payload as a string
+      # literal — a build that ran first would stamp every canary's events with
+      # the previous release's version.
+      - name: Compute and stamp canary version
+        if: steps.mode.outputs.mode == 'canary'
+        id: canary
+        run: |
+          VERSION="$(node scripts/next-canary-version.mjs --write)"
+          echo "Canary version: ${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - run: npm run build -w @swmansion/argent
         env:
           # Release-only: build-package-artifact.yml deliberately builds without
@@ -223,21 +239,6 @@ jobs:
       - run: head -c4 packages/argent/assets/trace-processor/trace_processor.wasm | grep -q $'\x00asm'
       - run: ls packages/argent/bin/argent-android-devtools-*.apk
 
-      # Canary version: <patch-bump of highest published>-next.<counter>, where
-      # the counter resets to 0 per base and increments per publish (derived
-      # from the registry). Stamped into package.json so the published build
-      # reports it. Done after `npm ci` (the checked-out lockfile still matches
-      # the original version at install time) and after the build (the CLI reads
-      # its version from package.json at runtime — nothing bakes it in), but
-      # before pack/publish.
-      - name: Compute and stamp canary version
-        if: steps.mode.outputs.mode == 'canary'
-        id: canary
-        run: |
-          VERSION="$(node scripts/next-canary-version.mjs --write)"
-          echo "Canary version: ${VERSION}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
       # The shipped CLI reads its version from package.json at runtime, so this
       # is exactly what `argent --version` prints after install. Fail loudly if
       # they ever diverge.
@@ -248,6 +249,47 @@ jobs:
           EXPECTED="${{ steps.canary.outputs.version }}"
           echo "argent --version → ${REPORTED} (expected ${EXPECTED})"
           [ "${REPORTED}" = "${EXPECTED}" ] || { echo "::error::argent --version (${REPORTED}) != published version (${EXPECTED})"; exit 1; }
+
+      # `argent --version` reads package.json at runtime, so it stays correct
+      # however the build is sequenced and cannot catch a stale *baked* version.
+      # Telemetry's cli_version is a different value: esbuild substitutes it into
+      # each bundle at build time, so it is only right while the stamp precedes
+      # the build. Assert the literal every bundle actually carries, so a
+      # re-ordering that silently mis-attributes every canary's events fails the
+      # publish instead of shipping.
+      - name: Verify the bundled telemetry version matches the canary version
+        if: steps.mode.outputs.mode == 'canary'
+        env:
+          EXPECTED: ${{ steps.canary.outputs.version }}
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const expected = process.env.EXPECTED;
+            const dir = "packages/argent/dist";
+            // esbuild folds the ARGENT_CLI_VERSION define into readCliVersion.
+            const re = /function readCliVersion\(\)\s*\{[^}]*?return\s*"([^"]*)"/s;
+            let checked = 0;
+            let failed = false;
+            for (const file of fs.readdirSync(dir).filter((f) => /\.(mjs|cjs)$/.test(f))) {
+              const m = re.exec(fs.readFileSync(path.join(dir, file), "utf8"));
+              // Bundles that do not carry telemetry (e.g. mcp-server) bake no version.
+              if (!m) continue;
+              checked++;
+              const ok = m[1] === expected;
+              console.log(`${ok ? "ok  " : "FAIL"} ${file}: baked cli_version ${m[1]} (expected ${expected})`);
+              if (!ok) failed = true;
+            }
+            if (checked === 0) {
+              console.log(`::error::no bundle in ${dir} bakes a telemetry cli_version — the check can no longer see what ships`);
+              process.exit(1);
+            }
+            if (failed) {
+              console.log("::error::bundled telemetry cli_version != published version — the canary stamp must run before the bundle build");
+              process.exit(1);
+            }
+            console.log(`Verified the baked telemetry version in ${checked} bundle(s).`);
+          '
 
       - run: npm pack --dry-run -w @swmansion/argent
 


### PR DESCRIPTION
`next`-channel builds report the **previous release's version** in every telemetry event.

## What happens

`publish-npm.yml` ran `npm run build -w @swmansion/argent` (which bundles, and bakes `ARGENT_CLI_VERSION` in via esbuild `define`) *before* `Compute and stamp canary version` wrote the canary version into `packages/argent/package.json`. The define therefore captured whatever version was checked out — the last release.

Verified against the published artifact:

```
$ npm pack @swmansion/argent@0.21.1-next.4
$ grep -A5 'function readCliVersion' package/dist/cli-cmds.mjs
function readCliVersion() {
  if (true) {
    return "0.21.0";      # <- published as 0.21.1-next.4
  }
```

and end to end, running that published build:

```
{"event":"toolserver:start","properties":{"cli_version":"0.21.0", ...}}
```

So every canary's events are attributed to the preceding stable version, and `next` traffic is indistinguishable from `latest` traffic in the collector.

The step comment asserted the opposite — "the CLI reads its version from package.json at runtime — nothing bakes it in". That is true of `argent --version`, which is why the existing `Verify argent --version` check stayed green: it reads `package.json` at runtime and so is correct however the build is sequenced. Telemetry's `cli_version` is a different value, and nothing looked at it. The comment predates nothing — `ARGENT_CLI_VERSION` has been baked in since #274, and the unified workflow (#565) carried the claim in.

## Change

- Move `Compute and stamp canary version` to sit between `npx tsc --build` and the bundle build. It stays after `npm ci` (the checked-out lockfile still matches the original version at install time), which was the other constraint the old comment recorded.
- Add `Verify the bundled telemetry version matches the canary version`, asserting the literal each bundle actually carries. It scans every `dist/*.{mjs,cjs}`, skips bundles that carry no telemetry (`mcp-server`), and fails if none carries one — so the check cannot silently stop looking at anything.
- Correct the stale comment.

Only the canary path was affected; a dispatch release publishes the ref's verbatim version, which is already correct in `package.json` at checkout.

## Verification

Built the real bundle in a worktree and ran the new guard, extracted verbatim from the workflow YAML:

| ordering | baked | guard |
| --- | --- | --- |
| build, then stamp `0.21.1-next.99` (old) | `0.21.0` | exits 1 on all 3 telemetry bundles, no false failure on `mcp-server` |
| stamp `0.21.1-next.99`, then build (new) | `0.21.1-next.99` | passes, "Verified the baked telemetry version in 3 bundle(s)" |

End to end on the rebuilt bundle, `ARGENT_TELEMETRY_DEBUG=1` under an isolated `HOME`:

```
2 "cli_version":"0.21.1-next.99"
1 "event":"cli:run_fail"
1 "event":"toolserver:start"
```

Also confirmed the bundle build does not run a workspace-version check, so building with `packages/argent` ahead of the other workspaces succeeds (exit 0), and `next-canary-version.mjs --write` touches only `packages/argent/package.json`.