### PR TITLE
feat(installer): allowlist.enabled config — opt out of allowlist refresh on update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7534,6 +7534,7 @@
       "name": "@argent/installer",
       "version": "0.22.1",
       "dependencies": {
+        "@argent/configuration-core": "file:../configuration-core",
         "@argent/registry": "file:../registry",
         "@argent/telemetry": "file:../telemetry",
         "@argent/tools-client": "file:../argent-tools-client",

--- a/packages/argent-installer/package.json
+++ b/packages/argent-installer/package.json
@@ -12,6 +12,7 @@
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
+    "@argent/configuration-core": "file:../configuration-core",
     "@argent/registry": "file:../registry",
     "@argent/telemetry": "file:../telemetry",
     "@argent/tools-client": "file:../argent-tools-client",

--- a/packages/argent-installer/src/update.ts
+++ b/packages/argent-installer/src/update.ts
@@ -16,6 +16,7 @@ import {
   type McpServerEntry,
 } from "./mcp-configs.js";
 import { cleanupStaleMcpConfigs } from "./init-stale-config.js";
+import { getConfigValueByKey } from "@argent/configuration-core";
 import {
   getGloballyInstalledVersion,
   getGloballyInstalledPackageRoot,
@@ -721,14 +722,21 @@ export async function update(args: string[]): Promise<void> {
         );
       }
 
-      // Allowlists only for scopes that already had argent configured.
-      for (const [scope, adapters] of adaptersByScope) {
-        for (const adapter of adapters) {
-          if (!adapter.addAllowlist) continue;
-          try {
-            adapter.addAllowlist(projectRoot, scope);
-          } catch {
-            // non-fatal
+      // Allowlists only for scopes that already had argent configured — unless
+      // the user opted out (`argent config set allowlist.enabled false`): then
+      // update leaves editor allowlists entirely alone. Unset keeps the
+      // refresh, so nothing changes for existing installs.
+      const allowlistDisabled =
+        getConfigValueByKey("allowlist.enabled", { cwd: projectRoot }) === false;
+      if (!allowlistDisabled) {
+        for (const [scope, adapters] of adaptersByScope) {
+          for (const adapter of adapters) {
+            if (!adapter.addAllowlist) continue;
+            try {
+              adapter.addAllowlist(projectRoot, scope);
+            } catch {
+              // non-fatal
+            }
           }
         }
       }
@@ -742,6 +750,12 @@ export async function update(args: string[]): Promise<void> {
       ];
 
       spinner.stop("Configuration refreshed.");
+
+      if (allowlistDisabled) {
+        p.log.info(
+          pc.dim("Left editor auto-approve allowlists alone (allowlist.enabled is false).")
+        );
+      }
 
       if (results.length > 0) {
         p.note(results.join("\n"), "MCP Configs Updated");

--- a/packages/configuration-core/src/config-schema.ts
+++ b/packages/configuration-core/src/config-schema.ts
@@ -101,6 +101,19 @@ export const CONFIG_SCHEMA: readonly ConfigDefinition[] = [
     manageCommand: "argent telemetry",
   },
   {
+    key: "allowlist.enabled",
+    description:
+      "Whether `argent update` re-applies editor auto-approve allowlist rules. Unset (the " +
+      "default) keeps the current behavior: update refreshes the rules for editors that " +
+      "already have argent configured. Set to `false` to keep update from touching editor " +
+      "allowlists. `false` in either scope wins, so a committed project opt-out holds for " +
+      "every teammate.",
+    scopes: ["project", "global"],
+    parse: asBoolean,
+    merge: "prioritize-restrictive",
+    example: "false",
+  },
+  {
     key: "lens.agent",
     description: "Coding-agent id remembered by `argent lens` to skip the picker.",
     scopes: ["project", "global"],

--- a/packages/configuration-core/tests/config-access.test.ts
+++ b/packages/configuration-core/tests/config-access.test.ts
@@ -182,6 +182,27 @@ describe("setConfigValue — return value", () => {
   });
 });
 
+describe("getConfigValue — allowlist.enabled (prioritize-restrictive, no default)", () => {
+  it("reads as unset when never decided", () => {
+    expect(getConfigValueByKey("allowlist.enabled", opts())).toBeUndefined();
+  });
+
+  it("false in either scope wins over true in the other", () => {
+    setConfigValue("allowlist.enabled", true, "global", opts());
+    setConfigValue("allowlist.enabled", false, "project", opts());
+    expect(getConfigValueByKey("allowlist.enabled", opts())).toBe(false);
+
+    setConfigValue("allowlist.enabled", false, "global", opts());
+    setConfigValue("allowlist.enabled", true, "project", opts());
+    expect(getConfigValueByKey("allowlist.enabled", opts())).toBe(false);
+  });
+
+  it("a lone true opts in", () => {
+    setConfigValue("allowlist.enabled", true, "global", opts());
+    expect(getConfigValueByKey("allowlist.enabled", opts())).toBe(true);
+  });
+});
+
 describe("listConfig", () => {
   it("reports every schema entry with per-scope and effective values", () => {
     setConfigValue("lens.agent", "claude", "global", opts());

--- a/packages/docs/docs/reference/configuration.mdx
+++ b/packages/docs/docs/reference/configuration.mdx
@@ -36,11 +36,14 @@ argent config get ios.additionalDeviceSets
 | Key                        | Scopes          | Merge            | Description                                                                                                                             |
 | -------------------------- | --------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `telemetry.enabled`        | project, global | restrictive wins | Whether anonymous telemetry is on. Default `true`. Read-only here: use `argent telemetry` (with `--scope project` for the project file) |
+| `allowlist.enabled`        | project, global | restrictive wins | Set to `false` to keep `argent update` from re-applying editor auto-approve allowlist rules. Unset keeps the refresh                    |
 | `lens.agent`               | project, global | project wins     | The coding agent that `argent lens` starts without the picker, for example `claude` or `codex`                                          |
 | `ios.additionalDeviceSets` | project, global | union            | Additional CoreSimulator device-set directories. Argent lists the simulators in these sets next to the default set. An array of paths   |
 | `recordings.directory`     | project, global | project wins     | The directory where Argent saves a finished screen recording. Default `.argent/recordings` under the project root                       |
 
 A path value is absolute, starts with `~`, or is relative. For `ios.additionalDeviceSets`, Argent resolves a relative entry against the scope that set it: the project root for the project file, the home directory for the global file.
+
+`allowlist.enabled` only affects `argent update`. When it is `false`, an update leaves editor auto-approve allowlists entirely alone — rules already written stay, and `argent init` still asks its auto-approve question as before. When the key is unset (the default), nothing changes: update keeps refreshing the rules for editors that already have Argent configured. `false` in either scope wins, so a committed project file opts out a whole team.
 
 Argent resolves `recordings.directory` on the client host, the machine that receives the mp4. A relative value always resolves against the project root, or the home directory when there is no project, regardless of which file set the value.
 


### PR DESCRIPTION
A minimal opt-out for the allowlist refresh in `argent update`: a new config key **`allowlist.enabled`** (project + global scopes, restrictive merge — `false` in either scope wins, so a committed project opt-out holds for the team).

**Nothing changes by default.** The key has no default value; while it is unset, `argent init` and `argent update` behave exactly as today. Only an explicit

```
argent config set allowlist.enabled false
```

changes anything: `argent update` then skips re-applying editor auto-approve allowlist rules entirely (rules already written stay) and prints a dim one-liner saying why. `argent init` is untouched — it still asks its auto-approve question and applies the answer as before.

### Docs

`reference/configuration.mdx` gains the key's row and a short behavior note. `docusaurus build` and `npm run format` are clean.

### Tests

- `allowlist.enabled` merge semantics (restrictive, no default) in configuration-core.
- Suites: installer 555, configuration-core 125; tsc, eslint --max-warnings 0, prettier, both knip gates clean.
- Live-tested from a packed tgz in an isolated HOME: `init -y` and `update` with the key unset are byte-identical to main's behavior; with `allowlist.enabled false`, `update` re-imposes nothing and prints the skip note.

Supersedes #787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b5AyEqWd16k1s8xvve3dS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `allowlist.enabled` setting to control editor auto-approve allowlist updates.
  - Allowlist updates now run when enabled or unset, while an explicit disabled setting prevents changes.

- **Documentation**
  - Added configuration reference details, including scope precedence and unset behavior.

- **Bug Fixes**
  - Preserved non-blocking handling when individual editor allowlist updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->