### PR TITLE
chore(docs): add Google Search Console verification meta tag

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -38,6 +38,16 @@ const config = {
     locales: ["en"],
   },
 
+  headTags: [
+    {
+      tagName: "meta",
+      attributes: {
+        name: "google-site-verification",
+        content: "U0xic78Z5DjD9r0wrxOYQrLZPuSF_DZidnZeXPR4D0k",
+      },
+    },
+  ],
+
   stylesheets: [
     "https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&display=swap",
   ],


### PR DESCRIPTION
Adds the `google-site-verification` meta tag to the docs site via Docusaurus `headTags`, so docs.swmansion.com/argent can be verified as a property in Google Search Console.

## Test plan

- `npx docusaurus build` in `packages/docs/`, confirm the meta tag renders in the built HTML `<head>`.
- After deploy, hit Verify in Google Search Console.

No further docs update needed: this is a site config change with no user facing capability change.