### PR TITLE
test(run-sequence): pin the one observation a sequence returns

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  profile: assertive

--- a/packages/argent-mcp/test/content.test.ts
+++ b/packages/argent-mcp/test/content.test.ts
@@ -255,6 +255,31 @@ describe("toMcpContent with artifact ctx", () => {
     expect((result[1] as { text: string }).text).toMatch(/^Saved: .*shot\.png$/);
   });
 
+  // The renderer's half of the one-observation guarantee; the allow-list half
+  // is tool-server's run-sequence-observation-gate.test.ts. The result is
+  // walked whole, steps included, and every artifact handle found becomes its
+  // own image block — so a sequence holds at one frame only while its steps
+  // report none.
+  it("renders a multi-step sequence result without a frame of its own", async () => {
+    const result = await toMcpContent(
+      {
+        completed: 3,
+        total: 3,
+        steps: [
+          { tool: "gesture-swipe", result: { swiped: true, timestampMs: 1 } },
+          { tool: "keyboard", result: { typed: "hello", keys: 0 } },
+          { tool: "gesture-tap", result: { tapped: true, timestampMs: 2 } },
+        ],
+      },
+      undefined,
+      { toolsUrl: "http://remote:3001", deviceId: "DEV-1" }
+    );
+
+    expect(result.filter((b) => b.type === "image")).toEqual([]);
+    expect(result).toHaveLength(1);
+    expect((result[0] as { text: string }).text).toContain("gesture-tap");
+  });
+
   it("rewrites non-image artifacts to local paths inside the JSON result", async () => {
     const result = await toMcpContent(
       { exportedFiles: { cpu: artifactHandle("cpu1", "cpu.xml", "application/xml") } },

--- a/packages/argent-mcp/test/content.test.ts
+++ b/packages/argent-mcp/test/content.test.ts
@@ -261,6 +261,11 @@ describe("toMcpContent with artifact ctx", () => {
   // own image block — so a sequence holds at one frame only while its steps
   // report none.
   it("renders a multi-step sequence result without a frame of its own", async () => {
+    // A fetch that resolves. Left to the global one, a step-carried handle
+    // would fail to download and be swallowed, so the assertions below would
+    // hold just as well for a sequence whose frames were merely unreachable.
+    const fetchImpl = vi.fn(fetchReturning([...PNG_SIGNATURE, 0x42]));
+
     const result = await toMcpContent(
       {
         completed: 3,
@@ -272,12 +277,34 @@ describe("toMcpContent with artifact ctx", () => {
         ],
       },
       undefined,
-      { toolsUrl: "http://remote:3001", deviceId: "DEV-1" }
+      { toolsUrl: "http://remote:3001", deviceId: "DEV-1", fetchImpl }
     );
 
+    expect(fetchImpl).not.toHaveBeenCalled();
     expect(result.filter((b) => b.type === "image")).toEqual([]);
     expect(result).toHaveLength(1);
     expect((result[0] as { text: string }).text).toContain("gesture-tap");
+  });
+
+  it("materializes an artifact handle carried on a step result", async () => {
+    // Keeps the pin above honest: the walk really does reach steps[].result,
+    // so a step tool that returned a frame would be inlined mid-sequence.
+    const pngBytes = [...PNG_SIGNATURE, 0x42];
+    const result = await toMcpContent(
+      {
+        completed: 1,
+        total: 1,
+        steps: [
+          { tool: "gesture-tap", result: { image: artifactHandle("s0", "shot.png", "image/png") } },
+        ],
+      },
+      undefined,
+      { toolsUrl: "http://remote:3001", deviceId: "DEV-1", fetchImpl: fetchReturning(pngBytes) }
+    );
+
+    expect(result.filter((b) => b.type === "image")).toEqual([
+      { type: "image", data: Buffer.from(pngBytes).toString("base64"), mimeType: "image/png" },
+    ]);
   });
 
   it("rewrites non-image artifacts to local paths inside the JSON result", async () => {

--- a/packages/tool-server/src/tools/run-sequence/index.ts
+++ b/packages/tool-server/src/tools/run-sequence/index.ts
@@ -6,7 +6,10 @@ import { sleepOrAbort, DEFAULT_INTER_STEP_DELAY_MS } from "../../utils/timing";
 import { invokeSubTool } from "../../utils/sub-invoke";
 import { AWAIT_UI_ELEMENT_TOOL_ID, isUnmetUiWaitResult } from "../await-ui-element";
 
-const ALLOWED_TOOLS = new Set([
+// No tool here returns an image or an artifact handle — that is what keeps a
+// sequence to the single capture the MCP layer appends after the last step.
+// Gated by test/run-sequence-observation-gate.test.ts.
+export const ALLOWED_TOOLS = new Set([
   "gesture-tap",
   "gesture-swipe",
   "gesture-scroll",

--- a/packages/tool-server/test/run-sequence-observation-gate.test.ts
+++ b/packages/tool-server/test/run-sequence-observation-gate.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Gate on the guarantee run-sequence advertises to agents: "One screenshot is
+ * captured automatically after the whole sequence (not per step)".
+ *
+ * Nothing in run-sequence enforces it. The capture is appended once, by the MCP
+ * layer, because `run-sequence` is in that layer's AUTO_SCREENSHOT_TOOLS
+ * (pinned in argent-mcp's auto-screenshot test). The steps stay silent only
+ * because no tool the allow-list admits returns an image or an artifact handle.
+ *
+ * A step that returned one would be inlined: the sequence result reaches
+ * `toMcpContent` whole, and its `materializeArtifacts` walk collects handles
+ * from anywhere inside it — `steps[].result` included — appending one image
+ * block per handle. That walk recurses into arrays with `Promise.all`, so those
+ * frames arrive in completion order rather than step order, leaving the agent
+ * unable to tell which is the screen the sequence ended on. Hence the gate sits
+ * on the allow-list: such a tool has to be caught before it can be a step.
+ */
+import { describe, it, expect } from "vitest";
+import { ALLOWED_TOOLS } from "../src/tools/run-sequence";
+import { createRegistry } from "../src/utils/setup-registry";
+
+// Spelled out rather than counted: adding an entry means answering the question
+// this file exists to ask — does that tool put a frame of its own in front of
+// the agent?
+const EXPECTED_ALLOWED_TOOLS = [
+  "await-ui-element",
+  "button",
+  "gesture-custom",
+  "gesture-drag",
+  "gesture-pinch",
+  "gesture-rotate",
+  "gesture-scroll",
+  "gesture-swipe",
+  "gesture-tap",
+  "keyboard",
+  "paste",
+  "rotate",
+  "shake",
+  "tv-remote",
+];
+
+describe("run-sequence — one observation per sequence", () => {
+  it("admits exactly the reviewed set of step tools", () => {
+    expect([...ALLOWED_TOOLS].sort()).toEqual(EXPECTED_ALLOWED_TOOLS);
+  });
+
+  it("names only tools that are actually registered", () => {
+    const registry = createRegistry();
+    for (const id of ALLOWED_TOOLS) {
+      // A name the registry no longer answers to still reads as allowed, and
+      // the description still advertises it, but every step naming it dies on
+      // ToolNotFoundError and halts the sequence. It also leaves the check
+      // below no definition to inspect.
+      expect(
+        registry.getTool(id),
+        `${id} is allowed in run-sequence but not registered`
+      ).toBeDefined();
+    }
+  });
+
+  it("admits no tool that renders as a frame of its own", () => {
+    const registry = createRegistry();
+    for (const id of ALLOWED_TOOLS) {
+      // `outputHint: "image"` declares a result that IS a picture — screenshot
+      // alone today. Such a tool also hands back the artifact behind it, so
+      // admitting one puts a mid-sequence frame in front of the agent.
+      expect(registry.getTool(id)?.outputHint, `${id}.outputHint`).not.toBe("image");
+    }
+  });
+});


### PR DESCRIPTION
## What

`run-sequence` tells agents:

> One screenshot is captured automatically after the whole sequence (not per step)

The MCP-side half of that promise is already pinned — argent-mcp's auto-screenshot tests name `run-sequence` explicitly, twice. The tool-server half is pinned by nothing: this adds the gate that pins it, plus the renderer-side pin in argent-mcp. **No behavior change.**

## Why it is unpinned

The steps stay silent only because no tool `ALLOWED_TOOLS` admits returns an image or an artifact handle. Nothing checks:

- which tools the allow-list admits,
- that every admitted name still resolves to a registered tool (a stale name still reads as allowed and stays advertised in the description, but every step naming it dies on `ToolNotFoundError` and halts the sequence),
- that none of them declares `outputHint: "image"`.

Admitting a frame-producing tool would go unnoticed: a sequence result reaches `toMcpContent` whole, and its `materializeArtifacts` walk collects handles from anywhere inside it, `steps[].result` included, appending one image block per handle. That walk recurses into arrays with `Promise.all`, so those frames arrive in **completion order, not step order** — the agent could not even tell which one is the screen the sequence ended on.

Both halves are verified against the code, not assumed:

- Putting an artifact handle in one step's result makes `toMcpContent` emit an image block for it, confirming the walk reaches `steps[].result`.
- Materializing three step handles whose fetches complete fastest-last yields `[s2, s1, s0]` — exactly reversed from step order.

## What is gated

**tool-server** — `test/run-sequence-observation-gate.test.ts`, against the real registry (`createRegistry()`, no device). `ALLOWED_TOOLS` is exported for it:

- the allow-list admits exactly the reviewed set of 14 step tools
- every name still resolves to a registered tool
- none of them declares `outputHint: "image"`

**argent-mcp** — `test/content.test.ts`:

- a multi-step sequence result renders with no frame of its own, against a `fetchImpl` that resolves and is asserted never to be called (without a resolving fetch the assertion would hold equally for a sequence whose step frames merely failed to download, since `materializeArtifacts` swallows a failed download and renders the handle as nothing)
- the positive control that pin rests on: a handle on `steps[].result` does surface as an image block, so the walk ceasing to reach steps cannot turn the pin vacuous

The membership of `run-sequence` in `AUTO_SCREENSHOT_TOOLS` was already pinned by existing assertions and needed no new test.

## Verification

Every test was mutation-checked — each fails on the broken code, not just passes on the good:

| Mutation | Fails |
| --- | --- |
| add `screenshot` to `ALLOWED_TOOLS` | reviewed-set + `outputHint` checks |
| rename an allow-list entry the registry lost | reviewed-set + registration checks |
| give a step result an image artifact handle | the frameless-sequence check, on both its fetch-call and its image-block assertion |
| stop `materializeArtifacts` recursing into arrays | the step-carried-handle check, and nothing else in the file |

Locally green: `prettier --check`, `tsc --build`, `typecheck:tests` for both touched packages, the full argent-mcp suite (82 tests), and the gate test (3 tests).

## Scope note

The allow-list is spelled out rather than counted, so adding a step tool means answering the question the file exists to ask — does it put a frame of its own in front of the agent? The gate deliberately sits on the allow-list rather than on the renderer: a tool that would break the guarantee is caught before it can be dispatched as a step, rather than having its frames filtered afterwards.

