### PR TITLE
fix(describe): name the reboot's cost in the standing degraded caveat

### DIFF
--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -38,7 +38,8 @@ const DEGRADED_BLIND_HINT =
 const DEGRADED_STANDING_HINT =
   "This simulator was not booted through argent, so system dialogs and native modals may not appear " +
   "in this tree; everything else reads normally. If something you expect is missing, boot-device with " +
-  "force=true reboots the simulator with the full accessibility settings";
+  "force=true reboots the simulator with the full accessibility settings — at the cost of restarting " +
+  "it and everything running on it";
 
 // Devices already told DEGRADED_STANDING_HINT. Bounded by the number of
 // simulators driven in one server lifetime, and not cleared on shutdown or


### PR DESCRIPTION
Fixes #871. `main` is currently red, and every PR opened against it inherits the failure in its merge ref.

## What broke

`DEGRADED_STANDING_HINT` lost its closing clause in a late wording trim on #583, between that PR's last green CI run (`6e08aa4f`, 2026-08-17) and the merge commit (`6d31aed75`):

```diff
- "force=true reboots the simulator with the full accessibility settings — at the cost of restarting "
- "it and everything running on it.";
+ "force=true reboots the simulator with the full accessibility settings";
```

`describe-tool.test.ts:793` asserts the caveat still names what the remedy costs:

```ts
// It still names the remedy and what the remedy costs.
expect(result.hint).toMatch(/boot-device/);
expect(result.hint).toMatch(/restart/i);
```

"restart" survived only inside the removed clause, so the trim — not the test — is what moved. Those assertions are unchanged since the green run.

The failing case (`describe-tool.test.ts:765`, "states the limitation without ordering a reboot when the degraded read returned a tree") feeds a degraded read that returned one element, so `tree.children.length > 0` selects `DEGRADED_STANDING_HINT` rather than `DEGRADED_BLIND_HINT`. Only the blind hint still contains "restart".

## Why restore rather than drop the assertion

`DEGRADED_BLIND_HINT` still ends `"— this restarts the simulator"`. Both caveats point the agent at the same `boot-device force=true` remedy, and after the trim only one of them said that the remedy restarts the simulator and everything running on it. Restoring the clause puts the pair back in symmetry and keeps the contract the test's own comment states.

The change is confined to the string; the softening #583 set out to do — no MUST, no "now", no "before continuing" — is untouched, and the three assertions guarding that (`:789-791`) still pass.

## Verification

Reproduced on a pristine `origin/main` worktree, no PR branch involved:

```
$ git worktree add --detach ../argent-worktrees/main-ci-check origin/main
$ cd packages/tool-server && npx vitest run test/describe-tool.test.ts
AssertionError: expected 'This simulator was not booted through…' to match /restart/i
 ❯ test/describe-tool.test.ts:793:25
 Test Files  1 failed (1)
      Tests  1 failed | 36 passed (37)
```

After this change, in the same file:

```
 Test Files  1 passed (1)
      Tests  37 passed (37)
```

Not order-dependent — it fails alone and alongside its sibling describe suites; the module-level `bootCaveatToldDevices` set is cleared by `__resetBootCaveatStateForTests()` in `beforeEach`.
