### PR TITLE
fix(tool-server): frame device sockets on \n only — U+2028 in a label stalled describe for 15 s

### DIFF
--- a/packages/tool-server/src/blueprints/ax-service.ts
+++ b/packages/tool-server/src/blueprints/ax-service.ts
@@ -1,7 +1,7 @@
 import * as net from "node:net";
 import * as fs from "node:fs";
-import * as readline from "node:readline";
 import { ChildProcess } from "node:child_process";
+import { attachNdjsonReader, reportDroppedFrameToStderr } from "../utils/ndjson-socket";
 import {
   FAILURE_CODES,
   FailureError,
@@ -274,38 +274,34 @@ export const axServiceBlueprint: ServiceBlueprint<AXServiceApi, DeviceInfo> = {
       }
       daemonSocket = socket;
 
-      const rl = readline.createInterface({ input: socket });
-      rl.on("line", (raw) => {
-        let msg: { id?: number; result?: unknown; error?: unknown };
-        try {
-          msg = JSON.parse(raw);
-        } catch {
-          return;
-        }
-        if (typeof msg.id !== "number") return;
-        const pending = pendingRpc.get(msg.id);
-        if (!pending) return;
-        pendingRpc.delete(msg.id);
-        clearTimeout(pending.timer);
-        if (msg.error !== undefined && msg.error !== null) {
-          pending.reject(
-            new FailureError(
-              typeof msg.error === "string" ? msg.error : JSON.stringify(msg.error),
-              {
-                error_code: FAILURE_CODES.AX_QUERY_FAILED,
-                failure_stage: "ax_service_query_rpc",
-                failure_area: "tool_server",
-                error_kind: "unknown",
-              }
-            )
-          );
-        } else {
-          pending.resolve(msg.result);
-        }
+      attachNdjsonReader(socket, {
+        onDropped: reportDroppedFrameToStderr(`ax-service ${udid.slice(0, 8)}`),
+        onMessage: (parsed) => {
+          const msg = parsed as { id?: number; result?: unknown; error?: unknown };
+          if (typeof msg.id !== "number") return;
+          const pending = pendingRpc.get(msg.id);
+          if (!pending) return;
+          pendingRpc.delete(msg.id);
+          clearTimeout(pending.timer);
+          if (msg.error !== undefined && msg.error !== null) {
+            pending.reject(
+              new FailureError(
+                typeof msg.error === "string" ? msg.error : JSON.stringify(msg.error),
+                {
+                  error_code: FAILURE_CODES.AX_QUERY_FAILED,
+                  failure_stage: "ax_service_query_rpc",
+                  failure_area: "tool_server",
+                  error_kind: "unknown",
+                }
+              )
+            );
+          } else {
+            pending.resolve(msg.result);
+          }
+        },
       });
 
       socket.on("close", () => {
-        rl.close();
         if (daemonSocket === socket) {
           daemonSocket = null;
           if (!disposed) {

--- a/packages/tool-server/src/blueprints/native-devtools.ts
+++ b/packages/tool-server/src/blueprints/native-devtools.ts
@@ -1,6 +1,6 @@
 import * as net from "node:net";
 import * as fs from "node:fs";
-import * as readline from "node:readline";
+import { attachNdjsonReader, reportDroppedFrameToStderr } from "../utils/ndjson-socket";
 import {
   TypedEventEmitter,
   FAILURE_CODES,
@@ -705,78 +705,73 @@ export const nativeDevtoolsBlueprint: ServiceBlueprint<NativeDevtoolsApi, Device
 
     const server = net.createServer((socket) => {
       let bundleId: string | null = null;
-      const rl = readline.createInterface({ input: socket });
+      attachNdjsonReader(socket, {
+        onDropped: reportDroppedFrameToStderr(`native-devtools ${udid.slice(0, 8)}`),
+        onMessage: (parsed) => {
+          const msg = parsed as { type: string; payload: any };
 
-      rl.on("line", (raw) => {
-        let msg: { type: string; payload: any };
-        try {
-          msg = JSON.parse(raw);
-        } catch {
-          return;
-        }
+          // Handshake: must be the first message.
+          if (bundleId === null) {
+            if (msg.type !== "Control") return;
+            bundleId = msg.payload.bundleId as string;
 
-        // Handshake: must be the first message.
-        if (bundleId === null) {
-          if (msg.type !== "Control") return;
-          bundleId = msg.payload.bundleId as string;
+            // The same app reconnecting (fast restart) supersedes the old socket.
+            const existing = connections.get(bundleId);
+            if (existing) {
+              existing.socket.destroy();
+            }
 
-          // The same app reconnecting (fast restart) supersedes the old socket.
-          const existing = connections.get(bundleId);
-          if (existing) {
-            existing.socket.destroy();
+            connections.set(bundleId, { socket, networkLog: [] });
+
+            if (activatedBundleIds.has(bundleId)) {
+              socket.write(
+                JSON.stringify({
+                  type: "Control",
+                  payload: { command: "activateNetworkInspection" },
+                }) + "\n"
+              );
+            }
+            return;
           }
 
-          connections.set(bundleId, { socket, networkLog: [] });
-
-          if (activatedBundleIds.has(bundleId)) {
-            socket.write(
-              JSON.stringify({
-                type: "Control",
-                payload: { command: "activateNetworkInspection" },
-              }) + "\n"
-            );
-          }
-          return;
-        }
-
-        if (msg.type === "CDP") {
-          const p = msg.payload;
-          // Unsolicited events have method but no id
-          if (p.method && p.id === undefined) {
-            const conn = connections.get(bundleId);
-            if (conn) {
-              if (conn.networkLog.length >= MAX_LOG_ENTRIES) {
-                conn.networkLog.shift();
+          if (msg.type === "CDP") {
+            const p = msg.payload;
+            // Unsolicited events have method but no id
+            if (p.method && p.id === undefined) {
+              const conn = connections.get(bundleId);
+              if (conn) {
+                if (conn.networkLog.length >= MAX_LOG_ENTRIES) {
+                  conn.networkLog.shift();
+                }
+                conn.networkLog.push({
+                  method: p.method,
+                  params: p.params,
+                  timestamp: Date.now(),
+                });
               }
-              conn.networkLog.push({
-                method: p.method,
-                params: p.params,
-                timestamp: Date.now(),
-              });
             }
           }
-        }
 
-        if (msg.type === "ViewInspector") {
-          const p = msg.payload;
-          const pending = pendingRpc.get(p.id);
-          if (!pending) return;
-          pendingRpc.delete(p.id);
-          if (p.error) {
-            pending.reject(
-              new FailureError(p.error.message, {
-                error_code: FAILURE_CODES.NATIVE_DEVTOOLS_RPC_ERROR,
-                failure_stage: "native_devtools_rpc_response",
-                failure_area: "tool_server",
-                error_kind: "subprocess",
-              })
-            );
-          } else pending.resolve(p.result);
-        }
+          if (msg.type === "ViewInspector") {
+            const p = msg.payload;
+            const pending = pendingRpc.get(p.id);
+            if (!pending) return;
+            pendingRpc.delete(p.id);
+            if (p.error) {
+              pending.reject(
+                new FailureError(p.error.message, {
+                  error_code: FAILURE_CODES.NATIVE_DEVTOOLS_RPC_ERROR,
+                  failure_stage: "native_devtools_rpc_response",
+                  failure_area: "tool_server",
+                  error_kind: "subprocess",
+                })
+              );
+            } else pending.resolve(p.result);
+          }
+        },
       });
 
       socket.on("close", () => {
-        rl.close();
         if (bundleId !== null) {
           // A fast reconnect may have already replaced this socket.
           if (connections.get(bundleId)?.socket === socket) {

--- a/packages/tool-server/src/tools/describe/platforms/ios/index.ts
+++ b/packages/tool-server/src/tools/describe/platforms/ios/index.ts
@@ -138,24 +138,35 @@ export async function describeIos(
     return { tree: emptyTree(), source: "ax-service", hint: TVOS_HINT };
   }
 
-  let tree: DescribeNode;
+  let tree: DescribeNode = emptyTree();
   let degraded: boolean;
   // A resolver failure that names its own cause, which outranks the boot caveat.
   let resolverHint: string | undefined;
+  // The daemon came up but the read itself failed (a query timeout, an RPC
+  // error). That says nothing about how the sim was booted, so it must not be
+  // reported as the boot caveat — which prescribes a reboot the developer pays
+  // for and that would not have helped.
+  let readFailureHint: string | undefined;
 
+  let axApi: AXServiceApi | undefined;
   try {
     const axRef = axServiceRef(device);
-    const axApi = await registry.resolveService<AXServiceApi>(axRef.urn, axRef.options);
-    const response = await axApi.describe();
-    tree = adaptAXDescribeToDescribeResult(response);
+    axApi = await registry.resolveService<AXServiceApi>(axRef.urn, axRef.options);
     degraded = axApi.degraded;
   } catch (err) {
     // Carry on with an empty tree so the native-devtools fallback below still
     // runs. A missing TCP-transport artifact is a config error, not a boot-state
     // one, so it must not read as degraded.
-    tree = emptyTree();
     resolverHint = tcpArtifactHint(err);
     degraded = resolverHint === undefined;
+  }
+
+  if (axApi) {
+    try {
+      tree = adaptAXDescribeToDescribeResult(await axApi.describe());
+    } catch (err) {
+      readFailureHint = `The accessibility read failed (${errMsg(err)}).`;
+    }
   }
 
   // Keyed to what the ACCESSIBILITY read produced, not to the tree finally
@@ -167,7 +178,13 @@ export async function describeIos(
     : tree.children.length === 0
       ? DEGRADED_BLIND_HINT
       : DEGRADED_STANDING_HINT;
-  const hint = resolverHint ?? degradedHint;
+  const hint =
+    resolverHint ??
+    (readFailureHint
+      ? degradedHint
+        ? `${degradedHint}. ${readFailureHint}`
+        : readFailureHint
+      : degradedHint);
 
   if (tree.children.length > 0) {
     return { tree, source: "ax-service", hint };

--- a/packages/tool-server/src/utils/android-devtools-client.ts
+++ b/packages/tool-server/src/utils/android-devtools-client.ts
@@ -1,6 +1,6 @@
 import * as net from "node:net";
-import * as readline from "node:readline";
 import { FAILURE_CODES, FailureError } from "@argent/registry";
+import { attachNdjsonReader, reportDroppedFrameToStderr } from "./ndjson-socket";
 
 /** Newline-delimited JSON socket client for the android-devtools helper. */
 
@@ -62,36 +62,36 @@ export function connectAndroidDevtoolsClient(
     };
 
     socket.once("connect", () => {
-      const rl = readline.createInterface({ input: socket });
-      rl.on("line", (line) => {
-        if (!line.trim()) return;
-        let parsed: { id?: number; result?: unknown; error?: { message?: string; type?: string } };
-        try {
-          parsed = JSON.parse(line);
-        } catch {
-          return;
-        }
-        if (typeof parsed.id !== "number") return;
-        const req = pending.get(parsed.id);
-        if (!req) return;
-        pending.delete(parsed.id);
-        clearTimeout(req.timer);
-        if (parsed.error) {
-          const message = parsed.error.message ?? "Unknown helper error";
-          const type = parsed.error.type ?? "HelperError";
-          req.reject(
-            new FailureError(`${type}: ${message}`, {
-              error_code: FAILURE_CODES.ANDROID_DEVTOOLS_RPC_ERROR,
-              failure_stage: "android_devtools_rpc_response",
-              failure_area: "tool_server",
-              error_kind: "subprocess",
-            })
-          );
-        } else {
-          req.resolve(parsed.result);
-        }
+      attachNdjsonReader(socket, {
+        onDropped: reportDroppedFrameToStderr("android-devtools"),
+        onMessage: (raw) => {
+          const parsed = raw as {
+            id?: number;
+            result?: unknown;
+            error?: { message?: string; type?: string };
+          };
+          if (typeof parsed.id !== "number") return;
+          const req = pending.get(parsed.id);
+          if (!req) return;
+          pending.delete(parsed.id);
+          clearTimeout(req.timer);
+          if (parsed.error) {
+            const message = parsed.error.message ?? "Unknown helper error";
+            const type = parsed.error.type ?? "HelperError";
+            req.reject(
+              new FailureError(`${type}: ${message}`, {
+                error_code: FAILURE_CODES.ANDROID_DEVTOOLS_RPC_ERROR,
+                failure_stage: "android_devtools_rpc_response",
+                failure_area: "tool_server",
+                error_kind: "subprocess",
+              })
+            );
+          } else {
+            req.resolve(parsed.result);
+          }
+        },
       });
-      rl.on("close", () => cleanup());
+      socket.on("close", () => cleanup());
 
       resolve({
         request<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {

--- a/packages/tool-server/src/utils/ndjson-socket.ts
+++ b/packages/tool-server/src/utils/ndjson-socket.ts
@@ -1,0 +1,71 @@
+import type * as net from "node:net";
+
+/**
+ * Frame a newline-delimited JSON socket on the `\n` byte and nothing else.
+ *
+ * `readline.createInterface` splits on the four ECMAScript line terminators —
+ * `\n`, `\r`, U+2028 and U+2029. JSON permits U+2028/U+2029 unescaped inside a
+ * string, and the device daemons (NSJSONSerialization, org.json) emit them
+ * raw, so a perfectly valid reply carrying one — any accessibility label with a
+ * rich-text line separator — was cut into fragments none of which parsed, and
+ * its RPC waited out the timeout. A `\n` byte can never occur inside a
+ * multi-byte UTF-8 sequence, so splitting on it alone is exact.
+ *
+ * Every frame that fails to parse is reported through `onDropped` rather than
+ * vanishing: a silent drop is what turned a framing defect into a
+ * fifteen-second mystery.
+ */
+interface NdjsonReaderHandlers {
+  onMessage: (msg: unknown) => void;
+  onDropped: (info: { bytes: number; preview: string }) => void;
+}
+
+const PREVIEW_CHARS = 80;
+
+function preview(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  const printable = raw.replace(/[\x00-\x1f\x7f\u2028\u2029]/g, "·");
+  return printable.length > PREVIEW_CHARS ? `${printable.slice(0, PREVIEW_CHARS)}…` : printable;
+}
+
+/** The conventional `onDropped`: one stderr line tagged with the owning service. */
+export function reportDroppedFrameToStderr(tag: string): NdjsonReaderHandlers["onDropped"] {
+  return ({ bytes, preview }) => {
+    process.stderr.write(`[${tag}] dropped unparseable frame (${bytes} bytes): ${preview}\n`);
+  };
+}
+
+export function attachNdjsonReader(socket: net.Socket, handlers: NdjsonReaderHandlers): void {
+  socket.setEncoding("utf8");
+  let buf = "";
+
+  const deliver = (raw: string): void => {
+    if (raw.length === 0 || raw === "\r") return;
+    let msg: unknown;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      handlers.onDropped({ bytes: Buffer.byteLength(raw, "utf8"), preview: preview(raw) });
+      return;
+    }
+    handlers.onMessage(msg);
+  };
+
+  socket.on("data", (chunk: string | Buffer) => {
+    buf += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    let nl: number;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const raw = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      deliver(raw);
+    }
+  });
+
+  // Parity with readline: a final frame without a trailing newline is still
+  // delivered when the peer ends the stream.
+  socket.on("end", () => {
+    const rest = buf;
+    buf = "";
+    if (rest.length > 0) deliver(rest);
+  });
+}

--- a/packages/tool-server/test/describe-tool.test.ts
+++ b/packages/tool-server/test/describe-tool.test.ts
@@ -1050,3 +1050,75 @@ describe("describe tool", () => {
     );
   });
 });
+
+describe("describe tool — ax-service read failure", () => {
+  beforeEach(() => {
+    __resetDepCacheForTests();
+    __primeDepCacheForTests(["xcrun", "adb"]);
+    mockIsTvOsSimulator.mockResolvedValue(false);
+    __resetBootCaveatStateForTests();
+  });
+
+  function throwingAxApi(degraded: boolean): AXServiceApi {
+    return {
+      degraded,
+      describe: async () => {
+        throw new Error("ax-service query timed out: describe");
+      },
+      alertCheck: async () => false,
+      ping: async () => true,
+    };
+  }
+
+  // A query timeout on a sim that WAS booted through argent used to be reported
+  // as the boot caveat — "call boot-device with force=true" — sending the agent
+  // to reboot a healthy simulator. The read failure has to be named as itself.
+  it("names the read failure instead of the boot caveat when the sim was booted through argent", async () => {
+    const registry = makeMockRegistry({ axService: throwingAxApi(false) });
+    const tool = createDescribeTool(registry);
+    const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
+    expect(elementLineCount(result.description)).toBe(0);
+    expect(result.hint).toContain("ax-service query timed out: describe");
+    expect(result.hint).not.toContain("not booted through argent");
+  });
+
+  it("keeps the boot caveat ahead of the read failure when the sim was booted externally", async () => {
+    const registry = makeMockRegistry({ axService: throwingAxApi(true) });
+    const tool = createDescribeTool(registry);
+    const result = await tool.execute({}, { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" });
+    expect(result.hint).toContain("not booted through argent");
+    expect(result.hint).toContain("ax-service query timed out: describe");
+    expect(result.hint!.indexOf("not booted")).toBeLessThan(result.hint!.indexOf("timed out"));
+  });
+
+  it("still serves the native-devtools tree after a read failure", async () => {
+    const nativeApi = makeNativeDevtoolsApi({
+      connectedBundleIds: ["com.example.app"],
+      describeScreenResult: {
+        screenFrame: { x: 0, y: 0, width: 440, height: 956 },
+        elements: [
+          {
+            frame: { x: 20, y: 150, width: 400, height: 44 },
+            tapPoint: { x: 220, y: 172 },
+            normalizedFrame: { x: 0.045, y: 0.157, width: 0.909, height: 0.046 },
+            normalizedTapPoint: { x: 0.5, y: 0.18 },
+            traits: ["button"],
+            label: "Go",
+          },
+        ],
+      },
+    });
+    const registry = makeMockRegistry({
+      axService: throwingAxApi(false),
+      nativeDevtools: nativeApi,
+    });
+    const tool = createDescribeTool(registry);
+    const result = await tool.execute(
+      {},
+      { udid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", bundleId: "com.example.app" }
+    );
+    expect(result.source).toBe("native-devtools");
+    expect(result.hint).toContain("ax-service query timed out: describe");
+    expect(result.hint).not.toContain("not booted through argent");
+  });
+});

--- a/packages/tool-server/test/ndjson-socket.test.ts
+++ b/packages/tool-server/test/ndjson-socket.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { PassThrough } from "node:stream";
+import type * as net from "node:net";
+import { attachNdjsonReader } from "../src/utils/ndjson-socket";
+
+// A PassThrough stands in for the net.Socket: the reader only needs
+// setEncoding / on("data") / on("end").
+function harness() {
+  const stream = new PassThrough();
+  const messages: unknown[] = [];
+  const dropped: { bytes: number; preview: string }[] = [];
+  attachNdjsonReader(stream as unknown as net.Socket, {
+    onMessage: (m) => messages.push(m),
+    onDropped: (d) => dropped.push(d),
+  });
+  return { stream, messages, dropped };
+}
+
+const settle = () => new Promise((r) => setImmediate(r));
+
+describe("attachNdjsonReader", () => {
+  it("keeps U+2028 / U+2029 inside a string in one frame (the Element stall)", async () => {
+    const { stream, messages, dropped } = harness();
+    const label = "In reply to Dave\u2028Loving it so far\u2029next";
+    stream.write(JSON.stringify({ id: 1, result: { label } }) + "\n");
+    await settle();
+    expect(messages).toEqual([{ id: 1, result: { label } }]);
+    expect(dropped).toEqual([]);
+  });
+
+  it("reassembles a frame split across chunks, including mid multi-byte character", async () => {
+    const { stream, messages } = harness();
+    const bytes = Buffer.from(JSON.stringify({ id: 2, label: "café\u2028ünïcode" }) + "\n", "utf8");
+    // Cut inside the 3-byte U+2028 sequence.
+    const cut = bytes.indexOf(Buffer.from("\u2028", "utf8")) + 1;
+    stream.write(bytes.subarray(0, cut));
+    await settle();
+    expect(messages).toEqual([]);
+    stream.write(bytes.subarray(cut));
+    await settle();
+    expect(messages).toEqual([{ id: 2, label: "café\u2028ünïcode" }]);
+  });
+
+  it("delivers several frames arriving in one chunk, in order", async () => {
+    const { stream, messages } = harness();
+    stream.write('{"id":1}\n{"id":2}\n{"id":3}\n');
+    await settle();
+    expect(messages.map((m) => (m as { id: number }).id)).toEqual([1, 2, 3]);
+  });
+
+  it("skips empty lines and tolerates CRLF", async () => {
+    const { stream, messages, dropped } = harness();
+    stream.write('\n{"id":1}\r\n\r\n{"id":2}\n');
+    await settle();
+    expect(messages).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(dropped).toEqual([]);
+  });
+
+  it("reports an unparseable frame with byte length and a sanitised preview, then continues", async () => {
+    const { stream, messages, dropped } = harness();
+    stream.write("garbage\there\n" + '{"id":9}\n');
+    await settle();
+    expect(messages).toEqual([{ id: 9 }]);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]!.bytes).toBe(Buffer.byteLength("garbage\there"));
+    expect(dropped[0]!.preview).toBe("garbage·here");
+  });
+
+  it("delivers a trailing frame without newline when the stream ends", async () => {
+    const { stream, messages } = harness();
+    stream.write('{"id":7}');
+    stream.end();
+    await settle();
+    expect(messages).toEqual([{ id: 7 }]);
+  });
+});


### PR DESCRIPTION
## Problem

`describe` returned an empty tree after ~15 s whenever the screen had an accessibility label containing U+2028 (LINE SEPARATOR) — e.g. any Element/Matrix reply preview, or rich text pasted from the web. Nothing was wrong on the device: ax-service answered in ~170 ms with a full, valid tree.

The tool-server framed the ax-service socket with `readline.createInterface`, which splits on the four ECMAScript line terminators (`\n`, `\r`, **U+2028, U+2029**). JSON permits U+2028 unescaped inside a string and `NSJSONSerialization` emits it raw, so one valid frame became three fragments, none parsed, each was dropped by `catch { return }`, and the pending RPC waited out its 10 s timeout — then the native-devtools fallback waited out its 5 s. On top of that, the timeout was reported as *"this simulator was not booted through argent … call boot-device with force=true"*, sending the agent to reboot a healthy simulator.

Minimal repro (no device): `JSON.stringify({label:"a b"})+"\n"` through `readline` → 2 lines, 0 parsed.

## Fix

- **`utils/ndjson-socket.ts`** (new): `attachNdjsonReader` frames on the `\n` byte only (`0x0A` can never occur inside a multi-byte UTF-8 sequence, so this is exact) and reports every unparseable frame to stderr instead of swallowing it.
- Wired into the three device-facing JSON sockets: `ax-service.ts`, `native-devtools.ts`, `android-devtools-client.ts` (the Android helper's `org.json` and the iOS dylib's `NSJSONSerialization` both emit U+2028 raw, so all three were exposed). The two remaining `readline` uses read process **stdout** for readiness markers — no JSON, no user text — and are left alone.
- **`describe/platforms/ios/index.ts`**: a throw from `axApi.describe()` (timeout, RPC error) now carries the error message in the hint and uses the resolved api's real `degraded` flag, instead of being reported as the boot caveat. Separate commit so it can be reverted independently.

## Verification

- 6 new unit tests for the reader (U+2028/U+2029 in a string, chunk split mid-multibyte char, several frames per chunk, CRLF/empty lines, dropped-frame reporting, trailing frame on `end`) and 3 for the hint (`describe-tool.test.ts`). Full tool-server suite: 4816 passed.
- Live A/B on iPhone 16 / iOS 18.5, Safari page with `<meta charset=utf-8>` and a U+2028 inside a `<p>`:
  - argent 0.22.1 (`main`): `describe` **12.6 s**, `source: native-devtools`, web text missing, false "not booted through argent" hint.
  - This branch (`dist` against installed binaries): **50 ms**, `source: ax-service`, label `"In reply to Dave Loving it so far"` present, no hint, 0 dropped frames logged.

## Docs

No docs update needed — no tool, CLI, config or flow surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwqqHRhfuHXbKr6LYskxhJ