### PR TITLE
optimization: simplify flow-run description

### DIFF
--- a/packages/skills/skills/argent-create-flow/references/flow-yaml.md
+++ b/packages/skills/skills/argent-create-flow/references/flow-yaml.md
@@ -109,7 +109,7 @@ Scopes can combine and nest, with at most six scope keys. Use strict selectors f
 
 ## Directives
 
-Directives stop the flow on failure and skip later steps. `flow-execute` documents their shapes. The available directives are `launch`, `tap`, `long-press`, `swipe`, `type`, `scroll-to`, `pinch`, `rotate`, `await`, `assert`, `wait`, `snapshot`, `run`, `script`, `when`, `echo`, and `tool`.
+Directives stop the flow on failure and skip later steps. The available directives are `launch`, `tap`, `long-press`, `swipe`, `type`, `scroll-to`, `pinch`, `rotate`, `await`, `assert`, `wait`, `snapshot`, `run`, `script`, `when`, `echo`, and `tool`.
 
 Use the launch map for cross-platform flows. A bare launch applies everywhere and becomes an app path on Chromium. The map takes `native:`, `ios:`, `android:`, `vega:`, and `chromium:`. `native:` is one id shared by iOS, Android, and Vega, and a per-platform key overrides it for that platform. `chromium:` accepts a relative or absolute app path. A launch that declares no id for the run's platform is an error, not a cue to switch platforms. On iOS, a successful launch also pins later tree reads to that app until the next raw `tool:` step, so read [The runner tree is not the discovery tree](#the-runner-tree-is-not-the-discovery-tree) when a read describes the wrong screen.
 

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1223,7 +1223,7 @@ export function createRunFlowTool(
       failedMsg: ({ params, failureSignal }) =>
         `Failed to run flow ${displayFlowName(params)}: ${failureSignal.error_code}`,
     },
