### PR TITLE
feat(flow): stream run progress as NDJSON

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -1568,8 +1568,8 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
       baseUrl
     );
   } catch (err) {
-    if (args.jsonStream) writeJsonStreamError(err);
-    throw err;
+    if (!args.jsonStream) throw err;
+    return fail(err instanceof Error ? err.message : String(err), 2, err);
   }
 
   if (args.jsonStream) {

--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -1029,12 +1029,12 @@ async function collectFlowFiles(dir: string, recursive: boolean): Promise<string
  * remotely callable, but reject CLI routing that cannot guarantee the
  * shared filesystem. This deliberately rejects even single-file flows that
  * could run remotely — the CLI cannot tell them apart without parsing the
- * flow. Prints the recovery hint and returns false when remote routing is
+ * flow. Returns the refusal with its recovery hint when remote routing is
  * configured.
  */
-async function requireLocalToolServer(): Promise<boolean> {
+async function requireLocalToolServer(): Promise<string | undefined> {
   const routing = await getResolvedToolsUrl();
-  if (routing.source === "none") return true;
+  if (routing.source === "none") return undefined;
   // With ARGENT_TOOLS_URL set over an existing link file, unsetting only the
   // env var re-routes through the shadowed link — the same refusal with the
   // other source. Name both steps up front.
@@ -1045,10 +1045,7 @@ async function requireLocalToolServer(): Promise<boolean> {
           `a link to ${routing.shadowedLink.url} is also configured and takes over once the env var is unset.`
         : "Unset ARGENT_TOOLS_URL and try again."
       : "Run `argent unlink` and try again.";
-  console.error(
-    `argent flow run requires the auto-started local tool server; ${routing.source} routing is configured.\n${recovery}`
-  );
-  return false;
+  return `argent flow run requires the auto-started local tool server; ${routing.source} routing is configured.\n${recovery}`;
 }
 
 /** One flow-execute payload builder so single and batch runs cannot drift. */
@@ -1140,7 +1137,11 @@ async function runFlowDirectory(
     return exitAfterFlush(2);
   }
 
-  if (!(await requireLocalToolServer())) return exitAfterFlush(2);
+  const refusal = await requireLocalToolServer();
+  if (refusal) {
+    console.error(refusal);
+    return exitAfterFlush(2);
+  }
   const { callTool, baseUrl } = createToolsClient({ paths: options.paths });
 
   const outputBase = args.output ? path.resolve(args.output) : undefined;
@@ -1243,32 +1244,42 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     return exitAfterFlush(2);
   }
 
+  // Once streaming is requested stdout belongs exclusively to NDJSON. Help
+  // is still useful, but it is a diagnostic and therefore belongs on stderr.
+  const jsonStream = rest.some(
+    (tok) => tok === "--json-stream" || tok.startsWith("--json-stream=")
+  );
   // Checked before parseRunArgs so --help wins even when it trails a
   // value-taking flag (`--device --help` would otherwise throw "requires a
   // value" instead of printing help).
   if (rest.includes("--help") || rest.includes("-h")) {
-    // Once streaming is requested stdout belongs exclusively to NDJSON. Help
-    // is still useful, but it is a diagnostic and therefore belongs on stderr.
-    printHelp(rest.some((tok) => tok === "--json-stream" || tok.startsWith("--json-stream=")));
+    printHelp(jsonStream);
     return;
   }
+  const fail = (message: string, code: number, err: unknown = message): Promise<never> => {
+    if (jsonStream) writeJsonStreamError(err);
+    console.error(message);
+    return exitAfterFlush(code);
+  };
 
   let args: ReturnType<typeof parseRunArgs>;
   try {
     args = parseRunArgs(rest);
   } catch (err) {
     if (err instanceof FlagParseException) {
+      if (jsonStream) writeJsonStreamError(err);
       console.error(`Error: ${err.message}\n`);
-      printHelp(rest.some((tok) => tok === "--json-stream" || tok.startsWith("--json-stream=")));
+      printHelp(jsonStream);
       return exitAfterFlush(2);
     }
     throw err;
   }
   if (!args.flowRef) {
-    console.error(
-      "argent flow run <flow|flow.yaml|dir> requires a flow name, a YAML file path, or a directory path."
-    );
-    printHelp(args.jsonStream);
+    const message =
+      "argent flow run <flow|flow.yaml|dir> requires a flow name, a YAML file path, or a directory path.";
+    if (jsonStream) writeJsonStreamError(message);
+    console.error(message);
+    printHelp(jsonStream);
     return exitAfterFlush(2);
   }
 
@@ -1309,12 +1320,12 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
         // generic recovery stands.
       }
     }
