### PR TITLE
feat: support named screenshots

### DIFF
--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -258,6 +258,8 @@ When using `screenshot` for permission or native modal navigation:
 
 Optional rotation parameter: `{ "udid": "<UDID>", "rotation": "LandscapeLeft" }` — rotates the capture without changing simulator orientation.
 
+Pass `name` when the capture is a user-facing artifact or needs to be identifiable in EAS Simulator logs, for example `{ "udid": "<UDID>", "name": "checkout-complete" }`. The name appears in screenshot lifecycle events and becomes the PNG filename; Argent appends `.png` when omitted.
+
 Screenshots are downscaled by default (30% of original resolution) to reduce context size. Use the normal downscaled screenshot for UI context and state checks. `scale` accepts values from 0.01 to 1.0, but do not use `scale: 1.0` as a general readability or tapping aid.
 
 Use full-resolution screenshots only when saving baseline/current PNG files for comparison. In that case, suppress the image block so the full-size PNG is not loaded into agent context:

--- a/packages/tool-server/src/tools/screenshot/index.ts
+++ b/packages/tool-server/src/tools/screenshot/index.ts
@@ -1,9 +1,10 @@
 import { execFile } from "node:child_process";
+import { copyFile, mkdtemp } from "node:fs/promises";
 import { promisify } from "node:util";
 import * as os from "node:os";
 import * as path from "node:path";
 import { z } from "zod";
-import type { Registry, ToolCapability, ToolDefinition } from "@argent/registry";
+import type { ArtifactStore, Registry, ToolCapability, ToolDefinition } from "@argent/registry";
 import { simulatorServerRef, type SimulatorServerApi } from "../../blueprints/simulator-server";
 import { chromiumCdpRef, type ChromiumCdpApi } from "../../blueprints/chromium-cdp";
 import { resolveDevice } from "../../utils/device-info";
