### PR TITLE
test(chromium): pin the ports-file guard and the readiness failure code

### DIFF
--- a/packages/tool-server/test/boot-electron-kill.test.ts
+++ b/packages/tool-server/test/boot-electron-kill.test.ts
@@ -111,10 +111,9 @@ async function bootFakeChild(): Promise<{ child: FakeChild; port: number; close:
   const { port } = srv.address() as { port: number };
 
   await bootElectronApp({ appPath: appDir, port, readyTimeoutMs: 5000 });
-  // The mock above must actually intercept trackChromiumPort — deleted, or
-  // rewritten to call through, it is otherwise invisible while every boot here
-  // persists a live port. The scoped HOME is what keeps that port out of the
-  // developer's own ~/.argent/chromium-cdp-ports.json; both are load-bearing.
+  // Both guards are load-bearing: the mock above has to actually intercept
+  // trackChromiumPort — deleted or calling through, it is invisible — and the
+  // scoped HOME keeps the port every boot here persists out of the real file.
   expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(false);
   return { child, port, close: () => srv.close() };
 }

--- a/packages/tool-server/test/boot-electron-kill.test.ts
+++ b/packages/tool-server/test/boot-electron-kill.test.ts
@@ -111,9 +111,10 @@ async function bootFakeChild(): Promise<{ child: FakeChild; port: number; close:
   const { port } = srv.address() as { port: number };
 
   await bootElectronApp({ appPath: appDir, port, readyTimeoutMs: 5000 });
-  // The mock above must actually intercept trackChromiumPort. Deleted, or
-  // rewritten to call through, it stays invisible while every boot here
-  // appends a live port to the developer's ~/.argent/chromium-cdp-ports.json.
+  // The mock above must actually intercept trackChromiumPort — deleted, or
+  // rewritten to call through, it is otherwise invisible while every boot here
+  // persists a live port. The scoped HOME is what keeps that port out of the
+  // developer's own ~/.argent/chromium-cdp-ports.json; both are load-bearing.
   expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(false);
   return { child, port, close: () => srv.close() };
 }

--- a/packages/tool-server/test/boot-electron-kill.test.ts
+++ b/packages/tool-server/test/boot-electron-kill.test.ts
@@ -13,6 +13,9 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
+import { scopeTempHome } from "./helpers/temp-home";
+
+scopeTempHome("argent-boot-electron-kill-home-");
 
 const spawnMock = vi.fn();
 
@@ -108,6 +111,10 @@ async function bootFakeChild(): Promise<{ child: FakeChild; port: number; close:
   const { port } = srv.address() as { port: number };
 
   await bootElectronApp({ appPath: appDir, port, readyTimeoutMs: 5000 });
+  // The mock above must actually intercept trackChromiumPort. Deleted, or
+  // rewritten to call through, it stays invisible while every boot here
+  // appends a live port to the developer's ~/.argent/chromium-cdp-ports.json.
+  expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(false);
   return { child, port, close: () => srv.close() };
 }
 

--- a/packages/tool-server/test/boot-electron-ready-race.test.ts
+++ b/packages/tool-server/test/boot-electron-ready-race.test.ts
@@ -14,7 +14,10 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
+import { scopeTempHome } from "./helpers/temp-home";
 import { FAILURE_CODES, getFailureSignal } from "@argent/registry";
+
+scopeTempHome("argent-boot-electron-race-home-");
 
 const spawnMock = vi.fn();
 
