### PR TITLE
feat(flows): record a script step by running it

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -101,9 +101,8 @@ Run a YAML flow without an LLM in the loop. \`run\` takes any of these forms:
 For a name and for a file path alike, the
 filename (minus .yaml) names the run's report and artifacts, so it must
 contain only letters, numbers, "_", or "-" — the same charset a name must
-match. A flow that begins with a \`launch\` step runs its app from scratch; any
-other flow (a fragment) runs against the device's current state — handy while
-authoring one. Exception: a fragment whose first step \`run:\`s a chromium e2e
+match. A flow is e2e when its first non-\`echo\`/\`script\` step is \`launch\`.
+Other flows are fragments and use the device's current state. Exception: a fragment whose first step \`run:\`s a chromium e2e
 flow boots that flow's app before step 1 — when that launch is unambiguously
 chromium (a lone \`{ chromium: ... }\` target, or --platform chromium); a
 multi-platform launch auto-detects a device instead. Pass --device to attach to

--- a/packages/docs/docs/features/flows.mdx
+++ b/packages/docs/docs/features/flows.mdx
@@ -38,14 +38,16 @@ Argent stores each flow as a YAML file in the `.argent/flows/` directory of the 
 
 A flow has one of two shapes:
 
-| Shape           | First step          | Start state                                         |
-| --------------- | ------------------- | --------------------------------------------------- |
-| End-to-end flow | A launch of the app | Argent starts the app from scratch                  |
-| Fragment        | Any other step      | The app is already in the state that the flow needs |
+| Shape           | First app step | Start state                                         |
+| --------------- | -------------- | --------------------------------------------------- |
+| End-to-end flow | Launch         | Argent starts the app from scratch                  |
+| Fragment        | Any other step | The app is already in the state that the flow needs |
 
 A fragment declares its start state in a prerequisite. The prerequisite is a sentence, for example "The Settings screen is open". Before a replay, the agent reads the prerequisite and puts the app into that state.
 
 A flow can contain more than taps and text. A step can wait for an element, wait for the screen to settle, check a condition, take a screenshot and compare it to a baseline, run a different flow, or run a local script. See [Baselines in flows](/docs/features/visual-regression#baselines-in-flows) for the screenshot comparison.
+
+Use a local script for setup or cleanup that device steps cannot do. Ask the agent to add the script at the required point in the flow.
 
 The file is plain text. You can commit the file, review the file in a pull request and edit a step by hand.
 
@@ -61,6 +63,7 @@ A flow also runs without an agent. The `argent flow run` command replays a flow 
 - "Run the checkout flow and tell me which step fails."
 - "Run the login flow on the iOS simulator and on the Android emulator. Compare the results."
 - "Add a label before each screen change in the onboarding flow."
+- "Record the checkout flow. Before the app starts, seed the cart with `scripts/seed-cart.mjs`."
 - "Profile the app while you run the search flow. Then apply my fix and run the flow again."
 
 ## Limits
@@ -71,4 +74,4 @@ A flow also runs without an agent. The `argent flow run` command replays a flow 
 - The agent records a launch step for iOS, Android and Vega apps. For a Chromium or Electron app, add the launch step to the file by hand.
 - A replay needs the same connected instrumentation as the recording. When the agent cannot read the UI tree, a step that still uses coordinates sends the tap anyway and adds a warning. A step that uses a stable identifier fails instead, because it has no coordinates to fall back on.
 
-Argent does this with the `flow-start-recording`, `flow-add-step`, `flow-add-echo`, `flow-finish-recording`, `flow-read-prerequisite` and `flow-execute` tools, and with the `argent flow` command. The [tools reference](/docs/reference/tools) contains all tools. The [Flow YAML reference](/docs/reference/flow-yaml) contains the file format and the command options.
+Argent does this with the `flow-start-recording`, `flow-add-step`, `flow-add-echo`, `flow-add-script`, `flow-finish-recording`, `flow-read-prerequisite` and `flow-execute` tools, and with the `argent flow` command. The [tools reference](/docs/reference/tools) contains all tools. The [Flow YAML reference](/docs/reference/flow-yaml) contains the file format and the command options.

--- a/packages/docs/docs/reference/flow-yaml.mdx
+++ b/packages/docs/docs/reference/flow-yaml.mdx
@@ -272,16 +272,16 @@ Use a snapshot for layout, color, spacing, typography, clipping and icons. Do no
 - script: { path: ../../scripts/seed-order.mjs, timeout: 60000 }
 ```
 
-A `script` step runs a local `.mjs` file in a new Node process. Use a script for work that no device step does: a call to an API, a database seed, or a cleanup after the run.
+Use a `script` step for setup or cleanup that device steps cannot do. The script must be a local `.mjs` file.
 
 A `script` step needs no device. A flow of script steps alone runs with no simulator, emulator or browser, and the report names no device. A `run` step or a `when` step beside it makes the flow resolve one again, so a script inside a `when: { platform: ios }` block needs a booted iOS device.
 
 The value is always a map. Parsing rejects a bare `script: scripts/seed.mjs`.
 