-    description: `Run a saved flow — a YAML script of UI steps — end to end against a booted device. Use when
+    description: `Run a saved YAML flow end to end. Use when
 asked to replay a recorded path, re-run a QA regression, or check that a known journey still passes; for a
 one-off interaction use the gesture tools instead, and to author a flow use flow-start-recording. Pass
 exactly one flow source: name (under project_root) or flow_path.

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1226,9 +1226,8 @@ export function createRunFlowTool(
     description: `Run a saved flow — a YAML script of UI steps — end to end against a booted device. Use when
 asked to replay a recorded path, re-run a QA regression, or check that a known journey still passes; for a
 one-off interaction use the gesture tools instead, and to author a flow use flow-start-recording. Pass
-exactly one of name (under project_root) or flow_path.
-Returns a per-step report: the first failure stops the run and the rest report as skipped; a flow with an unacknowledged executionPrerequisite returns a
-notice instead of running; and a step that passes carrying a \`warning\` was sent, not verified.`,
+exactly one flow source: name (under project_root) or flow_path.
+Returns a per-step report: the first failure stops the run and the rest report as skipped.`,
     longRunning: true,
     zodSchema,
     fileInputs,

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1223,85 +1223,9 @@ export function createRunFlowTool(
       failedMsg: ({ params, failureSignal }) =>
         `Failed to run flow ${displayFlowName(params)}: ${failureSignal.error_code}`,
     },
-    description: `Run a saved flow from the .argent/flows/ directory, or an explicit boundary-managed flow_path.
-Use when a scenario is already authored as YAML and the whole of it should replay in one call with a
-per-step verdict; reach for the individual gesture tools when nothing is authored yet, and for
-run-sequence when the steps are an ad-hoc list rather than a stored flow.
-Steps run in order: \`launch\` starts an app from scratch (terminate + relaunch) and waits until it is
-ready (on iOS it also pins later element lookups to that app rather than auto-detecting the frontmost
-one); \`tool\` calls dispatch through the registry (a raw \`tool\` step ends that iOS pin, so lookups
-auto-detect again until the next \`launch\`, though a tool that cannot change the foreground app leaves the
-launched id as a fallback for a timed-out auto-detect, and \`launch-app\`/\`restart-app\` leave the id they
-started as that fallback instead); \`tap\`/\`long-press\`/\`type\` resolve a selector to an
-element and act on it (\`tap: { on, times: 2 }\` double-taps; \`long-press: { on, duration }\` presses and
-holds; \`tap\`/\`long-press\` alternatively take a raw normalized point — bare \`{ x, y }\` or \`on: { x, y }\`;
-any selector may scope its matches geometrically, the CSS combinators read off frames: \`within: <selector>\`
-(descendant — inside that container's frame), \`after: <selector>\` (CSS \`~\` — following it in reading
-order), \`next: <selector>\` (CSS \`+\` — the nearest such follower, which unlike CSS reaches past a
-non-matching neighbour rather than failing), plus \`any: true\` (CSS \`*\` — legal only WITH a scope and
-never beside text/id/role). Scopes nest to disambiguate — \`within: { id: card, within: { id: list } }\`
-reads "inside card inside list", each container's frame inside the next);
-\`swipe\` performs one finger flick (\`swipe: left\`, or \`swipe: { from?, direction|to|by, momentum?, duration? }\` —
-direction is the FINGER's travel, the opposite sense of scroll-to's content direction; \`by: { x?, y? }\` — signed
-0–1 screen fractions, combined length at least 0.03 (a diagonal clears it where neither axis does); duration in ms,
-default 300, minimum 150, maximum 10000; each bound is a parse error that rejects the file before any step runs;
-\`momentum: false\` lands exactly where the finger lifts instead of flinging);
-\`scroll-to\` scrolls (momentum-free) until a target is visible; \`pinch\` zooms
-(\`pinch: { on?, scale }\` — scale > 1 in, < 1 out; screen center when \`on\` is omitted); \`rotate\` is the
-two-finger rotation gesture (\`rotate: { on?, by }\` — degrees, + clockwise, within ±3000°; screen center
-when \`on\` is omitted; distinct from the \`rotate\` tool, which changes device orientation); \`await\` waits
-for a UI condition, and additionally takes the one condition that has no selector: \`idle: true\` waits
-until the screen has content and stops moving in BOTH the UI tree and the rendered pixels (it never
-fails a run — a screen that never settles passes carrying a \`warning\`, which is what makes it safe to
-persist; the one idle outcome that does stop the run is an \`error\` for a tree source THIS step could not
-read at all — a broken window rather than a verdict about the app, which leaves the run not-ok and skips
-every later step; it says nothing about WHICH screen settled — a dropped tap leaves the source screen
-perfectly idle — so pair it with the element check that names the destination); \`wait\` pauses for a fixed number of milliseconds; \`assert\` checks one now; \`snapshot\`
-diffs a screenshot — or, with \`cropOn: <selector>\`, one element's cropped region — against a stored
-baseline (a missing baseline fails the step — set updateBaselines to adopt the current screen; a
-cropped element whose size drifted fails on dimensions); \`echo\` annotates; \`run\` executes another flow
-inline — a YAML path resolved against the directory of the flow file that references it (co-located
-runs only); \`script\` runs a local .mjs file in a fresh Node process for setup, cleanup, or any work a device step cannot do
-(\`script: { path: ../../scripts/seed.mjs, timeout?: <ms> }\` — always a map, never a bare path; the path
-is resolved against the flow file that names the step, exactly as a \`run\` target is, so a saved flow
-climbs out of .argent/flows/ to reach the project's own scripts/ directory. The step needs no device, so
-a script-only flow runs with nothing booted — but a \`run\` or a \`when\` step beside it still resolves
-one, \`when\` even when the only thing it guards is another script, so a platform-gated seed needs a
-device of that platform. Its stdout and stderr come back on the step report. Co-located runs only.).
-A selector-less gesture — a coordinate \`tap\`/\`long-press\`/\`swipe\`, or a \`pinch\`/\`rotate\` with no \`on\` — resolves
-no frame out of the tree, so an unreadable tree source does NOT stop it the way it stops \`idle\`: it
-settles best-effort, dispatches anyway, and the step PASSES carrying a \`warning\` that quotes the source's
-own error. That green says the gesture was SENT, not that it landed. Restore the tree source (usually
-relaunch the app so the instrumentation loads), or accept the warning where the app can serve no tree;
-the first such gesture proves the outage and later ones spend that verdict without paying the settle
-window again. A tree read that comes back, or a relaunch, retires that verdict — which only makes the
-next gesture pay a fresh window, and it warns again if the source is still down.
-A \`when:\` block (condition + \`steps:\`, no else) runs its steps only if the condition holds —
-checked once with the short assert grace — for one-sided divergences like interstitials and coach
-marks; a skipped block reports distinctly and failures inside an entered block are real failures.
-A flow is self-contained when its first non-\`echo\`/\`script\` step is \`launch\`; it must not declare
-\`executionPrerequisite\`. Other flows use the device's current state. Device id is injected by the runner (flows store none) — pass \`device\` or
-\`platform\` to pick one, else the single booted device is used. On Chromium a \`launch\` step's value is an
-Electron app path ({ chromium: <path> | { path, args } }) the runner boots (on the tool-server host) rather
-than an installed app id it relaunches. With no explicit \`device\`, a run whose leading launch is
-unambiguously chromium (\`platform: chromium\`, or a lone \`{ chromium: … }\` target) boots that app and
-starts there — following a leading \`run:\`, \`echo:\` or \`script:\`, so a fragment that composes a chromium
-e2e flow boots too, and so does a flow that seeds a backend before it launches;
-otherwise the first launch attaches to an already-running instance and never kills it. Every later
-launch — a nested e2e flow's own, or a mid-flow relaunch — boots a fresh instance the run moves onto;
-an instance the run already owns for that same app is killed first (its exit awaited) so the
-replacement can't lose the race against its single-instance lock. Instances the runner still owns at
-run end are torn down then. A launch declaring no id for the run's platform is an error, not a cue to
-switch platforms. Every step hard-stops the flow on failure; later steps are reported as skipped.
-Returns a structured report ({ flow, device, executionPrerequisite, ok, aborted?, passed, failed,
-skipped, errored, steps }) — \`device\` is the device the run STARTED on; when launches moved it onto
-runner-booted instances, each names its instance in that step's reason and marks the move — \`run moved
-off <id>\`, or \`retired <id> (same app relaunched)\` when the instance it left was the one killed —
-a relaunch that retired an older owned instance names both.
-
-If a fragment has an execution prerequisite and prerequisiteAcknowledged is not set to true, the tool
-returns a notice with the prerequisite instead of running.
-Pass exactly one flow source: name for a saved flow under project_root, or flow_path for an explicit YAML — both together, or neither, fails the call.`,
+    description: `Run a saved flow — a YAML script of UI steps — end to end against a booted device, passing
+exactly one of name (under project_root) or flow_path, and returning a per-step report in which the first
+failure stops the run and a step that passes carrying a \`warning\` was sent, not verified.`,
     longRunning: true,
     zodSchema,
     fileInputs,

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -1223,9 +1223,12 @@ export function createRunFlowTool(
       failedMsg: ({ params, failureSignal }) =>
         `Failed to run flow ${displayFlowName(params)}: ${failureSignal.error_code}`,
     },
-    description: `Run a saved flow — a YAML script of UI steps — end to end against a booted device, passing
-exactly one of name (under project_root) or flow_path, and returning a per-step report in which the first
-failure stops the run and a step that passes carrying a \`warning\` was sent, not verified.`,
+    description: `Run a saved flow — a YAML script of UI steps — end to end against a booted device. Use when
+asked to replay a recorded path, re-run a QA regression, or check that a known journey still passes; for a
+one-off interaction use the gesture tools instead, and to author a flow use flow-start-recording. Pass
+exactly one of name (under project_root) or flow_path.
+Returns a per-step report: the first failure stops the run and the rest report as skipped; a flow with an unacknowledged executionPrerequisite returns a
+notice instead of running; and a step that passes carrying a \`warning\` was sent, not verified.`,
     longRunning: true,
     zodSchema,
     fileInputs,

--- a/packages/tool-server/test/flows/flow-skill-docs.test.ts
+++ b/packages/tool-server/test/flows/flow-skill-docs.test.ts
@@ -12,7 +12,6 @@ import {
   parseFlow,
   STEP_DIRECTIVE_KEYS,
 } from "../../src/tools/flows/flow-utils";
-import { createRunFlowTool } from "../../src/tools/flows/flow-run";
 import { createFlowAddStepTool, directiveCommandHint } from "../../src/tools/flows/flow-add-step";
 
 /**
@@ -92,16 +91,11 @@ describe("create-flow selector-scope docs", () => {
 
 // The `idle` account moved out of SKILL.md into the flow-yaml reference, so
 // these read it there. They are otherwise the guards that came with the
-// warn-instead-of-fail change: the two agent-facing descriptions of `idle`
-// have to agree with what it does, and the numbers the prose quotes have to be
-// the ones the parser enforces.
+// warn-instead-of-fail change: the reference has to agree with what `idle`
+// does, and the numbers the prose quotes have to be the ones the parser
+// enforces.
 describe("create-flow idle docs", () => {
-  it("the flow-execute description and the reference agree that idle warns rather than fails", () => {
-    const description = createRunFlowTool({} as unknown as Registry).description;
-    expect(description).toContain("idle: true");
-    expect(description).toMatch(/never\s+fails a run/);
-    expect(description).not.toMatch(/FAILS on timeout/i);
-
+  it("the reference says idle warns rather than fails", () => {
     const reference = readFileSync(FLOW_YAML, "utf8");
     expect(reference).toContain("It **never fails a run.**");
     // The one outcome that does stop a run is the window, never the app - and
@@ -109,10 +103,6 @@ describe("create-flow idle docs", () => {
     // leaves a selector-less gesture passing with a warning of its own.
     expect(reference).toMatch(/Only a tree source this step could not read stops the run/);
     expect(reference).toMatch(/stops no \[selector-less gesture\]/);
-    // Both surfaces have to carry that caveat: the description is what an
-    // authoring agent reads, and "never fails a run" on its own is not true
-    // of a tree nobody could read.
-    expect(description).toMatch(/unreadable|cannot be read|could not be read/);
   });
 
   it("the reference's idle defaults and settle span are the ones the parser enforces", () => {

--- a/packages/tool-server/test/flows/flow-skill-docs.test.ts
+++ b/packages/tool-server/test/flows/flow-skill-docs.test.ts
@@ -12,6 +12,7 @@ import {
   parseFlow,
   STEP_DIRECTIVE_KEYS,
 } from "../../src/tools/flows/flow-utils";
+import { createRunFlowTool } from "../../src/tools/flows/flow-run";
 import { createFlowAddStepTool, directiveCommandHint } from "../../src/tools/flows/flow-add-step";
 
 /**
@@ -225,38 +226,10 @@ describe("create-flow directive-answer docs", () => {
 });
 
 /**
- * The `script` account in the flow-execute description is the only agent-facing
- * statement of what the step needs and where its path points, so the two claims
- * an author acts on are pinned here rather than left to prose review.
+ * `project_root` is the only agent-facing statement of where a `script:` path
+ * resolves from, so that claim is pinned here rather than left to prose review.
  */
 describe("create-flow script docs", () => {
-  const description = (): string => {
-    const { description: text } = createRunFlowTool({} as unknown as Registry);
-    expect(text, "flow-execute no longer declares a description").toBeDefined();
-    return text!;
-  };
-
-  it("names every step that still resolves a device beside a deviceless script", () => {
-    // `run` and `when` are the two whose own body can be nothing but scripts
-    // and that resolve one anyway — `run` because the fragment is read at run
-    // time, `when` because the guard reads the device itself. A platform-gated
-    // seed is the natural next thing to write after this sentence, and on a
-    // host with no device of that platform the whole run is refused.
-    for (const kind of ["run", "when"]) {
-      expect(description(), kind).toMatch(
-        new RegExp(`a script-only flow runs with nothing booted[^.]*\`${kind}\``)
-      );
-    }
-  });
-
-  it("shows a script path that reaches the directory scripts really live in", () => {
-    // A path relative to the flow FILE, so a saved flow anchors in
-    // `.argent/flows/`. `scripts/seed.mjs` there names
-    // `.argent/flows/scripts/seed.mjs`, which is two directories from where the
-    // reference page and the skills put a script.
-    expect(description()).toContain("script: { path: ../../scripts/seed.mjs");
-  });
-
   it("lists a script path among what a flow_path run re-anchors", () => {
     // `project_root` still names the script's working directory either way; it
     // is the RESOLUTION that moves to the YAML, and a `script:` path is the
@@ -267,16 +240,5 @@ describe("create-flow script docs", () => {
     const projectRoot = schema.properties.project_root?.description;
     expect(projectRoot, "`project_root` no longer describes itself").toBeDefined();
     expect(projectRoot!).toMatch(/with flow_path[^.]*script:/);
-  });
-
-  it("lets the chromium hoist follow every step a leading launch can sit behind", () => {
-    // The same set `precedesLeadingLaunch` admits. A flow that seeds a backend
-    // before it launches is exactly the shape this PR added, and it boots its
-    // own instance like any other leading launch.
-    for (const kind of ["run:", "echo:", "script:"]) {
-      expect(description(), kind).toMatch(
-        new RegExp(`following a leading[^.]*\`${kind.replace(":", ":")}\``)
-      );
-    }
   });
 });


### PR DESCRIPTION
# Why

It is reported that benchmark results are getting worse and the `flow-execute` description has the largest optimization potential. The description field of MCP tools should describe what the tool does and when to call it, not reveal implementation details.

<img width="1195" height="382" alt="Screenshot 2026-08-25 at 12 45 30" src="https://github.com/user-attachments/assets/d83ba9c5-5e4f-4c65-ba3a-4af0588e5faa" />

# Warning

Not tested. I'd have to run this change twice against the benchmark repo but that feels like overkill. I am not sure about behavioral regressions, relying on CI here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Flow YAML reference to streamline directive documentation.
  - Revised the flow execution tool’s description with a concise overview of supported flow sources and per-step reports.
  - Clarified documentation around flow behavior, including warning handling and project-root configuration.
  - Removed outdated or overly detailed statements from the published guidance to keep the reference accurate and easier to scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->