### PR TITLE
feat: support iOS launch arguments

### DIFF
--- a/packages/tool-server/src/tools/launch-app/index.ts
+++ b/packages/tool-server/src/tools/launch-app/index.ts
@@ -41,6 +41,12 @@ const zodSchema = z.object({
     .describe(
       "Android-only: fully-qualified Activity name (e.g. `.MainActivity` or `com.example/com.example.MainActivity`). If omitted on Android, the app's default launcher activity is used. Ignored on iOS / Chromium."
     ),
+  launchArgs: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Apple simulator-only: process arguments forwarded verbatim after the bundle id in `simctl launch`. Useful for launch-time feature flags and UserDefaults overrides such as `["-FeatureFlag", "YES"]`. Ignored on Android / Chromium / Vega.'
+    ),
 });
 
 type Params = z.infer<typeof zodSchema>;
@@ -74,6 +80,7 @@ export function createLaunchAppTool(registry: Registry): ToolDefinition<Params, 
     description: `Open an app by its bundle id (iOS) or package name (Android), or confirm the running renderer (Chromium).
 Use when starting any app — prefer this over tapping home-screen / launcher icons. Also prepares the native-devtools injection before the app starts (the iOS slice on iOS, the tvOS slice on Apple TV); on tvOS, interaction is focus-driven — use the tv-* tools rather than coordinate taps.
 Returns { launched, bundleId }. Fails if the app is not installed on the target device (iOS / Android).
+On Apple simulators, pass launchArgs to forward process arguments after the bundle id in \`simctl launch\`.
 For Chromium, the app is already running behind a CDP port; this call simply refreshes the cached viewport and acknowledges the bundleId tag. To change the visible route, use \`open-url\`.
 On Vega (Fire TV), pass the interactive component app id from manifest.toml (e.g. com.example.app.main) as bundleId.
 

--- a/packages/tool-server/src/tools/launch-app/platforms/ios.ts
+++ b/packages/tool-server/src/tools/launch-app/platforms/ios.ts
@@ -37,7 +37,12 @@ export function makeIosImpl(
       try {
         await execFileAsync(
           "xcrun",
-          await simctlArgsForUdid(params.udid, ["launch", params.udid, params.bundleId])
+          await simctlArgsForUdid(params.udid, [
+            "launch",
+            params.udid,
+            params.bundleId,
+            ...(params.launchArgs ?? []),
+          ])
         );
       } catch (err) {
         throw new FailureError(

--- a/packages/tool-server/src/tools/launch-app/platforms/shared.ts
+++ b/packages/tool-server/src/tools/launch-app/platforms/shared.ts
@@ -17,7 +17,7 @@ export function buildIosLaunchHandler(backend: SimctlBackend) {
     const blocked = await precheckNativeDevtools(services.nativeDevtools, params.udid);
     if (blocked) return blocked;
     try {
-      await backend.launch(params.udid, params.bundleId);
+      await backend.launch(params.udid, params.bundleId, params.launchArgs);
     } catch (err) {
       throw new FailureError(
         `Failed to launch iOS app ${params.bundleId} on ${params.udid}.`,

--- a/packages/tool-server/src/tools/launch-app/types.ts
+++ b/packages/tool-server/src/tools/launch-app/types.ts
@@ -8,6 +8,8 @@ export interface LaunchAppParams {
   bundleId: string;
   /** Android-only: ignored on iOS. */
   activity?: string;
+  /** Apple simulator-only: appended to the simctl launch argv after the bundle id. */
+  launchArgs?: string[];
 }
 
 export type LaunchAppResult =

--- a/packages/tool-server/src/tools/restart-app/index.ts
+++ b/packages/tool-server/src/tools/restart-app/index.ts
@@ -34,6 +34,12 @@ const zodSchema = z.object({
     .describe(
       "Android-only: relaunch a non-launcher Activity (e.g. `.SettingsActivity` or `com.example/com.example.SettingsActivity`). If omitted, the app's default launcher activity is used. Ignored on iOS."
     ),
+  launchArgs: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Apple simulator-only: process arguments forwarded verbatim after the bundle id in `simctl launch`. Useful for launch-time feature flags and UserDefaults overrides such as `["-FeatureFlag", "YES"]`. Ignored on Android / Vega.'
+    ),
 });
 
 type Params = z.infer<typeof zodSchema>;
@@ -65,6 +71,7 @@ export function createRestartAppTool(registry: Registry): ToolDefinition<Params,
     },
     description: `Terminate then relaunch an app by bundle id / package name.
 Use when you need a clean in-memory state without a full reinstall. Also refreshes the native-devtools injection before the relaunch (the iOS slice on iOS, the tvOS slice on Apple TV); on tvOS, interaction is focus-driven — use the tv-* tools rather than coordinate taps.
