### PR TITLE
fix(cli): accept --help after a telemetry subcommand

### DIFF
--- a/packages/argent-cli/src/telemetry.ts
+++ b/packages/argent-cli/src/telemetry.ts
@@ -20,19 +20,30 @@ const TELEMETRY_OPTIONS = {
 export async function telemetry(args: string[]): Promise<void> {
   const sub = args[0];
   let scope: FlagScope = "global";
-  try {
-    const { positionals, options } = parseCommandArgs(args.slice(1), TELEMETRY_OPTIONS);
-    if (positionals.length > 0) {
-      throw new UsageError(`Unexpected argument "${positionals[0]}".`);
+  // Help is accepted in any position, including after a subcommand; the option
+  // parser below knows only `--scope` and would reject it as an unknown flag.
+  const wantsHelp = args.includes("--help") || args.includes("-h");
+  if (!wantsHelp) {
+    try {
+      const { positionals, options } = parseCommandArgs(args.slice(1), TELEMETRY_OPTIONS);
+      if (positionals.length > 0) {
+        throw new UsageError(`Unexpected argument "${positionals[0]}".`);
+      }
+      if (options.scope !== undefined) scope = options.scope as FlagScope;
+    } catch (err) {
+      if (!(err instanceof UsageError)) throw err;
+      console.error(`Error: ${err.message}`);
+      printUsage();
+      process.exit(2);
     }
-    if (options.scope !== undefined) scope = options.scope as FlagScope;
-  } catch (err) {
-    if (!(err instanceof UsageError)) throw err;
-    console.error(`Error: ${err.message}`);
-    printUsage();
-    process.exit(2);
   }
   telemetryInit("cli");
+
+  if (wantsHelp) {
+    printUsage();
+    await telemetryShutdown();
+    return;
+  }
 
   switch (sub) {
     case undefined:
@@ -48,11 +59,6 @@ export async function telemetry(args: string[]): Promise<void> {
       return;
     case "disable":
       await cmdDisable(scope);
-      return;
-    case "--help":
-    case "-h":
-      printUsage();
-      await telemetryShutdown();
       return;
     default:
       console.error(`Unknown subcommand: telemetry ${sub}`);

--- a/packages/argent-cli/test/telemetry-command.test.ts
+++ b/packages/argent-cli/test/telemetry-command.test.ts
@@ -122,4 +122,21 @@ describe("argent telemetry — scopes", () => {
     expect(globalConfig()).toBeNull();
     expect(projectConfig()).toBeNull();
   });
+
+  // `argent <command> --help` is what the top-level help tells the user to run,
+  // and every other subcommand honours it after its own subcommand too.
+  it.each([
+    ["--help"],
+    ["-h"],
+    ["status", "--help"],
+    ["status", "-h"],
+    ["enable", "--help"],
+    ["disable", "-h"],
+  ])("prints usage for %s and writes nothing", async (...args) => {
+    await telemetry(args);
+    expect(output()).toContain("argent telemetry status");
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(globalConfig()).toBeNull();
+    expect(projectConfig()).toBeNull();
+  });
 });


### PR DESCRIPTION
Found while differentially regression-testing the 0.22.1 release against a bundle built from `v0.22.0`.

## The problem

`argent telemetry status --help` exits 2 with `Error: Unknown flag: --help`. So do `-h`, and the same after `enable` / `disable`. On 0.22.0 all of them exited 0.

```
$ argent telemetry status --help
0.22.0   telemetry: / state: enabled / device id: not created     (rc=0)
0.22.1   Error: Unknown flag: --help                              (rc=2)
```

`telemetry` is the only subcommand that behaves this way. Checked against every sibling on both versions — `server status|logs|start`, `config list|get|set`, `flow list|run`, `secrets`, `flags`, `enable`, `link`, `unlink` all return 0 on both. And the top-level help tells the user to run exactly this: "Run `argent <command> --help` for command-specific help."

## Cause

`TELEMETRY_OPTIONS` declares only `scope`, and `parseCommandArgs(args.slice(1), …)` reads everything after the subcommand — so `--help` arrives as an unknown flag. The `case "--help"` arm in the switch only fires when help is `args[0]`, which is why bare `argent telemetry --help` still works.

Introduced when `telemetry` was converted to the declarative parser (#952, extended by #953).

## The fix

Hoist the help check above the parser, matching what `config.ts:220` and `flags.ts:92` already do; `server`, `link` and `lens` instead declare `help` in their option spec. Telemetry did neither. Ordering of `telemetryInit` / `telemetryShutdown` around the help path is unchanged, so a help invocation behaves exactly as `argent telemetry --help` did before.

## Tests

Six cases added to `telemetry-command.test.ts` covering `--help` / `-h`, bare and after each subcommand, asserting usage is printed and no config file is written.

Mutation-checked: with the source change reverted, 4 of the 6 fail (the 2 bare-help cases pass either way, since those already worked) — so the test pins the actual defect rather than the behaviour around it.

`@argent/cli`: 498 passed, 3 skipped. `tsc --build` clean, prettier clean.

## Docs

No docs update needed — this restores previously documented behaviour rather than changing a documented surface.
