### PR TITLE
fix(describe): drop the redundant restart assertion that reddened main

### DIFF
--- a/packages/tool-server/test/describe-tool.test.ts
+++ b/packages/tool-server/test/describe-tool.test.ts
@@ -788,9 +788,8 @@ describe("describe tool", () => {
     expect(result.hint).not.toMatch(/MUST/);
     expect(result.hint).not.toMatch(/\bnow\b/i);
     expect(result.hint).not.toMatch(/before continuing/i);
-    // It still names the remedy and what the remedy costs.
+    // It still names the remedy.
     expect(result.hint).toMatch(/boot-device/);
-    expect(result.hint).toMatch(/restart/i);
   });
 
   it("emits the degraded caveat once per device, not on every describe", async () => {


### PR DESCRIPTION
Fixes #871. Supersedes #872, which fixed this the wrong way round.

## The assertion was demanding a restatement

`describe-tool.test.ts:793` asserted:

```ts
// It still names the remedy and what the remedy costs.
expect(result.hint).toMatch(/boot-device/);
expect(result.hint).toMatch(/restart/i);
```

against `DEGRADED_STANDING_HINT`, which reads:

> …If something you expect is missing, **boot-device with force=true reboots the simulator** with the full accessibility settings

"reboots the simulator" is already there. So `/restart/i` could only ever be satisfied by a *second* clause restating the reboot — and that is precisely what #583 carried:

```
… with the full accessibility settings — at the cost of restarting it and everything running on it.
```

A review suggestion applied through the GitHub web editor trimmed that clause (`dd99a2625`, `07f39cea8`) at 07:41:49Z and 07:41:57Z. The squash-merge fired at **07:42:23Z** — 34 seconds later, so no CI ran on that head. The trim was right: it removed eight words that said the same thing twice. The test was what was wrong.

#872 restored the redundant clause to turn CI green. This deletes the assertion instead, and leaves the shipped hint byte-for-byte as it is on main today.

## No coverage leaves with it

The four remaining assertions are the ones that carry the test's purpose — #583 existed to stop the caveat *ordering* a reboot that kills the developer's Metro session:

```ts
expect(result.hint).not.toMatch(/MUST/);
expect(result.hint).not.toMatch(/\bnow\b/i);
expect(result.hint).not.toMatch(/before continuing/i);
expect(result.hint).toMatch(/boot-device/);
```

Mutation-checked. Restoring the pre-#583 wording — `"You MUST call boot-device with force=true now to restart the simulator … before continuing."` — fails the test on the first assertion:

```
× states the limitation without ordering a reboot when the degraded read returned a tree
AssertionError: expected 'This simulator was not booted through…' not to match /MUST/
 Test Files  1 failed (1) | Tests  1 failed | 36 passed (37)
```

So the regression the test guards is still guarded. The deleted line was pinning a redundancy, not a behaviour.

## Verification

Branched off `dd5d82383` (current main). Reproduced the failure there first — `1 failed | 36 passed` on the untouched tree.

| gate | result |
|---|---|
| `vitest run` (tool-server) | **351 files, 4313 passed, 1 skipped**, exit 0 |
| `tsc --build` | clean |
| `typecheck:tests --workspaces` | clean |
| `eslint . --max-warnings 0` | clean |
| `prettier --check` | clean |

Diff is one test file, one assertion and half a comment:

```diff
-    // It still names the remedy and what the remedy costs.
+    // It still names the remedy.
     expect(result.hint).toMatch(/boot-device/);
-    expect(result.hint).toMatch(/restart/i);
```

The comment loses "and what the remedy costs" because that half described the assertion being removed.