-    console.error(
+    return fail(
       `Flow path must not contain ".." segments — they are collapsed without following symlinks, ` +
         `so the path can name a different file than the one your shell opens: ${suppliedPath}\n` +
-        recovery
+        recovery,
+      2
     );
-    return exitAfterFlush(2);
   }
   const resolvedPath = path.resolve(projectRoot, suppliedPath);
   // Stat-first so a directory named `foo.yaml` still batches; on a failed stat
@@ -1330,25 +1341,23 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     // name resolves to a .yaml file it never named, so "directory not found"
     // would quote a path they never typed. That form falls through instead.
     if (args.recursive && !fromName) {
-      console.error(`Flow directory not found: ${resolvedPath}`);
-      return exitAfterFlush(2);
+      return fail(`Flow directory not found: ${resolvedPath}`, 2);
     }
   }
   if (isDirectory) {
     if (args.jsonStream) {
-      console.error("--json-stream supports a single flow; directory runs are not supported.");
-      return exitAfterFlush(2);
+      return fail("--json-stream supports a single flow; directory runs are not supported.", 2);
     }
     return runFlowDirectory(resolvedPath, args, projectRoot, options);
   }
   if (args.recursive) {
-    console.error(
+    return fail(
       fromName
         ? `flow run --recursive requires a directory path; "${args.flowRef}" is a saved-flow name, ` +
             `which always addresses the single file ${suppliedPath}.`
-        : `flow run --recursive requires a directory path: ${suppliedPath}`
+        : `flow run --recursive requires a directory path: ${suppliedPath}`,
+      2
     );
-    return exitAfterFlush(2);
   }
   // A trailing separator asserts the path names a directory. When it does —
   // the directory dispatch above already ran — that assertion is honest (a
@@ -1375,13 +1384,13 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     const hint = SAFE_FLOW_NAME.test(separatorTrimmedPath)
       ? `.${path.sep}${separatorTrimmedPath}`
       : separatorTrimmedPath;
-    console.error(
+    return fail(
       `Flow path must not end in a path separator — the separator claims a directory, ` +
         `which the kernel would refuse to open as a file, so the CLI would run a file ` +
         `this string does not name: ${suppliedPath}\n` +
-        `Did you mean: argent flow run ${shellQuoteArg(hint)}`
+        `Did you mean: argent flow run ${shellQuoteArg(hint)}`,
+      2
     );
-    return exitAfterFlush(2);
   }
   if (path.extname(suppliedPath) !== ".yaml") {
     // A valid name never reaches here — resolveFlowRef already rewrote it to a
@@ -1397,39 +1406,41 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
       path.extname(suppliedPath) === "";
     if (path.basename(suppliedPath).toLowerCase() === ".yaml") {
       // path.extname treats a bare ".yaml" as an extensionless dotfile, so name the missing stem.
-      console.error(
-        `Flow filename must have a non-empty name containing only letters, numbers, "_", or "-": ${suppliedPath}`
+      return fail(
+        `Flow filename must have a non-empty name containing only letters, numbers, "_", or "-": ${suppliedPath}`,
+        2
       );
-    } else if (looksLikeName) {
-      console.error(
-        `Flow name must contain only letters, numbers, "_", or "-": ${suppliedPath}\n` +
-          `Names run \`${FLOWS_DIR}/<name>.yaml\`; pass a path ending in .yaml to run a flow file kept elsewhere.`
-      );
-    } else if (path.extname(suppliedPath).toLowerCase() === ".yaml") {
-      // On case-insensitive filesystems the path looks valid to the user, so name the real problem.
-      console.error(
-        `Flow extension must be lowercase .yaml, not ${path.extname(suppliedPath)}: ${suppliedPath}`
-      );
-    } else {
-      console.error(`Flow path must end in .yaml: ${suppliedPath}`);
     }
-    return exitAfterFlush(2);
+    if (looksLikeName) {
+      return fail(
+        `Flow name must contain only letters, numbers, "_", or "-": ${suppliedPath}\n` +
+          `Names run \`${FLOWS_DIR}/<name>.yaml\`; pass a path ending in .yaml to run a flow file kept elsewhere.`,
+        2
+      );
+    }
+    if (path.extname(suppliedPath).toLowerCase() === ".yaml") {
+      // On case-insensitive filesystems the path looks valid to the user, so name the real problem.
+      return fail(
+        `Flow extension must be lowercase .yaml, not ${path.extname(suppliedPath)}: ${suppliedPath}`,
+        2
+      );
+    }
+    return fail(`Flow path must end in .yaml: ${suppliedPath}`, 2);
   }
 
   const flowName = path.basename(suppliedPath, ".yaml");
   if (!SAFE_FLOW_NAME.test(flowName)) {
-    console.error(
-      `Flow filename must have a non-empty name containing only letters, numbers, "_", or "-": ${suppliedPath}`
+    return fail(
+      `Flow filename must have a non-empty name containing only letters, numbers, "_", or "-": ${suppliedPath}`,
+      2
     );
-    return exitAfterFlush(2);
   }
 
   const flowPath = resolvedPath;
   try {
     const stat = await fsp.stat(flowPath);
     if (!stat.isFile()) {
-      console.error(`Flow path is not a file: ${flowPath}`);
-      return exitAfterFlush(2);
+      return fail(`Flow path is not a file: ${flowPath}`, 2);
     }
     await fsp.access(flowPath, fsConstants.R_OK);
   } catch (err) {
@@ -1448,8 +1459,7 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
         ? `\nNo flow named "${args.flowRef}" is saved there — run \`argent flow list\` to see the saved flows.`
         : await savedFlowHint(projectRoot, flowPath);
     }
-    console.error(`${detail}: ${flowPath}${recovery}`);
-    return exitAfterFlush(2);
+    return fail(`${detail}: ${flowPath}${recovery}`, 2);
   }
 
   // The stat above matched the basename by the filesystem's rules, which on a
@@ -1487,17 +1497,18 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
       : actual !== undefined
         ? `Rename ${actual} to ${suppliedBase} to run it — flow files must be lowercase .yaml.`
         : "Pass the flow file's name exactly as it appears on disk.";
-    console.error(
+    return fail(
       `Flow path must name the file as it appears on disk — this filesystem matched ` +
         `${JSON.stringify(suppliedBase)} case-insensitively` +
         `${actual !== undefined ? ` to ${JSON.stringify(actual)}` : ""}, so the flow name ` +
         `(which keys the report, __baselines__/, and --output) would be one no file carries: ` +
-        `${suppliedPath}\n${recovery}`
+        `${suppliedPath}\n${recovery}`,
+      2
     );
-    return exitAfterFlush(2);
   }
 
-  if (!(await requireLocalToolServer())) return exitAfterFlush(2);
+  const refusal = await requireLocalToolServer();
+  if (refusal) return fail(refusal, 2);
 
   const { callTool, baseUrl } = createToolsClient({ paths: options.paths });
 
@@ -1542,16 +1553,11 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     // --output copies are fetched, below.
     report = resp.data as FlowReport;
   } catch (err) {
-    if (args.jsonStream) writeJsonStreamError(err);
-    console.error(err instanceof Error ? err.message : String(err));
-    return exitAfterFlush(1);
+    return fail(err instanceof Error ? err.message : String(err), 1, err);
   }
 
   if (!report || typeof report !== "object" || !("steps" in report)) {
-    const message = `"${flowName}" did not produce a run report.`;
-    if (args.jsonStream) writeJsonStreamError(new Error(message));
-    console.error(message);
-    return exitAfterFlush(2);
+    return fail(`"${flowName}" did not produce a run report.`, 2);
   }
 
   try {
@@ -1563,8 +1569,7 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     );
   } catch (err) {
     if (args.jsonStream) writeJsonStreamError(err);
-    console.error(err instanceof Error ? err.message : String(err));
-    return exitAfterFlush(1);
+    throw err;
   }
 
   if (args.jsonStream) {

--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -1249,11 +1249,7 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
   if (rest.includes("--help") || rest.includes("-h")) {
     // Once streaming is requested stdout belongs exclusively to NDJSON. Help
     // is still useful, but it is a diagnostic and therefore belongs on stderr.
-    printHelp(
-      rest.some(
-        (tok) => tok === "--json-stream" || tok.startsWith("--json-stream=")
-      )
-    );
+    printHelp(rest.some((tok) => tok === "--json-stream" || tok.startsWith("--json-stream=")));
     return;
   }
 

--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -97,8 +97,9 @@ function stepIndent(depth: number | undefined): string {
   return "  ".repeat(Math.min(depth, MAX_RENDER_DEPTH));
 }
 
-function printHelp(): void {
-  console.log(`Usage: argent flow <subcommand> [options]
+function printHelp(toStderr = false): void {
+  const print = toStderr ? console.error : console.log;
+  print(`Usage: argent flow <subcommand> [options]
 
 Run a YAML flow without an LLM in the loop. \`run\` takes any of these forms:
 
@@ -148,6 +149,7 @@ Options (run):
                          overwritten
   -r, --recursive        With a directory path, also run flows in subdirectories
   --json                 Print the raw JSON report
+  --json-stream          Print progress and the final report as NDJSON (single flow only)
   --help, -h             Show this help
   --                     End of options — only needed for a flow whose name
                          starts with "-" (\`argent flow run -- -nightly\`)
@@ -174,11 +176,13 @@ export function parseRunArgs(argv: string[]): {
   updateBaselines: boolean;
   recursive: boolean;
   json: boolean;
+  jsonStream: boolean;
 } {
   const out = {
     updateBaselines: false,
     recursive: false,
     json: false,
+    jsonStream: false,
   } as ReturnType<typeof parseRunArgs>;
   // Positionals are collected through one helper so the end-of-options marker
   // below cannot drift from the ordinary path in what it accepts.
@@ -247,6 +251,9 @@ export function parseRunArgs(argv: string[]): {
     } else if (flag === "--json") {
       noValue("--json");
       out.json = true;
+    } else if (flag === "--json-stream") {
+      noValue("--json-stream");
+      out.jsonStream = true;
     } else if (flag === "--recursive" || flag === "-r") {
       // Bare `-r` never carries an inline value (the `=` split applies to
       // `--` tokens only), so noValue guards just the long form.
@@ -259,6 +266,9 @@ export function parseRunArgs(argv: string[]): {
     // not silently fall back to device auto-detection. --help/-h never reach
     // this parser: flow() intercepts them before calling parseRunArgs.
     else throw new FlagParseException(`unknown flag ${tok}`);
+  }
+  if (out.json && out.jsonStream) {
+    throw new FlagParseException("--json and --json-stream cannot be combined");
   }
   return out;
 }
@@ -1059,6 +1069,22 @@ function buildRunPayload(
   return payload;
 }
 
+/** Write one machine-readable flow record. Each record occupies exactly one line. */
+function writeJsonStreamRecord(record: Record<string, unknown>): void {
+  console.log(JSON.stringify(record));
+}
+
+/** Mirror a tool invocation failure without putting human text on stdout. */
+function writeJsonStreamError(err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  writeJsonStreamRecord({
+    event: "error",
+    error: message,
+    ...(err instanceof ToolInvocationError && err.errorCode ? { error_code: err.errorCode } : {}),
+    ...(err instanceof ToolInvocationError && err.errorKind ? { error_kind: err.errorKind } : {}),
+  });
+}
+
 /**
  * Durable diff output: copy failed-snapshot images out of the tool-server's
  * cache before any renderer prints paths, so every output mode shows the
@@ -1221,7 +1247,13 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
   // value-taking flag (`--device --help` would otherwise throw "requires a
   // value" instead of printing help).
   if (rest.includes("--help") || rest.includes("-h")) {
-    printHelp();
+    // Once streaming is requested stdout belongs exclusively to NDJSON. Help
+    // is still useful, but it is a diagnostic and therefore belongs on stderr.
+    printHelp(
+      rest.some(
+        (tok) => tok === "--json-stream" || tok.startsWith("--json-stream=")
+      )
+    );
     return;
   }
 
@@ -1231,7 +1263,7 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
   } catch (err) {
     if (err instanceof FlagParseException) {
       console.error(`Error: ${err.message}\n`);
-      printHelp();
+      printHelp(rest.some((tok) => tok === "--json-stream" || tok.startsWith("--json-stream=")));
       return exitAfterFlush(2);
     }
     throw err;
@@ -1240,7 +1272,7 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     console.error(
       "argent flow run <flow|flow.yaml|dir> requires a flow name, a YAML file path, or a directory path."
     );
-    printHelp();
+    printHelp(args.jsonStream);
     return exitAfterFlush(2);
   }
 
@@ -1307,6 +1339,10 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     }
   }
   if (isDirectory) {
+    if (args.jsonStream) {
+      console.error("--json-stream supports a single flow; directory runs are not supported.");
+      return exitAfterFlush(2);
+    }
     return runFlowDirectory(resolvedPath, args, projectRoot, options);
   }
   if (args.recursive) {
@@ -1479,6 +1515,10 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
   let liveIndex = 0;
   const onStepReport = (event: unknown): void => {
     const s = event as StepReport;
+    if (args.jsonStream) {
+      writeJsonStreamRecord({ event: "progress", data: s });
+      return;
+    }
     if (liveSteps === 0) console.log(`Flow "${flowName}"`);
     liveSteps++;
     if (s.kind === "echo") {
@@ -1506,23 +1546,34 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     // --output copies are fetched, below.
     report = resp.data as FlowReport;
   } catch (err) {
+    if (args.jsonStream) writeJsonStreamError(err);
     console.error(err instanceof Error ? err.message : String(err));
     return exitAfterFlush(1);
   }
 
-  if (!report || !("steps" in report)) {
-    console.error(`"${flowName}" did not produce a run report.`);
+  if (!report || typeof report !== "object" || !("steps" in report)) {
+    const message = `"${flowName}" did not produce a run report.`;
+    if (args.jsonStream) writeJsonStreamError(new Error(message));
+    console.error(message);
     return exitAfterFlush(2);
   }
 
-  await exportAndResolveArtifacts(
-    report,
-    args.output ? path.resolve(args.output) : undefined,
-    flowPath,
-    baseUrl
-  );
+  try {
+    await exportAndResolveArtifacts(
+      report,
+      args.output ? path.resolve(args.output) : undefined,
+      flowPath,
+      baseUrl
+    );
+  } catch (err) {
+    if (args.jsonStream) writeJsonStreamError(err);
+    console.error(err instanceof Error ? err.message : String(err));
+    return exitAfterFlush(1);
+  }
 
-  if (args.json) {
+  if (args.jsonStream) {
+    writeJsonStreamRecord({ event: "result", data: report });
+  } else if (args.json) {
     console.log(JSON.stringify(report, null, 2));
   } else if (liveSteps > 0) {
     // Steps already printed live — emit only what the final report knows:

--- a/packages/argent-cli/test/flow.test.ts
+++ b/packages/argent-cli/test/flow.test.ts
@@ -1322,6 +1322,20 @@ describe("argent flow run", () => {
     ]);
   });
 
+  it("emits a structured error and exits 2 when artifact export fails in streaming mode", async () => {
+    toolsClientMock.callTool.mockResolvedValue({ data: report() });
+    toolsClientMock.baseUrl.mockRejectedValueOnce(new Error("tool server unreachable"));
+
+    await expect(
+      flow(["run", checkoutPath, "--json-stream", "--output", path.join(tempRoot, "out")], opts)
+    ).rejects.toThrow("process.exit:2");
+
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      { event: "error", error: "tool server unreachable" },
+    ]);
+    expect(errs).toEqual(["tool server unreachable"]);
+  });
+
   it("emits a structured error for a primitive non-report in streaming mode", async () => {
     toolsClientMock.callTool.mockResolvedValue({ data: "not-a-report" });
 

--- a/packages/argent-cli/test/flow.test.ts
+++ b/packages/argent-cli/test/flow.test.ts
@@ -1296,7 +1296,9 @@ describe("argent flow run", () => {
     );
 
     expect(toolsClientMock.callTool).not.toHaveBeenCalled();
-    expect(logs).toEqual([]);
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      { event: "error", error: "--json and --json-stream cannot be combined" },
+    ]);
     expect(errs.join("\n")).toContain("--json and --json-stream cannot be combined");
     expect(errs.join("\n")).toContain("Usage: argent flow");
   });
@@ -1308,6 +1310,16 @@ describe("argent flow run", () => {
     expect(logs).toEqual([]);
     expect(errs.join("\n")).toContain("Usage: argent flow");
     expect(errs.join("\n")).toContain("--json-stream");
+  });
+
+  it("emits a structured error for a pre-flight refusal in streaming mode", async () => {
+    const missing = path.join(path.dirname(checkoutPath), "missing.yaml");
+    await expect(flow(["run", missing, "--json-stream"], opts)).rejects.toThrow("process.exit:2");
+
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      { event: "error", error: expect.stringContaining(`Flow file not found: ${missing}`) },
+    ]);
   });
 
   it("emits a structured error for a primitive non-report in streaming mode", async () => {
@@ -1608,7 +1620,12 @@ describe("argent flow run <dir>", () => {
     await expect(flow(["run", flowsDir, "--json-stream"], opts)).rejects.toThrow("process.exit:2");
 
     expect(toolsClientMock.callTool).not.toHaveBeenCalled();
-    expect(logs).toEqual([]);
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      {
+        event: "error",
+        error: "--json-stream supports a single flow; directory runs are not supported.",
+      },
+    ]);
     expect(errs.join("\n")).toContain(
       "--json-stream supports a single flow; directory runs are not supported"
     );

--- a/packages/argent-cli/test/flow.test.ts
+++ b/packages/argent-cli/test/flow.test.ts
@@ -112,6 +112,7 @@ describe("parseRunArgs", () => {
       updateBaselines: false,
       recursive: false,
       json: false,
+      jsonStream: false,
     });
   });
 
@@ -132,8 +133,10 @@ describe("parseRunArgs", () => {
       updateBaselines: true,
       recursive: false,
       json: false,
+      jsonStream: false,
     });
     expect(parseRunArgs(["--json", "checkout.yaml"]).json).toBe(true);
+    expect(parseRunArgs(["--json-stream", "checkout.yaml"]).jsonStream).toBe(true);
   });
 
   it("accepts -r and --recursive in any position", () => {
@@ -180,6 +183,7 @@ describe("parseRunArgs", () => {
       updateBaselines: false,
       recursive: false,
       json: false,
+      jsonStream: false,
     });
   });
 
@@ -191,6 +195,7 @@ describe("parseRunArgs", () => {
       updateBaselines: false,
       recursive: false,
       json: false,
+      jsonStream: false,
     });
   });
 
@@ -201,10 +206,19 @@ describe("parseRunArgs", () => {
     expect(out.json).toBe(true);
   });
 
+  it("rejects combining --json and --json-stream", () => {
+    expect(() => parseRunArgs(["checkout.yaml", "--json", "--json-stream"])).toThrow(
+      "--json and --json-stream cannot be combined"
+    );
+  });
+
   it("throws when a boolean flag is given an inline value", () => {
     expect(() => parseRunArgs(["checkout.yaml", "--json=true"])).toThrow(FlagParseException);
     expect(() => parseRunArgs(["checkout.yaml", "--json=true"])).toThrow(
       "--json does not take a value"
+    );
+    expect(() => parseRunArgs(["checkout.yaml", "--json-stream=true"])).toThrow(
+      "--json-stream does not take a value"
     );
     expect(() => parseRunArgs(["checkout.yaml", "--update-baselines=1"])).toThrow(
       "--update-baselines does not take a value"
@@ -238,6 +252,7 @@ describe("parseRunArgs", () => {
       updateBaselines: false,
       recursive: false,
       json: false,
+      jsonStream: false,
     });
     // The marker relaxes flag parsing, not the one-positional rule.
     expect(() => parseRunArgs(["--", "a", "b"])).toThrow(
@@ -1203,6 +1218,111 @@ describe("argent flow run", () => {
     expect(JSON.parse(logs.join("\n"))).toEqual(report());
   });
 
+  it("prints each progress step followed by one final result with --json-stream", async () => {
+    let finish!: () => void;
+    const finalGate = new Promise<void>((resolve) => (finish = resolve));
+    const step = { index: 0, kind: "tap", status: "pass" };
+    const finalReport = report({ steps: [step] });
+    toolsClientMock.callTool.mockImplementation(
+      async (
+        _name: string,
+        _payload: unknown,
+        options?: { onProgress?: (event: unknown) => void }
+      ) => {
+        options?.onProgress?.(step);
+        await finalGate;
+        return { data: finalReport };
+      }
+    );
+
+    const running = flow(["run", checkoutPath, "--json-stream"], opts);
+    await vi.waitFor(() => {
+      expect(logs).toHaveLength(1);
+      expect(JSON.parse(logs[0]!)).toEqual({ event: "progress", data: step });
+    });
+    finish();
+    await expect(running).rejects.toThrow("process.exit:0");
+
+    const records = logs.map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toEqual([
+      { event: "progress", data: step },
+      { event: "result", data: finalReport },
+    ]);
+    expect(errs).toEqual([]);
+  });
+
+  it("prints one final result and exits 1 for a failed report with --json-stream", async () => {
+    const failedReport = report({
+      ok: false,
+      passed: 0,
+      failed: 1,
+      steps: [{ index: 0, kind: "assert", status: "fail", reason: "not visible" }],
+    });
+    toolsClientMock.callTool.mockResolvedValue({ data: failedReport });
+
+    await expect(flow(["run", checkoutPath, "--json-stream"], opts)).rejects.toThrow(
+      "process.exit:1"
+    );
+
+    expect(logs.map((line) => JSON.parse(line))).toEqual([{ event: "result", data: failedReport }]);
+  });
+
+  it("prints a structured error on stdout and diagnostics on stderr with --json-stream", async () => {
+    toolsClientMock.callTool.mockRejectedValue(
+      new ToolInvocationError("invalid flow", {
+        errorCode: "FLOW_FILE_INVALID",
+        errorKind: "validation",
+      })
+    );
+
+    await expect(flow(["run", checkoutPath, "--json-stream"], opts)).rejects.toThrow(
+      "process.exit:1"
+    );
+
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      {
+        event: "error",
+        error: "invalid flow",
+        error_code: "FLOW_FILE_INVALID",
+        error_kind: "validation",
+      },
+    ]);
+    expect(errs).toEqual(["invalid flow"]);
+  });
+
+  it("rejects --json with --json-stream without writing human text to stdout", async () => {
+    await expect(flow(["run", checkoutPath, "--json", "--json-stream"], opts)).rejects.toThrow(
+      "process.exit:2"
+    );
+
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+    expect(logs).toEqual([]);
+    expect(errs.join("\n")).toContain("--json and --json-stream cannot be combined");
+    expect(errs.join("\n")).toContain("Usage: argent flow");
+  });
+
+  it("keeps help off stdout after --json-stream selects machine mode", async () => {
+    await flow(["run", checkoutPath, "--json-stream", "--help"], opts);
+
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+    expect(logs).toEqual([]);
+    expect(errs.join("\n")).toContain("Usage: argent flow");
+    expect(errs.join("\n")).toContain("--json-stream");
+  });
+
+  it("emits a structured error for a primitive non-report in streaming mode", async () => {
+    toolsClientMock.callTool.mockResolvedValue({ data: "not-a-report" });
+
+    await expect(flow(["run", checkoutPath, "--json-stream"], opts)).rejects.toThrow(
+      "process.exit:2"
+    );
+
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      { event: "error", error: '"checkout" did not produce a run report.' },
+    ]);
+    expect(errs.join("\n")).toContain('"checkout" did not produce a run report.');
+  });
+
   it("renders failed-snapshot handles as server paths without fetching when --output is absent", async () => {
     toolsClientMock.callTool.mockResolvedValue({
       data: report({
@@ -1384,6 +1504,7 @@ describe("argent flow run", () => {
     expect(logs.join("\n")).toContain(
       "ARGENT_TOOLS_URL and `argent link` routing are not supported"
     );
+    expect(logs.join("\n")).toContain("--json-stream");
     expect(getResolvedToolsUrlMock).not.toHaveBeenCalled();
     expect(toolsClientMock.callTool).not.toHaveBeenCalled();
   });
@@ -1481,6 +1602,16 @@ describe("argent flow run <dir>", () => {
     // Passing steps stay silent in batch mode.
     expect(out).not.toMatch(/✓ {2}1 tap/);
     expect(out).toContain("PASS — 2 flows: 2 passed, 0 failed, 0 skipped");
+  });
+
+  it("rejects directory runs with --json-stream", async () => {
+    await expect(flow(["run", flowsDir, "--json-stream"], opts)).rejects.toThrow("process.exit:2");
+
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+    expect(logs).toEqual([]);
+    expect(errs.join("\n")).toContain(
+      "--json-stream supports a single flow; directory runs are not supported"
+    );
   });
 
   it("forwards run flags to every flow in the batch", async () => {


### PR DESCRIPTION
## Summary

- add `argent flow run --json-stream`
- stream flow progress as JSON lines
- finish with a JSON result or error

## Why

`--json` prints only after a flow finishes. `--json-stream` lets scripts and CI see live progress.

## Why this is a separate PR

This is useful without the custom-tools feature in #856.

## Validation

- `npm test -w @argent/cli -- flow.test.ts` — 106 tests passed
- `npm run typecheck:tests -w @argent/cli`
- `npm run build -w @argent/cli`
