### PR TITLE
docs: cover the paste tool on the interacting features page

### DIFF
--- a/packages/docs/docs/features/interacting-with-apps.mdx
+++ b/packages/docs/docs/features/interacting-with-apps.mdx
@@ -35,7 +35,7 @@ The agent opens an app by its bundle id or package name. The agent does not tap 
 
 ## Gestures and text
 
-The agent taps, swipes, pinches, rotates content, and sends custom touch sequences for long press or drag and drop. On Chromium, the agent scrolls with the mouse wheel and drags with the mouse. The agent taps a text field first, then types text and special keys such as enter or escape.
+The agent taps, swipes, pinches, rotates content, and sends custom touch sequences for long press or drag and drop. On Chromium, the agent scrolls with the mouse wheel and drags with the mouse. The agent taps a text field first, then types text and special keys such as enter or escape. When a user would use paste, the agent puts the text on the device clipboard and pastes it in one step.
 
 To type a credential, the agent uses a secret placeholder. Argent fills the value from your environment. The value does not enter the context of the agent.
 
@@ -79,7 +79,7 @@ If the agent knows several actions before the start, and there is nothing to exa
 
 - TV targets are focus-driven. The agent does not use touch gestures on them.
 - Swipe is for touch targets. On Chromium, the agent scrolls and drags with the mouse.
-- Shake works on simulators and emulators only.
+- Shake and paste work on simulators and emulators only.
 - On Chromium, each action goes to the active tab.
 
 The [tools reference](/docs/reference/tools) contains all tools, including the ones in the **Interacting** and **Devices and apps** groups.


### PR DESCRIPTION
The `paste` tool was the only capability in the **Interacting** tool group with no mention on the `features/interacting-with-apps` page — typing, gestures, shake, buttons and permissions are all covered there. It already has its row in the tools reference.

This adds the minimal parity:

- one sentence in **Gestures and text**: for long text, the agent puts the text on the clipboard and pastes it in one step;
- the **Limits** bullet for the sim/emu-only restriction, merged into the existing shake bullet, which has the same restriction.

No reference changes needed — `reference/tools.mdx` already lists `paste`.

Checks: `npx docusaurus build` in `packages/docs` passes; `npm run format` from the repo root leaves the file unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPSUSz8gDxGm7tb9tA3b4D