@@ -20,6 +21,18 @@ const zodSchema = z.object({
     .string()
     .describe(
       "Target device id from `list-devices` (iOS UDID, Android serial, Apple TV UDID, Vega serial, or Chromium id)."
+    ),
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(120)
+    .regex(/^[A-Za-z0-9][A-Za-z0-9 ._-]*$/, {
+      message: "Use letters, numbers, spaces, dots, underscores, or hyphens.",
+    })
+    .optional()
+    .describe(
+      "Optional human-readable screenshot name. Included in event logs and used for the PNG filename; `.png` is appended when omitted."
     ),
   rotation: z
     .enum(["Portrait", "LandscapeLeft", "LandscapeRight", "PortraitUpsideDown"])
@@ -61,6 +74,51 @@ interface Result {
    * is remote.
    */
   image: ArtifactHandle;
+}
+
+/**
+ * Turn the human label into a stable, path-safe PNG basename. The schema
+ * rejects separators/control characters, and the replacement here keeps the
+ * filesystem sink safe even if a test or future internal caller bypasses
+ * registry validation. Whitespace becomes hyphens so the same name is pleasant
+ * to use from shells and artifact browsers.
+ */
+function namedScreenshotFilename(name: string): string {
+  const stem = name
+    .trim()
+    .replace(/\.png$/i, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^[._-]+|[._-]+$/g, "")
+    .slice(0, 120);
+  return `${stem || "screenshot"}.png`;
+}
+
+/**
+ * A filename override on the artifact handle is enough for a remote download,
+ * but a co-located client uses `hostPath` directly. Stage named captures under
+ * their real basename too, so both paths (including EAS Simulator collection)
+ * observe the human filename instead of the backend's timestamp/UUID.
+ */
+async function stageNamedScreenshot(capturedPath: string, name?: string): Promise<string> {
+  if (!name) return capturedPath;
+  const dir = await mkdtemp(path.join(os.tmpdir(), "argent-named-screenshot-"));
+  const namedPath = path.join(dir, namedScreenshotFilename(name));
+  await copyFile(capturedPath, namedPath);
+  return namedPath;
+}
+
+async function registerScreenshotArtifact(
+  artifacts: ArtifactStore,
+  capturedPath: string,
+  name?: string
+): Promise<ArtifactHandle> {
+  const artifactPath = await stageNamedScreenshot(capturedPath, name);
+  return artifacts.register(artifactPath, {
+    mimeType: "image/png",
+    ...(name ? { filename: namedScreenshotFilename(name) } : {}),
+  });
 }
 
 const capability: ToolCapability = {
@@ -127,9 +185,11 @@ export function createScreenshotTool(registry: Registry): ToolDefinition<Params,
   return {
     id: "screenshot",
     interaction: {
-      startedMsg: () => "Capturing screenshot",
+      startedMsg: ({ params }) =>
+        params.name ? `Capturing screenshot ${params.name}` : "Capturing screenshot",
       completedMsg: ({ result }) => `Captured screenshot ${result.image.filename}`,
-      failedMsg: ({ failureSignal }) => `Failed to capture screenshot: ${failureSignal.error_code}`,
+      failedMsg: ({ params, failureSignal }) =>
+        `Failed to capture screenshot${params.name ? ` ${params.name}` : ""}: ${failureSignal.error_code}`,
     },
     description: `Capture a screenshot of the device screen (iOS simulator, Android emulator, Apple TV simulator, Vega, or Chromium app). Returns { image }; the MCP adapter renders it as a visible image unless the caller passed includeImageInContext: false.
 Use when you need a baseline image before an interaction or to inspect the current screen state after a delay.
@@ -157,7 +217,11 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
           scale: params.scale,
           downscaler: params.downscaler,
         });
-        const image = await requireArtifacts(ctx).register(capturedPath, { mimeType: "image/png" });
+        const image = await registerScreenshotArtifact(
+          requireArtifacts(ctx),
+          capturedPath,
+          params.name
+        );
         return { image };
       }
 
@@ -165,7 +229,7 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
       // tvOS has no simulator-server backend, so capture via xcrun instead.
       if (device.platform === "ios" && (await isTvOsSimulator(params.udid))) {
         const pngPath = await tvScreenshot(params.udid, scale, signal);
-        const image = await requireArtifacts(ctx).register(pngPath, { mimeType: "image/png" });
+        const image = await registerScreenshotArtifact(requireArtifacts(ctx), pngPath, params.name);
         return { image };
       }
 
@@ -174,7 +238,7 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
       // Vega device would throw), so capture directly here.
       if (device.platform === "vega") {
         const pngPath = await captureVegaScreenshotPng({ scale: params.scale });
-        const image = await requireArtifacts(ctx).register(pngPath, { mimeType: "image/png" });
+        const image = await registerScreenshotArtifact(requireArtifacts(ctx), pngPath, params.name);
         return { image };
       }
 
@@ -186,7 +250,11 @@ Fails if the simulator-server / emulator backend / Chromium CDP is not reachable
         signal,
         params.scale
       );
-      const image = await requireArtifacts(ctx).register(capturedPath, { mimeType: "image/png" });
+      const image = await registerScreenshotArtifact(
+        requireArtifacts(ctx),
+        capturedPath,
+        params.name
+      );
       return { image };
     },
   };

--- a/packages/tool-server/test/interaction-messages.test.ts
+++ b/packages/tool-server/test/interaction-messages.test.ts
@@ -76,12 +76,29 @@ describe("tool interaction messages", () => {
       "Pressed a key"
     );
 
+    const screenshot = definitions.get("screenshot")!.interaction!;
     expect(
-      definitions.get("screenshot")!.interaction!.completedMsg!({
+      screenshot.completedMsg!({
         params: { udid: "device-1" },
         result: { image: { filename: "screenshot.png" } },
       })
     ).toBe("Captured screenshot screenshot.png");
+    expect(
+      screenshot.startedMsg!({ params: { udid: "device-1", name: "Checkout complete" } })
+    ).toBe("Capturing screenshot Checkout complete");
+    expect(
+      screenshot.completedMsg!({
+        params: { udid: "device-1", name: "Checkout complete" },
+        result: { image: { filename: "Checkout-complete.png" } },
+      })
+    ).toBe("Captured screenshot Checkout-complete.png");
+    expect(
+      screenshot.failedMsg!({
+        params: { udid: "device-1", name: "Checkout complete" },
+        error: new Error("raw error"),
+        failureSignal,
+      })
+    ).toBe(`Failed to capture screenshot Checkout complete: ${failureSignal.error_code}`);
 
     expect(
       definitions.get("gesture-tap")!.interaction!.failedMsg!({

--- a/packages/tool-server/test/screenshot-tool.test.ts
+++ b/packages/tool-server/test/screenshot-tool.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ArtifactStore } from "@argent/registry";
 import { createScreenshotTool } from "../src/tools/screenshot";
 
@@ -47,5 +50,69 @@ describe("screenshot tool", () => {
     });
     expect(result).not.toHaveProperty("includeImageInContext");
     expect(result).not.toHaveProperty("url");
+  });
+
+  it("uses a human name in both the artifact filename and the real staged path", async () => {
+    const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-tool-test-"));
+    const sourcePath = path.join(sourceDir, "624543000-1786034937633.png");
+    const png = Buffer.from("fake-png");
+    await fs.writeFile(sourcePath, png);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          url: "http://localhost/624543000-1786034937633.png",
+          path: sourcePath,
+        }),
+      })
+    );
+
+    const registry = {
+      resolveService: vi.fn().mockResolvedValue({ apiUrl: "http://localhost:4949" }),
+    } as unknown as import("@argent/registry").Registry;
+    const screenshotTool = createScreenshotTool(registry);
+    const params = {
+      udid: "ABC",
+      name: "Checkout complete.png",
+      includeImageInContext: true,
+    };
+    screenshotTool.zodSchema!.parse(params);
+    let stagedPath: string | undefined;
+
+    try {
+      const result = await screenshotTool.execute({}, params, { artifacts: new ArtifactStore() });
+      stagedPath = result.image.hostPath;
+
+      expect(result.image).toMatchObject({
+        __argentArtifact: true,
+        filename: "Checkout-complete.png",
+        mimeType: "image/png",
+      });
+      expect(path.basename(result.image.hostPath)).toBe("Checkout-complete.png");
+      expect(result.image.hostPath).not.toBe(sourcePath);
+      expect(await fs.readFile(result.image.hostPath)).toEqual(png);
+    } finally {
+      await fs.rm(sourceDir, { recursive: true, force: true });
+      if (stagedPath) {
+        await fs.rm(path.dirname(stagedPath), { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("rejects screenshot names that could be interpreted as paths", () => {
+    const registry = {
+      resolveService: vi.fn(),
+    } as unknown as import("@argent/registry").Registry;
+    const screenshotTool = createScreenshotTool(registry);
+
+    expect(
+      screenshotTool.zodSchema!.safeParse({ udid: "ABC", name: "../../checkout" }).success
+    ).toBe(false);
+    expect(
+      screenshotTool.zodSchema!.safeParse({ udid: "ABC", name: "checkout\nsecret" }).success
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- add an optional human-readable `name` to the `screenshot` tool
- include named screenshots in lifecycle event messages
- stage the captured PNG under its normalized name so both local and remote/EAS Simulator artifact paths are readable
- validate names against path traversal and control characters
- document named capture usage in the device interaction skill

## Why

Screenshot artifacts currently inherit opaque backend-generated filenames such as `624543000-1786034937633.png`. Those names also appear in Argent's event logs, which makes captures difficult to identify in EAS Simulator runs.

Named captures now produce readable files such as `checkout-complete.png` while preserving the existing behavior for callers that omit `name`.

## Validation

- `npm run build`
- `npm run typecheck:tests -w @argent/tool-server`
- `npm test -w @argent/tool-server -- --run test/screenshot-tool.test.ts test/interaction-messages.test.ts test/tool-input-schema-contract.test.ts` (87 tests)
- targeted ESLint and Prettier checks
