### PR TITLE
fix(packaging): ship one shared copy of the Android screen-sharing agent

### DIFF
--- a/packages/argent/scripts/bundle-tools.cjs
+++ b/packages/argent/scripts/bundle-tools.cjs
@@ -562,18 +562,6 @@ for (const platform of SUPPORTED_HOST_PLATFORMS) {
     fs.copyFileSync(src, dest);
     fs.chmodSync(dest, 0o755);
     console.log(`✓ Copied simulator-server (${platform}) → ${path.relative(process.cwd(), dest)}`);
-    // Screen-sharing agent resources (jar + per-ABI .so) the `android_device`
-    // controller pushes to a connected phone. simulator-server resolves them
-    // relative to its working directory, which the spawn sets to its own
-    // platform dir. Optional: physical-device support degrades without them.
-    const resourcesSrc = path.join(BIN_SRC_ROOT, platform, "resources");
-    if (fs.existsSync(resourcesSrc)) {
-      const resourcesDest = path.join(destDir, "resources");
-      fs.cpSync(resourcesSrc, resourcesDest, { recursive: true });
-      console.log(
-        `✓ Copied screen-sharing agent resources (${platform}) → ${path.relative(process.cwd(), resourcesDest)}`
-      );
-    }
   } else if (platform === "darwin" && process.platform === "darwin") {
     throw new Error(
       `simulator-server binary not found at ${src}.\n` +
@@ -582,6 +570,20 @@ for (const platform of SUPPORTED_HOST_PLATFORMS) {
   } else {
     console.warn(`⚠ simulator-server (${platform}) not found at ${src} — skipping`);
   }
+}
+
+// Screen-sharing agent resources (host-independent jar + per-ABI .so the
+// `android_device` controller pushes to a connected phone over adb): one shared
+// copy at the bin root; simulatorServerRunDir() points the spawn cwd here.
+// Optional: physical-device support degrades without them.
+const RESOURCES_SRC = path.join(BIN_SRC_ROOT, "resources");
+if (fs.existsSync(RESOURCES_SRC)) {
+  fs.cpSync(RESOURCES_SRC, path.join(BIN_DIR, "resources"), { recursive: true });
+  console.log(
+    `✓ Copied screen-sharing agent resources → ${path.relative(process.cwd(), BIN_DIR)}/resources`
+  );
+} else {
+  console.warn(`⚠ screen-sharing agent resources not found at ${RESOURCES_SRC} — skipping`);
 }
 
 // The Android helper APK is the only Android native artifact left (the trace

--- a/packages/native-devtools-ios/src/index.ts
+++ b/packages/native-devtools-ios/src/index.ts
@@ -161,7 +161,14 @@ export function simulatorServerBinaryPath(): string {
   return p;
 }
 
-export function simulatorServerBinaryDir(): string {
+// Working directory for the simulator-server spawn: the binary resolves the
+// screen-sharing agent at `resources/android/` relative to cwd. One shared
+// copy lives at the bin root; fall back to the per-platform dir for pre-dedup
+// layouts (e.g. an ARGENT_SIMULATOR_SERVER_DIR override on an old install).
+export function simulatorServerRunDir(): string {
+  if (fs.existsSync(path.join(BIN_DIR, "resources", "android"))) {
+    return BIN_DIR;
+  }
   return platformBinDir();
 }
 

--- a/packages/native-devtools-ios/test/index.test.ts
+++ b/packages/native-devtools-ios/test/index.test.ts
@@ -197,7 +197,18 @@ describe("simulator-server path resolution", () => {
     process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
     const r = await loadResolver();
     expect(r.simulatorServerBinaryPath()).toBe(binPath);
-    expect(r.simulatorServerBinaryDir()).toBe(platDir);
+    expect(r.simulatorServerRunDir()).toBe(platDir);
+  });
+
+  it("run dir is the bin root when the shared resources/android copy exists", async () => {
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "shared-resources-"));
+    const platDir = path.join(dir, process.platform);
+    fs.mkdirSync(platDir, { recursive: true });
+    fs.writeFileSync(path.join(platDir, ssBinName()), "", { mode: 0o755 });
+    fs.mkdirSync(path.join(dir, "resources", "android"), { recursive: true });
+    process.env.ARGENT_SIMULATOR_SERVER_DIR = dir;
+    const r = await loadResolver();
+    expect(r.simulatorServerRunDir()).toBe(dir);
   });
 
   it("throws when the per-platform binary is missing", async () => {
@@ -246,7 +257,7 @@ describe("host platform key (arch-aware Linux bin dirs)", () => {
     const r = await loadResolver();
     expect(r.hostPlatformKey()).toBe("linux-arm64");
     expect(r.simulatorServerBinaryPath()).toBe(binPath);
-    expect(r.simulatorServerBinaryDir()).toBe(platDir);
+    expect(r.simulatorServerRunDir()).toBe(platDir);
   });
 
   it("keeps resolving bin/linux on x86_64 Linux", async () => {
@@ -310,7 +321,7 @@ describe("Windows (win32) binary resolution", () => {
     expect(r.hostPlatformKey()).toBe("win32");
     expect(r.simulatorServerBinaryName()).toBe("simulator-server.exe");
     expect(r.simulatorServerBinaryPath()).toBe(binPath);
-    expect(r.simulatorServerBinaryDir()).toBe(platDir);
+    expect(r.simulatorServerRunDir()).toBe(platDir);
   });
 
   it("does not resolve an extensionless binary on Windows", async () => {

--- a/packages/tool-server/src/blueprints/simulator-server.ts
+++ b/packages/tool-server/src/blueprints/simulator-server.ts
@@ -11,7 +11,7 @@ import {
   type ServiceInstance,
   type ServiceEvents,
 } from "@argent/registry";
-import { simulatorServerBinaryPath, simulatorServerBinaryDir } from "@argent/native-devtools-ios";
+import { simulatorServerBinaryPath, simulatorServerRunDir } from "@argent/native-devtools-ios";
 import { ensureAutomationEnabled } from "./ax-service";
 import { ensureDep } from "../utils/check-deps";
 import { isTvOsSimulator } from "../utils/ios-devices";
@@ -45,8 +45,8 @@ export function simulatorServerRef(device: DeviceInfo): {
 
 const getPaths = () => {
   const BINARY_PATH = simulatorServerBinaryPath();
-  const BINARY_DIR = simulatorServerBinaryDir();
-  return { BINARY_PATH, BINARY_DIR };
+  const RUN_DIR = simulatorServerRunDir();
+  return { BINARY_PATH, RUN_DIR };
 };
 
 const READY_TIMEOUT_MS = 30_000;
@@ -143,13 +143,13 @@ async function spawnSimulatorServerProcess(
   // the binary is told which set to attach through; default-set devices keep the
   // bare argv.
   const deviceSet = subcommand === "ios" ? await deviceSetForUdid(udid) : null;
-  const { BINARY_PATH, BINARY_DIR } = getPaths();
+  const { BINARY_PATH, RUN_DIR } = getPaths();
   return new Promise((resolve, reject) => {
     const args = [subcommand, "--id", udid];
     if (deviceSet) args.push("--device-set", deviceSet);
 
     const proc = spawn(BINARY_PATH, args, {
-      cwd: BINARY_DIR,
+      cwd: RUN_DIR,
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/packages/tool-server/test/describe-missing-xcrun-424.test.ts
+++ b/packages/tool-server/test/describe-missing-xcrun-424.test.ts
@@ -25,7 +25,7 @@ vi.mock("node:child_process", async () => {
 vi.mock("@argent/native-devtools-ios", () => ({
   bootstrapDylibPath: () => "/fake/bootstrap.dylib",
   simulatorServerBinaryPath: () => "/fake/sim-server",
-  simulatorServerBinaryDir: () => "/fake",
+  simulatorServerRunDir: () => "/fake",
   axServiceBinaryPath: () => "/fake/ax-service",
 }));
 

--- a/packages/tool-server/test/ios-only-blueprint-gate.test.ts
+++ b/packages/tool-server/test/ios-only-blueprint-gate.test.ts
@@ -9,7 +9,7 @@ import { processScopedUdid } from "./helpers/process-scoped-udid";
 vi.mock("@argent/native-devtools-ios", () => ({
   bootstrapDylibPath: () => "/fake/bootstrap.dylib",
   simulatorServerBinaryPath: () => "/fake/sim-server",
-  simulatorServerBinaryDir: () => "/fake",
+  simulatorServerRunDir: () => "/fake",
 }));
 
 // The proof-of-gate iOS test below runs the native-devtools factory for real,

--- a/packages/tool-server/test/simulator-server-blueprint.test.ts
+++ b/packages/tool-server/test/simulator-server-blueprint.test.ts
@@ -29,7 +29,7 @@ vi.mock("../src/blueprints/ax-service", () => ({
 
 vi.mock("@argent/native-devtools-ios", () => ({
   simulatorServerBinaryPath: () => "/fake/bin/simulator-server",
-  simulatorServerBinaryDir: () => "/fake/bin",
+  simulatorServerRunDir: () => "/fake/bin",
 }));
 
 // The factory now probes the runtime kind to reject tvOS sims. Mock it to the
@@ -192,6 +192,8 @@ describe("simulatorServerBlueprint.factory — receives a pre-resolved DeviceInf
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(spawnMock.mock.calls[0]![1]).toEqual(["android_device", "--id", serial]);
+    // The binary resolves resources/android relative to cwd — must be the run dir.
+    expect(spawnMock.mock.calls[0]![2]).toMatchObject({ cwd: "/fake/bin" });
   });
 
   it("trusts the supplied DeviceInfo and does not reclassify the id", async () => {

--- a/scripts/download-simulator-server.sh
+++ b/scripts/download-simulator-server.sh
@@ -94,8 +94,8 @@ find "${DEST_DIR}" \( -name simulator-server -o -name 'simulator-server.exe' \) 
 # The simulator-server `android_device` controller pushes the screen-sharing
 # agent (host-independent .jar + per-ABI .so) to the phone over adb, resolving
 # it from `resources/android/` relative to its working directory — which the
-# blueprint sets to the binary's own platform dir. The payload runs on the
-# phone, so one tarball serves every host; extract a copy next to each binary.
+# blueprint sets to the bin root via simulatorServerRunDir(). The payload runs
+# on the phone, so one shared copy serves every host platform.
 # A missing asset is tolerated: physical-device support is then unavailable.
 AGENT_ASSET="screen-sharing-agent.tar.gz"
 AGENT_TMP="$(mktemp -d)"
@@ -108,14 +108,11 @@ if gh release download "${TAG}" \
      --dir "${AGENT_TMP}" \
      --clobber 2>"${GH_STDERR}"; then
   rm -f "${GH_STDERR}"
-  while IFS= read -r bin; do
-    plat_dir="$(dirname "${bin}")"
-    res_dir="${plat_dir}/resources/android"
-    rm -rf "${res_dir}"
-    mkdir -p "${res_dir}"
-    tar -xzf "${AGENT_TMP}/${AGENT_ASSET}" -C "${res_dir}"
-    echo "  ✓ screen-sharing agent → ${res_dir}"
-  done < <(find "${DEST_DIR}" \( -name simulator-server -o -name 'simulator-server.exe' \) -type f)
+  res_dir="${DEST_DIR}/resources/android"
+  rm -rf "${res_dir}"
+  mkdir -p "${res_dir}"
+  tar -xzf "${AGENT_TMP}/${AGENT_ASSET}" -C "${res_dir}"
+  echo "  ✓ screen-sharing agent → ${res_dir}"
 else
   GH_MSG=$(<"${GH_STDERR}")
   rm -f "${GH_STDERR}"


### PR DESCRIPTION
## Summary

Fixes the biggest chunk of #980: the published package shipped **four byte-identical copies** of the Android screen-sharing agent (`resources/android/`: jar + per-ABI `.so`, ~12.7 MiB each) — one next to each platform's simulator-server binary, because the binary resolves the agent relative to its working directory and the spawn set cwd to the per-platform dir.

This ships **one shared copy** at `bin/resources/android/` and points the spawn cwd at the bin root instead.

Package size (built from this branch, same artifact set as 0.22.1):

|  | before | after |
|---|---|---|
| unpacked | 115.5 MB | **76.4 MB** |
| packed | 37.6 MB | 25.4 MB |

76.4 MB is under npmmirror's 83886080-byte unpacked-size cap (the limit #980 trips — note it applies to `dist.unpackedSize`, not the tarball). Already-published oversized versions are immutable, so the mirror also needs the `cnpm/unpkg-white-list` entry to sync the backlog; this PR keeps future versions under the cap.

## Changes

- `scripts/download-simulator-server.sh` extracts the agent tarball once, to `bin/resources/android/`, instead of next to each binary.
- `bundle-tools.cjs` copies that single shared directory into the package.
- `@argent/native-devtools-ios` replaces `simulatorServerBinaryDir()` with `simulatorServerRunDir()`: the bin root when the shared `resources/android/` exists there, falling back to the per-platform dir so an `ARGENT_SIMULATOR_SERVER_DIR` override pointing at a pre-dedup layout keeps working.
- The blueprint spawns simulator-server with `cwd: RUN_DIR` (binary path stays absolute; the agent lookup is the only cwd-relative path in the simulator-server crate — audited: every other fs path there is a tempdir, `dirs::cache_dir()`, or caller-supplied).

No symlinks, no postinstall scripts — plain files plus a different cwd, so nothing changes for npm/pnpm/yarn/bun or Windows.

## Testing

- Unit: resolver tests updated + new shared-layout case; blueprint test asserts the spawn cwd.
- Packaging: ran the modified download script + `npm run pack` end-to-end; tarball contains exactly one `bin/resources/android/` (94 files vs 112).
- Live: branch tool-server with `ARGENT_SIMULATOR_SERVER_DIR` pointed at the new layout — iOS simulator (screenshot) and Android emulator (boot-device, screenshot, gesture-tap) green; `lsof` confirms both spawned simulator-servers run with cwd = bin root, where `resources/android/<jar>` and each per-ABI `.so` resolve (verified present at those exact relative paths).
- Physical Android phone (Galaxy S24, the one path that actually pushes the agent): live-tested — the `android_device` controller resolved the agent from the shared layout, pushed it, and connected ("All agent connections established successfully"); screenshot and tap through the on-phone agent both green, spawn cwd confirmed as the shared bin root.

No docs update needed: internal packaging/layout only — no MCP tool, CLI, config, or flow-file surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGAsAvYBJ3Jy9DKLaX9aoZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulator-server resource handling by using one shared screen-sharing resource location across host platforms.
  * Added a warning when required shared resources are unavailable.
  * Ensured simulator-server processes start from the correct runtime directory.

* **Documentation**
  * Clarified simulator-server runtime and shared resource behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