-| Key       | Required | Description                                                                                                                |
-| --------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `path`    | yes      | A file with a lowercase `.mjs` suffix. The path resolves as a `run` path does. The letter case must match the file on disk |
-| `timeout` | no       | The limit of the step in milliseconds. The minimum is 100, and the default is 30000                                        |
+| Key       | Required | Description                                                                                                                        |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `path`    | yes      | An `.mjs` file, relative to the flow file that holds the step. Write the extension in lowercase, and match the letter case on disk |
+| `timeout` | no       | The time limit of the step in milliseconds. The minimum is 100, and the default is 30000                                           |
 
 Argent runs the script with the project root as the working directory. Argent gives the script an allowlist of environment names. Argent copies each value from the tool-server, not from the shell that starts the run. The tool-server is a long-lived process, so the values are the ones it held when it started. A variable you export now reaches a script only after you restart the tool-server. See [Environment variables](/docs/reference/configuration#environment-variables). The allowlist holds these groups:
 
@@ -298,13 +298,11 @@ Three entries in the list give access to a credential. Each entry holds the valu
 
 `PATH` is the value of the tool-server too. A script that runs `psql`, `docker` or `pnpm` finds the binary on that `PATH`. An editor that starts the tool-server gives it the `PATH` of the editor. The script also runs under the Node binary of the tool-server, not the binary on the `PATH` of your shell.
 
-Argent prints the standard output and the standard error below the step line, on a pass and on a failure. The limit is 64 KiB for one step and 256 KiB for the run. **Argent does not redact this log.** Do not print a credential from a script.
-
 A failed step stops the flow. The verdict names the side that caused the failure.
 
 | Verdict | Cause      | Examples                                                                                                                   |
 | ------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Failed  | The script | An error, a load failure, a non-zero exit code, or a value in the `output` global that Argent cannot serialize             |
+| Failed  | The script | A missing file, a load error, a thrown error, or a non-zero exit code                                                      |
 | Errored | The host   | A time limit, a heap limit, a signal, a process that did not start, a full queue, a cancelled run, or a mis-cased filename |
 
 A step that a thrown error stopped reports the message of the error and the frames of the script. Argent gives each frame a path relative to the project root. Argent removes the frames of Node and of its own runner, and keeps at most six.

--- a/packages/docs/docs/reference/tools.mdx
+++ b/packages/docs/docs/reference/tools.mdx
@@ -120,6 +120,7 @@ Argent supports physical iPhones; physical iPads are not supported yet. `list-de
 | `flow-start-recording`   | Start recording a new flow, resetting `.argent/flows/<name>.yaml` |
 | `flow-add-step`          | Execute a tool call and record it as a step in the open recording |
 | `flow-add-echo`          | Record an echo step that prints a message during replay           |
+| `flow-add-script`        | Run a local `.mjs` file and add it to the open recording          |
 | `flow-finish-recording`  | Finish the recording and write the flow to disk                   |
 | `flow-execute`           | Run a saved flow                                                  |
 | `flow-read-prerequisite` | Read a flow's execution prerequisite without running it           |

--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -22,8 +22,9 @@ For a saved QA test case, ticket, or acceptance criterion, load `argent-qa-flows
 2. **Record checks when their states appear.** Record `await-ui-element` live, then convert it during polish. An echo records intent or diagnostic context, not app behavior or a verdict. A screenshot is human evidence, not an executable verdict. For absence, record the same selector as `visible`, perform the removing action, then record it as `hidden`.
 3. **Use semantic targets.** Prefer a strict id, then stable text or an accessibility label. Use `scroll-to` for off-screen elements. Resolve every raw-point warning immediately through the [coordinate fallback gate](references/reliability-and-recovery.md#coordinate-fallback-gate).
 4. **Prove every screen change.** Record a destination-only identity check. During polish, follow it with `await: { idle: true }`. Stillness does not prove identity, and `idle` can pass with a warning.
-5. **Polish only executed behavior.** Convert recorded steps without changing their meaning. Record any missing action or structural check live. The only unrecorded insertions are a planned `snapshot:`, a navigation `await: { idle: true }`, a `script:` step, and the documented Chromium packaging `launch:`.
-6. **Replay the final YAML end to end.** A normal flow needs one uninterrupted full pass. `argent-qa-flows` requires two consecutive passes.
+5. **Polish only executed behavior.** Convert recorded steps without changing their meaning. Record any missing action or structural check live. The only unrecorded insertions are a planned `snapshot:`, a navigation `await: { idle: true }`, and the documented Chromium packaging `launch:`.
+6. **Use scripts only when the user requests them.** Read [Flow YAML: Local scripts](references/flow-yaml.md#local-scripts), then record each script with `flow-add-script`.
+7. **Replay the final YAML end to end.** A normal flow needs one uninterrupted full pass. `argent-qa-flows` requires two consecutive passes.
 
 ### Stable selectors
 

--- a/packages/skills/skills/argent-create-flow/references/flow-yaml.md
+++ b/packages/skills/skills/argent-create-flow/references/flow-yaml.md
@@ -8,15 +8,13 @@ Read this reference when polishing, composing, or manually reviewing a flow.
     - [The runner tree is not the discovery tree](#the-runner-tree-is-not-the-discovery-tree)
     - [Relational scopes](#relational-scopes)
   - [Directives](#directives)
+    - [`swipe`](#swipe)
   - [Verification conditions](#verification-conditions)
   - [Prove a navigation: identity, then readiness](#prove-a-navigation-identity-then-readiness)
     - [`idle` readiness](#idle-readiness)
   - [Optional divergences](#optional-divergences)
   - [Composition and platform limits](#composition-and-platform-limits)
-  - [Local scripts: `script`](#local-scripts-script)
-    - [Where `path` points](#where-path-points)
-    - [What the script gets](#what-the-script-gets)
-    - [What the step reports](#what-the-step-reports)
+  - [Local scripts](#local-scripts)
   - [Snapshots and standalone runs](#snapshots-and-standalone-runs)
   - [YAML safety](#yaml-safety)
 
@@ -29,7 +27,7 @@ steps:
   - await: { idle: true }
 ```
 
-An e2e flow has a literal `launch:` as its first step that is not `echo:` or `script:`. A flow that runs a setup script before its launch is therefore e2e too. It cannot declare `executionPrerequisite`. Put the named start state in a leading echo.
+An e2e flow has a literal `launch:` as its first step that is not `echo:` or `script:`. It cannot declare `executionPrerequisite`. Put the named start state in a leading echo.
 
 A leading `run:` does not classify the outer flow as e2e, but the runner still follows the chain to the launch it reaches, and on Chromium that launch boots the app before step 1. A flow whose `run:` chain reaches a launch is refused an `executionPrerequisite` too: parse accepts the file, then the run rejects it. The one exception is a run pinned to a Chromium instance you brought to the required state yourself (`--device chromium-cdp-<port>`), where that leading launch only attaches.
 
@@ -231,36 +229,23 @@ A `run:` target is a YAML path resolved against the directory of the flow file c
 - Chromium boots one instance per launch **step**, not one per run. The leading launch — the flow's own, or the one its leading `run:` chain reaches — boots before step 1, unless you pinned the run with an explicit `device`, where it only attaches. Every later launch boots a fresh instance, moves the run onto it, and tears down the instance the run already owned for that app path. Nesting a Chromium e2e flow with its own launch is therefore the supported way to give a sub-scenario its own restart. Chromium rejects `pinch` and `rotate`. Use the app's own zoom or rotate controls.
 - Vega uses `tool: tv-remote` and raw `tool: keyboard`. The touch directives (`tap`, `long-press`, `swipe`, `type`, `scroll-to`, `pinch`, `rotate`) are unsupported. Gate focus and navigation results with `await`.
 
-## Local scripts: `script`
+## Local scripts
 
-A `script:` step runs a local `.mjs` file in a new Node process. Use it for work that no device step can do: call an API, a database seed, or clean up after a run.
+Use a local `.mjs` script only when the user requests one. Record it with `flow-add-script` at the point where it must run.
 
 ```yaml
 - script: { path: ../../scripts/seed-order.mjs }
 - script: { path: ../../scripts/seed-order.mjs, timeout: 60000 }
 ```
 
-### Where `path` points
+Use the map form shown above. A bare `script: scripts/seed.mjs` is invalid.
 
-`path` resolves against the directory of the flow file that **contains the step**, so a fragment finds the same script in each flow that composes it. Always write the extension.
+- **`path`** is relative to the flow file that contains the step. Include `.mjs` and match the file name's letter case.
+- **`timeout`** is optional and uses milliseconds. The default is 30000. The minimum is 100.
 
-`timeout` is milliseconds and defaults to 30000. Parse rejects one below 100, because the step starts a Node process first and that start alone costs tens of milliseconds. A smaller limit ends the step at its limit, or makes the verdict depend on the load of the host.
+If `flow-add-script` cannot access the file, finish the recording. Add the step to YAML, then replay it locally.
 
-### What the script gets
-
-- The working directory is `project_root`, not the directory of the script file, so `fs.readFileSync("./fixtures/order.json")` reads `<project_root>/fixtures/order.json`. A bare `import` is different: Node resolves it from the script file and up, so a script outside the project cannot import the project's dependencies.
-- The environment is an allowlist, not a copy of your shell: `PATH`, `HOME`, the identity, shell, locale, terminal, temp-directory, cache and Windows platform names, the proxy and TLS names, the Node, npm, Android, Java and Apple toolchain names, `CI`, `SSH_AUTH_SOCK`, and every `npm_config_` name. All other names are absent, such as `NODE_ENV`, `DATABASE_URL`, each value in a project `.env`, and the tool-server's own token and port. Two of the names that do pass carry a credential: `SSH_AUTH_SOCK` reaches the SSH agent, and an `npm_config_` name can hold a registry token. Let the script read what it needs from a file.
-
-### What the step reports
-
-The step report carries the stdout and stderr of the script and prints them below the step line, on a pass and on a failure. The limit is 64 KiB for one step and 256 KiB for the run, and the runner says on its own line that it cut the output. **The log has no redaction**, and it reaches the step report, the terminal and each CI log. Do not print a credential from a script.
-
-Both verdicts stop the flow. The verdict names the side that caused the failure, so CI can separate a regression from the machine that ran it.
-
-| Verdict     | Cause      | Examples                                                                                                                   |
-| ----------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
-| **failed**  | the script | threw an error, did not load, exited non-zero, or wrote an `output` value that the runner cannot serialize                 |
-| **errored** | the host   | a time limit, a heap limit, a signal, a process that did not start, a full queue, a cancelled run, or a mis-cased filename |
+If a script fails, check its changes before you retry.
 
 ## Snapshots and standalone runs
 

--- a/packages/skills/skills/argent-create-flow/references/live-authoring.md
+++ b/packages/skills/skills/argent-create-flow/references/live-authoring.md
@@ -32,6 +32,8 @@ args: "{\"udid\":\"DEVICE\",\"x\":0.5,\"y\":0.35}"
 
 A recorded `flow-execute` has two names. The top-level `name` identifies the recording. `args.name` identifies the sibling flow captured as `run:`.
 
+When the user requests a script, call `flow-add-script` at the point where it must run. Read [Flow YAML: Local scripts](flow-yaml.md#local-scripts) first. If the call fails, check its changes before you retry.
+
 Obey these lifecycle rules:
 
 1. Pass the same `name` and absolute `project_root` to every recording tool.
@@ -39,7 +41,7 @@ Obey these lifecycle rules:
 3. Give concurrent recordings separate devices. Their files are isolated, but their live device actions are not.
 4. Treat `flow-start-recording` as destructive. It always truncates the named YAML, including a finished or committed flow. `restarted` reports only a displaced live take.
 5. If a call says the recording is inactive, do not restart under that name. The completed take can still be on disk. Copy it aside or record under a fresh name.
-6. Inspect `toolResult`, `message`, and `recorded` after each call. A call that errors records nothing, but a call that returns normally while reporting an unmet condition **does** append the step, and `message` says the step was added either way. `await-ui-element` is the case that turns up in practice (see [Live waits and checks](#live-waits-and-checks)). Only `flow-start-recording` and `flow-finish-recording` return the whole YAML as `flowFile`. A step call returns `recorded` — one summary line for the step it appended — plus a running `stepCount`. Read `recorded`: the recorder does not always store the tool call you made, and that line is where a rewrite shows up. To see the whole file mid-recording, read it at `savedTo`. A `savedTo` that comes back `null` means the write failed on your side. The step is still in the recording, so continue: the next step rewrites the whole file, and `flow-finish-recording` returns `flowFile` regardless.
+6. Inspect `toolResult`, `message`, and `recorded` after each call. A call that errors records nothing, but a call that returns normally while reporting an unmet condition **does** append the step, and `message` says the step was added either way. A failed `flow-add-script` call appends nothing. `await-ui-element` is the case that turns up in practice (see [Live waits and checks](#live-waits-and-checks)). Only `flow-start-recording` and `flow-finish-recording` return the whole YAML as `flowFile`. A step call returns `recorded` — one summary line for the step it appended — plus a running `stepCount`. Read `recorded`: the recorder does not always store the tool call you made, and that line is where a rewrite shows up. To see the whole file mid-recording, read it at `savedTo`. A `savedTo` that comes back `null` means the write failed on your side. The step is still in the recording, so continue: the next step rewrites the whole file, and `flow-finish-recording` returns `flowFile` regardless.
 7. Edit or reorder the YAML only after `flow-finish-recording`. An active remote recording can overwrite mid-recording edits.
 
 ## Start in the correct order
@@ -47,7 +49,7 @@ Obey these lifecycle rules:
 ### iOS, Android, and Vega e2e flows
 
 1. Call `flow-start-recording` before launching or touching the app.
-2. Record a plain `restart-app` as the first non-echo action. Pass only the device id and app id. The recorder converts it to `launch:`.
+2. Record a plain `restart-app` as the first action that is neither an echo nor a script. Pass only the device id and app id. The recorder converts it to `launch:`.
 3. Record `await-ui-element` for the real first screen immediately after restart.
 
 Extra restart arguments prevent `launch:` conversion. An Android `activity`, for example, leaves a raw tool step and therefore a fragment.
@@ -190,7 +192,6 @@ Only these unrecorded insertions are allowed, at states observed live:
 
 - A planned `snapshot:` for pixel-level evidence.
 - `await: { idle: true }` after a navigation identity check.
-- A `script:` step for setup or cleanup that no recorded step can do. See [Flow YAML](flow-yaml.md#local-scripts-script).
 - The Chromium launch that packages the live boot.
 
 Keep raw forms only when conversion changes behavior. Examples include point-anchored or panning pinch, an edge swipe or one with exotic velocity control, or rotation with a tested start angle, radius, pivot, duration, or speed. Keep screenshots for human evidence. Use `snapshot:` for automated visual comparison. Read [Flow YAML](flow-yaml.md) for syntax.
@@ -265,7 +266,7 @@ Resolve every hit and confirm:
 
 Run `flow-execute` on the complete YAML with the absolute project root. For a fragment, verify its prerequisite before setting `prerequisiteAcknowledged: true`.
 
-`flow-execute` takes exactly one flow source: `name`, for a flow saved under `.argent/flows/`, or `flow_path`, an absolute path to any flow `.yaml`. `run:` targets and baselines resolve on the tool server's filesystem, beside the YAML it actually reads. `flow_path` therefore requires the agent and the tool server to share a filesystem and is refused when they do not. `name` still runs remotely, but the server receives only that one YAML in a fresh temp directory, so a `run:` target fails as a missing fragment and a `snapshot` fails for a missing baseline. A `script:` step is refused before the run starts, because its `.mjs` file stays on the client. Replay self-contained flows remotely; a composing, snapshotting, or script-bearing flow needs one shared filesystem.
+`flow-execute` takes exactly one flow source: `name`, for a flow saved under `.argent/flows/`, or `flow_path`, an absolute path to any flow `.yaml`. `run:` targets and baselines resolve on the tool server's filesystem, beside the YAML it actually reads. `flow_path` therefore requires the agent and the tool server to share a filesystem and is refused when they do not. `name` still runs remotely, but the server receives only that one YAML in a fresh temp directory. It checks the whole flow first and refuses a `run:`, `script:`, or `snapshot:` step at any depth, naming the missing co-location rather than a missing fragment, script, or baseline. Replay self-contained flows remotely; a composing, scripting, or snapshotting flow needs one shared filesystem.
 
 Manual rescue invalidates the pass. An `errored` step was never evaluated: an `idle` wait whose tree source could not be read, a step that threw, an unresolvable `run:` target, or a `launch:` that did not start the app. Read the reason — most name the environment, but a failed `launch:` is a verdict about the app. Unconfirmed focus is not in this class at all: the replay focus poll has no failure return, so a `type:` step whose focus was never confirmed is scored a **pass**, and only the value check after typing catches it.
 

--- a/packages/skills/skills/argent-qa-flows/SKILL.md
+++ b/packages/skills/skills/argent-qa-flows/SKILL.md
@@ -18,7 +18,7 @@ Load `argent-create-flow` as the authoring engine. Follow its required reference
 A QA flow is complete only when:
 
 1. The first step that is not `echo:` or `script:` is `launch:`. In-flow setup proves a deterministic data baseline. Repeated runs do not accumulate artifacts or require manual cleanup.
-2. The first walkthrough recorded every action and live structural check. Only the four documented polish insertions are unrecorded.
+2. The first walkthrough recorded every action and live structural check. Only the three documented polish insertions are unrecorded.
 3. Every requirement maps to a hard `await:`, `assert:`, or reviewed `snapshot:`. Echoes and screenshots are not verdicts. A negative check needs the same stable selector established as visible earlier.
 4. Every screen change has destination identity followed by `idle` readiness.
 5. Targets satisfy the stable-selector and coordinate-fallback rules. QA keeps coordinates only for genuinely unlabeled targets. Vacuous on Vega, which has no coordinate targets.
@@ -45,7 +45,12 @@ Make repeated runs deterministic:
 3. After setup navigation, echo the named baseline and hard-check it before the first scenario mutation. Use `assert:` or a destination `await:` that fully proves the baseline.
 4. Prefer to restore the baseline at the end.
 
-Use `run:` for a separately recorded reset or seed flow, and `script:` for setup or cleanup that no recorded flow can do. There is no other fixture mechanism. Ask before cleanup that creates or deletes meaningful user data outside the request.
+A flow has two fixture mechanisms:
+
+- `run:` replays a separately recorded reset or seed flow.
+- `script:` runs requested local setup or cleanup. Record it with `flow-add-script` where it belongs in the walkthrough.
+
+Ask before cleanup that creates or deletes meaningful user data outside the request.
 
 ### Compact example
 
@@ -93,7 +98,7 @@ Complete the create-flow polish and blocking audit. Then:
 | ------------------ | ----------- | ------------------------- | --------- |
 | Tap `settings-tab` | Settings    | `settings-screen` visible | `idle`    |
 
-The two are repaired differently. A missing identity check must be recorded live on the restored screen. A missing `idle` check is added in YAML, because `await: { idle: true }` has no recorder form and is one of `argent-create-flow`'s four permitted polish insertions. Re-record any missing action or other structural check.
+The two are repaired differently. A missing identity check must be recorded live on the restored screen. A missing `idle` check is added in YAML, because `await: { idle: true }` has no recorder form and is one of `argent-create-flow`'s three permitted polish insertions. Re-record any missing action or other structural check.
 
 ## 5. Prove two consecutive passes
 

--- a/packages/tool-server/src/tools/flows/flow-add-script.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-script.ts
@@ -1,0 +1,279 @@
+import { z } from "zod";
+import * as nodePath from "node:path";
+import {
+  FAILURE_CODES,
+  FailureError,
+  getFailureSignal,
+  wrapFailure,
+  type ToolDefinition,
+} from "@argent/registry";
+import {
+  appendStepToFlow,
+  countStepsOnDisk,
+  parseScriptPath,
+  parseScriptTimeout,
+  recordingSessionState,
+  requireRecordingSession,
+  type FlowSavedTo,
+  type FlowStep,
+  type RecordingSession,
+} from "./flow-utils";
+import { canonicalFlowPath } from "./flow-file-refs";
+import { runFlowScriptStep, type ScriptRan } from "./flow-script-step";
+import { utf8SafeCut } from "./script/flow-script-executor";
+import { summarizeStep } from "./flow-step-definitions";
+
+const OUTPUT_RENDER_LIMIT_BYTES = 64 * 1024;
+
+const zodSchema = z.object({
+  name: z.string().describe("Flow name passed to flow-start-recording."),
+  project_root: z.string().describe("Absolute project root passed to flow-start-recording."),
+  path: z
+    .string()
+    .describe(
+      'Path to the .mjs file, relative to the flow YAML. For example: "../../scripts/seed-order.mjs".'
+    ),
+  timeout: z
+    .number()
+    .optional()
+    .describe("Optional time limit in milliseconds. The default is 30000 and the minimum is 100."),
+});
+
+interface FlowAddScriptResult {
+  message: string;
+  status: "pass" | "fail" | "error";
+  reason?: string;
+  log?: string;
+  logTruncated?: true;
+  durationMs?: number;
+  /**
+   * The document the script returned, as JSON text. Present only on a pass.
+   *
+   * Text rather than the parsed object: the client deep-walks every tool result
+   * for `__argentClientFile` directives and `__argentArtifact` handles, both
+   * matched on shape alone, and a script's document is the one part of a result
+   * this server does not author.
+   */
+  outputJson?: string;
+  outputTruncated?: true;
+  stepCount: number;
+  recorded?: string;
+  savedTo?: FlowSavedTo;
+}
+
+/**
+ * Steps in the recording, counted off the file — as {@link appendStepToFlow}
+ * counts them on the success path. The session's in-memory copy only catches up
+ * on each append, so a hand-edit made mid-recording would otherwise make the two
+ * paths report counts of two different things.
+ *
+ * A file that will not read or parse leaves only that in-memory copy, which is a
+ * count of a third thing again: the steps as of the last append. The number
+ * still comes back, since nothing else in the answer depends on it, but it says
+ * where it came from — the sibling recorder qualifies the same state the same
+ * way, and a bare number here would be the one writer that does not.
+ */
+async function recordedStepCount(
+  session: RecordingSession
+): Promise<{ stepCount: number; note?: string }> {
+  const onDisk = await countStepsOnDisk(session.filePath);
+  if (onDisk !== undefined) return { stepCount: onDisk };
+  return {
+    stepCount: session.flow.steps.length,
+    note: `Could not verify stepCount from ${session.filePath}.`,
+  };
+}
+
+/**
+ * How a failed call opens, and what it asks the author to do next. The two are
+ * written as one entry because the lead may claim no more than the move below
+ * it: an agent reads the first clause and stops, so a headline saying the
+ * script could not be run answers "is there state to check?" with a no that the
+ * rest of the same message then takes back.
+ */
+const FAILED_CALL: Record<ScriptRan, { lead: string; nextMove: string; leftBehind: string }> = {
+  yes: {
+    lead: "failed",
+    nextMove: "Check or restore its changes before you retry.",
+    leftBehind: "Check or restore its changes.",
+  },
+  no: {
+    lead: "did not run",
+    nextMove: "Fix the reason before you retry.",
+    leftBehind: "Nothing ran.",
+  },
+  unknown: {
+    lead: "may have run",
+    nextMove: "Check its changes before you retry.",
+    leftBehind: "Check its changes.",
+  },
+};
+
+function renderOutput(output: Record<string, unknown>): {
+  outputJson: string;
+  outputTruncated?: true;
+} {
+  const encoded = JSON.stringify(output);
+  const bytes = Buffer.from(encoded, "utf8");
+  if (bytes.length <= OUTPUT_RENDER_LIMIT_BYTES) return { outputJson: encoded };
+  const kept = bytes.subarray(0, utf8SafeCut(bytes, OUTPUT_RENDER_LIMIT_BYTES));
+  return { outputJson: kept.toString("utf8"), outputTruncated: true };
+}
+
+export const flowAddScriptTool: ToolDefinition<z.infer<typeof zodSchema>, FlowAddScriptResult> = {
+  id: "flow-add-script",
+  interaction: {
+    startedMsg: ({ params }) => `Running script for flow ${params.name}`,
+    completedMsg: ({ params, result }) =>
+      result.status === "pass"
+        ? `Added script step to flow ${params.name}`
+        : `Script for flow ${params.name} failed; nothing recorded`,
+    failedMsg: ({ params, failureSignal }) =>
+      `Failed to add script step to flow ${params.name}: ${failureSignal.error_code}`,
+  },
+  description: `Run a local .mjs file and record it as a \`script:\` step in an active flow. Use this tool only when the user requests a local script in the flow. Pass the same \`name\` and \`project_root\` as \`flow-start-recording\`, and call it where the script must run. A failed script is not recorded. Check \`reason\` and the affected state before you retry.`,
+  // A script's default limit is 30s and its host cap five minutes, against the
+  // MCP adapter's 30s per-request fetch budget. Without this the adapter aborts
+  // a slow call and RETRIES it, re-running a script whose whole purpose is a
+  // side effect. It also keeps the server's idle timer warm for the call's
+  // duration, so auto-shutdown cannot reap the host mid-script.
+  //
+  // The flag only skips the adapter's own abort timer; its retry loop is
+  // untouched, so a call that fails some other way is still re-POSTed.
+  longRunning: true,
+  zodSchema,
+  services: () => ({}),
+  async execute(_services, params, ctx) {
+    const session = await requireRecordingSession(params.project_root, params.name);
+
+    if (session.persist !== "host") {
+      throw new FailureError(
+        `Cannot access the script for flow "${params.name}". Finish the recording, add the ` +
+          `\`script:\` step to the YAML, and replay it locally.`,
+        {
+          error_code: FAILURE_CODES.FLOW_FILE_INVALID,
+          failure_stage: "flow_add_script_client_mode",
+          failure_area: "tool_server",
+          error_kind: "validation",
+        }
+      );
+    }
+
+    // Validated by the flow parser's own helpers, against the entry they would
+    // read out of YAML: a path this tool accepts is a path parseFlow accepts,
+    // and a rejection reads the same as in a hand-written flow.
+    const entry = {
+      script: {
+        path: params.path,
+        ...(params.timeout !== undefined ? { timeout: params.timeout } : {}),
+      },
+    };
+    const step: Extract<FlowStep, { kind: "script" }> = {
+      kind: "script",
+      path: parseScriptPath(entry, params.path),
+      ...(params.timeout !== undefined
+        ? { timeout: parseScriptTimeout(entry, params.timeout) }
+        : {}),
+    };
+
+    const flowDir = nodePath.dirname(await canonicalFlowPath(session.filePath));
+
+    // Run BEFORE taking the flow-file lock: a script may run for minutes, and
+    // appendStepToFlow holds a per-key lock that would block every other call on
+    // this recording for that whole duration.
+    //
+    // No `logBudget`: the run-scoped allowance would silently truncate a late
+    // script's logs during authoring. The per-step limit still applies.
+    const { outcome, result, ran } = await runFlowScriptStep({
+      flowDir,
+      step,
+      projectRoot: params.project_root,
+      ...(ctx?.signal ? { signal: ctx.signal } : {}),
+    });
+
+    const common = {
+      status: outcome.status,
+      ...(outcome.reason !== undefined ? { reason: outcome.reason } : {}),
+      ...(outcome.scriptLog !== undefined ? { log: outcome.scriptLog } : {}),
+      ...(outcome.scriptLogTruncated ? { logTruncated: true as const } : {}),
+      ...(result ? { durationMs: result.durationMs } : {}),
+    };
+
+    if (outcome.status !== "pass") {
+      const { lead, nextMove, leftBehind } = FAILED_CALL[ran];
+      // The script ran outside the flow-file lock, so the recording this call
+      // resolved up front may have been finished or restarted in that window —
+      // the same race `appendStepToFlow` catches for a script that PASSED. This
+      // exit writes nothing and so never reaches that guard, and both claims it
+      // would otherwise make are then about a file another take owns: that the
+      // flow is as it was, and the count read back off it. Say what is true
+      // instead, and do not send the author back to a key that is no longer
+      // theirs — the retry `nextMove` invites appends into the take that
+      // replaced it. Split the two losses the way the guard does: a restart put
+      // a live take on the key, a finish left it free with a finished flow on
+      // disk, and only the first makes the file another take's.
+      const state = recordingSessionState(session);
+      if (state !== "live") {
+        const lost =
+          state === "restarted"
+            ? `Recording "${params.name}" was replaced.`
+            : `Recording "${params.name}" ended.`;
+        return {
+          ...common,
+          message:
+            `Script "${step.path}" ${lead}; no step was recorded. ${lost} ${leftBehind} ` +
+            `Use a new flow name because flow-start-recording overwrites the existing file. ` +
+            `stepCount is from the ended recording.`,
+          stepCount: session.flow.steps.length,
+        };
+      }
+      const { stepCount, note } = await recordedStepCount(session);
+      return {
+        ...common,
+        message:
+          `Script "${step.path}" ${lead}; no step was recorded. ${nextMove}` +
+          (note ? ` ${note}` : ""),
+        stepCount,
+      };
+    }
+
+    let savedTo: FlowSavedTo;
+    let stepCount: number;
+    try {
+      ({ savedTo, stepCount } = await appendStepToFlow(session, step));
+    } catch (err) {
+      // A host-mode append re-parses the WHOLE file before it pushes, so the
+      // scan that refuses an output reference judges the steps already in it as
+      // well — and a mid-recording hand edit is a supported way for one of those
+      // to carry one. A `script` step spells none of the fields that scan reads,
+      // so a refusal on this path is never about the step just run: saying
+      // "recording it failed" would send the author back over the one call that
+      // did nothing wrong, and never name the edit that has to be undone.
+      const refusedAnEarlierStep = getFailureSignal(err)?.failure_stage === "flow_output_reference";
+      throw wrapFailure(
+        err,
+        {
+          error_code: FAILURE_CODES.FLOW_FILE_WRITE_FAILED,
+          failure_stage: "flow_add_script_append",
+          failure_area: "tool_server",
+          error_kind: "unknown",
+        },
+        `Script "${step.path}" passed, but the step was not recorded. ` +
+          (refusedAnEarlierStep
+            ? `Fix the existing step named below in ${session.filePath}. `
+            : "Check the script's changes before you retry. ") +
+          `${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    const rendered = result?.output ? renderOutput(result.output) : undefined;
+    return {
+      ...common,
+      message: `Added script step to "${params.name}" flow.`,
+      ...(rendered ?? {}),
+      stepCount,
+      recorded: summarizeStep(step, stepCount),
+      savedTo,
+    };
+  },
+};

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -4,13 +4,16 @@ import * as path from "node:path";
 import {
   FAILURE_CODES,
   FailureError,
+  getFailureSignal,
   ToolNotFoundError,
+  wrapFailure,
   type Registry,
   type ToolDefinition,
 } from "@argent/registry";
 import {
   requireRecordingSession,
   appendStepToFlow,
+  holdsOutputReference,
   appIdForPlatform,
   parseFlow,
   assertSafeFlowName,
@@ -58,16 +61,7 @@ const zodSchema = z.object({
   command: z
     .string()
     .describe(
-      'MCP tool name (e.g. "gesture-tap", "screenshot", "launch-app") — a TOOL, not a flow directive. ' +
-        'A flow-file directive name ("tap", "launch", "run", "type", "await", "assert", "pinch", ' +
-        '"swipe", "echo", "script", "wait", "long-press", "scroll-to", "snapshot", "when") is ' +
-        "answered with guidance, " +
-        "and nothing runs or is recorded: most name the tool that records the directive, while " +
-        '"script", "wait", "long-press", "scroll-to", "snapshot" and "when" have no recording tool ' +
-        "at all and " +
-        "are answered with what to do instead. A recording tool (flow-add-step, flow-add-echo, " +
-        "flow-start-recording, flow-finish-recording) is refused the same way, each for its own " +
-        "reason — nesting one would erase this flow at replay, end the take, or write the step twice."
+      'MCP tool to execute and record, for example "gesture-tap". Do not pass a flow directive or a recording tool. Call flow-add-script directly for a requested script step.'
     ),
   args: z
     .string()
@@ -720,6 +714,8 @@ const NESTED_RECORDER_TOOLS: Record<string, string> = {
     "`flow-add-echo` records a step itself, so it must be called DIRECTLY, not through " +
     "flow-add-step — nesting it would write the echo AND a `tool: flow-add-echo` step that " +
     "fails on every replay.",
+  "flow-add-script":
+    "`flow-add-script` records its own step. Call it directly, not through flow-add-step.",
   "flow-add-step":
     "flow-add-step cannot record itself. Pass the MCP tool you want to execute as `command`.",
   "flow-start-recording":
@@ -767,11 +763,7 @@ export function directiveCommandHint(command: string): string | undefined {
     );
   }
   if (command === "script") {
-    return (
-      `"script" is a flow directive, not a tool, and no tool records one — it runs a local .mjs ` +
-      `file you write, which no recorded call produces. Add the \`script:\` step by hand, ` +
-      `pointing it at that file, and prove it with the replay.`
-    );
+    return `"script" is a flow directive. Call \`flow-add-script\` directly.`;
   }
   if (command === "wait") {
     return (
@@ -1086,10 +1078,10 @@ async function captureRunTarget(
     // as-written flows dir under the caller's project_root. When the recording
     // is a symlink out of the flows dir the two anchors can name different
     // files, so require them to canonicalize to the same one, matching the
-    // runner's own canonicalization (canonicalFlowPath in flow-run.ts realpaths
-    // before reading). An executed path that cannot be canonicalized (e.g.
-    // ENOENT) means nothing verifiable ran from the flows dir, and the raw step
-    // is then the honest record: it replays via name + project_root.
+    // runner's own canonicalization (canonicalFlowPath in flow-file-refs.ts
+    // realpaths before reading). An executed path that cannot be canonicalized
+    // (e.g. ENOENT) means nothing verifiable ran from the flows dir, and the raw
+    // step is then the honest record: it replays via name + project_root.
     let executedPath: string | undefined;
     try {
       executedPath = await fs.realpath(path.join(flowsDirFor(projectRoot), `${name}.yaml`));
@@ -1141,10 +1133,9 @@ export function createFlowAddStepTool(registry: Registry): ToolDefinition<
       failedMsg: ({ params, failureSignal }) =>
         `Failed to add ${params.command} step to flow ${params.name}: ${failureSignal.error_code}`,
     },
-    description: `Execute a tool call and record it as a step in the flow named by \`name\` + \`project_root\` (the recording must already be open — see flow-start-recording). Use when recording a flow and you want to run and capture each action. A coordinate \`gesture-tap\` is recorded as a portable \`tap: { selector }\` step when the tapped element has stable text/identifier (otherwise coordinates are kept with a warning); a \`restart-app\` is recorded as a \`launch\` step (record one FIRST to make the flow a self-contained e2e flow; restart-app has no chromium support, so a chromium flow records as a fragment — add the \`launch: { chromium: <app path> }\` line to the YAML afterward, deleting the executionPrerequisite line if one was recorded: a flow that starts with a launch must not declare it).
-A recorded \`await-ui-element\` that PASSED is re-probed against the tree the RUNNER resolves \`await:\`/\`assert:\` directives against, which is NOT the tree the live call read; a wait that came back \`{ success: false }\` is not probed at all, and its warning says so; when the condition does not hold there the step is still recorded and \`message\` carries a warning to read before converting — whether the conversion actually breaks depends on WHY the two disagree, since a screen that moved on between the live wait and the re-probe reads the same way. If that tree could not be read at all, the warning says so instead: the conversion is UNKNOWN, not known-bad. The probe judges the selector exactly as recorded, so write the conversion in the strict map spelling (\`{ visible: { text: Continue } }\`, copying the step's \`selector:\`) — the bare-string spelling (\`{ visible: Continue }\`) re-parses as a loose selector that resolves identifier-first and falls back to text, which is a different check. \`message\` also warns when the live wait itself came back \`{ success: false }\` — that tool reports a failed wait by returning rather than throwing, so the step is recorded either way. That warning names the cause, because only one of them judges the condition: a genuine miss will stop the run at replay, while a wait whose tree source was unreadable, or one that was cancelled, observed nothing and leaves the condition UNKNOWN.
-Returns { message, toolResult, stepCount, recorded, savedTo } on success — \`message\` is \`Step added to "<name>" flow\` plus any warning about what was recorded (read it; a warning never means the step was skipped). If it fails an error is returned and nothing is recorded. Two calls SUCCEED while recording nothing, and omit \`recorded\` to say so: a \`command\` naming a recording tool, and one naming a flow-file directive rather than a tool. Both answer with what to do instead — usually the call to make (the tool that records that directive, or the recording tool called directly), but \`script\`, \`wait\`, \`long-press\`, \`scroll-to\`, \`snapshot\` and \`when\` have no recording tool, so those name no call and say what to record or add by hand in its place. Either way nothing runs at the device and the take is left untouched — read \`recorded\`, not the status, to know whether a step was appended.
-If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-recording\` rather than during the recording: against a remote client the in-memory copy is authoritative and every write serializes it over your edit, and in host mode a mid-recording edit renumbers the steps, which costs the finish the cross-tree verdicts anchored to them.`,
+    description: `Execute one MCP tool and record its flow step, in the flow named by \`name\` + \`project_root\`. Use when recording a flow and you want each action run and captured; the recording must already be open.
+A coordinate \`gesture-tap\` records as a portable \`tap\` selector step; \`restart-app\` as a \`launch\`.
+Returns { message, stepCount, recorded, savedTo }; \`recorded\`, not the status, says whether a step was appended. Fails with an error, recording nothing. Call recording tools, including \`flow-add-script\`, directly.`,
     // The recorded tool RUNS here, so this call lasts as long as whatever it
     // wraps, and the three it most often wraps declare this too. Without it the
     // MCP adapter capped the POST at 30s and retried the identical body four
@@ -1308,7 +1299,33 @@ If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-
         };
       }
 
-      const { savedTo, stepCount } = await appendStepToFlow(session, step);
+      let savedTo: FlowSavedTo;
+      let stepCount: number;
+      try {
+        ({ savedTo, stepCount } = await appendStepToFlow(session, step));
+      } catch (err) {
+        if (getFailureSignal(err)?.failure_stage !== "flow_output_reference") throw err;
+        const refused = err instanceof Error ? err.message : String(err);
+        // A host-mode append re-parses the file, so the scan that refuses an
+        // output reference sees the steps ALREADY there as well — and a
+        // mid-recording hand edit is a supported way for one of those to carry
+        // one. Blaming the just-run call for that step's field would send the
+        // author back over a call whose args were clean.
+        throw wrapFailure(
+          err,
+          {
+            error_code: FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED,
+            failure_stage: "flow_output_reference",
+            failure_area: "tool_server",
+            error_kind: "validation",
+          },
+          holdsOutputReference(step)
+            ? `The \`${params.command}\` call ran, but its step failed validation and was not ` +
+                `recorded. Check the call's changes before you retry. ${refused}`
+            : `The \`${params.command}\` call ran, but an existing flow step failed validation. ` +
+                `Fix the step named below. Check the call's changes before you retry. ${refused}`
+        );
+      }
 
       // Keep the probe's verdict for `flow-finish-recording`. It answers a
       // polish-time question, and polish starts after the recording closes — by

--- a/packages/tool-server/src/tools/flows/flow-file-refs.ts
+++ b/packages/tool-server/src/tools/flows/flow-file-refs.ts
@@ -1,0 +1,91 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { classifyOnDiskSpelling, type OnDiskSpelling } from "./flow-utils";
+
+/**
+ * The input must arrive with any `..` segments intact (no path.resolve/join
+ * over the string): a `..` that follows a symlinked directory component names
+ * the parent of the link's TARGET, which only the kernel can know, so a lexical
+ * collapse first silently picks a different file than the spelling denotes on
+ * disk. fs/promises' realpath keeps kernel semantics (realpath(3), unlike
+ * callback fs.realpath, which path.resolve()s first). When realpath fails the
+ * containing directory is still kernel-resolved before the basename is
+ * re-appended, so the subsequent read opens — and its ENOENT names — the file
+ * the spelling denotes rather than an existing impostor a collapse could have
+ * named; when the directory chain itself is broken the spelling is returned
+ * verbatim, for the same reason.
+ *
+ * Callers must pass an absolute path: every return value, the verbatim fallback
+ * included, is consumed as absolute with no resolve step after this point.
+ */
+export async function canonicalFlowPath(p: string): Promise<string> {
+  try {
+    return await fs.realpath(p);
+  } catch {
+    try {
+      return path.join(await fs.realpath(path.dirname(p)), path.basename(p));
+    } catch {
+      return p;
+    }
+  }
+}
+
+interface ResolvedFlowRelativeFile {
+  canonical: string;
+  spelling: OnDiskSpelling;
+}
+
+/**
+ * Three things here are load-bearing:
+ *
+ * - **The anchor is the CONTAINING file's canonical directory**, never the root
+ *   flow's. A root anchor would make a fragment resolve a different file
+ *   depending on which flow composed it, so a shared fragment would stop being
+ *   self-contained — the one property `run:` composition exists to have.
+ * - **The join is string concatenation, not `path.resolve`/`path.join`.** Those
+ *   collapse a `..` lexically before the kernel ever sees the spelling, and
+ *   after a symlinked directory component the collapse names a different file
+ *   than the one on disk. Both name kinds deliberately admit `..` (shared
+ *   fragments and shared scripts may live outside the referencing file's
+ *   directory), so the spelling has to reach the kernel intact. The anchor is
+ *   absolute and the target relative — parse rejects an absolute or
+ *   drive-prefixed target — so the concatenation is well-formed.
+ * - **The casing check lists the directory the target is SPELLED in**, not
+ *   `path.dirname(canonical)`. The basename compared is always the SUPPLIED one
+ *   (`path.posix.basename(target)`), and only the spelled directory is
+ *   guaranteed to hold an entry under that name: for a symlink whose target
+ *   lives elsewhere, the canonical directory holds the target's name instead,
+ *   so a mis-cased spelling of the link's own name would go unjudged.
+ *   `path.dirname` removes a segment without collapsing `..`, so a `..` still
+ *   reaches readdir intact.
+ *
+ * There is deliberately NO path fence here. A target is reachable exactly when
+ * the tool-server user can read it, which is the reach the front door already
+ * grants: an operator can point `flow_path` at any YAML on the host.
+ *
+ * An uploaded flow — the one route that carries untrusted content — cannot name
+ * a target of its OWN: `assertUploadSelfContained` rejects every `run:` and
+ * `script:` step it declares, and a recording whose files are not on this host
+ * is refused by `flow-add-script` before it gets here. It does still ARRIVE
+ * here, through a nested `tool: flow-execute` naming a flow already on this
+ * host — `invokeSubTool` forwards no `fileInputs`, so the inner run is an
+ * ordinary `name` run with `viaUpload` false and that flow's own targets
+ * resolve through this function. The decision above does not rest on uploads
+ * being absent: it rests on the reach being unchanged, since a caller who can
+ * send the wrapping upload can call `flow-execute` with that same `name`
+ * directly and get the same result.
+ */
+export async function resolveFlowRelativeFile(
+  anchorDir: string,
+  target: string,
+  addressable: RegExp
+): Promise<ResolvedFlowRelativeFile> {
+  const spelled = anchorDir + path.sep + target;
+  const canonical = await canonicalFlowPath(spelled);
+  const spelling = await classifyOnDiskSpelling(
+    path.dirname(spelled),
+    path.posix.basename(target),
+    addressable
+  );
+  return { canonical, spelling };
+}

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1,13 +1,11 @@
 import { z } from "zod";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import {
   FAILURE_CODES,
   FailureError,
   FLOW_FILE_NAME_PATTERN,
   FLOW_NAME_PATTERN,
-  SCRIPT_FILE_NAME_PATTERN,
   getFailureSignal,
   isLiveServiceState,
   wrapFailure,
@@ -37,16 +35,11 @@ import {
   type FlowFile,
   type FlowStep,
   type Launch,
-  type OnDiskSpelling,
   LAUNCH_PLATFORMS,
 } from "./flow-utils";
-import {
-  createScriptLogBudget,
-  flowScriptExecutor,
-  type FlowScriptFailureKind,
-  type FlowScriptLogBudget,
-  type FlowScriptResult,
-} from "./script/flow-script-executor";
+import { createScriptLogBudget, type FlowScriptLogBudget } from "./script/flow-script-executor";
+import { canonicalFlowPath, resolveFlowRelativeFile } from "./flow-file-refs";
+import { runFlowScriptStep } from "./flow-script-step";
 import { describeWhenCondition, stepTarget } from "./flow-step-definitions";
 import { sleepOrAbort } from "../../utils/timing";
 import { invokeSubTool, describeNestedParamError } from "../../utils/sub-invoke";
@@ -193,9 +186,9 @@ export interface StepReport {
    * Machine-readable explanation of the outcome. Always set when the step did
    * not pass; also set on some passing reports whose result is self-narrating —
    * the `when:` guard marker, snapshot passes, a `script` step carrying an
-   * executor note ({@link scriptVerdict}), and a chromium `launch` whose
-   * instance the runner booted and owns. An attach to an instance the runner
-   * does not own reports no reason.
+   * executor note (`scriptVerdict`, in flow-script-step.ts), and a chromium
+   * `launch` whose instance the runner booted and owns. An attach to an instance
+   * the runner does not own reports no reason.
    */
   reason?: string;
   /**
@@ -1286,8 +1279,8 @@ next gesture pay a fresh window, and it warns again if the source is still down.
 A \`when:\` block (condition + \`steps:\`, no else) runs its steps only if the condition holds —
 checked once with the short assert grace — for one-sided divergences like interstitials and coach
 marks; a skipped block reports distinctly and failures inside an entered block are real failures.
-A flow that begins with a \`launch\` step is a self-contained e2e flow; one that doesn't runs against the
-device's current state. Device id is injected by the runner (flows store none) — pass \`device\` or
+A flow is self-contained when its first non-\`echo\`/\`script\` step is \`launch\`; it must not declare
+\`executionPrerequisite\`. Other flows use the device's current state. Device id is injected by the runner (flows store none) — pass \`device\` or
 \`platform\` to pick one, else the single booted device is used. On Chromium a \`launch\` step's value is an
 Electron app path ({ chromium: <path> | { path, args } }) the runner boots (on the tool-server host) rather
 than an installed app id it relaunches. With no explicit \`device\`, a run whose leading launch is
@@ -2164,97 +2157,6 @@ async function execWhenStep(
 }
 
 /**
- * Canonicalize a flow path — the cycle guard's identity key and the root
- * anchor derivation (flowsDir + runStack seed). The input must arrive with any
- * `..` segments intact (no path.resolve/path.join over the string): a `..` that
- * follows a symlinked directory component names the parent of the link's
- * TARGET, which only the kernel can know. fs/promises' realpath keeps kernel
- * semantics (like callback fs.realpath.native — unlike callback fs.realpath,
- * which path.resolve()s first), so the un-collapsed string is sufficient.
- *
- * When realpath fails (the file is gone), the containing directory is still
- * kernel-resolved before the basename is re-appended, so the subsequent read
- * names the file the spelling denotes rather than an existing impostor; when the
- * directory chain itself is broken, the spelling is returned verbatim so the read
- * fails with the kernel's ENOENT for the spelling instead of succeeding on a
- * collapse. That failed read hard-stops the flow before any runStack entry is
- * pushed, so the verbatim key never reaches the cycle guard.
- *
- * Callers must pass an absolute path — every return value, including the
- * verbatim fallback, is consumed as absolute with no resolve step after this
- * point.
- */
-async function canonicalFlowPath(p: string): Promise<string> {
-  try {
-    return await fs.realpath(p);
-  } catch {
-    try {
-      return path.join(await fs.realpath(path.dirname(p)), path.basename(p));
-    } catch {
-      return p;
-    }
-  }
-}
-
-interface ResolvedFlowRelativeFile {
-  canonical: string;
-  spelling: OnDiskSpelling;
-}
-
-/**
- * One hop from a flow file to a file it NAMES — a `run:` target's YAML, a
- * `script:` step's `.mjs`.
- *
- * - The anchor is the CONTAINING file's canonical directory, never the root
- *   flow's: a root anchor would make a fragment resolve a different file
- *   depending on which flow composed it, so a shared fragment would stop being
- *   self-contained — the one property `run:` composition exists to have.
- * - Joined by concatenation, NOT `path.resolve`/`path.join`: those collapse a
- *   `..` lexically before the kernel ever sees the spelling, and after a
- *   symlinked directory component the collapse names a different file than the
- *   one on disk (see {@link canonicalFlowPath}). Both name kinds deliberately
- *   admit `..` — shared fragments and shared scripts may live outside the
- *   referencing file's directory. The anchor is absolute and the target
- *   relative (parse rejects an absolute or drive-prefixed target), so the
- *   concatenation is well-formed.
- * - The casing check lists the directory the target is SPELLED in, NOT
- *   `path.dirname(canonical)`. The basename compared is always the SUPPLIED
- *   one, and only the spelled directory is guaranteed to hold an entry under
- *   that name: for a symlink whose target lives elsewhere, the canonical
- *   directory holds the target's name instead, so a mis-cased spelling of the
- *   link's own name would go unjudged. `path.dirname` removes a segment without
- *   collapsing `..`, so a `..` still reaches readdir intact.
- *
- * There is deliberately NO path fence here. A target is reachable exactly when
- * the tool-server user can read it, the same reach the front door already
- * grants: an operator can point `flow_path` at any YAML on the host.
- *
- * An uploaded flow — the one route that carries untrusted content — cannot name
- * a target of its OWN: {@link assertUploadSelfContained} rejects every `run:`
- * and `script:` step it declares. It does still ARRIVE here, through a nested
- * `tool: flow-execute` naming a flow already on this host — `invokeSubTool`
- * forwards no `fileInputs`, so the inner run is an ordinary `name` run with
- * `viaUpload` false and that flow's own targets resolve through this function.
- * The decision above does not rest on uploads being absent: it rests on the
- * reach being unchanged, since a caller who can send the wrapping upload can
- * call `flow-execute` with that same `name` directly and get the same result.
- */
-async function resolveFlowRelativeFile(
-  anchorDir: string,
-  target: string,
-  addressable: RegExp
-): Promise<ResolvedFlowRelativeFile> {
-  const spelled = anchorDir + path.sep + target;
-  const canonical = await canonicalFlowPath(spelled);
-  const spelling = await classifyOnDiskSpelling(
-    path.dirname(spelled),
-    path.posix.basename(target),
-    addressable
-  );
-  return { canonical, spelling };
-}
-
-/**
  * The `__baselines__/<segment>` a run's snapshots key their baseline store
  * under. The store is `<flowsDir>/__baselines__/<key>` and `flowsDir` is the
  * CANONICAL root flow's directory, so the key must name the canonical file too.
@@ -2435,193 +2337,16 @@ async function runScriptStep(
   step: Extract<FlowStep, { kind: "script" }>,
   scope: StepScope
 ): Promise<ScriptStepOutcome> {
-  const outcome = await execScriptStep(state, step, scope);
-  return outcome.reason === undefined
-    ? outcome
-    : { ...outcome, reason: oneLineReason(outcome.reason) };
-}
-
-/**
- * How many of the script's own frames ride into the reason. A thrown message
- * alone names no file and no line, and a throw writes nothing to stderr, so
- * without these the step's whole diagnostic is one sentence and there is
- * nothing in CI to re-run against. Six is what a rethrow needs to show where it
- * came from without turning the step line into the whole stack; the executor's
- * `SCRIPT_MAX_FAILURE_STACK_CHARS` still holds what it captured.
- */
-const SCRIPT_REASON_MAX_FRAMES = 6;
-
-/** A frame in the host's own machinery, not in anything the author wrote. */
-function isHostFrame(frame: string): boolean {
-  return (
-    frame.includes("node:internal") ||
-    frame.includes("flow-script-runner.mjs") ||
-    frame.includes("flow-script-watchdog")
-  );
-}
-
-/**
- * `file:///abs/path/seed.mjs:1:30` reads as `scripts/seed.mjs:1:30`. The frames
- * go on ONE step line, so the anchor is the run's own `project_root` — the
- * directory the script also ran in. A script outside it keeps its absolute
- * path, because a `..` chain says less than the path does.
- *
- * `roots` is that directory both as given and canonicalized, because only one
- * of the two ever matches: Node resolves a module to its REAL path, so every
- * frame is canonical, while `project_root` arrives as the caller spelled it. On
- * macOS a project under `/var` (or any symlinked parent) is the ordinary case
- * of the two differing.
- */
-function readableFrame(frame: string, roots: readonly string[]): string {
-  return frame.replace(/file:\/\/[^\s)]+/g, (match) => {
-    const split = /^(.*?)(:\d+:\d+)$/.exec(match);
-    const url = split ? split[1]! : match;
-    const position = split ? split[2]! : "";
-    let file: string;
-    try {
-      file = fileURLToPath(url);
-    } catch {
-      return match;
-    }
-    for (const root of roots) {
-      const relative = path.relative(root, file);
-      if (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)) {
-        return `${relative}${position}`;
-      }
-    }
-    return `${file}${position}`;
-  });
-}
-
-/**
- * The frames of a failed script, as a block appended to its message. Newline
- * separated on purpose: {@link oneLineReason} escapes them, so the block reads
- * as `\n    at …` on the step's own line and a reader can still tell one frame
- * from the next. The stack's first line is dropped — it only repeats the
- * message the reason already opens with.
- */
-function scriptFrames(stack: string | undefined, roots: readonly string[]): string {
-  if (!stack) return "";
-  const frames: string[] = [];
-  let dropped = 0;
-  for (const line of stack.split("\n")) {
-    const frame = line.trim();
-    if (!frame.startsWith("at ") || isHostFrame(frame)) continue;
-    if (frames.length >= SCRIPT_REASON_MAX_FRAMES) {
-      dropped++;
-      continue;
-    }
-    frames.push(`    ${readableFrame(frame, roots)}`);
-  }
-  if (frames.length === 0) return "";
-  if (dropped > 0) frames.push(`    … ${dropped} more frame${dropped === 1 ? "" : "s"}`);
-  return `\n${frames.join("\n")}`;
-}
-
-async function execScriptStep(
-  state: ExecState,
-  step: Extract<FlowStep, { kind: "script" }>,
-  scope: StepScope
-): Promise<ScriptStepOutcome> {
-  const target = step.path;
-  const { canonical, spelling } = await resolveFlowRelativeFile(
-    scopeFlowDir(scope),
-    target,
-    SCRIPT_FILE_NAME_PATTERN
-  );
-  const suppliedBase = path.posix.basename(target);
-
-  if (spelling.state === "case_folded") {
-    const recovery = spelling.addressable
-      ? `write it as "${target.slice(0, target.length - suppliedBase.length)}${spelling.actual}"`
-      : `rename "${spelling.actual}" to "${suppliedBase}" to run it — a script filename must ` +
-        `match ${SCRIPT_FILE_NAME_PATTERN}`;
-    return {
-      status: "error",
-      reason:
-        `mis-cased script path "${target}": the directory holds "${spelling.actual}", not ` +
-        `"${suppliedBase}" — a case-sensitive checkout (Linux CI) fails this step with ENOENT — ${recovery}`,
-    };
-  }
-
-  const missing = await scriptFileProblem(canonical);
-  if (missing) {
-    return {
-      status: "fail",
-      reason: `script "${target}" ${missing} (resolved to ${canonical})`,
-    };
-  }
-
-  const result = await flowScriptExecutor().execute({
-    scriptPath: canonical,
-    output: {},
-    ...(step.timeout !== undefined ? { timeoutMs: step.timeout } : {}),
-    projectRoot: state.projectRoot,
+  const { outcome } = await runFlowScriptStep({
     flowDir: scopeFlowDir(scope),
+    step,
+    projectRoot: state.projectRoot,
     logBudget: state.scriptLogBudget,
     ...(state.signal ? { signal: state.signal } : {}),
   });
-
-  const verdict = scriptVerdict(result);
-  const frames = result.ok
-    ? ""
-    : scriptFrames(result.failure?.stack, [
-        state.projectRoot,
-        await canonicalFlowPath(state.projectRoot),
-      ]);
-  return {
-    ...verdict,
-    ...(frames && verdict.reason !== undefined ? { reason: verdict.reason + frames } : {}),
-    ...(result.log ? { scriptLog: result.log } : {}),
-    ...(result.logTruncated ? { scriptLogTruncated: true } : {}),
-  };
-}
-
-async function scriptFileProblem(canonical: string): Promise<string | null> {
-  try {
-    const stat = await fs.stat(canonical);
-    return stat.isFile() ? null : "is not a file";
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    return code === "ENOENT" || code === "ENOTDIR"
-      ? "does not exist"
-      : `cannot be read: ${errMsg(err)}`;
-  }
-}
-
-function scriptVerdict(result: FlowScriptResult): Pick<StepReport, "status" | "reason"> {
-  const notes = result.notes.join(" ");
-  if (result.ok) return { status: "pass", ...(notes ? { reason: notes } : {}) };
-  const failure = result.failure;
-  const message = failure?.message ?? "The script produced no verdict.";
-  return {
-    status: failure ? scriptFailureStatus(failure.kind) : "error",
-    reason: notes ? `${message} ${notes}` : message,
-  };
-}
-
-function scriptFailureStatus(kind: FlowScriptFailureKind): "fail" | "error" {
-  switch (kind) {
-    case "load":
-    case "runtime":
-    case "output":
-    case "exit":
-      return "fail";
-    case "protocol":
-    case "timeout":
-    case "cancelled":
-    case "signal":
-    case "heap":
-    case "spawn":
-    case "queue":
-    case "invalid":
-      return "error";
-    default: {
-      const unclassified: never = kind;
-      void unclassified;
-      return "error";
-    }
-  }
+  return outcome.reason === undefined
+    ? outcome
+    : { ...outcome, reason: oneLineReason(outcome.reason) };
 }
 
 type LeafStep = Exclude<FlowStep, BlockStep | { kind: "run" }>;

--- a/packages/tool-server/src/tools/flows/flow-script-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-script-step.ts
@@ -1,0 +1,315 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { SCRIPT_FILE_NAME_PATTERN } from "@argent/registry";
+import type { FlowStep } from "./flow-utils";
+import { canonicalFlowPath, resolveFlowRelativeFile } from "./flow-file-refs";
+import {
+  flowScriptExecutor,
+  type FlowScriptFailureKind,
+  type FlowScriptLogBudget,
+  type FlowScriptResult,
+} from "./script/flow-script-executor";
+
+/**
+ * One `script` step, from a path to a verdict.
+ *
+ * The flow runner and `flow-add-script` both come through here: a recorded step
+ * that ran differently from the way it will replay would make the recording
+ * prove nothing, so there is one path and each caller supplies only its own
+ * anchor and its own run-scoped extras.
+ */
+
+interface FlowScriptStepOutcome {
+  status: "pass" | "fail" | "error";
+  reason?: string;
+  scriptLog?: string;
+  scriptLogTruncated?: true;
+}
+
+interface FlowScriptStepRun {
+  outcome: FlowScriptStepOutcome;
+  result?: FlowScriptResult;
+  ran: ScriptRan;
+}
+
+interface FlowScriptStepRequest {
+  /**
+   * Directory of the flow file that NAMES the step — the resolution anchor.
+   * Canonical (symlink-resolved), because the runner's is.
+   */
+  flowDir: string;
+  step: Extract<FlowStep, { kind: "script" }>;
+  projectRoot: string;
+  logBudget?: FlowScriptLogBudget;
+  signal?: AbortSignal;
+}
+
+export async function runFlowScriptStep(
+  request: FlowScriptStepRequest
+): Promise<FlowScriptStepRun> {
+  const { flowDir, step } = request;
+  const target = step.path;
+  const { canonical, spelling } = await resolveFlowRelativeFile(
+    flowDir,
+    target,
+    SCRIPT_FILE_NAME_PATTERN
+  );
+  const suppliedBase = path.posix.basename(target);
+
+  // macOS (APFS) and Windows (NTFS) compare file names without case, so
+  // `path: scripts/CreateUser.mjs` opens a file really named `createUser.mjs`:
+  // the flow passes here every time it is repeated, then fails with ENOENT on
+  // Linux CI with nothing in the flow file to show why. Only `case_folded`
+  // refuses — a basename matching nothing at all is an ordinary missing file,
+  // reported below, and an unreadable listing vouches for nothing.
+  if (spelling.state === "case_folded") {
+    const recovery = spelling.addressable
+      ? `Use "${target.slice(0, target.length - suppliedBase.length)}${spelling.actual}".`
+      : `Rename "${spelling.actual}" to "${suppliedBase}".`;
+    return {
+      ran: "no",
+      outcome: {
+        status: "error",
+        reason: `Script path "${target}" has the wrong letter case. ${recovery}`,
+      },
+    };
+  }
+
+  const missing = await scriptFileProblem(canonical);
+  if (missing) {
+    return {
+      ran: "no",
+      outcome: {
+        status: "fail",
+        reason: `Script "${target}" ${missing}. Resolved path: ${canonical}.`,
+      },
+    };
+  }
+
+  const result = await flowScriptExecutor().execute({
+    scriptPath: canonical,
+    output: {},
+    ...(step.timeout !== undefined ? { timeoutMs: step.timeout } : {}),
+    projectRoot: request.projectRoot,
+    flowDir,
+    // No `secrets`: nothing resolves one into a script step yet, so there is
+    // nothing for the executor to redact out of the captured log.
+    ...(request.logBudget ? { logBudget: request.logBudget } : {}),
+    ...(request.signal ? { signal: request.signal } : {}),
+  });
+
+  const verdict = scriptVerdict(result);
+  const frames = result.ok
+    ? ""
+    : scriptFrames(result.failure?.stack, [
+        request.projectRoot,
+        await canonicalFlowPath(request.projectRoot),
+      ]);
+  return {
+    outcome: {
+      ...verdict,
+      ...(frames && verdict.reason !== undefined ? { reason: verdict.reason + frames } : {}),
+      ...(result.log ? { scriptLog: result.log } : {}),
+      ...(result.logTruncated ? { scriptLogTruncated: true } : {}),
+    },
+    result,
+    ran: scriptRan(result),
+  };
+}
+
+/**
+ * How many of the script's own frames ride into the reason. A thrown message
+ * alone names no file and no line, and a throw writes nothing to stderr, so
+ * without these the step's whole diagnostic is one sentence and there is
+ * nothing in CI to re-run against. Six is what a rethrow needs to show where it
+ * came from without turning the step line into the whole stack; the executor's
+ * `SCRIPT_MAX_FAILURE_STACK_CHARS` still holds what it captured.
+ */
+const SCRIPT_REASON_MAX_FRAMES = 6;
+
+/** A frame in the host's own machinery, not in anything the author wrote. */
+function isHostFrame(frame: string): boolean {
+  return (
+    frame.includes("node:internal") ||
+    frame.includes("flow-script-runner.mjs") ||
+    frame.includes("flow-script-watchdog")
+  );
+}
+
+/**
+ * `file:///abs/path/seed.mjs:1:30` reads as `scripts/seed.mjs:1:30`. The frames
+ * go on ONE step line, so the anchor is the run's own `project_root` — the
+ * directory the script also ran in. A script outside it keeps its absolute
+ * path, because a `..` chain says less than the path does.
+ *
+ * `roots` is that directory both as given and canonicalized, because only one
+ * of the two ever matches: Node resolves a module to its REAL path, so every
+ * frame is canonical, while `project_root` arrives as the caller spelled it. On
+ * macOS a project under `/var` (or any symlinked parent) is the ordinary case
+ * of the two differing.
+ */
+function readableFrame(frame: string, roots: readonly string[]): string {
+  return frame.replace(/file:\/\/[^\s)]+/g, (match) => {
+    const split = /^(.*?)(:\d+:\d+)$/.exec(match);
+    const url = split ? split[1]! : match;
+    const position = split ? split[2]! : "";
+    let file: string;
+    try {
+      file = fileURLToPath(url);
+    } catch {
+      return match;
+    }
+    for (const root of roots) {
+      const relative = path.relative(root, file);
+      if (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+        return `${relative}${position}`;
+      }
+    }
+    return `${file}${position}`;
+  });
+}
+
+/**
+ * The frames of a failed script, as a block appended to its message. Newline
+ * separated on purpose: `oneLineReason` escapes them, so the block reads as
+ * `\n    at …` on the step's own line and a reader can still tell one frame
+ * from the next. The stack's first line is dropped — it only repeats the
+ * message the reason already opens with.
+ */
+function scriptFrames(stack: string | undefined, roots: readonly string[]): string {
+  if (!stack) return "";
+  const frames: string[] = [];
+  let dropped = 0;
+  for (const line of stack.split("\n")) {
+    const frame = line.trim();
+    if (!frame.startsWith("at ") || isHostFrame(frame)) continue;
+    if (frames.length >= SCRIPT_REASON_MAX_FRAMES) {
+      dropped++;
+      continue;
+    }
+    frames.push(`    ${readableFrame(frame, roots)}`);
+  }
+  if (frames.length === 0) return "";
+  if (dropped > 0) frames.push(`    … ${dropped} more frame${dropped === 1 ? "" : "s"}`);
+  return `\n${frames.join("\n")}`;
+}
+
+export type ScriptRan = "yes" | "no" | "unknown";
+
+const NEVER_FORKED: ReadonlySet<FlowScriptFailureKind> = new Set(["invalid", "spawn", "queue"]);
+
+/**
+ * Whether the author's script left anything behind — the question "is there
+ * something to clean up" turns on, and one a result's mere presence does not
+ * answer: the executor returns a full result for a queue it could not admit the
+ * step to and for a spawn that never happened.
+ *
+ * Read the executor's own `beforeFork` first, because it is the only signal
+ * that separates the two halves of `cancelled`. That kind lands either side of
+ * the fork: a signal already aborted when the call arrived, or one raised while
+ * the step waited for a slot, never reached a child — while a cancellation that
+ * stopped a running process left whatever it had already done. The kinds below
+ * answer from the kind alone; this one cannot, and "nothing to clean up" is the
+ * answer that has to be proved rather than balanced on which half is likelier.
+ *
+ * `protocol` is the one kind that cannot be answered either way, so it does not
+ * pretend to. It is the runner failing AROUND the script, and every protocol
+ * failure the executor raises itself lands before Node evaluates the entry — a
+ * malformed request the runner parked on, a channel that closed before the
+ * request arrived, a runner that exited without ever saying it started — so
+ * usually nothing ran. But the runner's `process.send` is not the only way onto
+ * that channel: a script that writes a line to the channel descriptor reaches
+ * the same kind having already done its work, and "nothing ran" is the more
+ * dangerous of the two to claim wrongly.
+ *
+ * Everything else answers yes: the script was forked, so it had the chance.
+ */
+function scriptRan(result: FlowScriptResult): ScriptRan {
+  if (result.ok || !result.failure) return "yes";
+  const { kind, beforeFork } = result.failure;
+  if (beforeFork || NEVER_FORKED.has(kind)) return "no";
+  return kind === "protocol" ? "unknown" : "yes";
+}
+
+async function scriptFileProblem(canonical: string): Promise<string | null> {
+  try {
+    const stat = await fs.stat(canonical);
+    return stat.isFile() ? null : "is not a file";
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code === "ENOENT" || code === "ENOTDIR"
+      ? "does not exist"
+      : `cannot be read: ${errMsg(err)}`;
+  }
+}
+
+/**
+ * The line between `fail` and `error` is who is at fault. A `fail` is the
+ * SCRIPT's answer: it threw, it never loaded, it returned something that cannot
+ * cross into flow state, or it stopped its own process. An `error` is
+ * everything the runner did to it — a process it could not start, a limit it
+ * hit, a signal it did not choose, a queue it never left. That split is what
+ * lets CI read a red script step: a `fail` is a regression in the flow or the
+ * system it talks to, an `error` is the machine it ran on.
+ *
+ * `cancelled` is an `error`, not a `skip`: every reader of a report takes
+ * `skip` to mean the step did not run (the CLI's not-executed line,
+ * `FlowRunResult.skipped`), and a script killed after reaching the system it
+ * talks to left that state behind. A cancellation also lands on the near side
+ * of the fork — a signal already aborted when the call arrived, or one raised
+ * while the step waited for a concurrency slot — and the status does not try to
+ * separate the two: `beforeFork` does, and {@link scriptRan} is what reads it.
+ * What a runner marks `skip` is the step it never dispatched, at its own
+ * pre-step abort gate; `flow-add-script` has no such gate and hands its
+ * request's signal straight in, so an abort that arrived before the call does
+ * reach here.
+ *
+ * Notes ride into the reason on every outcome, pass included. They are how the
+ * executor says a time limit was clamped to the host's maximum, or that the
+ * working directory it was given did not exist — and dropping them on a pass is
+ * how a script that silently ran somewhere else stays silent.
+ *
+ * Exported for the test that pins the recorder's verdict and the runner's
+ * against it, kind for kind.
+ */
+export function scriptVerdict(
+  result: FlowScriptResult
+): Pick<FlowScriptStepOutcome, "status" | "reason"> {
+  const notes = result.notes.join(" ");
+  if (result.ok) return { status: "pass", ...(notes ? { reason: notes } : {}) };
+  const failure = result.failure;
+  const message = failure?.message ?? "Script failed without a reason.";
+  return {
+    status: failure ? scriptFailureStatus(failure.kind) : "error",
+    reason: notes ? `${message} ${notes}` : message,
+  };
+}
+
+function scriptFailureStatus(kind: FlowScriptFailureKind): "fail" | "error" {
+  switch (kind) {
+    case "load":
+    case "runtime":
+    case "output":
+    case "exit":
+      return "fail";
+    case "protocol":
+    case "timeout":
+    case "cancelled":
+    case "signal":
+    case "heap":
+    case "spawn":
+    case "queue":
+    case "invalid":
+      return "error";
+    default: {
+      const unclassified: never = kind;
+      void unclassified;
+      return "error";
+    }
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/tool-server/src/tools/flows/flow-start-recording.ts
+++ b/packages/tool-server/src/tools/flows/flow-start-recording.ts
@@ -98,8 +98,9 @@ wait DIRECTLY. A wait nested inside a recorded run-sequence gets neither warning
 — that tool reports its own shape — so for those, read \`toolResult\`. For a self-contained
 e2e flow, record a restart-app of the app under test as the FIRST step (captured
 as the flow's \`launch\` step); for a reusable fragment, skip that and pass
-executionPrerequisite instead. Use flow-add-echo to add labels. Call
-flow-finish-recording when done.
+executionPrerequisite instead. Use flow-add-echo to add labels, and
+flow-add-script to run a local .mjs file and record it as a \`script:\` step.
+Call flow-finish-recording when done.
 
 If a recorded step turns out to be wrong, edit the .yaml file directly to
 remove or reorder steps - after flow-finish-recording, not during the

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -2737,9 +2737,9 @@ export function runTargetName(target: string): string {
  * `../shared/login.yaml` is a documented layout. Only the SHAPE is checked here;
  * nothing about WHERE the path lands. At run time execRunStep joins it onto the
  * containing flow file's own directory and resolves the result with kernel
- * semantics (see canonicalFlowPath in flow-run.ts) — deliberately not a lexical
- * collapse, since a `..` after a symlinked component names the parent of the
- * link's target, not of the spelling. There is no path fence there: a target
+ * semantics (see canonicalFlowPath in flow-file-refs.ts) — deliberately not a
+ * lexical collapse, since a `..` after a symlinked component names the parent of
+ * the link's target, not of the spelling. There is no path fence there: a target
  * runs if the tool server can read it, and fails with that file's own ENOENT if
  * it cannot.
  */
@@ -2838,7 +2838,7 @@ function parseScriptStep(raw: unknown, body: unknown): FlowStep {
   return step;
 }
 
-function parseScriptPath(raw: unknown, value: unknown): string {
+export function parseScriptPath(raw: unknown, value: unknown): string {
   if (typeof value !== "string" || value.length === 0) {
     badEntry(
       raw,
@@ -2899,7 +2899,7 @@ function parseScriptPath(raw: unknown, value: unknown): string {
  * ran. Refused here, deviceless and naming the key, rather than after the run
  * has started.
  */
-function parseScriptTimeout(raw: unknown, value: unknown): number {
+export function parseScriptTimeout(raw: unknown, value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     badEntry(raw, "script.timeout needs a positive number of milliseconds (e.g. `timeout: 30000`)");
   }
@@ -2912,6 +2912,236 @@ function parseScriptTimeout(raw: unknown, value: unknown): number {
     );
   }
   return value as number;
+}
+
+const OUTPUT_REFERENCE_MARKER = "{{output:";
+
+interface StepField {
+  where: string;
+  /**
+   * A second spelling of the same field, when the parse cannot tell which one
+   * the author wrote. Set only by the gesture targets — see
+   * {@link gestureTargetPath}.
+   */
+  altWhere?: string;
+  value: string;
+}
+
+/**
+ * A selector's own string leaves, addressed by their YAML spellings.
+ *
+ * `patterns` adds the regex spelling `text: { matches }`, which the walk
+ * otherwise skips — see {@link outputReferenceFields} for the one context that
+ * asks for it.
+ */
+function* selectorFields(sel: FlowSelector, where: string, patterns = false): Generator<StepField> {
+  if (sel.text !== undefined) yield { where: `${where}.text`, value: sel.text };
+  // `textMatches` spells `text: { matches }` in the file (see selectorToYaml).
+  if (patterns && sel.textMatches !== undefined) {
+    yield { where: `${where}.text.matches`, value: sel.textMatches };
+  }
+  if (sel.identifier !== undefined) yield { where: `${where}.id`, value: sel.identifier };
+  if (sel.role !== undefined) yield { where: `${where}.role`, value: sel.role };
+  for (const relation of SELECTOR_RELATIONS) {
+    const nested = sel[relation];
+    if (nested !== undefined) yield* selectorFields(nested, `${where}.${relation}`, patterns);
+  }
+}
+
+/**
+ * Every string leaf of a `tool` step's args, addressed by its own path.
+ *
+ * `args:` is the one step body the parser does not constrain, so a YAML anchor
+ * can make it cyclic (`args: &a { self: *a }`) and the walk has to survive one
+ * rather than blow the stack. `seen` holds the containers on the current path
+ * only: a node reached twice down two different branches is two real leaves and
+ * must be yielded twice, while a node that contains itself is dropped at the
+ * point it closes the loop.
+ */
+function* argFields(
+  value: unknown,
+  where: string,
+  seen: Set<object> = new Set()
+): Generator<StepField> {
+  if (typeof value === "string") {
+    yield { where, value };
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+  if (seen.has(value)) return;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const [i, item] of value.entries()) yield* argFields(item, `${where}[${i}]`, seen);
+  } else if (value instanceof Map) {
+    // `%YAML 1.1` + `!!omap` materializes a real Map, whose entries
+    // Object.entries reports as none.
+    for (const [key, item] of value) yield* argFields(item, `${where}.${String(key)}`, seen);
+  } else if (value instanceof Set) {
+    // `!!set` members ARE the values, so they carry no key of their own and the
+    // path stays the container's.
+    for (const item of value) yield* argFields(item, where, seen);
+  } else {
+    for (const [key, item] of Object.entries(value))
+      yield* argFields(item, `${where}.${key}`, seen);
+  }
+  seen.delete(value);
+}
+
+/**
+ * Where a gesture step's target sits in the file: `tap.on` for the options
+ * form, `tap` for the bare one.
+ *
+ * `pinch` and `rotate` have only the options form, so those are certain. `tap`
+ * and `long-press` take both, and the parsed step keeps no record of which was
+ * written — `duration` is optional in long-press's options form and `times: 1`
+ * normalizes to `undefined`, so a step carrying neither could have been spelled
+ * either way. Naming one spelling there would name a path that is not in the
+ * author's file, so `alt` carries the other and the refusal offers both.
+ */
+function gestureTargetPath(
+  step: Extract<FlowStep, { kind: "tap" | "long-press" | "pinch" | "rotate" }>
+): { path: string; alt?: string } {
+  if (step.kind === "pinch" || step.kind === "rotate") return { path: `${step.kind}.on` };
+  const option = step.kind === "tap" ? step.times : step.duration;
+  if (option !== undefined) return { path: `${step.kind}.on` };
+  return { path: step.kind, alt: `${step.kind}.on` };
+}
+
+function* conditionFields(
+  kind: string,
+  cond: {
+    condition: WaitCondition;
+    selector: FlowSelector;
+    expectedText?: string;
+    textMatch?: TextMatchMode;
+  },
+  patterns = false
+): Generator<StepField> {
+  yield* selectorFields(
+    cond.selector,
+    cond.condition === "text" ? `${kind}.text.in` : `${kind}.${cond.condition}`,
+    patterns
+  );
+  if (cond.expectedText !== undefined && (patterns || cond.textMatch !== "matches")) {
+    yield {
+      where: cond.textMatch ? `${kind}.text.${cond.textMatch}` : `${kind}.text`,
+      value: cond.expectedText,
+    };
+  }
+}
+
+function* outputReferenceFields(step: FlowStep): Generator<StepField> {
+  switch (step.kind) {
+    case "echo":
+      yield { where: "echo", value: step.message };
+      return;
+    case "tool":
+      yield* argFields(step.args, "args");
+      return;
+    case "type":
+      yield* selectorFields(step.into, "type.into");
+      yield { where: "type.text", value: step.text };
+      return;
+    case "await":
+    case "assert":
+      yield* conditionFields(step.kind, step);
+      return;
+    case "when":
+      // Patterns included HERE and nowhere else. `{{output:…}}` is on no
+      // resolver list, so a regex carrying one matches nothing — which a `tap`,
+      // an `await` or an `assert` reports on its first run. A `when` does not:
+      // an unmatchable guard is simply not met, the block is skipped, and the
+      // run is green. Same reasoning, and same field set, as the `{{secret:`
+      // scan in parseWhenCondition.
+      if (step.condition.kind === "ui") yield* conditionFields("when", step.condition, true);
+      return;
+    case "tap":
+    case "long-press":
+    case "pinch":
+    case "rotate": {
+      if (!step.selector) return;
+      const { path, alt } = gestureTargetPath(step);
+      for (const field of selectorFields(step.selector, path)) {
+        // Every path this walk yields opens with `path`, so the alternative
+        // spelling is that prefix swapped for the other one.
+        yield alt ? { ...field, altWhere: `${alt}${field.where.slice(path.length)}` } : field;
+      }
+      return;
+    }
+    // Both ends are optional and either may be a bare point, so each is
+    // guarded on its own. Neither spelling is ambiguous the way a `tap`'s is:
+    // `from`/`to` exist only in the options form, so there is no `altWhere`.
+    case "swipe":
+      if (step.from && "selector" in step.from) {
+        yield* selectorFields(step.from.selector, "swipe.from");
+      }
+      if (step.to && "selector" in step.to) {
+        yield* selectorFields(step.to.selector, "swipe.to");
+      }
+      return;
+    case "scroll-to":
+      yield* selectorFields(step.target, "scroll-to.target");
+      if (step.within) yield* selectorFields(step.within, "scroll-to.within");
+      return;
+    case "snapshot":
+      if (step.cropOn) yield* selectorFields(step.cropOn, "snapshot.cropOn");
+      return;
+    case "script":
+      return;
+    case "launch":
+    case "run":
+    case "idle":
+    case "wait":
+      return;
+    default: {
+      const unclassified: never = step;
+      void unclassified;
+      return;
+    }
+  }
+}
+
+/**
+ * Whether this step, or one nested in it, spells an output reference.
+ *
+ * {@link assertNoOutputReferences} judges a WHOLE flow, and a host-mode append
+ * re-parses the file before it pushes — so its refusal can name a step that was
+ * already there (a mid-recording hand edit) rather than the one being appended.
+ * A caller that reports the refusal asks this which of the two it is holding.
+ */
+export function holdsOutputReference(step: FlowStep): boolean {
+  for (const field of outputReferenceFields(step)) {
+    if (field.value.includes(OUTPUT_REFERENCE_MARKER)) return true;
+  }
+  return blockSteps(step)?.some(holdsOutputReference) ?? false;
+}
+
+function assertNoOutputReferences(steps: FlowStep[], trail: number[] = []): void {
+  steps.forEach((step, i) => {
+    const at = [...trail, i + 1];
+    for (const field of outputReferenceFields(step)) {
+      if (!field.value.includes(OUTPUT_REFERENCE_MARKER)) continue;
+      const rendered =
+        field.value.length > MAX_ENTRY_RENDER_CHARS
+          ? `${field.value.slice(0, MAX_ENTRY_RENDER_CHARS)}…`
+          : field.value;
+      const locator = field.altWhere
+        ? `\`${field.where}\` (spelled \`${field.altWhere}\` if the target sits under \`on:\`)`
+        : `\`${field.where}\``;
+      throw new FailureError(
+        `Step ${at.join(".")} (\`${step.kind}\`): ${locator} uses unsupported template syntax. ` +
+          `Replace it with the literal value the step needs: ${JSON.stringify(rendered)}`,
+        {
+          error_code: FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED,
+          failure_stage: "flow_output_reference",
+          failure_area: "tool_server",
+          error_kind: "validation",
+        }
+      );
+    }
+    const inner = blockSteps(step);
+    if (inner) assertNoOutputReferences(inner, at);
+  });
 }
 
 const SWIPE_DIRECTIONS: readonly SwipeDirection[] = ["up", "down", "left", "right"];
@@ -3300,8 +3530,8 @@ export function serializeFlow(flow: FlowFile): string {
   return yamlStringify(doc, { blockQuote: false });
 }
 
-/** Validate cross-field invariants that are checkable without other files. */
 export function validateFlow(flow: FlowFile): void {
+  assertNoOutputReferences(flow.steps);
   if (isE2eFlow(flow) && flow.executionPrerequisite) {
     throw new FailureError(
       "A flow whose first step other than `echo:`/`script:` is a `launch` must not declare executionPrerequisite — it launches its own app and controls its start state. Drop that launch to make it a fragment, or drop executionPrerequisite.",
@@ -3779,15 +4009,35 @@ export type FlowSavedTo = string | ClientFileDirective;
  * step still lands in the file it was recorded for, and only the NEXT call on
  * the key reports the recording gone.
  */
-function assertSessionStillLive(session: RecordingSession, step: FlowStep): void {
+/**
+ * Whether this session still holds its key, and if not, how it lost it.
+ *
+ * `restarted` means a DIFFERENT session occupies the key; `gone` means the key
+ * is empty, which is either a finish or the MAX_RECORDINGS backstop — the
+ * server cannot tell those apart after the fact. {@link assertSessionStillLive}
+ * asks this for a caller about to WRITE, and throws on anything but `live`. A
+ * caller whose step already ran and has nothing to write still has a report to
+ * make, and every claim in it about the flow file — that it is unchanged, and
+ * how many steps it holds — is about a file another take may already own.
+ * Outside the flow-file lock the answer can go stale the moment it returns, so
+ * such a caller reads it to qualify a sentence, never to decide a write.
+ */
+export function recordingSessionState(session: RecordingSession): "live" | "restarted" | "gone" {
   const current = recordings.get(session.key);
-  if (current === session) return;
+  if (current === session) return "live";
+  return current ? "restarted" : "gone";
+}
+
+function assertSessionStillLive(session: RecordingSession, step: FlowStep): void {
+  const state = recordingSessionState(session);
+  if (state === "live") return;
   // A key that is occupied by a DIFFERENT session was restarted; an empty key
   // was either finished or evicted by the MAX_RECORDINGS backstop, which the
   // server cannot tell apart after the fact — so name both rather than guess.
-  const why = current
-    ? "it was restarted while this step was running, so the step belongs to the discarded take"
-    : "it was finished (or dropped by the concurrent-recording cap) while this step was running";
+  const why =
+    state === "restarted"
+      ? "it was restarted while this step was running, so the step belongs to the discarded take"
+      : "it was finished (or dropped by the concurrent-recording cap) while this step was running";
   // Do NOT send the agent to flow-start-recording here. It truncates
   // unconditionally, and on every branch there is something to lose: the live
   // take that just claimed this key, or the finished flow sitting on disk.
@@ -3798,17 +4048,19 @@ function assertSessionStillLive(session: RecordingSession, step: FlowStep): void
   // because the key is empty, and `startRecordingSession` registers under this
   // key's lock — so naming a competing agent that does not exist would send the
   // reader after the wrong cause.
-  const whatIsAtStake = current
-    ? `This key now belongs to another take and flow-start-recording truncates, so re-record ` +
-      `under a fresh name rather than restarting this one.`
-    : `The key is now free, but the finished take is on disk and flow-start-recording truncates ` +
-      `it unconditionally, so re-record under a fresh name rather than restarting this one.`;
-  const recovery =
-    `Nothing was added to the flow file` +
-    (step.kind === "echo"
+  const whatIsAtStake =
+    state === "restarted"
+      ? `This key now belongs to another take and flow-start-recording truncates, so re-record ` +
+        `under a fresh name rather than restarting this one.`
+      : `The key is now free, but the finished take is on disk and flow-start-recording truncates ` +
+        `it unconditionally, so re-record under a fresh name rather than restarting this one.`;
+  const alreadySpent =
+    step.kind === "echo"
       ? ". "
-      : ", but the step itself already ran on the device — repeating it repeats that action. ") +
-    whatIsAtStake;
+      : step.kind === "script"
+        ? ", but the script already ran — repeating it repeats whatever it did. "
+        : ", but the step itself already ran on the device — repeating it repeats that action. ";
+  const recovery = `Nothing was added to the flow file` + alreadySpent + whatIsAtStake;
   throw new FailureError(
     `Recording of "${session.name}" in ${session.projectRoot} is no longer active — ${why}. ` +
       recovery,

--- a/packages/tool-server/src/tools/flows/script/flow-script-executor.ts
+++ b/packages/tool-server/src/tools/flows/script/flow-script-executor.ts
@@ -238,6 +238,15 @@ export interface FlowScriptFailure {
   kind: FlowScriptFailureKind;
   message: string;
   stack?: string;
+  /**
+   * Set when this failure was raised with no child process in existence, so no
+   * line of the author's script can have run. Most kinds answer that on their
+   * own — a `queue` never left the queue, a `spawn` never started — but
+   * `cancelled` reaches a caller from both sides of the fork, and a caller
+   * telling its author there is nothing to clean up needs the answer proved
+   * rather than guessed.
+   */
+  beforeFork?: true;
 }
 
 export interface FlowScriptResult {
@@ -1457,7 +1466,7 @@ function partialSecretTail(text: string, secrets: readonly FlowScriptSecret[]): 
   return keep;
 }
 
-function utf8SafeCut(buffer: Buffer, max: number): number {
+export function utf8SafeCut(buffer: Buffer, max: number): number {
   let cut = Math.min(max, buffer.length);
   while (cut > 0 && (buffer[cut] & 0xc0) === 0x80) cut -= 1;
   return cut;
@@ -1534,13 +1543,20 @@ class V8FrameCollapser {
   }
 }
 
+/**
+ * The result for a failure raised before anything was forked. Every caller is
+ * on that side of the fork — a queue the step never left, a cancellation that
+ * beat the fork, a request that could not be prepared, and a `fork` that threw
+ * — which is what {@link FlowScriptFailure.beforeFork} reports to a caller
+ * that has to say whether there is state to clean up.
+ */
 function emptyResult(
   failure: FlowScriptFailure,
   extras: { notes?: string[]; queuedMs?: number; durationMs?: number } = {}
 ): FlowScriptResult {
   return {
     ok: false,
-    failure,
+    failure: { ...failure, beforeFork: true },
     log: "",
     logTruncated: false,
     durationMs: extras.durationMs ?? 0,

--- a/packages/tool-server/src/utils/setup-registry.ts
+++ b/packages/tool-server/src/utils/setup-registry.ts
@@ -79,6 +79,7 @@ import { stopMetroTool } from "../tools/simulator/stop-metro";
 import { flowStartRecordingTool } from "../tools/flows/flow-start-recording";
 import { createFlowAddStepTool } from "../tools/flows/flow-add-step";
 import { flowInsertEchoTool } from "../tools/flows/flow-insert-echo";
+import { flowAddScriptTool } from "../tools/flows/flow-add-script";
 import { flowFinishRecordingTool } from "../tools/flows/flow-finish-recording";
 import { createRunFlowTool } from "../tools/flows/flow-run";
 import { flowReadPrerequisiteTool } from "../tools/flows/flow-read-prerequisite";
@@ -185,6 +186,7 @@ export function createRegistry(): Registry {
   registry.registerTool(flowStartRecordingTool);
   registry.registerTool(createFlowAddStepTool(registry));
   registry.registerTool(flowInsertEchoTool);
+  registry.registerTool(flowAddScriptTool);
   registry.registerTool(flowFinishRecordingTool);
   registry.registerTool(flowReadPrerequisiteTool);
   registry.registerTool(createRunFlowTool(registry));

--- a/packages/tool-server/test/flows/flow-concurrent-recording.test.ts
+++ b/packages/tool-server/test/flows/flow-concurrent-recording.test.ts
@@ -7,6 +7,7 @@ import type { Registry } from "@argent/registry";
 
 import { flowStartRecordingTool } from "../../src/tools/flows/flow-start-recording";
 import { flowInsertEchoTool } from "../../src/tools/flows/flow-insert-echo";
+import { flowAddScriptTool } from "../../src/tools/flows/flow-add-script";
 import { flowFinishRecordingTool } from "../../src/tools/flows/flow-finish-recording";
 import { createFlowAddStepTool } from "../../src/tools/flows/flow-add-step";
 import { createRunFlowTool } from "../../src/tools/flows/flow-run";
@@ -143,6 +144,31 @@ function addStep(root: string, name: string, marker: string) {
 
 function addEcho(root: string, name: string, message: string) {
   return flowInsertEchoTool.execute({}, { name, project_root: root, message });
+}
+
+async function writeScript(root: string, source: string): Promise<void> {
+  await fs.mkdir(path.join(root, "scripts"), { recursive: true });
+  await fs.writeFile(path.join(root, "scripts", "seed.mjs"), source, "utf8");
+}
+
+/**
+ * Call the tool with the .mjs already on disk.
+ *
+ * The file write is a real await, so a test that races this call against a
+ * lock-holding tool needs the session resolved on the FIRST turn — writing the
+ * script inside the call would let the race resolve first.
+ */
+function runAddScript(root: string, name: string) {
+  return flowAddScriptTool.execute({}, {
+    name,
+    project_root: root,
+    path: "../../scripts/seed.mjs",
+  } as never);
+}
+
+async function addScript(root: string, name: string, source = "output.ok = true;") {
+  await writeScript(root, source);
+  return runAddScript(root, name);
 }
 
 function finish(root: string, name: string) {
@@ -1372,6 +1398,90 @@ describe("a restart that lands while a step is still running", () => {
     expect((err as Error).message).toContain("Nothing was added to the flow file");
     expect((err as Error).message).toContain("fresh name");
     expect((err as Error).message).not.toContain("already ran on the device");
+  });
+
+  it("tells a superseded SCRIPT that the script ran, not that a device did", async () => {
+    const root = await makeRoot("supersede-script");
+    await start(root, "alpha");
+
+    // flow-add-script runs the script BEFORE it takes the flow-file lock, so a
+    // restart queued ahead of it lands first, exactly as it would for a script
+    // that took minutes.
+    const gate = openGate();
+    const held = withFlowFileLock(root, "alpha", () => gate.promise);
+    const restarting = start(root, "alpha");
+    const recording = addScript(root, "alpha");
+
+    gate.open();
+    await held;
+    expect((await restarting).restarted).toBe(true);
+
+    const err = await captureFailure(recording);
+    expect(getFailureSignal(err)?.failure_stage).toBe("flow_session_superseded");
+    expect((err as Error).message).toContain("Nothing was added to the flow file");
+    expect((err as Error).message).toContain("the script already ran");
+    expect((err as Error).message).not.toContain("already ran on the device");
+    expect((err as Error).message).toContain("fresh name");
+    expect((err as Error).message).toContain("passed, but the step was not recorded");
+    expect((err as Error).message).toContain("Check the script's changes before you retry");
+
+    expect(await readMarkers(root, "alpha")).toEqual([]);
+  });
+
+  it("tells a superseded FAILING script that its recording is gone, not that the flow is intact", async () => {
+    // The passing case above throws from the append guard. A script that FAILS
+    // never reaches an append, so this exit is the tool's own — and on the
+    // base wording it answered a restarted take with "the flow is exactly as
+    // it was" plus a step count read back off the replacement's file.
+    const root = await makeRoot("supersede-script-fail");
+    await start(root, "alpha");
+    await addEcho(root, "alpha", "one");
+    await addEcho(root, "alpha", "two");
+
+    await writeScript(root, "throw new Error('boom');");
+    const gate = openGate();
+    const held = withFlowFileLock(root, "alpha", () => gate.promise);
+    const restarting = start(root, "alpha");
+    const recording = runAddScript(root, "alpha");
+
+    gate.open();
+    await held;
+    expect((await restarting).restarted).toBe(true);
+
+    const result = (await recording) as { status: string; stepCount: number; message: string };
+    expect(result.status).toBe("fail");
+    expect(result.message).not.toContain("the flow is exactly as it was");
+    expect(result.message).toContain('Recording "alpha" was replaced');
+    expect(result.message).toContain("Use a new flow name");
+    // The replacement take owns the file and holds no steps; the count that
+    // comes back is this take's own, and the message says which it is.
+    expect(result.stepCount).toBe(2);
+    expect(result.message).toContain("stepCount is from the ended recording");
+    expect(await readMarkers(root, "alpha")).toEqual([]);
+  });
+
+  it("names the finished take, not a competing one, when a finish superseded the script", async () => {
+    // `gone` is the other half of the guard's split: the key is free, and the
+    // file holds the take that just finished rather than a rival's.
+    const root = await makeRoot("supersede-script-finish");
+    await start(root, "alpha");
+    await addEcho(root, "alpha", "one");
+
+    await writeScript(root, "throw new Error('boom');");
+    const gate = openGate();
+    const held = withFlowFileLock(root, "alpha", () => gate.promise);
+    const finishing = finish(root, "alpha");
+    const recording = runAddScript(root, "alpha");
+
+    gate.open();
+    await held;
+    await finishing;
+
+    const result = (await recording) as { status: string; stepCount: number; message: string };
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain('Recording "alpha" ended');
+    expect(result.message).toContain("Use a new flow name");
+    expect(result.message).not.toContain("the flow is exactly as it was");
   });
 
   it("truncates and re-registers only once the flow's lock is free", async () => {

--- a/packages/tool-server/test/flows/flow-record-cross-tree.test.ts
+++ b/packages/tool-server/test/flows/flow-record-cross-tree.test.ts
@@ -2093,6 +2093,17 @@ describe("a flow-directive name points at the tool that records it", () => {
     expect(await recordedSteps("hints")).toEqual([]);
   });
 
+  it("sends `script` to flow-add-script, not to a hand-written step", async () => {
+    // The other half of the same contract as the nested-recorder refusal above:
+    // one of the two names is the call to make, the other refuses the nesting.
+    const result = await hint("script");
+    expect(result.message).toContain('"script" is a flow directive');
+    expect(result.message).toContain("Call `flow-add-script` directly");
+    expect(result.message).not.toContain("Add the `script:` step by hand");
+    expect(result.stepCount).toBe(0);
+    expect(await recordedSteps("hints")).toEqual([]);
+  });
+
   it("names gesture-pinch for `pinch`, stored raw", async () => {
     const result = await hint("pinch");
     expect(result.message).toContain("gesture-pinch");
@@ -2120,6 +2131,7 @@ describe("a flow-directive name points at the tool that records it", () => {
     const tool = createFlowAddStepTool(registryWhereWaitSucceeds());
     for (const command of [
       "flow-add-echo",
+      "flow-add-script",
       "flow-add-step",
       "flow-start-recording",
       "flow-finish-recording",
@@ -2140,6 +2152,11 @@ describe("a flow-directive name points at the tool that records it", () => {
       [
         "flow-add-echo",
         ["must be called DIRECTLY", "fails on every replay"],
+        ["truncates", "ends the recording"],
+      ],
+      [
+        "flow-add-script",
+        ["records its own step", "Call it directly", "not through flow-add-step"],
         ["truncates", "ends the recording"],
       ],
       ["flow-add-step", ["cannot record itself"], ["truncates", "ends the recording"]],

--- a/packages/tool-server/test/flows/flow-skill-docs.test.ts
+++ b/packages/tool-server/test/flows/flow-skill-docs.test.ts
@@ -28,6 +28,18 @@ const LIVE_AUTHORING = path.resolve(
   __dirname,
   "../../../skills/skills/argent-create-flow/references/live-authoring.md"
 );
+const SPELLED = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight"];
+/**
+ * How each insertion in {@link LIVE_AUTHORING}'s list is spelled in rule 5 of
+ * the core skill, which enumerates them rather than counting them. Kept in
+ * step with that list by the length assertion in the guard below, so a fourth
+ * bullet cannot be added while rule 5 still says "the only" three.
+ */
+const RULE_5_INSERTIONS = ["`snapshot:`", "`await: { idle: true }`", "Chromium"];
+const INSERTION_COUNT_CITATIONS = [
+  path.resolve(__dirname, "../../../skills/skills/argent-qa-flows/SKILL.md"),
+];
+
 /**
  * The three surfaces that quote the number of `idle` warnings instead of
  * listing them. They cite the reference rather than restating it, so a warning
@@ -122,15 +134,44 @@ describe("create-flow idle docs", () => {
     );
   });
 
+  it("every doc that quotes the number of permitted insertions quotes the number listed", () => {
+    const list = between(
+      LIVE_AUTHORING,
+      "Only these unrecorded insertions are allowed, at states observed live:",
+      "\nKeep raw forms only"
+    );
+    const listed = [...list.matchAll(/^- /gm)].length;
+    expect(listed).toBeGreaterThan(1);
+    const spelled = SPELLED[listed];
+    expect(spelled, `no spelling for ${listed} insertions`).toBeDefined();
+    for (const file of INSERTION_COUNT_CITATIONS) {
+      const quotes = [
+        ...readFileSync(file, "utf8").matchAll(/(\w+) (?:documented|permitted) polish insertions/g),
+      ];
+      expect(quotes.length, `${file} no longer cites the insertion count`).toBeGreaterThan(0);
+      for (const quote of quotes) expect(quote[1], file).toBe(spelled);
+    }
+    // Rule 5 cites no number — it ENUMERATES the insertions inline — so the
+    // spelled count above cannot police it. Hold it to the same list instead,
+    // and read only that sentence: `await: { idle: true }` is also in rule 4,
+    // so a file-wide search would pass with rule 5's copy of it deleted.
+    const rule5 = between(SKILL, "The only unrecorded insertions are", "\n");
+    expect(
+      RULE_5_INSERTIONS,
+      `rule 5 names ${RULE_5_INSERTIONS.length} insertions, the reference lists ${listed}`
+    ).toHaveLength(listed);
+    for (const token of RULE_5_INSERTIONS) {
+      expect(rule5, `rule 5 no longer names ${token} as an insertion`).toContain(token);
+    }
+  });
+
   it("every doc that quotes the number of idle warnings quotes the number the reference lists", () => {
     const warnings = between(FLOW_YAML, "It **never fails a run.**", "\nOnly a tree source");
     const listed = [...warnings.matchAll(/^- \*\*/gm)].length;
     // Guard the reader itself: a section that stopped matching would count 0
     // and then agree with nothing, which is not the failure we want reported.
     expect(listed).toBeGreaterThan(1);
-    const spelled = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight"][
-      listed
-    ];
+    const spelled = SPELLED[listed];
     expect(spelled, `no spelling for ${listed} warnings`).toBeDefined();
     for (const file of WARNING_COUNT_CITATIONS) {
       // Anchored on the linked citation, not on any "… warnings" phrase: these
@@ -164,16 +205,6 @@ describe("create-flow idle docs", () => {
 
 describe("create-flow directive-answer docs", () => {
   const answered = STEP_DIRECTIVE_KEYS.filter((key) => directiveCommandHint(key) !== undefined);
-  const withoutRecordingTool = answered.filter((key) =>
-    directiveCommandHint(key)!.includes("records one")
-  );
-  const withRecordingTool = answered.filter((key) => !withoutRecordingTool.includes(key));
-
-  function sentenceWith(paragraph: string, marker: string): string {
-    const hit = paragraph.split(". ").find((s) => s.includes(marker));
-    expect(hit, `no sentence mentions "${marker}"`).toBeDefined();
-    return hit!;
-  }
 
   function commandParamDescription(): string {
     const schema = zodObjectToJsonSchema(createFlowAddStepTool({} as Registry).zodSchema!) as {
@@ -184,23 +215,22 @@ describe("create-flow directive-answer docs", () => {
     return described!;
   }
 
-  it("names every directive it answers, so a new one cannot go unmentioned", () => {
-    expect(answered.length).toBeGreaterThan(0);
-    const clause = sentenceWith(commandParamDescription(), "is answered with guidance");
-    for (const key of answered) expect(clause, key).toContain(`"${key}"`);
+  it("keeps directive guidance out of the command schema", () => {
+    const description = commandParamDescription();
+    expect(description).toContain("MCP tool to execute and record");
+    expect(description).toContain("Do not pass a flow directive or a recording tool");
+    expect(description).toContain("Call flow-add-script directly");
+    expect(description.split(/\s+/).length).toBeLessThan(40);
   });
 
-  it("names each directive that has no recording tool, on both surfaces", () => {
-    expect(withoutRecordingTool.length).toBeGreaterThan(0);
-    const { description } = createFlowAddStepTool({} as Registry);
-    expect(description, "flow-add-step no longer declares a description").toBeDefined();
-    for (const key of withoutRecordingTool) {
-      expect(sentenceWith(description!, "have no recording tool"), key).toContain(`\`${key}\``);
-      expect(commandParamDescription(), key).toContain(`"${key}"`);
+  it("returns guidance for each answered directive", () => {
+    expect(answered.length).toBeGreaterThan(0);
+    for (const key of answered) {
+      expect(directiveCommandHint(key), key).toContain(`"${key}"`);
     }
-    for (const key of withRecordingTool) {
-      expect(sentenceWith(description!, "have no recording tool"), key).not.toContain(`\`${key}\``);
-    }
+    expect(directiveCommandHint("script")).toBe(
+      '"script" is a flow directive. Call `flow-add-script` directly.'
+    );
   });
 });
 

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -3,7 +3,13 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { ToolContext } from "@argent/registry";
-import { ArtifactStore, Registry, zodObjectToJsonSchema } from "@argent/registry";
+import {
+  ArtifactStore,
+  FAILURE_CODES,
+  getFailureSignal,
+  Registry,
+  zodObjectToJsonSchema,
+} from "@argent/registry";
 
 import { flowStartRecordingTool } from "../../src/tools/flows/flow-start-recording";
 import { flowInsertEchoTool } from "../../src/tools/flows/flow-insert-echo";
@@ -354,6 +360,170 @@ describe("flow-add-echo", () => {
     expect(err.message).toContain(`No active recording for flow "wrong-root" in ${otherDir}`);
     expect(err.message).toContain("Active recordings: none in this project (plus 1 in other");
     expect(err.message).not.toContain(tmpDir);
+  });
+});
+
+describe("a step the recorder refuses", () => {
+  it("leaves the flow file exactly as it was, and the recording usable", async () => {
+    await flowStartRecordingTool.execute({}, { name: "poison", project_root: tmpDir });
+    await flowInsertEchoTool.execute({}, { name: "poison", project_root: tmpDir, message: "one" });
+
+    const err = await flowInsertEchoTool
+      .execute({}, { name: "poison", project_root: tmpDir, message: "created {{output:user.id}}" })
+      .catch((e: unknown) => e as Error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("unsupported template syntax");
+    expect(parseFlow(await onDisk("poison")).steps).toEqual([{ kind: "echo", message: "one" }]);
+
+    await flowInsertEchoTool.execute({}, { name: "poison", project_root: tmpDir, message: "two" });
+    const finished = await flowFinishRecordingTool.execute({}, {
+      name: "poison",
+      project_root: tmpDir,
+    } as never);
+    expect(finished.steps).toBe(2);
+  });
+
+  it("keeps a client-mode recording just as clean", async () => {
+    const clientRoot = path.join(os.tmpdir(), "not-on-this-host", "agent-project");
+    const ctx = {
+      artifacts: new ArtifactStore(),
+      fileInputs: {
+        project_root: { clientPath: clientRoot, presentOnHost: false, viaUpload: false },
+      },
+    } as unknown as ToolContext;
+    await flowStartRecordingTool.execute({}, { name: "poison", project_root: clientRoot }, ctx);
+    await flowInsertEchoTool.execute(
+      {},
+      { name: "poison", project_root: clientRoot, message: "one" }
+    );
+
+    const err = await flowInsertEchoTool
+      .execute({}, { name: "poison", project_root: clientRoot, message: "{{output:user.id}}" })
+      .catch((e: unknown) => e as Error);
+
+    expect((err as Error).message).toContain("unsupported template syntax");
+    const session = await getRecordingSession(clientRoot, "poison");
+    expect(session?.flow.steps).toEqual([{ kind: "echo", message: "one" }]);
+  });
+
+  it("says the tool call already ran when the refusal lands after it", async () => {
+    const registry = createMockRegistry({ keyboard: { result: { typed: "…", keys: 15 } } });
+    const tool = createFlowAddStepTool(registry);
+    await flowStartRecordingTool.execute(
+      {},
+      { name: "already-ran", project_root: tmpDir, executionPrerequisite: PREREQ }
+    );
+
+    const err = await tool
+      .execute(
+        {},
+        {
+          name: "already-ran",
+          project_root: tmpDir,
+          command: "keyboard",
+          args: '{"text":"{{output:code}}"}',
+        }
+      )
+      .catch((e: unknown) => e as Error);
+
+    expect(registry.invokeTool).toHaveBeenCalledWith("keyboard", { text: "{{output:code}}" });
+    expect((err as Error).message).toContain("`keyboard` call ran");
+    expect((err as Error).message).toContain("unsupported template syntax");
+    expect(getFailureSignal(err as Error)?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
+    expect(parseFlow(await onDisk("already-ran")).steps).toEqual([]);
+  });
+
+  // A host-mode append re-parses the file, so the same guard also judges the
+  // steps already in it — and a mid-recording hand edit is how one of those
+  // comes to hold a reference the recorder never accepted.
+  it("does not blame the just-run call for a reference an earlier step already held", async () => {
+    const registry = createMockRegistry({ keyboard: { result: { typed: "…", keys: 15 } } });
+    const tool = createFlowAddStepTool(registry);
+    await flowStartRecordingTool.execute(
+      {},
+      { name: "hand-edited", project_root: tmpDir, executionPrerequisite: PREREQ }
+    );
+    await fs.writeFile(
+      path.join(flowsDirFor(tmpDir), "hand-edited.yaml"),
+      `executionPrerequisite: ${PREREQ}\nsteps:\n  - echo: "created {{output:user.id}}"\n`
+    );
+
+    const err = await tool
+      .execute(
+        {},
+        {
+          name: "hand-edited",
+          project_root: tmpDir,
+          command: "keyboard",
+          args: '{"text":"hi"}',
+        }
+      )
+      .catch((e: unknown) => e as Error);
+
+    const message = (err as Error).message;
+    expect(registry.invokeTool).toHaveBeenCalledWith("keyboard", { text: "hi" });
+    // The call ran, so that half stands — but the field the scan refused is the
+    // hand-edited step's, and the wrap has to say so.
+    expect(message).toContain("`keyboard` call ran");
+    expect(message).toContain("an existing flow step failed validation");
+    expect(message).toContain("Step 1 (`echo`)");
+    expect(message).not.toContain("its step failed validation");
+  });
+
+  // The other half of that claim: the tool's description tells an agent a
+  // failure ran the call unless it landed in one of the checks that precede the
+  // dispatch, and this is the check an agent meets most often. A dispatch moved
+  // above it would make the description advise cleanup for an action that never
+  // happened.
+  it("rejects a call for a recording that was never started without dispatching it", async () => {
+    const registry = createMockRegistry({ keyboard: { result: { typed: "…", keys: 15 } } });
+    const tool = createFlowAddStepTool(registry);
+
+    const err = await tool
+      .execute(
+        {},
+        {
+          name: "never-started",
+          project_root: tmpDir,
+          command: "keyboard",
+          args: '{"text":"hi"}',
+        }
+      )
+      .catch((e: unknown) => e as Error);
+
+    expect(getFailureSignal(err as Error)?.error_code).toBe(FAILURE_CODES.FLOW_NO_ACTIVE_RECORDING);
+    expect(registry.invokeTool).not.toHaveBeenCalled();
+  });
+
+  it("leaves the refusals it did not introduce worded as they were", async () => {
+    const registry = createMockRegistry({ "restart-app": { result: { restarted: true } } });
+    const tool = createFlowAddStepTool(registry);
+    await flowStartRecordingTool.execute(
+      {},
+      { name: "prereq", project_root: tmpDir, executionPrerequisite: PREREQ }
+    );
+
+    const err = await tool
+      .execute(
+        {},
+        {
+          name: "prereq",
+          project_root: tmpDir,
+          command: "restart-app",
+          args: '{"bundleId":"com.acme.notes"}',
+        }
+      )
+      .catch((e: unknown) => e as Error);
+
+    expect(registry.invokeTool).toHaveBeenCalledWith("restart-app", {
+      bundleId: "com.acme.notes",
+    });
+    expect((err as Error).message).toContain("must not declare executionPrerequisite");
+    expect((err as Error).message).not.toContain("already ran");
+    expect(getFailureSignal(err as Error)?.error_code).toBe(
+      FAILURE_CODES.FLOW_E2E_HAS_PREREQUISITE
+    );
   });
 });
 
@@ -2865,10 +3035,11 @@ describe("the flow-add-step schema the CLI tests hand-copy", () => {
     expect(schema.properties["args"]).toMatchObject({ type: "string" });
   });
 
-  it("still opens its description with the sentence those fixtures quote verbatim", () => {
-    expect(createFlowAddStepTool({} as unknown as Registry).description).toContain(
-      "Execute a tool call and record it as a step in the flow named by `name` + `project_root`"
-    );
+  it("keeps the description focused on how to use the tool", () => {
+    const description = createFlowAddStepTool({} as unknown as Registry).description!;
+    expect(description).toContain("Execute one MCP tool and record its flow step");
+    expect(description).toContain("Call recording tools, including `flow-add-script`, directly");
+    expect(description.split(/\s+/).length).toBeLessThan(80);
   });
 });
 

--- a/packages/tool-server/test/flows/flow-utils.test.ts
+++ b/packages/tool-server/test/flows/flow-utils.test.ts
@@ -1010,6 +1010,380 @@ const BLOCK_DIRECTIVE_SIBLING_REJECTIONS: Record<
   },
 };
 
+describe("output references", () => {
+  const REFUSALS: [label: string, yaml: string][] = [
+    ["an echo message", 'steps:\n  - echo: "created {{output:user.id}}"\n'],
+    ["typed text", 'steps:\n  - type: { into: { id: name }, text: "{{output:user.name}}" }\n'],
+    ["a typed-into selector", 'steps:\n  - type: { into: { id: "{{output:field}}" }, text: hi }\n'],
+    ["selector text", 'steps:\n  - tap: { text: "{{output:user.name}}" }\n'],
+    ["a selector identifier", 'steps:\n  - tap: { id: "{{output:row}}" }\n'],
+    ["a selector role", 'steps:\n  - tap: { id: row, role: "{{output:kind}}" }\n'],
+    [
+      "a nested relation's selector",
+      'steps:\n  - tap: { id: row, within: { id: "{{output:card}}" } }\n',
+    ],
+    ["an await selector", 'steps:\n  - await: { visible: { id: "{{output:row}}" } }\n'],
+    [
+      "an await expectation",
+      'steps:\n  - await: { text: { in: total, equals: "{{output:sum}}" } }\n',
+    ],
+    [
+      "the selector an await text condition locates",
+      'steps:\n  - await: { text: { in: { id: "{{output:row}}" }, contains: Done } }\n',
+    ],
+    [
+      "an assert expectation",
+      'steps:\n  - assert: { text: { in: total, contains: "{{output:sum}}" } }\n',
+    ],
+    [
+      "a when guard selector",
+      'steps:\n  - when: { visible: { id: "{{output:row}}" } }\n    steps:\n      - echo: hi\n',
+    ],
+    [
+      "a when guard expectation",
+      'steps:\n  - when: { text: { in: total, equals: "{{output:sum}}" } }\n    steps:\n      - echo: hi\n',
+    ],
+    [
+      "a scroll-to target",
+      'steps:\n  - scroll-to: { target: { id: "{{output:row}}" }, direction: down }\n',
+    ],
+    [
+      "a scroll-to container",
+      'steps:\n  - scroll-to: { target: row, direction: down, within: { id: "{{output:list}}" } }\n',
+    ],
+    ["a long-press selector", 'steps:\n  - long-press: { on: { id: "{{output:row}}" } }\n'],
+    ["a pinch selector", 'steps:\n  - pinch: { on: { id: "{{output:map}}" }, scale: 2 }\n'],
+    ["a rotate selector", 'steps:\n  - rotate: { on: { id: "{{output:map}}" }, by: 45 }\n'],
+    [
+      "a snapshot crop selector",
+      'steps:\n  - snapshot: { name: home, cropOn: { id: "{{output:row}}" } }\n',
+    ],
+    ["a tool arg", 'steps:\n  - tool: keyboard\n    args: { text: "{{output:code}}" }\n'],
+    [
+      "a tool arg nested in an array",
+      'steps:\n  - tool: run-sequence\n    args: { steps: [{ args: { text: "{{output:code}}" } }] }\n',
+    ],
+    [
+      "a step inside a when block",
+      'steps:\n  - when: { visible: { id: row } }\n    steps:\n      - echo: "{{output:user.id}}"\n',
+    ],
+    ["an exists condition's selector", 'steps:\n  - await: { exists: { id: "{{output:row}}" } }\n'],
+    ["a hidden condition's selector", 'steps:\n  - await: { hidden: { id: "{{output:row}}" } }\n'],
+    ["an after relation", 'steps:\n  - tap: { id: row, after: { id: "{{output:card}}" } }\n'],
+    ["a next relation", 'steps:\n  - tap: { id: row, next: { id: "{{output:card}}" } }\n'],
+    [
+      "a step inside a platform-guarded when block",
+      'steps:\n  - when: { platform: ios }\n    steps:\n      - echo: "{{output:user.id}}"\n',
+    ],
+  ];
+
+  it.each(REFUSALS)("refuses one in %s", (_label, yaml) => {
+    expect(() => parseFlow(yaml)).toThrow(/unsupported template syntax/);
+  });
+
+  it("names the field and asks for a literal value", () => {
+    let message = "";
+    try {
+      parseFlow('steps:\n  - type: { into: { id: name }, text: "{{output:user.name}}" }\n');
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain("`type.text`");
+    expect(message).toContain("{{output:");
+    expect(message).toContain("Replace it with the literal value the step needs");
+  });
+
+  it("addresses a condition's selector and its expectation apart", () => {
+    const fieldNamed = (yaml: string): string => {
+      try {
+        parseFlow(yaml);
+      } catch (err) {
+        return /`([^`]+)` uses unsupported template syntax/.exec(
+          err instanceof Error ? err.message : ""
+        )![1]!;
+      }
+      throw new Error(`expected parseFlow to reject: ${yaml}`);
+    };
+
+    expect(
+      fieldNamed('steps:\n  - await: { text: { in: { id: "{{output:row}}" }, contains: Done } }\n')
+    ).toBe("await.text.in.id");
+    expect(
+      fieldNamed('steps:\n  - await: { text: { in: total, contains: "{{output:sum}}" } }\n')
+    ).toBe("await.text.contains");
+    expect(fieldNamed('steps:\n  - assert: { visible: { id: "{{output:row}}" } }\n')).toBe(
+      "assert.visible.id"
+    );
+    expect(
+      fieldNamed(
+        'steps:\n  - when: { text: { in: total, equals: "{{output:sum}}" } }\n    steps:\n      - echo: hi\n'
+      )
+    ).toBe("when.text.equals");
+    expect(
+      fieldNamed('steps:\n  - scroll-to: { target: { id: "{{output:row}}" }, direction: down }\n')
+    ).toBe("scroll-to.target.id");
+  });
+
+  it("addresses a relation scope apart from the target it narrows", () => {
+    const locatorNamed = (yaml: string): string => {
+      try {
+        parseFlow(yaml);
+      } catch (err) {
+        return /\): (.*?) uses unsupported template syntax/.exec(
+          err instanceof Error ? err.message : ""
+        )![1]!;
+      }
+      throw new Error(`expected parseFlow to reject: ${yaml}`);
+    };
+
+    expect(
+      locatorNamed(
+        'steps:\n  - await: { visible: { text: Ok, within: { text: "{{output:x}}" } } }\n'
+      )
+    ).toBe("`await.visible.within.text`");
+    expect(
+      locatorNamed('steps:\n  - tap: { id: a, within: { id: b, after: { id: "{{output:x}}" } } }\n')
+    ).toBe(
+      "`tap.within.after.id` (spelled `tap.on.within.after.id` if the target sits under `on:`)"
+    );
+  });
+
+  it("addresses a gesture target under `on:` whenever the step is known to spell it there", () => {
+    const locatorNamed = (yaml: string): string => {
+      try {
+        parseFlow(yaml);
+      } catch (err) {
+        return /\): (.*?) uses unsupported template syntax/.exec(
+          err instanceof Error ? err.message : ""
+        )![1]!;
+      }
+      throw new Error(`expected parseFlow to reject: ${yaml}`);
+    };
+
+    // An option beside the target proves the options form; `pinch` and
+    // `rotate` have no other form. Each of these names one path.
+    expect(locatorNamed('steps:\n  - tap: { on: { id: "{{output:row}}" }, times: 2 }\n')).toBe(
+      "`tap.on.id`"
+    );
+    expect(
+      locatorNamed('steps:\n  - long-press: { on: { id: "{{output:row}}" }, duration: 900 }\n')
+    ).toBe("`long-press.on.id`");
+    expect(locatorNamed('steps:\n  - pinch: { on: { id: "{{output:map}}" }, scale: 2 }\n')).toBe(
+      "`pinch.on.id`"
+    );
+    expect(locatorNamed('steps:\n  - rotate: { on: { id: "{{output:map}}" }, by: 45 }\n')).toBe(
+      "`rotate.on.id`"
+    );
+  });
+
+  it("names both gesture spellings when the parse cannot tell them apart", () => {
+    // A `tap`/`long-press` step with no option beside its target parses the
+    // same from either form, so exactly one of these two paths is in the
+    // author's file and the parse cannot say which. `times: 1` and an omitted
+    // `duration` are the shapes that reach this: both normalize away.
+    const locatorNamed = (yaml: string): string => {
+      try {
+        parseFlow(yaml);
+      } catch (err) {
+        return /\): (.*?) uses unsupported template syntax/.exec(
+          err instanceof Error ? err.message : ""
+        )![1]!;
+      }
+      throw new Error(`expected parseFlow to reject: ${yaml}`);
+    };
+
+    expect(locatorNamed('steps:\n  - tap: { id: "{{output:row}}" }\n')).toBe(
+      "`tap.id` (spelled `tap.on.id` if the target sits under `on:`)"
+    );
+    expect(locatorNamed('steps:\n  - tap: { on: { id: "{{output:row}}" }, times: 1 }\n')).toBe(
+      "`tap.id` (spelled `tap.on.id` if the target sits under `on:`)"
+    );
+    expect(locatorNamed('steps:\n  - long-press: { on: { id: "{{output:row}}" } }\n')).toBe(
+      "`long-press.id` (spelled `long-press.on.id` if the target sits under `on:`)"
+    );
+  });
+
+  it("names the constraint a bare-string target parses into", () => {
+    const locatorNamed = (yaml: string): string => {
+      try {
+        parseFlow(yaml);
+      } catch (err) {
+        return /\): (.*?) uses unsupported template syntax/.exec(
+          err instanceof Error ? err.message : ""
+        )![1]!;
+      }
+      throw new Error(`expected parseFlow to reject: ${yaml}`);
+    };
+
+    expect(locatorNamed('steps:\n  - tap: "{{output:row}}"\n')).toBe(
+      "`tap.text` (spelled `tap.on.text` if the target sits under `on:`)"
+    );
+    expect(
+      locatorNamed('steps:\n  - scroll-to: { target: "{{output:row}}", direction: down }\n')
+    ).toBe("`scroll-to.target.text`");
+  });
+
+  it("names the step, so a reference inside a block says which one", () => {
+    let message = "";
+    try {
+      parseFlow(
+        'steps:\n  - echo: first\n  - when: { visible: { id: row } }\n    steps:\n      - echo: ok\n      - echo: "{{output:user.id}}"\n'
+      );
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain("Step 2.2 (`echo`)");
+  });
+
+  it("addresses a tool arg by its own path through the args", () => {
+    let message = "";
+    try {
+      parseFlow(
+        'steps:\n  - tool: run-sequence\n    args: { steps: [{ args: { text: "{{output:code}}" } }] }\n'
+      );
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain("`args.steps[0].args.text`");
+  });
+
+  it("carries the parser's own entry failure code", () => {
+    let signal;
+    try {
+      parseFlow('steps:\n  - echo: "{{output:user.id}}"\n');
+    } catch (err) {
+      signal = getFailureSignal(err);
+    }
+    expect(signal?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
+  });
+
+  it("survives a cyclic tool-args anchor rather than blowing the stack", () => {
+    expect(() =>
+      parseFlow("steps:\n  - tool: keyboard\n    args: &a\n      self: *a\n")
+    ).not.toThrow();
+    expect(() =>
+      parseFlow(
+        'steps:\n  - tool: keyboard\n    args: &a\n      self: *a\n      text: "{{output:code}}"\n'
+      )
+    ).toThrow(/unsupported template syntax/);
+  });
+
+  it("reaches a leaf inside the two containers own properties do not show", () => {
+    expect(() =>
+      parseFlow(
+        '%YAML 1.1\n---\nsteps:\n  - tool: t\n    args:\n      inner: !!set\n        ? "{{output:x}}"\n'
+      )
+    ).toThrow(/`args.inner` uses unsupported template syntax/);
+    expect(() =>
+      parseFlow(
+        '%YAML 1.1\n---\nsteps:\n  - tool: t\n    args: !!omap\n      - k: "{{output:x}}"\n'
+      )
+    ).toThrow(/`args.k` uses unsupported template syntax/);
+  });
+
+  it("leaves fields off the supported list alone", () => {
+    expect(parseFlow('steps:\n  - launch: "com.acme.{{output:app}}"\n').steps[0]).toEqual({
+      kind: "launch",
+      app: "com.acme.{{output:app}}",
+    });
+    expect(
+      parseFlow(
+        'steps:\n  - launch: { chromium: { path: ./app, args: ["--seed={{output:order.id}}"] } }\n'
+      ).steps[0]
+    ).toEqual({
+      kind: "launch",
+      app: { chromium: { path: "./app", args: ["--seed={{output:order.id}}"] } },
+    });
+    expect(parseFlow('steps:\n  - run: "{{output:x}}/login.yaml"\n').steps[0]).toEqual({
+      kind: "run",
+      flow: "{{output:x}}/login.yaml",
+    });
+  });
+
+  it("refuses the three unscanned names whose own charset already forbids one", () => {
+    expect(() => parseFlow('steps:\n  - run: "{{output:x}}"\n')).toThrow(/must end in .yaml/);
+    expect(() => parseFlow('steps:\n  - script: { path: "{{output:x}}.mjs" }\n')).toThrow(
+      /filename must match/
+    );
+    expect(() => parseFlow('steps:\n  - snapshot: "{{output:x}}"\n')).toThrow(
+      /snapshot name .* must match/
+    );
+  });
+
+  it("cuts a long offending value in the message rather than quoting all of it", () => {
+    const filler = "x".repeat(400);
+    let message = "";
+    try {
+      parseFlow(`steps:\n  - echo: "{{output:user.id}}${filler}"\n`);
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    const quoted = /Replace it with the literal value the step needs: "(.*)"$/s.exec(message)?.[1];
+    expect(quoted).toBeDefined();
+    expect(quoted!.endsWith("…")).toBe(true);
+    // `MAX_ENTRY_RENDER_CHARS` (200) plus the ellipsis that replaces the rest.
+    expect(quoted!.length).toBe(201);
+    expect(message.length).toBeLessThan(1000);
+  });
+
+  it("leaves a pattern alone, at both levels that spell one", () => {
+    // A regular expression is not a literal — a `{{` in one is a
+    // quantifier-shaped sequence the author meant — so no regex is on the
+    // supported list. The marker is UNESCAPED in both patterns here: an escaped
+    // `\\{\\{output:` does not contain the marker at all, so it would pass
+    // whether or not the field were scanned, and pin nothing.
+    expect(parseFlow('steps:\n  - tap: { text: { matches: "{{output:.*" } }\n').steps[0]).toEqual({
+      kind: "tap",
+      selector: { textMatches: "{{output:.*" },
+    });
+    expect(
+      parseFlow('steps:\n  - assert: { text: { in: total, matches: "{{output:.*" } }\n').steps[0]
+    ).toMatchObject({ kind: "assert", expectedText: "{{output:.*", textMatch: "matches" });
+  });
+
+  it("refuses a pattern in a `when` guard, the one context where it fails silently", () => {
+    // The exemption above holds where an unmatchable pattern is LOUD: a tap
+    // finds nothing, an assert fails. A `when` guard that matches nothing is
+    // simply not met — the block is skipped and the run is green — so the two
+    // regex spellings are scanned there, exactly as the `{{secret:` guard in
+    // parseWhenCondition scans them.
+    const fieldNamed = (yaml: string): string => {
+      try {
+        parseFlow(yaml);
+      } catch (err) {
+        return /`([^`]+)` uses unsupported template syntax/.exec(
+          err instanceof Error ? err.message : ""
+        )![1]!;
+      }
+      throw new Error(`expected parseFlow to reject: ${yaml}`);
+    };
+
+    expect(
+      fieldNamed(
+        'steps:\n  - when: { visible: { text: { matches: "{{output:x}}" } } }\n    steps:\n      - echo: hi\n'
+      )
+    ).toBe("when.visible.text.matches");
+    expect(
+      fieldNamed(
+        'steps:\n  - when: { text: { in: { text: Total }, matches: "{{output:sum}}" } }\n    steps:\n      - echo: hi\n'
+      )
+    ).toBe("when.text.matches");
+    // A pattern in a relational scope of the guard degrades it the same way.
+    expect(
+      fieldNamed(
+        'steps:\n  - when: { visible: { text: Ok, within: { text: { matches: "{{output:x}}" } } } }\n    steps:\n      - echo: hi\n'
+      )
+    ).toBe("when.visible.within.text.matches");
+  });
+
+  it("does not confuse a secret placeholder for one", () => {
+    expect(
+      parseFlow('steps:\n  - type: { into: { id: pw }, text: "{{secret:APP_PASSWORD}}" }\n')
+        .steps[0]
+    ).toMatchObject({ kind: "type", text: "{{secret:APP_PASSWORD}}" });
+  });
+});
+
 // The parser's block list and blockSteps' runtime answer are the same claim
 // asked twice; a directive only one of them knows drops its whole block from
 // every skip expansion and from the upload preflight, silently.

--- a/packages/tool-server/test/flows/script/flow-script-lifecycle.test.ts
+++ b/packages/tool-server/test/flows/script/flow-script-lifecycle.test.ts
@@ -219,6 +219,8 @@ describe("flow script executor — time limits and cancellation", () => {
 
     expect(result.failure?.kind).toBe("cancelled");
     expect(result.durationMs).toBeLessThan(10_000);
+    // The script was forked and ran for 300ms, so whatever it did stands.
+    expect(result.failure?.beforeFork).toBeUndefined();
   });
 
   it("honours an abort raised in the same tick as the call", async () => {
@@ -242,6 +244,28 @@ describe("flow script executor — time limits and cancellation", () => {
     expect(result.failure?.kind).toBe("cancelled");
     expect(result.log).not.toContain("finished work");
     expect(result.durationMs).toBeLessThan(1_000);
+    expect(result.failure?.beforeFork).toBe(true);
+  });
+
+  // The same kind carries both halves of a cancellation, and only the executor
+  // knows which one it raised: a caller that tells its author to go clean up
+  // after a script that was never forked sends them after state that does not
+  // exist.
+  it("marks a cancellation that arrived before the call as never forked", async () => {
+    const ws = workspace();
+    const script = ws.write("seed.mjs", `output.seeded = true;`);
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await executor().execute({
+      scriptPath: script,
+      projectRoot: ws.dir,
+      signal: controller.signal,
+    });
+
+    expect(result.failure?.kind).toBe("cancelled");
+    expect(result.failure?.message).toContain("before the script started");
+    expect(result.failure?.beforeFork).toBe(true);
   });
 
   it("does not relabel a cancellation as a timeout when the deadline passes mid-stop", async () => {

--- a/packages/tool-server/test/flows/script/flow-script-queue.test.ts
+++ b/packages/tool-server/test/flows/script/flow-script-queue.test.ts
@@ -125,6 +125,8 @@ describe("flow script executor — concurrency", () => {
     const cancelled = await queued;
     const answeredAfterMs = Date.now() - abortedAt;
     expect(cancelled.failure?.kind).toBe("cancelled");
+    // It never left the queue, so no child of it exists to have done anything.
+    expect(cancelled.failure?.beforeFork).toBe(true);
     // The occupier keeps the only slot for another ~700ms. Without the queue's
     // own abort listener the waiter would take a slot later and `runOne`'s
     // guard would answer with the same kind, so the kind alone proves nothing.

--- a/packages/tool-server/test/flows/script/flow-script-record.test.ts
+++ b/packages/tool-server/test/flows/script/flow-script-record.test.ts
@@ -1,0 +1,840 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  ArtifactStore,
+  FAILURE_CODES,
+  getFailureSignal,
+  type Registry,
+  type ToolContext,
+} from "@argent/registry";
+import { flowStartRecordingTool } from "../../../src/tools/flows/flow-start-recording";
+import { flowInsertEchoTool } from "../../../src/tools/flows/flow-insert-echo";
+import { flowAddScriptTool } from "../../../src/tools/flows/flow-add-script";
+import { flowFinishRecordingTool } from "../../../src/tools/flows/flow-finish-recording";
+import { createFlowAddStepTool } from "../../../src/tools/flows/flow-add-step";
+import {
+  __resetRecordingsForTesting,
+  getRecordingSession,
+  holdsOutputReference,
+  parseFlow,
+  type FlowStep,
+} from "../../../src/tools/flows/flow-utils";
+import { SCRIPT_STEP_LOG_LIMIT_BYTES } from "../../../src/tools/flows/script/flow-script-executor";
+
+/** Real child processes, so the budgets are generous. */
+vi.setConfig({ testTimeout: 30_000 });
+
+let root: string;
+
+async function write(relative: string, contents: string): Promise<string> {
+  const file = path.join(root, relative);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, contents, "utf8");
+  return file;
+}
+
+function deepFindMarker(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const hit = deepFindMarker(item);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      if (key.startsWith("__argent")) return key;
+      const hit = deepFindMarker(nested);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+function flowPath(name: string, projectRoot = root): string {
+  return path.join(projectRoot, ".argent", "flows", `${name}.yaml`);
+}
+
+async function steps(name: string, projectRoot = root): Promise<FlowStep[]> {
+  return parseFlow(await fs.readFile(flowPath(name, projectRoot), "utf8")).steps;
+}
+
+async function start(name: string, projectRoot = root, ctx?: ToolContext) {
+  return flowStartRecordingTool.execute({}, { name, project_root: projectRoot }, ctx);
+}
+
+async function addScript(
+  name: string,
+  scriptPath: string,
+  extra: { timeout?: number; project_root?: string } = {},
+  ctx?: ToolContext
+) {
+  const { project_root: projectRoot = root, ...rest } = extra;
+  return flowAddScriptTool.execute(
+    {},
+    {
+      name,
+      project_root: projectRoot,
+      path: scriptPath,
+      ...rest,
+    } as never,
+    ctx
+  );
+}
+
+function mockRegistry(): Registry {
+  return {
+    invokeTool: vi.fn(async () => ({ ok: true })),
+    getTool: vi.fn(() => ({ inputSchema: { properties: { udid: {} } } })),
+  } as unknown as Registry;
+}
+
+async function addScriptError(name: string, scriptPath: string): Promise<string> {
+  try {
+    await addScript(name, scriptPath);
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error(`expected flow-add-script to reject "${scriptPath}"`);
+}
+
+function parseError(scriptYaml: string): string {
+  try {
+    parseFlow(`steps:\n  - script: { ${scriptYaml} }\n`);
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error(`expected parseFlow to reject "${scriptYaml}"`);
+}
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "flow-script-record-"));
+  __resetRecordingsForTesting();
+});
+
+afterEach(async () => {
+  __resetRecordingsForTesting();
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("recording a script step", () => {
+  it("runs the script and appends the step it ran", async () => {
+    await write(
+      "scripts/seed.mjs",
+      `console.log("seeded order 4711");\noutput.order = { id: 4711 };`
+    );
+    await start("checkout");
+
+    const result = await addScript("checkout", "../../scripts/seed.mjs");
+
+    expect(result.status).toBe("pass");
+    expect(result.log).toContain("seeded order 4711");
+    expect(result.outputJson).toBe('{"order":{"id":4711}}');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    expect(result.stepCount).toBe(1);
+    expect(result.recorded).toBe("1. script: ../../scripts/seed.mjs");
+    expect(result.savedTo).toBe(flowPath("checkout"));
+    expect(await steps("checkout")).toEqual([{ kind: "script", path: "../../scripts/seed.mjs" }]);
+  });
+
+  it("does not add output details to the success message", async () => {
+    await write("scripts/seed.mjs", `output.user = { id: "u_1" };`);
+    await start("checkout");
+
+    const result = await addScript("checkout", "../../scripts/seed.mjs");
+
+    expect(result.outputJson).toBe('{"user":{"id":"u_1"}}');
+    expect(result.message).toBe('Added script step to "checkout" flow.');
+  });
+
+  it("hands the document over as text, so nothing in it is read as a directive", async () => {
+    // The client deep-walks every result for `__argentClientFile` (writes a
+    // file on the agent's machine) and `__argentArtifact` (fetches one),
+    // matching on shape alone — and a script relaying what a backend answered
+    // is the one part of a result this server does not author. As JSON text
+    // there is no object for either walk to match.
+    await write(
+      "scripts/relay.mjs",
+      `output.body = JSON.parse('{"orderId":"ord_1","meta":{"__argentClientFile":true,` +
+        `"path":"/tmp/planted/.argent/flows/planted.yaml","content":"steps: []"}}');`
+    );
+    await start("relay");
+
+    const result = await addScript("relay", "../../scripts/relay.mjs");
+
+    expect(result.status).toBe("pass");
+    expect(typeof result.outputJson).toBe("string");
+    expect(JSON.parse(result.outputJson!)).toEqual({
+      body: {
+        orderId: "ord_1",
+        meta: {
+          __argentClientFile: true,
+          path: "/tmp/planted/.argent/flows/planted.yaml",
+          content: "steps: []",
+        },
+      },
+    });
+    expect(deepFindMarker(result)).toBeNull();
+  });
+
+  it("cuts a document too large to hand on without adding output prose", async () => {
+    await write("scripts/big.mjs", `output.blob = "y".repeat(1024 * 1024 - 200);`);
+    await start("big");
+
+    const result = await addScript("big", "../../scripts/big.mjs");
+
+    expect(result.status).toBe("pass");
+    expect(Buffer.byteLength(result.outputJson!, "utf8")).toBe(64 * 1024);
+    expect(result.outputTruncated).toBe(true);
+    expect(result.outputJson).toMatch(/^\{"blob":"y+$/);
+    expect(result.stepCount).toBe(1);
+    expect(result.message).toBe('Added script step to "big" flow.');
+    expect(() => JSON.parse(result.outputJson!)).toThrow();
+  });
+
+  it("keeps a document of exactly the render limit whole", async () => {
+    // The limit is inclusive, and nothing else in the suite sits ON it: the
+    // cases either side are 1000 bytes and ~90 KB, so `<=` could become `<`
+    // and only a document of exactly this size would notice.
+    const limit = 64 * 1024;
+    const filler = limit - Buffer.byteLength('{"blob":""}', "utf8");
+    await write("scripts/exact.mjs", `output.blob = "y".repeat(${filler});`);
+    await start("exact");
+
+    const result = await addScript("exact", "../../scripts/exact.mjs");
+
+    expect(result.status).toBe("pass");
+    expect(Buffer.byteLength(result.outputJson!, "utf8")).toBe(limit);
+    expect(result).not.toHaveProperty("outputTruncated");
+    expect(JSON.parse(result.outputJson!)).toEqual({ blob: "y".repeat(filler) });
+  });
+
+  it("cuts a document one byte past the render limit", async () => {
+    const limit = 64 * 1024;
+    const filler = limit - Buffer.byteLength('{"blob":""}', "utf8") + 1;
+    await write("scripts/over.mjs", `output.blob = "y".repeat(${filler});`);
+    await start("over");
+
+    const result = await addScript("over", "../../scripts/over.mjs");
+
+    expect(result.status).toBe("pass");
+    expect(result.outputTruncated).toBe(true);
+    expect(Buffer.byteLength(result.outputJson!, "utf8")).toBe(limit);
+  });
+
+  it("records the timeout the caller asked for, even when the run clamped it", async () => {
+    // Above the executor's absolute ceiling (Node's largest timer), so the
+    // clamp holds whatever `scripts.maxTimeoutMs` the host running this
+    // configures. The recorder writes what was asked for either way: the YAML
+    // is the request, and the clamp is the host's answer to it.
+    const asked = 2_147_483_648;
+    await write("scripts/quick.mjs", `output.ok = true;`);
+    await start("clamped");
+
+    const result = await addScript("clamped", "../../scripts/quick.mjs", { timeout: asked });
+
+    expect(result.status).toBe("pass");
+    expect(result.reason).toContain("above this host's maximum");
+    expect(await steps("clamped")).toEqual([
+      { kind: "script", path: "../../scripts/quick.mjs", timeout: asked },
+    ]);
+  });
+
+  it("stops the script when the caller cancels the call", async () => {
+    const started = path.join(root, "started.txt");
+    await write(
+      "scripts/slow.mjs",
+      `import { writeFileSync } from "node:fs";\n` +
+        `writeFileSync(${JSON.stringify(started)}, "x");\n` +
+        `await new Promise((r) => setTimeout(r, 20000));\n`
+    );
+    await start("cancelled");
+    const controller = new AbortController();
+
+    const call = addScript("cancelled", "../../scripts/slow.mjs", {}, {
+      signal: controller.signal,
+    } as unknown as ToolContext);
+    // Cancel only once the child is provably running, so the case is a stopped
+    // script rather than one that never left the queue.
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      if (
+        await fs.access(started).then(
+          () => true,
+          () => false
+        )
+      )
+        break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    controller.abort();
+    const result = await call;
+
+    expect(result.status).toBe("error");
+    expect(result.reason).toMatch(/cancelled/i);
+    expect(result.durationMs).toBeLessThan(15_000);
+    expect(result.message).toContain("no step was recorded");
+    expect(result.message).toContain("Check or restore its changes before you retry");
+    expect(await steps("cancelled")).toEqual([]);
+  });
+
+  it("says the script ran when a write failure stops it being recorded", async () => {
+    await write("scripts/seed.mjs", `output.ok = true;`);
+    await start("readonly");
+    const flowsDir = path.dirname(flowPath("readonly"));
+    await fs.chmod(flowsDir, 0o500);
+    try {
+      const err = await addScript("readonly", "../../scripts/seed.mjs").catch(
+        (e: unknown) => e as Error
+      );
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("passed, but the step was not recorded");
+      expect((err as Error).message).toContain("Check the script's changes before you retry");
+      expect(getFailureSignal(err as Error)?.failure_stage).toBe("flow_file_write");
+    } finally {
+      await fs.chmod(flowsDir, 0o700);
+    }
+  });
+
+  it("classifies a bare append failure the way every other write failure is classified", async () => {
+    await start("vanished");
+    await write(
+      "scripts/vanish.mjs",
+      `import * as fs from "node:fs";\n` +
+        `fs.unlinkSync(${JSON.stringify(flowPath("vanished"))});\n` +
+        `output.ok = true;`
+    );
+
+    const err = await addScript("vanished", "../../scripts/vanish.mjs").catch(
+      (e: unknown) => e as Error
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    const signal = getFailureSignal(err as Error);
+    expect(signal?.failure_stage).toBe("flow_add_script_append");
+    expect(signal?.error_code).toBe(FAILURE_CODES.FLOW_FILE_WRITE_FAILED);
+    expect(signal?.error_kind).toBe("unknown");
+    expect((err as Error).message).toContain("passed, but the step was not recorded");
+    expect((err as Error).message).toContain("Check the script's changes before you retry");
+  });
+
+  it("blames the hand-edited step, not the script, when the re-parse refuses an earlier one", async () => {
+    // The append re-parses the whole file, so an output reference a mid-recording
+    // hand edit put in an EARLIER step refuses this write. The script itself ran
+    // and passed; wording it as "recording it failed" would send the author back
+    // over the one call that did nothing wrong.
+    await write("scripts/seed.mjs", `output.ok = true;`);
+    await start("handedited");
+    await fs.writeFile(
+      flowPath("handedited"),
+      `steps:\n  - echo: "created {{output:user.id}}"\n`,
+      "utf8"
+    );
+
+    const err = (await addScript("handedited", "../../scripts/seed.mjs").catch(
+      (e: unknown) => e
+    )) as Error;
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("passed, but the step was not recorded");
+    expect(err.message).toContain("Fix the existing step named below");
+    expect(err.message).toContain(flowPath("handedited"));
+    expect(err.message).toContain("Step 1 (`echo`)");
+    // The refusal keeps its own signal; only the framing around it changed.
+    expect(getFailureSignal(err)?.error_code).toBe(FAILURE_CODES.FLOW_ENTRY_UNRECOGNIZED);
+  });
+
+  it("is never itself the step an output-reference refusal names", async () => {
+    // What lets the message above say "not this script" without asking: the scan
+    // reads no field a `script:` step has, so a refusal on the append path can
+    // only be about a step that was already in the file.
+    expect(
+      holdsOutputReference({ kind: "script", path: "../../scripts/{{output:user.id}}.mjs" })
+    ).toBe(false);
+  });
+
+  it("leaves a document inside the limit whole and unflagged", async () => {
+    await write("scripts/seed.mjs", `output.blob = "y".repeat(1000);`);
+    await start("small");
+
+    const result = await addScript("small", "../../scripts/seed.mjs");
+
+    expect(result.outputJson).toBe(JSON.stringify({ blob: "y".repeat(1000) }));
+    expect(result).not.toHaveProperty("outputTruncated");
+    expect(result.message).toBe('Added script step to "small" flow.');
+  });
+
+  it("never cuts a multi-byte character in half", async () => {
+    // The cut lands on the encoded bytes, so a 3-byte character straddling the
+    // ceiling has to be dropped whole — otherwise the field carries a lone
+    // replacement character the script never wrote. 30000 of them encode to
+    // 90 KB: over this ceiling, under the executor's own.
+    await write("scripts/wide.mjs", `output.blob = "\u3042".repeat(30000);`);
+    await start("wide");
+
+    const result = await addScript("wide", "../../scripts/wide.mjs");
+
+    expect(result.outputTruncated).toBe(true);
+    expect(result.outputJson).not.toContain("\uFFFD");
+    expect(Buffer.byteLength(result.outputJson!, "utf8")).toBe(64 * 1024 - 1);
+    expect(result.outputJson).toMatch(/^\{"blob":"\u3042+$/);
+  });
+
+  it("records the timeout when one is given, and nothing when it is not", async () => {
+    await write("scripts/seed.mjs", `output.ok = true;`);
+
+    await start("timed");
+    await addScript("timed", "../../scripts/seed.mjs", { timeout: 45_000 });
+    expect(await steps("timed")).toEqual([
+      { kind: "script", path: "../../scripts/seed.mjs", timeout: 45000 },
+    ]);
+
+    await start("untimed");
+    await addScript("untimed", "../../scripts/seed.mjs");
+    expect(await steps("untimed")).toEqual([{ kind: "script", path: "../../scripts/seed.mjs" }]);
+  });
+
+  it("appends after the steps already recorded, and survives the ones after it", async () => {
+    await write("scripts/seed.mjs", `output.ok = true;`);
+    await start("mixed");
+    await flowInsertEchoTool.execute({}, { name: "mixed", project_root: root, message: "seeding" });
+
+    const script = await addScript("mixed", "../../scripts/seed.mjs", { timeout: 30_000 });
+    expect(script.stepCount).toBe(2);
+
+    await createFlowAddStepTool(mockRegistry()).execute(
+      {},
+      {
+        name: "mixed",
+        project_root: root,
+        command: "restart-app",
+        args: JSON.stringify({ udid: "device-1", bundleId: "com.acme.notes" }),
+      }
+    );
+    const finished = await flowFinishRecordingTool.execute({}, {
+      name: "mixed",
+      project_root: root,
+    } as never);
+
+    expect(finished.summary).toEqual([
+      "1. echo: seeding",
+      "2. script: ../../scripts/seed.mjs (timeout 30000ms)",
+      "3. launch: com.acme.notes",
+    ]);
+    expect(await steps("mixed")).toEqual([
+      { kind: "echo", message: "seeding" },
+      { kind: "script", path: "../../scripts/seed.mjs", timeout: 30000 },
+      { kind: "launch", app: "com.acme.notes" },
+    ]);
+  });
+
+  it("needs no device of any kind", async () => {
+    expect(Object.keys(flowAddScriptTool.zodSchema!.shape).sort()).toEqual([
+      "name",
+      "path",
+      "project_root",
+      "timeout",
+    ]);
+
+    await write("scripts/seed.mjs", `output.ok = true;`);
+    await start("deviceless");
+    expect((await addScript("deviceless", "../../scripts/seed.mjs")).status).toBe("pass");
+  });
+
+  it("is declared longRunning, because a script may outlive the MCP fetch budget", async () => {
+    expect(flowAddScriptTool.longRunning).toBe(true);
+  });
+
+  it("runs in the working directory replay gives it", async () => {
+    await write("fixtures/order.json", `{ "item": "espresso machine" }`);
+    await write(
+      "scripts/read-fixture.mjs",
+      `import { readFileSync } from "node:fs";
+       output.item = JSON.parse(readFileSync("./fixtures/order.json", "utf8")).item;`
+    );
+    await start("cwd");
+
+    const result = await addScript("cwd", "../../scripts/read-fixture.mjs");
+
+    expect(result.status).toBe("pass");
+    expect(result.outputJson).toBe('{"item":"espresso machine"}');
+  });
+
+  it("resolves a path against the flow file, reaching a directory beside the project", async () => {
+    const sibling = path.join(path.dirname(root), `${path.basename(root)}-shared`);
+    await fs.mkdir(sibling, { recursive: true });
+    await fs.writeFile(path.join(sibling, "shared.mjs"), `output.shared = true;`, "utf8");
+    try {
+      await start("outside");
+      const relative = `../../../${path.basename(sibling)}/shared.mjs`;
+
+      const result = await addScript("outside", relative);
+
+      expect(result.status).toBe("pass");
+      expect(result.outputJson).toBe('{"shared":true}');
+      expect(await steps("outside")).toEqual([{ kind: "script", path: relative }]);
+    } finally {
+      await fs.rm(sibling, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the script's logs, and flags a log the step limit cut", async () => {
+    await write(
+      "scripts/chatty.mjs",
+      `console.log("x".repeat(${SCRIPT_STEP_LOG_LIMIT_BYTES + 1024}));\nconsole.error("and a warning");`
+    );
+    await start("chatty");
+
+    const result = await addScript("chatty", "../../scripts/chatty.mjs");
+
+    expect(result.status).toBe("pass");
+    expect(result.logTruncated).toBe(true);
+    expect(result.log!.length).toBeLessThanOrEqual(SCRIPT_STEP_LOG_LIMIT_BYTES);
+    // The cut leaves nothing in the text, which is why the flag is the only
+    // signal and the tool description tells the caller to read it.
+    expect(result.log).not.toContain("truncated");
+    expect(await steps("chatty")).toHaveLength(1);
+  });
+
+  it("flags a log the frame collapser cut, far inside the step limit", async () => {
+    // The cap is not the only thing that raises the flag: the executor also
+    // raises it when its collapser drops a fatal error's frame dump, which
+    // reaches no limit at all. A description naming only the cap would send the
+    // author looking for a log too long to keep.
+    await write(
+      "scripts/framey.mjs",
+      `console.error("FATAL ERROR: build step failed");\n` +
+        `for (let i = 1; i <= 6; i++) console.error(\` \${i}: 0x1049\${i}1aec some symbol\`);\n` +
+        `output.ok = true;`
+    );
+    await start("framey");
+
+    const result = await addScript("framey", "../../scripts/framey.mjs");
+
+    expect(result.status).toBe("pass");
+    expect(result.logTruncated).toBe(true);
+    expect(result.log).toMatch(/\[6 V8 stack frames omitted]/);
+    expect(Buffer.byteLength(result.log!, "utf8")).toBeLessThan(SCRIPT_STEP_LOG_LIMIT_BYTES / 2);
+  });
+});
+
+describe("a script that did not pass records nothing", () => {
+  it("returns the failure and leaves the recording untouched", async () => {
+    await write(
+      "scripts/half.mjs",
+      `console.log("created 2 of 3 records");\nthrow new Error("the backend refused the third");`
+    );
+    await start("failing");
+    await flowInsertEchoTool.execute(
+      {},
+      { name: "failing", project_root: root, message: "before" }
+    );
+
+    const result = await addScript("failing", "../../scripts/half.mjs");
+
+    expect(result.status).toBe("fail");
+    expect(result.reason).toContain("the backend refused the third");
+    expect(result.log).toContain("created 2 of 3 records");
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    expect(result.stepCount).toBe(1);
+    expect(result).not.toHaveProperty("recorded");
+    expect(result).not.toHaveProperty("savedTo");
+    expect(result).not.toHaveProperty("outputJson");
+    expect(await steps("failing")).toEqual([{ kind: "echo", message: "before" }]);
+  });
+
+  it("names the flow and the outcome in its completed line", async () => {
+    const completedMsg = flowAddScriptTool.interaction!.completedMsg!;
+    const params = { name: "checkout", project_root: root, path: "../../scripts/seed.mjs" };
+    const base = { message: "", stepCount: 1 } as const;
+
+    expect(completedMsg({ params, result: { ...base, status: "pass" } })).toBe(
+      "Added script step to flow checkout"
+    );
+    expect(completedMsg({ params, result: { ...base, status: "fail" } })).toBe(
+      "Script for flow checkout failed; nothing recorded"
+    );
+  });
+
+  it("says the failed script was not recorded and gives the next action", async () => {
+    await write("scripts/half.mjs", `throw new Error("boom");`);
+    await start("failing");
+
+    const result = await addScript("failing", "../../scripts/half.mjs");
+
+    expect(result.message).toContain("no step was recorded");
+    expect(result.message).toContain("Check or restore its changes before you retry");
+  });
+
+  it("counts the steps the flow FILE holds, as the success path does", async () => {
+    await start("counted");
+    await flowInsertEchoTool.execute(
+      {},
+      { name: "counted", project_root: root, message: "recorded" }
+    );
+    await fs.appendFile(flowPath("counted"), "  - echo: hand-added\n", "utf8");
+
+    const failed = await addScript("counted", "../../scripts/gone.mjs");
+    expect(failed.status).toBe("fail");
+    expect(failed.stepCount).toBe(2);
+
+    await write("scripts/seed.mjs", `output.ok = true;`);
+    const passed = await addScript("counted", "../../scripts/seed.mjs");
+    expect(passed.stepCount).toBe(3);
+  });
+
+  // With the file unreadable the only count left is the session's, which is the
+  // steps as of the last append - a third number again. An author comparing it
+  // with what the next append renumbers to has to know which one they are
+  // holding, so it is qualified here as the sibling recorder qualifies it.
+  it("says when the step count could not come off the file", async () => {
+    await start("counted");
+    await flowInsertEchoTool.execute(
+      {},
+      { name: "counted", project_root: root, message: "recorded" }
+    );
+    await fs.appendFile(flowPath("counted"), "  - echo: hand-added\n  - bogus: [\n", "utf8");
+
+    const failed = await addScript("counted", "../../scripts/gone.mjs");
+
+    expect(failed.status).toBe("fail");
+    // The in-memory snapshot, while the file itself holds two steps.
+    expect(failed.stepCount).toBe(1);
+    expect(failed.message).toContain("Could not verify stepCount from");
+  });
+
+  it("leaves the count unqualified while the file still parses", async () => {
+    await start("counted");
+    await flowInsertEchoTool.execute(
+      {},
+      { name: "counted", project_root: root, message: "recorded" }
+    );
+
+    const failed = await addScript("counted", "../../scripts/gone.mjs");
+
+    expect(failed.stepCount).toBe(1);
+    expect(failed.message).not.toContain("in-memory snapshot");
+  });
+
+  it("does not send an author cleaning up after a script that never ran", async () => {
+    await start("gone");
+
+    const result = await addScript("gone", "../../scripts/gone.mjs");
+
+    expect(result.message).toContain("did not run");
+    expect(result.message).toContain("Fix the reason before you retry");
+  });
+
+  // A cancellation reaches this tool from both sides of the fork under one
+  // failure kind, so the kind alone cannot answer it. Driven through the real
+  // executor: the file the script would have written is the proof that the
+  // answer matches what happened, not what the kind suggests.
+  it("does not send an author cleaning up after a cancellation that never forked", async () => {
+    const marker = path.join(root, "seeded.txt");
+    await write(
+      "scripts/seed.mjs",
+      `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "x");`
+    );
+    await start("cancelled");
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await addScript("cancelled", "../../scripts/seed.mjs", {}, {
+      signal: controller.signal,
+    } as unknown as ToolContext);
+
+    expect(result.status).toBe("error");
+    expect(result.reason).toContain("before the script started");
+    expect(result.message).toContain("did not run");
+    expect(result.message).toContain("Fix the reason before you retry");
+    await expect(fs.access(marker)).rejects.toThrow();
+    expect(await steps("cancelled")).toEqual([]);
+  });
+
+  it("refuses a missing file before any fork, naming what it looked for", async () => {
+    await start("gone");
+
+    const result = await addScript("gone", "../../scripts/gone.mjs");
+
+    expect(result.status).toBe("fail");
+    expect(result.reason).toContain('Script "../../scripts/gone.mjs" does not exist');
+    // Anchored at the flow file that named the step, with its `..` segments
+    // intact: only the kernel may collapse one, since a lexical collapse past a
+    // symlinked component names another file.
+    const flowsDir = path.dirname(await fs.realpath(flowPath("gone")));
+    expect(result.reason).toContain(`Resolved path: ${flowsDir}${path.sep}../../scripts/gone.mjs`);
+    expect(result).not.toHaveProperty("durationMs");
+    expect(result).not.toHaveProperty("log");
+    expect(await steps("gone")).toEqual([]);
+  });
+
+  it("refuses a directory that happens to be named like a script", async () => {
+    await fs.mkdir(path.join(root, "scripts", "seed.mjs"), { recursive: true });
+    await start("dir");
+
+    const result = await addScript("dir", "../../scripts/seed.mjs");
+
+    expect(result.status).toBe("fail");
+    expect(result.reason).toContain("is not a file");
+    expect(result).not.toHaveProperty("durationMs");
+    expect(await steps("dir")).toEqual([]);
+  });
+
+  it("refuses a mis-cased path, quoting the spelling on disk", async () => {
+    // The one authoring error a local run cannot find: a mis-cased path
+    // recorded here is committed and replayed on a case-sensitive checkout,
+    // where it fails with ENOENT.
+    //
+    // Ungated, because the verdict is not the filesystem's: classifyOnDiskSpelling
+    // compares the supplied basename against readdir's own entries, lowercased.
+    await write("scripts/createUser.mjs", `output.ok = true;`);
+    await start("cased");
+
+    const result = await addScript("cased", "../../scripts/CreateUser.mjs");
+
+    expect(result.status).toBe("error");
+    expect(result.reason).toContain(
+      'Script path "../../scripts/CreateUser.mjs" has the wrong letter case'
+    );
+    expect(result.reason).toContain('Use "../../scripts/createUser.mjs"');
+    expect(await steps("cased")).toEqual([]);
+  });
+});
+
+describe("the paths flow-add-script accepts", () => {
+  const REJECTED: [label: string, supplied: string, yaml: string][] = [
+    ["a backslash", "scripts\\seed.mjs", 'path: "scripts\\\\seed.mjs"'],
+    ["an absolute path", "/tmp/seed.mjs", 'path: "/tmp/seed.mjs"'],
+    ["a drive-relative prefix", "C:seed.mjs", 'path: "C:seed.mjs"'],
+    ["an uppercase extension", "scripts/SEED.MJS", 'path: "scripts/SEED.MJS"'],
+    ["a wrong extension", "scripts/seed.js", 'path: "scripts/seed.js"'],
+    ["a basename outside the charset", "scripts/seed order.mjs", 'path: "scripts/seed order.mjs"'],
+    ["an empty path", "", 'path: ""'],
+  ];
+
+  it.each(REJECTED)(
+    "rejects %s exactly as the YAML parser does",
+    async (_label, supplied, yaml) => {
+      await start("paths");
+      expect(await addScriptError("paths", supplied)).toBe(parseError(yaml));
+      expect(await steps("paths")).toEqual([]);
+    }
+  );
+
+  it("rejects a missing path exactly as the YAML parser does", async () => {
+    await start("paths");
+    let message = "";
+    try {
+      await flowAddScriptTool.execute({}, { name: "paths", project_root: root } as never);
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toBe(parseError(""));
+  });
+
+  it("rejects a non-positive timeout exactly as the YAML parser does", async () => {
+    await write("scripts/seed.mjs", `output.ok = true;`);
+    await start("paths");
+    let message = "";
+    try {
+      await addScript("paths", "../../scripts/seed.mjs", { timeout: 0 });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toBe(parseError('path: "../../scripts/seed.mjs", timeout: 0'));
+    expect(await steps("paths")).toEqual([]);
+  });
+
+  // The floor is the parser's second timeout rejection, and it admits values
+  // the non-positive check lets through — so parity has to be pinned on one of
+  // those too, or the recorder could keep running a limit `parseFlow` refuses.
+  it("rejects a timeout under the floor exactly as the YAML parser does", async () => {
+    const ran = path.join(root, "ran.txt");
+    await write(
+      "scripts/seed.mjs",
+      `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(ran)}, "1");\n`
+    );
+    await start("paths");
+    let message = "";
+    try {
+      await addScript("paths", "../../scripts/seed.mjs", { timeout: 50 });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toBe(parseError('path: "../../scripts/seed.mjs", timeout: 50'));
+    expect(message).toMatch(/script.timeout is in milliseconds and needs at least 100/);
+    expect(await steps("paths")).toEqual([]);
+    // Refused at parse, so the run never started — the recorder must not have
+    // spent the script's side effects on a step it then refuses to record.
+    await expect(fs.access(ran)).rejects.toThrow();
+  });
+});
+
+describe("a recording this server cannot reach", () => {
+  const CLIENT_ROOT = path.join(os.tmpdir(), "definitely-not-on-this-host", "agent-project");
+
+  function remoteCtx(): ToolContext {
+    return {
+      artifacts: new ArtifactStore(),
+      fileInputs: {
+        project_root: { clientPath: CLIENT_ROOT, presentOnHost: false, viaUpload: false },
+      },
+    };
+  }
+
+  it("refuses a client-mode recording without running anything", async () => {
+    const marker = path.join(root, "ran.txt");
+    await write(
+      "scripts/seed.mjs",
+      `import { writeFileSync } from "node:fs";
+       writeFileSync(${JSON.stringify(marker)}, "ran");`
+    );
+    await start("remote", CLIENT_ROOT, remoteCtx());
+
+    let signal;
+    let message = "";
+    try {
+      await addScript("remote", "../../scripts/seed.mjs", { project_root: CLIENT_ROOT });
+    } catch (err) {
+      signal = getFailureSignal(err);
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(signal?.error_code).toBe(FAILURE_CODES.FLOW_FILE_INVALID);
+    expect(signal?.failure_stage).toBe("flow_add_script_client_mode");
+    expect(message).toContain('Cannot access the script for flow "remote"');
+    expect(message).toContain("add the `script:` step to the YAML");
+    await expect(fs.stat(marker)).rejects.toThrow();
+    await expect(fs.stat(CLIENT_ROOT)).rejects.toThrow();
+    expect((await getRecordingSession(CLIENT_ROOT, "remote"))?.flow.steps).toEqual([]);
+  });
+});
+
+describe("a recording that is not live", () => {
+  it("fails the way every recording tool does", async () => {
+    await write("scripts/seed.mjs", `output.ok = true;`);
+
+    let signal;
+    try {
+      await addScript("never-started", "../../scripts/seed.mjs");
+    } catch (err) {
+      signal = getFailureSignal(err);
+    }
+
+    expect(signal?.error_code).toBe(FAILURE_CODES.FLOW_NO_ACTIVE_RECORDING);
+  });
+
+  it("refuses a relative project root before it resolves anything", async () => {
+    let signal;
+    try {
+      await addScript("anything", "../../scripts/seed.mjs", { project_root: "relative/path" });
+    } catch (err) {
+      signal = getFailureSignal(err);
+    }
+
+    expect(signal?.error_code).toBe(FAILURE_CODES.FLOW_PROJECT_ROOT_INVALID);
+  });
+});

--- a/packages/tool-server/test/flows/script/flow-script-step-run.test.ts
+++ b/packages/tool-server/test/flows/script/flow-script-step-run.test.ts
@@ -326,9 +326,9 @@ describe("a script path is checked at its own step", () => {
     const { result } = await runFlow("gone");
 
     expect(result.steps[0]).toMatchObject({ status: "fail", kind: "script" });
-    expect(result.steps[0]!.reason).toContain('script "../../scripts/gone.mjs" does not exist');
+    expect(result.steps[0]!.reason).toContain('Script "../../scripts/gone.mjs" does not exist');
     expect(result.steps[0]!.reason).toMatch(
-      /resolved to \S*[/\\]\.argent[/\\]flows[/\\]\.\.[/\\]\.\.[/\\]scripts[/\\]gone\.mjs\)$/
+      /Resolved path: \S*[/\\]\.argent[/\\]flows[/\\]\.\.[/\\]\.\.[/\\]scripts[/\\]gone\.mjs\.$/
     );
   });
 
@@ -405,9 +405,9 @@ describe("a script path is checked at its own step", () => {
 
     expect(result.steps[0]).toMatchObject({ status: "error" });
     expect(result.steps[0]!.reason).toContain(
-      'mis-cased script path "../../scripts/CreateUser.mjs"'
+      'Script path "../../scripts/CreateUser.mjs" has the wrong letter case'
     );
-    expect(result.steps[0]!.reason).toContain('write it as "../../scripts/createUser.mjs"');
+    expect(result.steps[0]!.reason).toContain('Use "../../scripts/createUser.mjs"');
   });
 
   it("refuses a mis-cased spelling of a script reached through a cross-directory symlink", async () => {
@@ -424,7 +424,7 @@ describe("a script path is checked at its own step", () => {
 
     expect(result.steps[0]).toMatchObject({ status: "error" });
     expect(result.steps[0]!.reason).toContain(
-      'mis-cased script path "../../scripts/createUser.mjs"'
+      'Script path "../../scripts/createUser.mjs" has the wrong letter case'
     );
   });
 
@@ -435,8 +435,8 @@ describe("a script path is checked at its own step", () => {
     const { result } = await runFlow("noncase");
 
     expect(result.steps[0]).toMatchObject({ status: "error" });
-    expect(result.steps[0]!.reason).toContain('rename "ALT.MJS" to "alt.mjs" to run it');
-    expect(result.steps[0]!.reason).not.toContain("write it as");
+    expect(result.steps[0]!.reason).toContain('Rename "ALT.MJS" to "alt.mjs"');
+    expect(result.steps[0]!.reason).not.toContain("Use");
   });
 
   it("treats a hyphen difference as an ordinary missing file, not a casing problem", async () => {
@@ -446,7 +446,7 @@ describe("a script path is checked at its own step", () => {
     const { result } = await runFlow("hyphen");
 
     expect(result.steps[0]!.reason).toContain("does not exist");
-    expect(result.steps[0]!.reason).not.toContain("mis-cased");
+    expect(result.steps[0]!.reason).not.toContain("wrong letter case");
   });
 });
 
@@ -552,6 +552,55 @@ describe("where a script path resolves", () => {
     const reported = fsSync.realpathSync(result.steps[0]!.scriptLog!.trim());
     expect(reported).toBe(fsSync.realpathSync(root));
     expect(reported).not.toBe(fsSync.realpathSync(path.join(root, "elsewhere")));
+  });
+});
+
+describe("which project root a script runs from", () => {
+  /**
+   * `flow-add-script` runs the script with the RECORDING's `project_root`; the
+   * runner uses the ROOT run's. A fragment recorded in one project and composed
+   * by a flow in another therefore runs its script somewhere else than where it
+   * was recorded — which is what the tool's "it ran here as a replay of this
+   * flow will" is qualified against.
+   */
+  it("gives a composed fragment's script the ROOT run's project root", async () => {
+    const composer = await fs.mkdtemp(path.join(os.tmpdir(), "flow-script-composer-"));
+    try {
+      await write(
+        "scripts/where.mjs",
+        `import { writeFileSync } from "node:fs";\n` +
+          `writeFileSync("./where.txt", process.cwd());`
+      );
+      await flow("frag", "steps:\n  - script: { path: ../../scripts/where.mjs }\n");
+      const composed = path.join(composer, ".argent", "flows", "main.yaml");
+      await fs.mkdir(path.dirname(composed), { recursive: true });
+      // `run:` is always relative to the flow file that names it.
+      const target = path
+        .relative(path.dirname(composed), path.join(root, ".argent", "flows", "frag.yaml"))
+        .split(path.sep)
+        .join("/");
+      await fs.writeFile(composed, `steps:\n  - run: ${target}\n`, "utf8");
+
+      const direct = await runFlow("frag");
+      expect(direct.result.ok).toBe(true);
+      expect(fsSync.existsSync(path.join(root, "where.txt"))).toBe(true);
+      await fs.rm(path.join(root, "where.txt"));
+
+      // A flow that uses `run:` resolves a device even when every leaf is a
+      // script — see "still resolves a device when the same flow uses run:".
+      const { registry } = mockRegistry({ booted: [DEVICE] });
+      const composedRun = await run(registry, {
+        project_root: composer,
+        name: "main",
+        device: DEVICE,
+      });
+
+      expect(composedRun.ok).toBe(true);
+      expect(fsSync.existsSync(path.join(composer, "where.txt"))).toBe(true);
+      expect(fsSync.existsSync(path.join(root, "where.txt"))).toBe(false);
+    } finally {
+      await fs.rm(composer, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/tool-server/test/flows/script/flow-script-verdict.test.ts
+++ b/packages/tool-server/test/flows/script/flow-script-verdict.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Registry } from "@argent/registry";
+import type { Registry, ToolContext } from "@argent/registry";
 import { createRunFlowTool, type FlowRunResult } from "../../../src/tools/flows/flow-run";
+import { flowStartRecordingTool } from "../../../src/tools/flows/flow-start-recording";
+import { flowAddScriptTool } from "../../../src/tools/flows/flow-add-script";
+import { scriptVerdict, type ScriptRan } from "../../../src/tools/flows/flow-script-step";
+import { __resetRecordingsForTesting, parseFlow } from "../../../src/tools/flows/flow-utils";
 import type {
   FlowScriptFailureKind,
   FlowScriptResult,
@@ -47,7 +51,30 @@ async function runScript(): Promise<FlowRunResult["steps"][number]> {
   return result.steps[0]!;
 }
 
+async function recordScript(ctx?: ToolContext) {
+  await flowStartRecordingTool.execute({}, { name: "recorded", project_root: root });
+  return flowAddScriptTool.execute(
+    {},
+    {
+      name: "recorded",
+      project_root: root,
+      path: "../../scripts/seed.mjs",
+    } as never,
+    ctx
+  );
+}
+
+function executedRequest(): Record<string, unknown> {
+  return executeMock.mock.calls[0]![0] as Record<string, unknown>;
+}
+
+async function recordedSteps() {
+  return parseFlow(await fs.readFile(path.join(root, ".argent", "flows", "recorded.yaml"), "utf8"))
+    .steps;
+}
+
 beforeEach(async () => {
+  __resetRecordingsForTesting();
   root = await fs.mkdtemp(path.join(os.tmpdir(), "flow-script-verdict-"));
   await fs.mkdir(path.join(root, ".argent", "flows"), { recursive: true });
   await fs.mkdir(path.join(root, "scripts"), { recursive: true });
@@ -61,6 +88,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  __resetRecordingsForTesting();
   await fs.rm(root, { recursive: true, force: true });
 });
 
@@ -78,6 +106,46 @@ const VERDICTS: Record<FlowScriptFailureKind, "fail" | "error"> = {
   queue: "error",
   invalid: "error",
 };
+
+/**
+ * Whether each failure leaves the author something to clean up, judged from the
+ * KIND alone — the answer for a failure the executor did not mark `beforeFork`.
+ * Total over the kinds, like {@link VERDICTS}: the dangerous mapping is a kind
+ * that DID fork being told "nothing ran", and a table listing only some kinds
+ * stays green while a kind moves in or out of the never-forked set.
+ */
+const RAN: Record<FlowScriptFailureKind, ScriptRan> = {
+  queue: "no",
+  spawn: "no",
+  invalid: "no",
+  protocol: "unknown",
+  load: "yes",
+  runtime: "yes",
+  output: "yes",
+  exit: "yes",
+  timeout: "yes",
+  cancelled: "yes",
+  signal: "yes",
+  heap: "yes",
+};
+
+/** The move each answer asks the author to make. */
+const NEXT_MOVE: Record<ScriptRan, string> = {
+  yes: "Check or restore its changes before you retry",
+  no: "Fix the reason before you retry",
+  unknown: "Check its changes before you retry",
+};
+
+/** How the same answer opens, anchored so a later "failed" cannot match it. */
+const LEAD: Record<ScriptRan, string> = {
+  yes: "failed",
+  no: "did not run",
+  unknown: "may have run",
+};
+
+function headline(ran: ScriptRan): string {
+  return `Script "../../scripts/seed.mjs" ${LEAD[ran]};`;
+}
 
 describe("which side of the fail/error line a script failure lands on", () => {
   it.each(Object.entries(VERDICTS))("reports a %s failure as %s", async (kind, status) => {
@@ -97,7 +165,7 @@ describe("which side of the fail/error line a script failure lands on", () => {
 
     expect(await runScript()).toMatchObject({
       status: "error",
-      reason: "The script produced no verdict.",
+      reason: "Script failed without a reason.",
     });
   });
 });
@@ -138,5 +206,102 @@ describe("an executor note on the step report", () => {
       status: "error",
       reason: "The script ran past its 1000ms limit. timeout clamped to 1000ms.",
     });
+  });
+});
+
+describe("the recorder reports the verdict the runner will", () => {
+  it.each(Object.keys(VERDICTS) as FlowScriptFailureKind[])(
+    "agrees with the runner about a %s failure",
+    async (kind) => {
+      const result = outcome({ failure: { kind, message: `the ${kind} message` } });
+      executeMock.mockResolvedValue(result);
+
+      const replayed = await runScript();
+      const recorded = await recordScript();
+
+      expect(recorded.status).toBe(scriptVerdict(result).status);
+      expect(recorded.status).toBe(replayed.status);
+      expect(recorded.reason).toBe(replayed.reason);
+      expect(await recordedSteps()).toEqual([]);
+    }
+  );
+
+  it.each(Object.entries(RAN) as [FlowScriptFailureKind, ScriptRan][])(
+    "tells the author whether a %s failure left anything behind",
+    async (kind, ran) => {
+      // The executor answers three of its failures WITHOUT forking anything, so
+      // "there is a result" does not mean "something ran", and telling an
+      // author to clean up after a queue that was full sends them hunting for
+      // state that was never created. `cancelled` counts as ran only once the
+      // executor has NOT marked it `beforeFork` - the half of that kind which
+      // stopped a process that was already running. `protocol` is the runner
+      // failing around the script - almost always before the script began, but
+      // reachable from a script that has already done its work, so it claims
+      // neither.
+      executeMock.mockResolvedValue(outcome({ failure: { kind, message: `the ${kind} message` } }));
+
+      const recorded = await recordScript();
+
+      expect(recorded.status).not.toBe("pass");
+      expect(recorded.message).toContain(NEXT_MOVE[ran]);
+      expect(recorded.message).toContain(headline(ran));
+      // The headline is the clause an agent acts on first, so it may not answer
+      // "is there state to check?" differently from the move that follows it.
+      for (const other of Object.keys(NEXT_MOVE) as ScriptRan[]) {
+        if (other !== ran) expect(recorded.message).not.toContain(headline(other));
+      }
+      expect(await recordedSteps()).toEqual([]);
+    }
+  );
+
+  // The executor's own answer outranks the table above: `cancelled` is the one
+  // kind that reaches this tool from both sides of the fork, and the executor
+  // marks the failures it raised before there was a child to run anything.
+  it.each(Object.keys(RAN) as FlowScriptFailureKind[])(
+    "believes the executor over the kind when a %s failure never forked",
+    async (kind) => {
+      executeMock.mockResolvedValue(
+        outcome({ failure: { kind, message: `the ${kind} message`, beforeFork: true } })
+      );
+
+      const recorded = await recordScript();
+
+      expect(recorded.message).toContain(NEXT_MOVE.no);
+      expect(recorded.message).toContain(headline("no"));
+      expect(recorded.message).not.toContain(NEXT_MOVE.yes);
+      expect(recorded.message).not.toContain(NEXT_MOVE.unknown);
+      expect(await recordedSteps()).toEqual([]);
+    }
+  );
+
+  it("agrees on a pass, and only then records the step", async () => {
+    const result = outcome({ ok: true, output: { order: { id: 7 } }, notes: ["a note."] });
+    executeMock.mockResolvedValue(result);
+
+    const replayed = await runScript();
+    const recorded = await recordScript();
+
+    expect(recorded.status).toBe("pass");
+    expect(recorded.status).toBe(replayed.status);
+    expect(recorded.reason).toBe(replayed.reason);
+    expect(recorded.outputJson).toBe('{"order":{"id":7}}');
+    expect(await recordedSteps()).toEqual([{ kind: "script", path: "../../scripts/seed.mjs" }]);
+  });
+
+  it("hands the executor the caller's cancellation signal", async () => {
+    executeMock.mockResolvedValue(outcome({ ok: true, output: {} }));
+    const controller = new AbortController();
+
+    await recordScript({ signal: controller.signal } as unknown as ToolContext);
+
+    expect(executedRequest().signal).toBe(controller.signal);
+  });
+
+  it("passes no signal when the caller has none", async () => {
+    executeMock.mockResolvedValue(outcome({ ok: true, output: {} }));
+
+    await recordScript();
+
+    expect("signal" in executedRequest()).toBe(false);
   });
 });

--- a/packages/tool-server/test/helpers/catalog.ts
+++ b/packages/tool-server/test/helpers/catalog.ts
@@ -3,7 +3,7 @@ import { createProposeVariantTool } from "../../src/tools/variants/propose-varia
 import { awaitUserSelectionTool } from "../../src/tools/variants/await-user-selection";
 
 /** Every tool argent can serve. Bump deliberately when a tool is added or removed. */
-export const EXPECTED_TOOL_COUNT = 77;
+export const EXPECTED_TOOL_COUNT = 78;
 
 /**
  * The full catalog, keyed by id. The Lens tools never reach

--- a/packages/tool-server/test/interaction-messages.test.ts
+++ b/packages/tool-server/test/interaction-messages.test.ts
@@ -187,21 +187,17 @@ describe("tool interaction messages", () => {
   it("names the flow in every recording-tool interaction line", () => {
     // Recordings are concurrent, so several of these lines interleave in one log
     // and an unqualified "flow recording" would not say which one died or
-    // finished. Only two of the twelve formatters on the four recording tools
-    // are pinned elsewhere (flow-start-recording.completedMsg above,
-    // flow-add-echo.completedMsg in the secrets test), so the other ten could
-    // silently revert to name-free wording. Hold every one to naming the flow —
-    // the property the concurrency support introduced — including the failure
+    // finished. Hold every formatter on every recording tool to naming the flow
+    // — the property the concurrency support introduced — including the failure
     // lines, which are the diagnostic when several recordings are live.
     const definitions = definitionsById(createRegistry());
     const name = "checkout";
     const params = { name, project_root: "/tmp/proj", command: "gesture-tap", message: "note" };
     // Each tool's OWN result shape. One shared `{ message, flowFile, savedTo }`
-    // used to stand in for all four, which stopped describing any of them once
+    // used to stand in for all of them, which stopped describing any once
     // the recorder dropped the per-step YAML: `flowFile` survives on start and
     // finish only, and add-step/add-echo report `stepCount` (plus `recorded`
-    // on add-step) instead. No formatter below reads a field that differs
-    // between them, but a fixture that misdescribes the contract is the one
+    // on add-step) instead. A fixture that misdescribes the contract is the one
     // that gets copied into a test that does.
     const results: Record<string, Record<string, unknown>> = {
       "flow-start-recording": { message: "", flowFile: "", savedTo: "project" },
@@ -213,6 +209,13 @@ describe("tool interaction messages", () => {
         savedTo: "project",
       },
       "flow-add-echo": { message: "", stepCount: 1, savedTo: "project" },
+      "flow-add-script": {
+        message: "",
+        status: "pass",
+        stepCount: 1,
+        recorded: "1. script: ../../scripts/seed.mjs",
+        savedTo: "project",
+      },
       "flow-finish-recording": {
         message: "",
         path: "/tmp/proj/.argent/flows/checkout.yaml",
@@ -228,6 +231,7 @@ describe("tool interaction messages", () => {
       "flow-start-recording",
       "flow-add-step",
       "flow-add-echo",
+      "flow-add-script",
       "flow-finish-recording",
     ]) {
       const i = definitions.get(id)!.interaction!;


### PR DESCRIPTION
#864 (the executor) and #865 (the `script:` step) are merged. This branch now
sits directly on `main` as a single commit, so the diff and the commit list are
this change alone.

A `script:` step could only enter a flow by being typed into the YAML after the
recording ended. The authoring skill said so in as many words, and listed it
among the legal unrecorded insertions. That made it the one directive exempt
from every rule the recorder exists to enforce, and it cost two things:

- **The script never ran while the flow was authored.** It first executed during
  the closing replay, where a failure reads as a flow that was never right
  rather than a script that needs one more attempt. Worse, the device steps
  recorded after it were walked against backend state the author had established
  by hand — so the recording proved nothing about whether the script establishes
  that same state.
- **The author never saw what the script returned.** A later release reads
  `{{output:user.id}}`; the only way to know that path exists is to have seen the
  document.

This adds one MCP tool, `flow-add-script`, that runs a local `.mjs` and records
the step it ran. **No new flow syntax** — the `script:` step is unchanged, and
this is a second way for one to enter a flow file.

```text
flow-add-script { name: "checkout", project_root: "/Users/dev/shop",
                  path: "../../scripts/seed-order.mjs", timeout: 60000 }
```

## What it adds

- **One shared execution path.** Path resolution, the on-disk casing guard, the
  executor call and the verdict were private to `flow-run.ts`. They are now
  `runFlowScriptStep` in `flow-script-step.ts`, with the file-ref helpers in
  `flow-file-refs.ts`, and `runScriptStep` is that call plus its `ExecState`
  plumbing. This is the load-bearing change: "the recording runs the script
  exactly as replay will" is one function, not two code paths that agree today.
- **A failure records nothing.** The opposite of `flow-add-step`, deliberately.
  A failed script did not establish the state the rest of the walkthrough would
  then be recorded against, so an appended red step costs every step after it,
  not just itself. The `message` also says whether a child actually *ran* — a
  path that resolved to no file forked nothing, while a script that threw
  halfway did not roll back — because the author's next move is a retry or a
  cleanup and they cannot pick without knowing.
- **The returned document, as JSON text.** Text rather than an object because
  this is the first tool result carrying bytes the server did not author: every
  result is deep-walked for `__argentClientFile` and `__argentArtifact`
  directives, which match on shape alone and write or fetch files on the agent's
  machine. As a string it inherits none of that. Bounded at 64 KiB with
  `outputTruncated`, for the reason `log` is bounded.
- **`{{output:` refused by `parseFlow`.** Surfacing the document invites an
  author to write a reference that has no meaning yet — it would be printed
  literally by a step that passes, green and wrong. The scan runs over exactly
  the field list the output release declares supported, so it is a seam that
  release converts from reject to resolve rather than scaffolding it deletes.
  Patterns are excluded: a `{{` in a regular expression is a quantifier the
  author meant.
- **Two boundaries.** A `client`-mode recording is refused — its `.mjs` never
  left the agent's machine, the same anchor reason `run:`, `snapshot` and
  uploaded flows are refused. And the tool is `longRunning`, so the MCP
  adapter's 30s fetch abort cannot retry a call whose whole purpose is a side
  effect; the comment records what that flag does *not* close, and where the
  rest belongs.
- **`flow-add-step` says when the call already ran.** The `{{output:` refusal is
  the one refusal this release adds on a path where the tool call has already
  fired, and its message asks for an edit-and-retry — which repeats the device
  action. Verified: a `keyboard` step recorded twice left
  `{{output:code}}{{output:code}}` in the field. That one refusal now carries
  what already happened.

## Documentation

Rule 5 of `argent-create-flow` no longer lists `script:` as a legal unrecorded
insertion — leaving it there would tell agents to keep doing the thing this PR
removes. `live-authoring.md` gains the recorder contract, the return fields that
are not self-evident, and the ordering rule: a setup script is recorded *before*
the `restart-app` it prepares state for, because that is where it runs at
replay. A leading script does not make the flow a fragment. `qa-flows` and
`reliability-and-recovery` follow the count and the wording.

## Verification

`npm run build`, `npx eslint . --max-warnings 0`, `npx prettier --check` over
tracked files, and `npm run typecheck:tests -w @argent/tool-server` are green.
`npm test -w @argent/tool-server`: 358 files, 4657 passed, 1 skipped.

Exercised end to end against a live tool server built from this branch, not
only in tests — recorded a flow, then replayed the saved YAML through
`argent flow run` with no hand editing:

```
flow-add-script → status "pass", durationMs 124
  log: "seeding order for the flow\nwarn: using the fake backend\n"
  outputJson: {"order":{"id":"ord_4417","total":39.5},
               "user":{"id":"usr_9","email":"buyer@example.com"}}
  recorded: 1. script: ../../scripts/seed-order.mjs (timeout 30000ms)
```

```yaml
steps:
  - script:
      path: ../../scripts/seed-order.mjs
      timeout: 30000
  - echo: order seeded; expect Home
```

```
Flow "checkout"
  ✓  1 script ../../scripts/seed-order.mjs
       │ seeding order for the flow
       │ warn: using the fake backend
  › order seeded; expect Home

PASS — 1 passed, 0 failed, 0 errored, 0 skipped
```

The three refusals, live on the same recording:

- A script that threw after creating records: `status "fail"`, `stepCount`
  unchanged at 1, and the message naming the side effects that were not rolled
  back.
- A path resolving to no file: refused before any fork, no `durationMs`, and
  "Nothing ran, so there is nothing to clean up".
- `flow-add-echo` holding `{{output:user.id}}`: refused with the author-facing
  message naming the step, the field and the later release.

No device is involved at any point — a recording may open with a seeding script
before it boots anything.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `flow-add-script` tool to run local `.mjs` scripts and record successful executions in flows.
  * Added script status, output, duration, logs, and failure details to recording results.
  * Added clearer handling for script cancellation, timeouts, missing files, and path casing.

* **Documentation**
  * Updated flow guidance to clarify end-to-end classification and script setup or cleanup usage.
  * Documented script path requirements, failure conditions, and recording workflows.

* **Bug Fixes**
  * Flows now reject unsupported output-reference templates with more precise diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->