### PR TITLE
fix: skip writing to allowlist when permissions.json is empty

### DIFF
--- a/packages/argent-installer/src/init-allowlist.ts
+++ b/packages/argent-installer/src/init-allowlist.ts
@@ -54,8 +54,16 @@ export async function configureAllowlist(args: {
       continue;
     }
     try {
-      adapter.addAllowlist!(effectiveRoot, scope);
-      lines.push(`${pc.green("+")} ${adapter.name}`);
+      // `false` means the adapter skipped on purpose: writing the rule would
+      // override an allowlist the editor is managing itself.
+      const applied = adapter.addAllowlist!(effectiveRoot, scope);
+      if (applied === false) {
+        lines.push(
+          `${pc.yellow("-")} ${adapter.name} ${pc.dim("(left the in-app allowlist in charge)")}`
+        );
+      } else {
+        lines.push(`${pc.green("+")} ${adapter.name}`);
+      }
     } catch (err) {
       lines.push(`${pc.red("x")} ${adapter.name}: ${pc.dim(String(err))}`);
     }

--- a/packages/argent-installer/src/mcp-configs.ts
+++ b/packages/argent-installer/src/mcp-configs.ts
@@ -85,7 +85,10 @@ export interface McpConfigAdapter {
   // Report argent state outside the projectPath/globalPath pair that can keep
   // the entry written at `writtenScope` from taking effect.
   findShadowingConfigs?(root: string, writtenScope: "local" | "global"): ShadowingConfigFinding[];
-  addAllowlist?(root: string, scope: "local" | "global"): void;
+  // Returns false when the adapter deliberately left the config untouched
+  // because writing an allowlist would make the user's permissions stricter.
+  // void (every other adapter) counts as applied.
+  addAllowlist?(root: string, scope: "local" | "global"): void | boolean;
   removeAllowlist?(root: string, scope: "local" | "global"): void;
 }
 
@@ -382,7 +385,8 @@ function cursorDirLooksArgentOnly(dir: string): boolean {
       return jsonLooksArgentServerOnly(full, "mcpServers");
     }
     if (entry === "permissions.json") {
-      // Written by this adapter's addAllowlist: { mcpAllowlist: ["argent:*"] }.
+      // As an older addAllowlist left it: { mcpAllowlist: ["argent:*"] }. It no
+      // longer creates this file, but installs that predate that still have one.
       const config = parseJsoncStrict(full);
       if (config === null) return false;
       const keys = Object.keys(config);
@@ -674,12 +678,27 @@ const cursorAdapter: McpConfigAdapter = {
 
   // The allowlist lives in a separate ~/.cursor/permissions.json that may carry
   // the user's own rules, so edit that one key instead of rewriting the file.
-  addAllowlist(): void {
+  //
+  // Skip an absent or empty one rather than creating it. Per Cursor's docs
+  // (cursor.com/docs/reference/permissions), the file is not an additive layer:
+  // while it is missing, unparseable or has no `mcpAllowlist` key Cursor "falls
+  // back to the IDE allowlist for that key", but defining the key "overrides
+  // the in-app MCP allowlist entirely" - unlisted servers go back to needing
+  // approval, and the allowlist editor turns read-only with its "Add to
+  // allowlist" button hidden. Creating the file to add argent would therefore
+  // discard whatever the user had allowed in the IDE and lock them out of the
+  // UI that manages it, to grant a permission the IDE allowlist can already
+  // hold. Only extend a file the user has already opted into.
+  addAllowlist(): boolean {
     const permPath = path.join(homedir(), ".cursor", "permissions.json");
     const config = readJsonc(permPath);
+    // Covers a missing file, an empty/whitespace one, `{}`, and unparseable
+    // content - readJsonc collapses all of them to an empty object.
+    if (Object.keys(config).length === 0) return false;
     const list = Array.isArray(config.mcpAllowlist) ? (config.mcpAllowlist as string[]) : [];
-    if (list.includes(CURSOR_ALLOWLIST_PATTERN)) return;
+    if (list.includes(CURSOR_ALLOWLIST_PATTERN)) return true;
     editJsoncFile(permPath, ["mcpAllowlist"], [...list, CURSOR_ALLOWLIST_PATTERN]);
+    return true;
   },
 
   removeAllowlist(_root: string, scope: "local" | "global"): void {

--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -2278,11 +2278,40 @@ describe("installer preserves foreign MCP config", () => {
     fs.rmSync(homedirOverride, { recursive: true, force: true });
   });
 
+  // While permissions.json is missing or unparseable Cursor falls back to the
+  // IDE allowlist, but an `mcpAllowlist` key overrides that in-app allowlist
+  // entirely. Creating the file would discard the user's IDE entries, so
+  // addAllowlist leaves an absent or empty one alone.
+  it.each([
+    ["missing", null],
+    ["empty", ""],
+    ["an empty object", "{}\n"],
+  ])("Cursor addAllowlist leaves %s permissions.json untouched", (_label, contents) => {
+    const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
+    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
+    if (contents !== null) {
+      fs.mkdirSync(path.dirname(permPath), { recursive: true });
+      fs.writeFileSync(permPath, contents);
+    }
+
+    expect(cursor.addAllowlist!(tmpDir, "global")).toBe(false);
+
+    if (contents === null) {
+      expect(fs.existsSync(permPath)).toBe(false);
+    } else {
+      expect(fs.readFileSync(permPath, "utf8")).toBe(contents);
+    }
+    fs.rmSync(homedirOverride, { recursive: true, force: true });
+  });
+
   it("Cursor removeAllowlist deletes the file when argent was the only rule", () => {
     const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
     homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
     const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
-    cursor.addAllowlist!(tmpDir, "global"); // fresh create: { mcpAllowlist: ["argent:*"] }
+    // As an older argent left it: addAllowlist no longer creates this file.
+    fs.mkdirSync(path.dirname(permPath), { recursive: true });
+    fs.writeFileSync(permPath, JSON.stringify({ mcpAllowlist: ["argent:*"] }));
     cursor.removeAllowlist!(tmpDir, "global");
     expect(fs.existsSync(permPath)).toBe(false);
     fs.rmSync(homedirOverride, { recursive: true, force: true });


### PR DESCRIPTION
Previously when Argent was installed or updated it would write to Cursor's `permissions.json` file to add argent to mcp allowlist.
The issue is that when this file is used to determine [run mode](https://cursor.com/docs/agent/security/run-modes). When it is empty the cursor allows the user to use 'Run Everything (unsandboxed), but when it is not empty the cursor will keep asking for permission every time it does something.
So when Argent adds itself to empty file it effectively removed permission for other mcps and commands.

This PR updates the Argent to not write to the `permissions.json` file when it is empty.