### PR TITLE
fix(sim-remote): pass the udid before -b in simctl bootstatus

### DIFF
--- a/packages/tool-server/src/utils/sim-remote.ts
+++ b/packages/tool-server/src/utils/sim-remote.ts
@@ -109,9 +109,8 @@ export async function simctlShutdown(udid: string): Promise<void> {
 }
 
 export async function simctlBootstatus(udid: string, opts?: { boot?: boolean }): Promise<void> {
-  const args = ["simctl", "bootstatus"];
+  const args = ["simctl", "bootstatus", stripRemotePrefix(udid)];
   if (opts?.boot) args.push("-b");
-  args.push(stripRemotePrefix(udid));
   // Cold boot can take minutes.
   await run(args, { timeoutMs: 5 * 60_000 });
 }


### PR DESCRIPTION
## What

`simctlBootstatus` in `packages/tool-server/src/utils/sim-remote.ts` built the command as `simctl bootstatus -b <udid>`, placing the flag before the device. simctl's grammar puts the device first — `bootstatus <udid> -b`.

## Why

Newer Argent Cloud deployments are more faithful to how the local `simctl` handles its arguments, so they now reject `-b` in that position as an unknown flag. The result is that **every remote boot fails**, on every device:

```
[tool: mcp__argent__boot-device]  ->  invalid option -- b
```

The local `xcrun` path already used the correct order (`boot-device.ts:461`), so this only affected sim-remote / Argent Cloud.

## Notes for the reviewer

- I checked the other `sim-remote` wrappers for the same flag-before-udid shape. `injectDylib` is the only other one with an optional flag and it already appends after the udid, so `bootstatus` was the sole offender.
- `packages/tool-server/test/boot-device.test.ts` passes (23/23), but it only exercises the local `xcrun` path — there is no existing test for the remote wrapper, so **this fix is not covered by tests**. It's worth a manual check against a Cloud device before merging.
- `tsc --noEmit` reports pre-existing errors in this package from a stale `@argent/registry` build; `sim-remote.ts` itself is clean and none of them are related to this change.
- No docs update needed: this is an internal argument-construction bug with no user-facing surface change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed simulator boot status checks by correcting the order of command-line arguments.
  * Ensured the simulator identifier is processed correctly when the optional boot flag is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->