+On Apple simulators, pass launchArgs to forward process arguments after the bundle id in \`simctl launch\`.
 Returns { restarted, bundleId }. Fails if the app is not installed.`,
     alwaysLoad: true,
     searchHint:

--- a/packages/tool-server/src/tools/restart-app/platforms/ios.ts
+++ b/packages/tool-server/src/tools/restart-app/platforms/ios.ts
@@ -41,7 +41,10 @@ export function makeIosImpl(
         // App may not be running — ignore
       }
       try {
-        await execFileAsync("xcrun", await simctlArgsForUdid(udid, ["launch", udid, bundleId]));
+        await execFileAsync(
+          "xcrun",
+          await simctlArgsForUdid(udid, ["launch", udid, bundleId, ...(params.launchArgs ?? [])])
+        );
       } catch (err) {
         throw new FailureError(
           `Failed to restart iOS app ${bundleId} on ${udid}.`,

--- a/packages/tool-server/src/tools/restart-app/platforms/shared.ts
+++ b/packages/tool-server/src/tools/restart-app/platforms/shared.ts
@@ -23,7 +23,7 @@ export function buildIosRestartHandler(backend: SimctlBackend) {
       // App may not be running — ignore.
     }
     try {
-      await backend.launch(udid, bundleId);
+      await backend.launch(udid, bundleId, params.launchArgs);
     } catch (err) {
       throw new FailureError(
         `Failed to restart iOS app ${bundleId} on ${udid}.`,

--- a/packages/tool-server/src/tools/restart-app/types.ts
+++ b/packages/tool-server/src/tools/restart-app/types.ts
@@ -6,7 +6,10 @@ import type {
 export interface RestartAppParams {
   udid: string;
   bundleId: string;
+  /** Android-only: ignored on iOS. */
   activity?: string;
+  /** Apple simulator-only: appended to the simctl launch argv after the bundle id. */
+  launchArgs?: string[];
 }
 
 export type RestartAppResult =

--- a/packages/tool-server/src/utils/simctl-backend.ts
+++ b/packages/tool-server/src/utils/simctl-backend.ts
@@ -11,13 +11,16 @@ const execFileAsync = promisify(execFile);
  * (`sim-remote simctl`) without an `isRemote` branch inside the handler body.
  */
 export interface SimctlBackend {
-  launch(udid: string, bundleId: string): Promise<void>;
+  launch(udid: string, bundleId: string, args?: string[]): Promise<void>;
   terminate(udid: string, bundleId: string): Promise<void>;
 }
 
 export const localSimctl: SimctlBackend = {
-  async launch(udid, bundleId) {
-    await execFileAsync("xcrun", await simctlArgsForUdid(udid, ["launch", udid, bundleId]));
+  async launch(udid, bundleId, args = []) {
+    await execFileAsync(
+      "xcrun",
+      await simctlArgsForUdid(udid, ["launch", udid, bundleId, ...args])
+    );
   },
   async terminate(udid, bundleId) {
     await execFileAsync("xcrun", await simctlArgsForUdid(udid, ["terminate", udid, bundleId]));

--- a/packages/tool-server/test/ios-launch-args.test.ts
+++ b/packages/tool-server/test/ios-launch-args.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.fn(
+  (
+    _cmd: string,
+    _args: readonly string[],
+    opts: unknown,
+    cb?: (err: Error | null, out: { stdout: string; stderr: string }) => void
+  ) => {
+    const callback = typeof opts === "function" ? opts : cb!;
+    callback(null, { stdout: "", stderr: "" });
+  }
+);
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, execFile: (...args: unknown[]) => (execFileMock as any)(...args) };
+});
+
+vi.mock("../src/utils/ios-devices", () => ({
+  isTvOsSimulator: vi.fn(async () => false),
+}));
+
+import type { NativeDevtoolsApi } from "../src/blueprints/native-devtools";
+import { createLaunchAppTool } from "../src/tools/launch-app";
+import { createRestartAppTool } from "../src/tools/restart-app";
+import { __primeDepCacheForTests, __resetDepCacheForTests } from "../src/utils/check-deps";
+
+const IOS_UDID = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA";
+const REMOTE_UDID = `remote:${IOS_UDID}`;
+const BUNDLE_ID = "dev.example.app";
+const LAUNCH_ARGS = ["-EXDevMenuIsOnboardingFinished", "1", "-EXDevMenuShowsAtLaunch", "0"];
+
+function makeNativeApi(): NativeDevtoolsApi {
+  return {
+    isEnvSetup: () => true,
+    socketPath: "/tmp/test.sock",
+    ensureEnvReady: async () => {},
+    reverifyEnv: async () => {},
+    getInitFailure: () => null,
+    isConnected: () => false,
+    isAppRunning: async () => false,
+    listConnectedBundleIds: () => [],
+    appConnectionState: async () => "connected",
+    activateNetworkInspection: () => {},
+    getNetworkLog: () => [],
+    clearNetworkLog: () => {},
+    getAppState: async () => {
+      throw new Error("not implemented");
+    },
+    detectFrontmostBundleId: async () => null,
+    queryViewHierarchy: async () => ({}),
+  } as NativeDevtoolsApi;
+}
+
+function makeRegistry() {
+  return { resolveService: vi.fn(async () => makeNativeApi() as unknown) } as any;
+}
+
+function expectLaunchCall(command: "xcrun" | "sim-remote") {
+  const call = execFileMock.mock.calls.find(
+    ([executable, args]) =>
+      executable === command && Array.isArray(args) && args[0] === "simctl" && args[1] === "launch"
+  );
+
+  expect(call?.slice(0, 2)).toEqual([
+    command,
+    ["simctl", "launch", IOS_UDID, BUNDLE_ID, ...LAUNCH_ARGS],
+  ]);
+}
+
+beforeEach(() => {
+  execFileMock.mockClear();
+  __resetDepCacheForTests();
+  __primeDepCacheForTests(["xcrun", "sim-remote"]);
+});
+
+describe("iOS launch arguments", () => {
+  it("launch-app forwards arguments to local simctl launch", async () => {
+    const tool = createLaunchAppTool(makeRegistry());
+
+    await tool.execute!({}, { udid: IOS_UDID, bundleId: BUNDLE_ID, launchArgs: LAUNCH_ARGS });
+
+    expectLaunchCall("xcrun");
+  });
+
+  it("restart-app forwards arguments to local simctl launch", async () => {
+    const tool = createRestartAppTool(makeRegistry());
+
+    await tool.execute!({}, { udid: IOS_UDID, bundleId: BUNDLE_ID, launchArgs: LAUNCH_ARGS });
+
+    expectLaunchCall("xcrun");
+  });
+
+  it("launch-app forwards arguments to remote simctl launch", async () => {
+    const tool = createLaunchAppTool(makeRegistry());
+
+    await tool.execute!(
+      { nativeDevtools: makeNativeApi() },
+      { udid: REMOTE_UDID, bundleId: BUNDLE_ID, launchArgs: LAUNCH_ARGS }
+    );
+
+    expectLaunchCall("sim-remote");
+  });
+
+  it("restart-app forwards arguments to remote simctl launch", async () => {
+    const tool = createRestartAppTool(makeRegistry());
+
+    await tool.execute!(
+      { nativeDevtools: makeNativeApi() },
+      { udid: REMOTE_UDID, bundleId: BUNDLE_ID, launchArgs: LAUNCH_ARGS }
+    );
+
+    expectLaunchCall("sim-remote");
+  });
+});


### PR DESCRIPTION
## What changed

- add an optional `launchArgs` array to the `launch-app` and `restart-app` tool schemas
- forward those arguments as discrete argv values after the bundle ID for local and remote Apple simulator launches
- cover launch and restart behavior on both `xcrun simctl` and `sim-remote simctl`

## Why

Some simulator workflows need process arguments at launch time, for example to override `UserDefaults` without modifying or rebuilding an app:

```json
{
  "udid": "remote:<udid>",
  "bundleId": "dev.example.app",
  "launchArgs": [
    "-EXDevMenuIsOnboardingFinished",
    "1",
    "-EXDevMenuShowsAtLaunch",
    "0"
  ]
}
```

The remote simctl helper already accepted trailing launch arguments, but the public lifecycle tools did not expose or forward them. This made the capability unavailable through Argent, including hosted EAS Simulator sessions.

## Impact

Callers can now supply launch-time feature flags and preference overrides through both `launch-app` and `restart-app`. Existing calls remain unchanged when `launchArgs` is omitted. Non-Apple platforms ignore the field as documented.

## Validation

- `npm run build`
- `npm run lint`
- `npm run typecheck:tests -w @argent/tool-server`
- `npm test -w @argent/tool-server -- --run test/ios-launch-args.test.ts test/launch-restart-system-app.test.ts test/launch-restart-tvos.test.ts test/restart-app-android-activity.test.ts` (20 tests)