@@ -173,6 +176,11 @@ describe("bootElectronApp — ready-vs-exit confirmation window", () => {
       expect(result.port).toBe(port);
       expect(result.pid).toBe(FAKE_PID);
       expect(trackChromiumPort).toHaveBeenCalledWith(port);
+      // ...through the mock, and no further. A mock that calls through still
+      // satisfies the line above while persisting the port for real.
+      expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(
+        false
+      );
 
       // The handle was retained: teardown kills through it, not the raw pid.
       killChromiumByPort(port, FAKE_PID);

--- a/packages/tool-server/test/boot-electron-ready-race.test.ts
+++ b/packages/tool-server/test/boot-electron-ready-race.test.ts
@@ -176,9 +176,8 @@ describe("bootElectronApp — ready-vs-exit confirmation window", () => {
       expect(result.port).toBe(port);
       expect(result.pid).toBe(FAKE_PID);
       expect(trackChromiumPort).toHaveBeenCalledWith(port);
-      // ...through the mock, and no further. A mock that calls through still
-      // satisfies the line above while really persisting the port, which the
-      // scoped HOME then contains.
+      // ...through the mock, and no further: one that calls through satisfies
+      // the line above while still persisting the port for real.
       expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(
         false
       );

--- a/packages/tool-server/test/boot-electron-ready-race.test.ts
+++ b/packages/tool-server/test/boot-electron-ready-race.test.ts
@@ -177,7 +177,8 @@ describe("bootElectronApp — ready-vs-exit confirmation window", () => {
       expect(result.pid).toBe(FAKE_PID);
       expect(trackChromiumPort).toHaveBeenCalledWith(port);
       // ...through the mock, and no further. A mock that calls through still
-      // satisfies the line above while persisting the port for real.
+      // satisfies the line above while really persisting the port, which the
+      // scoped HOME then contains.
       expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(
         false
       );

--- a/packages/tool-server/test/boot-electron-spawn-error.test.ts
+++ b/packages/tool-server/test/boot-electron-spawn-error.test.ts
@@ -16,6 +16,8 @@ import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { FAILURE_CODES, getFailureSignal } from "@argent/registry";
+import { scopeTempHome } from "./helpers/temp-home";
 
 /**
  * CDP port for the boots below, which must never reach a live endpoint: when
@@ -52,7 +54,6 @@ vi.mock("../src/utils/chromium-discovery", () => ({
 }));
 
 import { bootElectronApp } from "../src/tools/devices/boot-electron";
-import { trackChromiumPort } from "../src/utils/chromium-discovery";
 
 interface FakeChild extends EventEmitter {
   pid: number | undefined;
@@ -73,6 +74,8 @@ function makeFakeChild(opts: { pid?: number | undefined } = {}): FakeChild {
   ee.signalCode = null;
   return ee;
 }
+
+scopeTempHome("argent-boot-electron-home-");
 
 let appDir: string;
 beforeAll(() => {
@@ -296,10 +299,14 @@ describe("bootElectronApp — spawn error handling", () => {
         readyTimeoutMs: 5000,
       });
 
-      // A successful boot persists its port for later discovery. Asserting it
-      // pins the module mock above, whose absence would send that write to the
-      // developer's real ~/.argent/chromium-cdp-ports.json.
-      expect(trackChromiumPort).toHaveBeenCalledWith(realPort);
+      // A completed boot persists its port, and nothing here may let that
+      // reach the developer's real ~/.argent/chromium-cdp-ports.json. The
+      // module mock above is what holds it back; assert the absence, so a mock
+      // that stops intercepting fails here rather than silently appending an
+      // ephemeral port on every run.
+      expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(
+        false
+      );
 
       // After successful boot, both boot-time listeners MUST be detached.
       // Exactly one 'exit' listener remains: the kill-registry cleanup hook
@@ -344,17 +351,19 @@ describe("bootElectronApp — spawn error handling", () => {
     process.on("unhandledRejection", onUnhandled);
 
     try {
-      // No HTTP server on the port → waitForCdpReady times out fast, taking
-      // the catch path. earlyExit / spawnError aren't fired by us. Match the
-      // timeout message: a failure raised before spawn attaches no boot
-      // listener, so the assertions below would pass vacuously.
-      await expect(
-        bootElectronApp({
+      // The readiness probe cannot be answered, so waitForCdpReady exhausts
+      // readyTimeoutMs and the boot takes the catch path. earlyExit /
+      // spawnError aren't fired by us. Pin the failure code: a failure raised
+      // before spawn attaches no boot listener, so the assertions below would
+      // pass vacuously.
+      const signal = getFailureSignal(
+        await bootElectronApp({
           appPath: appDir,
           port: UNREACHABLE_CDP_PORT,
           readyTimeoutMs: 100,
-        })
-      ).rejects.toThrow(/CDP never became reachable/);
+        }).catch((e: unknown) => e)
+      );
+      expect(signal?.error_code).toBe(FAILURE_CODES.CHROMIUM_ELECTRON_CDP_TIMEOUT);
 
       // Both listeners must be detached in the catch path.
       expect(child.listenerCount("error")).toBe(0);

--- a/packages/tool-server/test/boot-electron-spawn-error.test.ts
+++ b/packages/tool-server/test/boot-electron-spawn-error.test.ts
@@ -299,12 +299,10 @@ describe("bootElectronApp — spawn error handling", () => {
         readyTimeoutMs: 5000,
       });
 
-      // A completed boot persists its port, and nothing here may let that
-      // reach the developer's real ~/.argent/chromium-cdp-ports.json. Two
-      // things hold it back: the module mock above, and the scoped HOME that
-      // keeps this check about this run's writes rather than a file the
-      // developer already had. Assert the absence, so a mock that stops
-      // intercepting fails here instead of silently appending a port per run.
+      // A completed boot persists its port. Two guards keep it out of the
+      // developer's real ~/.argent/chromium-cdp-ports.json — the mock above,
+      // and the scoped HOME that makes this about the run's own writes — and
+      // asserting the absence is what fails when either stops working.
       expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(
         false
       );
@@ -353,10 +351,9 @@ describe("bootElectronApp — spawn error handling", () => {
 
     try {
       // The readiness probe cannot be answered, so waitForCdpReady exhausts
-      // readyTimeoutMs and the boot takes the catch path. earlyExit /
-      // spawnError aren't fired by us. Pin the failure code: a failure raised
-      // before spawn attaches no boot listener, so the assertions below would
-      // pass vacuously.
+      // readyTimeoutMs and the boot takes the catch path; earlyExit and
+      // spawnError aren't fired by us. Pin the code: a failure raised before
+      // spawn attaches no listener, so the assertions below go vacuous.
       const signal = getFailureSignal(
         await bootElectronApp({
           appPath: appDir,

--- a/packages/tool-server/test/boot-electron-spawn-error.test.ts
+++ b/packages/tool-server/test/boot-electron-spawn-error.test.ts
@@ -300,10 +300,11 @@ describe("bootElectronApp — spawn error handling", () => {
       });
 
       // A completed boot persists its port, and nothing here may let that
-      // reach the developer's real ~/.argent/chromium-cdp-ports.json. The
-      // module mock above is what holds it back; assert the absence, so a mock
-      // that stops intercepting fails here rather than silently appending an
-      // ephemeral port on every run.
+      // reach the developer's real ~/.argent/chromium-cdp-ports.json. Two
+      // things hold it back: the module mock above, and the scoped HOME that
+      // keeps this check about this run's writes rather than a file the
+      // developer already had. Assert the absence, so a mock that stops
+      // intercepting fails here instead of silently appending a port per run.
       expect(fs.existsSync(path.join(os.homedir(), ".argent", "chromium-cdp-ports.json"))).toBe(
         false
       );
@@ -364,6 +365,7 @@ describe("bootElectronApp — spawn error handling", () => {
         }).catch((e: unknown) => e)
       );
       expect(signal?.error_code).toBe(FAILURE_CODES.CHROMIUM_ELECTRON_CDP_TIMEOUT);
+      expect(signal?.failure_stage).toBe("electron_cdp_ready");
 
       // Both listeners must be detached in the catch path.
       expect(child.listenerCount("error")).toBe(0);

--- a/packages/tool-server/test/chromium-discovery.test.ts
+++ b/packages/tool-server/test/chromium-discovery.test.ts
@@ -75,9 +75,9 @@ async function startFakeCdpServer(options?: {
 /**
  * A port whose probe can never be answered: Node's fetch refuses port 1 as a
  * WHATWG "bad port" before it opens a socket, so no listener can satisfy it.
- * A port from the kernel's ephemeral range can be — `listen(0)`, here and in
- * sibling test files, hands out exactly those, and the fake CDP server above
- * serves the very /json responses a probe accepts.
+ * A port from the kernel's ephemeral range can be: that is what `listen(0)`
+ * hands out, and the fake CDP server above answers the very /json requests a
+ * probe makes.
  */
 const UNREACHABLE_PORT = 1;
 

--- a/packages/tool-server/test/chromium-discovery.test.ts
+++ b/packages/tool-server/test/chromium-discovery.test.ts
@@ -73,9 +73,10 @@ async function startFakeCdpServer(options?: {
 
 /**
  * A port whose probe can never be answered: Node's fetch refuses port 1 as a
- * WHATWG "bad port" before it opens a socket. Anything in the unprivileged
- * range is bindable — a `listen(0)` fake CDP server in a sibling test file
- * serves the very /json responses that would make a probe here succeed.
+ * WHATWG "bad port" before it opens a socket, so no listener can satisfy it.
+ * A port from the kernel's ephemeral range can be — `listen(0)`, here and in
+ * sibling test files, hands out exactly those, and the fake CDP server below
+ * serves the very /json responses a probe accepts.
  */
 const UNREACHABLE_PORT = 1;
 

--- a/packages/tool-server/test/chromium-discovery.test.ts
+++ b/packages/tool-server/test/chromium-discovery.test.ts
@@ -75,7 +75,7 @@ async function startFakeCdpServer(options?: {
  * A port whose probe can never be answered: Node's fetch refuses port 1 as a
  * WHATWG "bad port" before it opens a socket, so no listener can satisfy it.
  * A port from the kernel's ephemeral range can be — `listen(0)`, here and in
- * sibling test files, hands out exactly those, and the fake CDP server below
+ * sibling test files, hands out exactly those, and the fake CDP server above
  * serves the very /json responses a probe accepts.
  */
 const UNREACHABLE_PORT = 1;

--- a/packages/tool-server/test/chromium-discovery.test.ts
+++ b/packages/tool-server/test/chromium-discovery.test.ts
@@ -4,6 +4,7 @@ import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AddressInfo } from "node:net";
+import { scopeTempHome } from "./helpers/temp-home";
 import {
   discoverChromiumDevices,
   getCandidateChromiumPorts,
@@ -85,6 +86,11 @@ const serversToCleanup: FakeCdpServer[] = [];
 
 // Redirect port persistence to a throwaway file so tests never touch the
 // real ~/.argent/chromium-cdp-ports.json on a developer machine or CI runner.
+// This file drives the real persistPorts, which merges rather than replaces, so
+// a lapsed redirect would leave test ports in that file for list-devices to
+// probe. Scope HOME too: the fallback path then lands somewhere disposable.
+scopeTempHome("argent-chromium-discovery-home-");
+
 const TEST_PORTS_FILE = path.join(os.tmpdir(), `argent-test-chromium-ports-${process.pid}.json`);
 
 beforeAll(() => {


### PR DESCRIPTION
Follow-up to #709, which merged while this was still under review. #709 landed the port fix; these are the two gaps a review pass over it turned up, both in the same two files.

## The ports-file guard was pinned by nothing

#714 added `vi.mock("../src/utils/chromium-discovery", …)` to `boot-electron-spawn-error.test.ts` so a completed boot stops persisting its port into the developer's real `~/.argent/chromium-cdp-ports.json`. Nothing asserted it still worked.

Measured, on the pre-change file: deleting the mock leaves the suite **green at 9/9** while `$HOME/.argent/chromium-cdp-ports.json` is created containing a live ephemeral port. Replacing it with a call-through variant — the shape `list-devices.test.ts:76-81` already uses on this same module — does the same:

```ts
vi.mock("../src/utils/chromium-discovery", async () => {
  const actual = await vi.importActual<...>("../src/utils/chromium-discovery");
  return { ...actual,
    trackChromiumPort: vi.fn(actual.trackChromiumPort),
    untrackChromiumPort: vi.fn(actual.untrackChromiumPort) };
});
```
→ `Tests 9 passed (9)`, and the ports file contains `[55770]`.

That is how the file accumulated entries before #714, so the guard rotting back is not hypothetical. Each file now scopes `HOME` with #714's own `scopeTempHome()` helper and asserts, after a completed boot, that no ports file exists. Both mutations now fail.

**All three files that carry this mock are fixed, not just the one.** `boot-electron-kill.test.ts` and `boot-electron-ready-race.test.ts` hold the byte-identical mock — under a comment naming each other — and each completes a real boot. Measured before this change: deleting the mock left `kill` green at **15/15** while eleven live ports, one per boot, were written; the call-through variant did the same to `ready-race` **while still satisfying its own `expect(trackChromiumPort).toHaveBeenCalledWith(port)` at line 175**, which is precisely why the absence assertion is the right shape.

Asserting the absence rather than `expect(trackChromiumPort).toHaveBeenCalledWith(port)` is deliberate: the call is already pinned by `boot-electron-ready-race.test.ts:175`, and a spy assertion only proves the export *is* a spy — the call-through mutation satisfies it while still writing.

## The readiness timeout was pinned by its wording, not its code

The catch-path test matched `/CDP never became reachable/`. `FAILURE_CODES.CHROMIUM_ELECTRON_CDP_TIMEOUT` had **no assertion anywhere in the repo** — `grep -rn CHROMIUM_ELECTRON_CDP_TIMEOUT packages/ --include=*.ts` outside `dist/` hits only the throw site and the enum. Swapping the throw site to `CHROMIUM_ELECTRON_SPAWN_FAILED` left `boot-electron-spawn-error` + `-kill` + `-ready-race` + `failure-classification` + `chromium-discovery` at **60/60 passed**.

So the half agents and telemetry bucket on was free to change, while a harmless reword would have broken the test. Now pinned by code via `getFailureSignal`, matching how `boot-electron-ready-race.test.ts:137` pins its own failure path. It still discriminates the vacuity the message match was added for: a nonexistent `appPath` yields `CHROMIUM_ELECTRON_APP_PATH_INVALID` and fails. `failure_stage` is pinned alongside it, as `ready-race` already does for its own path — `electron_cdp_ready` likewise had no assertion anywhere.

## Two rationales corrected

- The catch-path comment blamed "no HTTP server on the port" for the probe failing. `fetch` declines port 1 as a WHATWG bad port *before it dials* — verified with `net.connect` hooked: **0 sockets opened** for port 1, 2 sockets for ports 2, 1023 and 19222. No listener is involved either way, and the file's own constant JSDoc says so.
- The `chromium-discovery.test.ts` constant pointed at "a `listen(0)` fake CDP server **in a sibling test file**", when the server that makes the point is `startFakeCdpServer` in this same file, above the constant.
- It also credited "anything in the unprivileged range" with being bindable by `listen(0)`. `listen(0)` draws from the kernel's *ephemeral* range — `net.inet.ip.portrange` 49152-65535 on macOS, `ip_local_port_range` 32768-60999 on the Ubuntu runner. That narrower range is what put the old `43211` at risk; calling it "unprivileged" also revives the privilege reasoning the sibling constant explicitly disowns.

## `chromium-discovery.test.ts` gets a second layer too

It is the one file here that drives the **real** `persistPorts`, and its only guard was a single `beforeAll` line setting `ARGENT_CHROMIUM_PORTS_FILE`. That line is pinned — deleting it fails 3 tests — but the write lands before the detection, and `persistPorts` merges rather than replaces, so on a real machine the test ports would be appended for `list-devices` to probe afterwards. It now scopes `HOME` as well, so a lapsed redirect falls back somewhere disposable. Measured with a pre-seeded `$HOME/.argent/chromium-cdp-ports.json` = `[9222]`: deleting the redirect still fails 3 tests, and the seeded file comes back **unchanged**.

## Verification

| mutation | before | after |
|---|---|---|
| delete the module mock | 9/9 pass, ports file written | fails |
| call-through `vi.fn(actual.trackChromiumPort)` | 9/9 pass, ports file written | fails |
| swap `CHROMIUM_ELECTRON_CDP_TIMEOUT` at the throw site | 60/60 pass | fails |
| nonexistent `appPath` in the catch-path test | — | fails (`APP_PATH_INVALID`) |
| swap `failure_stage` at the throw site | — | fails |
| delete / call-through mock in `boot-electron-kill` | 15/15 pass, 11 ports written | 11 failed \| 4 passed |
| call-through mock in `boot-electron-ready-race` | 2/2 pass | 1 failed \| 1 passed |

Full `packages/tool-server` in 6 shards: 4303 passed, 1 skipped, every shard exit 0, and no `.argent` directory created under a redirected `HOME`. `eslint` 0, `prettier --check` 0, `tsc --build` 0, `tsc -p tsconfig.test.json` 0, `knip` 0 — exit codes read directly.
