### PR TITLE
fix(tool-server): stop the simulator watcher polling simctl for orphaned or idle servers

### DIFF
--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -192,7 +192,13 @@ export function start(): void {
   const serverStartedAt = Date.now();
   const updateChecker = startUpdateChecker();
 
-  const { stop: stopWatcher, ready: watcherReady } = startSimulatorWatcher(registry);
+  // Rebound to the HTTP app's idle timer once createHttpApp has run below; the
+  // watcher only consults it on interval ticks, never during the awaited first
+  // poll, so the placeholder is never observed as "stale".
+  let lastActivityAt: () => number = () => Date.now();
+  const { stop: stopWatcher, ready: watcherReady } = startSimulatorWatcher(registry, {
+    lastActivityAt: () => lastActivityAt(),
+  });
 
   let server: ReturnType<typeof httpHandle.app.listen> | null = null;
 
@@ -388,6 +394,7 @@ export function start(): void {
       });
     },
   });
+  lastActivityAt = () => httpHandle.getLastActivityAt();
 
   // Do not bind until the first watcher poll has attempted dylib injection for
   // every booted simulator (so launch-app cannot race it) and the identity

--- a/packages/tool-server/src/utils/simulator-watcher.ts
+++ b/packages/tool-server/src/utils/simulator-watcher.ts
@@ -18,6 +18,37 @@ const execFileAsync = promisify(execFile);
 
 const POLL_INTERVAL_MS = 10_000;
 
+// A tick is skipped once no client has talked to the server for this long. An
+// autospawned server whose editor died keeps running until its idle timeout, and
+// without this gate it kept spawning `simctl list` every tick — on Xcode 26 each
+// spawn makes CoreSimulator re-scan its cryptex runtime volumes, and a few such
+// orphans together were enough to saturate a laptop. The MCP health check
+// (`GET /tools` every 30 s) keeps a live client well inside the window.
+const CLIENT_ACTIVITY_WINDOW_MS = 120_000;
+
+export interface SimulatorWatcherOptions {
+  /**
+   * Epoch ms of the last inbound request the server saw. Omit to poll
+   * unconditionally (tests, or a caller with no request path to observe).
+   */
+  lastActivityAt?: () => number;
+}
+
+/**
+ * Every booted simulator runs a `launchd_sim`; none on the host means no
+ * simulator is booted. Far cheaper than `simctl list` — no CoreSimulator XPC, no
+ * runtime-volume scan. Exit 1 is pgrep's "no match"; any other failure (pgrep
+ * missing, signal) is not evidence of anything, so fall back to asking simctl.
+ */
+async function anySimulatorProcessRunning(): Promise<boolean> {
+  try {
+    await execFileAsync("pgrep", ["-x", "launchd_sim"]);
+    return true;
+  } catch (err) {
+    return (err as { code?: unknown }).code !== 1;
+  }
+}
+
 async function getBootedUdidsInSet(deviceSet: DeviceSetPath): Promise<Set<string>> {
   const { stdout } = await execFileAsync("xcrun", [
     ...simctlPrefix(deviceSet),
@@ -74,13 +105,22 @@ async function initUdid(
   }
 }
 
-export function startSimulatorWatcher(registry: Registry): {
+export function startSimulatorWatcher(
+  registry: Registry,
+  options: SimulatorWatcherOptions = {}
+): {
   stop: () => void;
   ready: Promise<void>;
 } {
   const trackedServices = new Map<string, NativeDevtoolsApi>();
 
   async function poll(shouldBlockUntilSettled: boolean): Promise<void> {
+    // Nothing tracked and no simulator process on the host: there is nothing to
+    // attach to and nothing to dispose, so skip the simctl round-trip. While a
+    // tracked simulator exists we still ask simctl, so its shutdown is seen and
+    // the service disposed.
+    if (trackedServices.size === 0 && !(await anySimulatorProcessRunning())) return;
+
     let booted: Set<string>;
     try {
       booted = await getBootedUdids();
@@ -117,7 +157,14 @@ export function startSimulatorWatcher(registry: Registry): {
   // every booted simulator, so launch-app cannot race it.
   const ready = poll(true);
 
-  const interval = setInterval(() => poll(false).catch(() => {}), POLL_INTERVAL_MS);
+  const interval = setInterval(() => {
+    // Stale client activity: nobody can act on what this tick would learn. The
+    // first request after the gap refreshes the timestamp and the next tick
+    // polls again.
+    const last = options.lastActivityAt?.();
+    if (last !== undefined && Date.now() - last > CLIENT_ACTIVITY_WINDOW_MS) return;
+    poll(false).catch(() => {});
+  }, POLL_INTERVAL_MS);
 
   return { stop: () => clearInterval(interval), ready };
 }

--- a/packages/tool-server/test/simulator-watcher-idle-gates.test.ts
+++ b/packages/tool-server/test/simulator-watcher-idle-gates.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const execFileMock = vi.fn();
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFile: (
+      cmd: string,
+      args: readonly string[],
+      opts: unknown,
+      cb?: (err: Error | null, out: { stdout: string; stderr: string }) => void
+    ) => {
+      const callback = typeof opts === "function" ? opts : cb!;
+      const result = execFileMock(cmd, args);
+      if (result instanceof Error) {
+        const e = result as Error & { stderr?: string; stdout?: string };
+        callback(e, { stdout: e.stdout ?? "", stderr: e.stderr ?? "" });
+      } else {
+        callback(null, result ?? { stdout: "", stderr: "" });
+      }
+    },
+  };
+});
+
+import type { Registry } from "@argent/registry";
+import type { NativeDevtoolsApi } from "../src/blueprints/native-devtools";
+import { startSimulatorWatcher } from "../src/utils/simulator-watcher";
+
+const UDID = "11111111-1111-1111-1111-111111111111";
+const TICK_MS = 10_000;
+
+function bootedListResponse(udids: string[]): { stdout: string; stderr: string } {
+  return {
+    stdout: JSON.stringify({
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-17-0": udids.map((udid) => ({
+          udid,
+          state: "Booted",
+        })),
+      },
+    }),
+    stderr: "",
+  };
+}
+
+/** pgrep's "no process matched" exit. */
+function pgrepNoMatch(): Error {
+  return Object.assign(new Error("pgrep exited 1"), { code: 1 });
+}
+
+function makeHealthyApi(): NativeDevtoolsApi {
+  return {
+    isEnvSetup: () => true,
+    socketPath: "/tmp/mock.sock",
+    ensureEnvReady: async () => {},
+    reverifyEnv: async () => {},
+    getInitFailure: () => null,
+    isConnected: () => false,
+    isAppRunning: async () => false,
+    listConnectedBundleIds: () => [],
+    appConnectionState: async () => "stale_process",
+    activateNetworkInspection: () => {},
+    getNetworkLog: () => [],
+    clearNetworkLog: () => {},
+    getAppState: async () => {
+      throw new Error("not implemented");
+    },
+    detectFrontmostBundleId: async () => null,
+    queryViewHierarchy: async () => ({}),
+  };
+}
+
+function makeRegistry(api: NativeDevtoolsApi): {
+  registry: Registry;
+  resolveService: ReturnType<typeof vi.fn>;
+  disposeService: ReturnType<typeof vi.fn>;
+} {
+  const resolveService = vi.fn(async () => api);
+  const disposeService = vi.fn(async () => {});
+  return {
+    registry: { resolveService, disposeService } as unknown as Registry,
+    resolveService,
+    disposeService,
+  };
+}
+
+/** The scripted host: which processes pgrep sees and what simctl reports. */
+function scriptHost(state: { launchdSim: boolean; booted: string[]; pgrepError?: Error }) {
+  execFileMock.mockImplementation((cmd: string) => {
+    if (cmd === "pgrep") {
+      if (state.pgrepError) return state.pgrepError;
+      return state.launchdSim ? { stdout: "123\n", stderr: "" } : pgrepNoMatch();
+    }
+    if (cmd === "xcrun") return bootedListResponse(state.booted);
+    return { stdout: "", stderr: "" };
+  });
+}
+
+function xcrunCalls(): number {
+  return execFileMock.mock.calls.filter(([cmd]) => cmd === "xcrun").length;
+}
+
+beforeEach(() => {
+  execFileMock.mockReset();
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("simulator-watcher · launchd_sim gate", () => {
+  it("does not ask simctl while no simulator process is running and nothing is tracked", async () => {
+    const host = { launchdSim: false, booted: [] as string[] };
+    scriptHost(host);
+    const { registry, resolveService } = makeRegistry(makeHealthyApi());
+
+    const { ready, stop } = startSimulatorWatcher(registry);
+    await ready;
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+
+    expect(xcrunCalls()).toBe(0);
+    expect(resolveService).not.toHaveBeenCalled();
+
+    // A simulator boots: launchd_sim appears, the next tick goes to simctl.
+    host.launchdSim = true;
+    host.booted = [UDID];
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+
+    expect(xcrunCalls()).toBe(1);
+    expect(resolveService).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("keeps asking simctl for a tracked simulator so its shutdown is disposed", async () => {
+    const host = { launchdSim: true, booted: [UDID] };
+    scriptHost(host);
+    const { registry, disposeService } = makeRegistry(makeHealthyApi());
+
+    const { ready, stop } = startSimulatorWatcher(registry);
+    await ready;
+    expect(xcrunCalls()).toBe(1);
+
+    // Simulator shut down: launchd_sim is gone, but the UDID is still tracked,
+    // so the gate must not short-circuit the tick that disposes it.
+    host.launchdSim = false;
+    host.booted = [];
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+
+    expect(xcrunCalls()).toBe(2);
+    expect(disposeService).toHaveBeenCalledWith(`NativeDevtools:${UDID}`);
+
+    // Now nothing is tracked and nothing runs: back to skipping simctl.
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    expect(xcrunCalls()).toBe(2);
+    stop();
+  });
+
+  it("falls back to simctl when pgrep fails for a reason other than 'no match'", async () => {
+    scriptHost({
+      launchdSim: false,
+      booted: [UDID],
+      pgrepError: Object.assign(new Error("spawn pgrep ENOENT"), { code: "ENOENT" }),
+    });
+    const { registry, resolveService } = makeRegistry(makeHealthyApi());
+
+    const { ready, stop } = startSimulatorWatcher(registry);
+    await ready;
+
+    expect(xcrunCalls()).toBe(1);
+    expect(resolveService).toHaveBeenCalledTimes(1);
+    stop();
+  });
+});
+
+describe("simulator-watcher · client activity gate", () => {
+  it("pauses interval polls once client activity is stale and resumes when it is fresh", async () => {
+    scriptHost({ launchdSim: true, booted: [UDID] });
+    const { registry } = makeRegistry(makeHealthyApi());
+
+    let lastActivityAt = Date.now();
+    const { ready, stop } = startSimulatorWatcher(registry, {
+      lastActivityAt: () => lastActivityAt,
+    });
+    await ready;
+    expect(xcrunCalls()).toBe(1);
+
+    // Fresh activity: ticks poll.
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    expect(xcrunCalls()).toBe(2);
+
+    // Three minutes without a request (an orphaned autospawn): ticks skip.
+    lastActivityAt = Date.now() - 3 * 60_000;
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    expect(xcrunCalls()).toBe(2);
+
+    // A request arrives: the next tick polls again.
+    lastActivityAt = Date.now();
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    expect(xcrunCalls()).toBe(3);
+    stop();
+  });
+
+  it("polls unconditionally when no activity source is given", async () => {
+    scriptHost({ launchdSim: true, booted: [UDID] });
+    const { registry } = makeRegistry(makeHealthyApi());
+
+    const { ready, stop } = startSimulatorWatcher(registry);
+    await ready;
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+
+    expect(xcrunCalls()).toBe(3);
+    stop();
+  });
+});


### PR DESCRIPTION
The simulator watcher runs `xcrun simctl list devices --json` every 10 seconds from the moment the tool-server starts, even when no simulator is booted and no client is connected anymore. An autospawned server outlives its MCP client (detached, 30 min idle timeout), so after an editor crash it keeps polling with nobody listening, and the next editor start adds another one. On Xcode 26 every simctl spawn makes CoreSimulator rescan the sealed cryptex runtime volumes, so a handful of orphaned pollers was enough to saturate my machine: load average 61 on an M1 Pro, vnode table full, three hard reboots in one evening.

This mitigates #327 (it makes an orphan go quiet instead of hammering CoreSimulator, though the lifecycle problem itself stays open) and composes with #480, which serializes the simctl calls that still happen.

The change is two gates in `simulator-watcher.ts`. Nothing changes for a live client with a booted simulator.

First, an interval tick is skipped when the server has seen no inbound request for 2 minutes. The timestamp comes from the HTTP app's idle timer, which every request and the MCP health check (`GET /tools` every 30 s) already touch, so a live client never hits the gate. The awaited first poll is not gated and startup semantics stay as they were; callers that don't pass the option keep the old unconditional polling.

Second, before calling simctl, `poll()` checks `pgrep -x launchd_sim`. Every booted simulator runs a `launchd_sim` process, so when nothing matches and the watcher tracks nothing there is nothing to attach or dispose, and the tick returns without spawning simctl. While a tracked simulator exists it still asks simctl, so a shutdown is observed and the native-devtools service disposed. pgrep exit 1 means "no match"; any other failure falls back to simctl, so the gate can only skip work, never hide a simulator.

New `test/simulator-watcher-idle-gates.test.ts` covers both gates, the pgrep fallback and the no-option path (5 tests, same execFile mock harness as the init-failure tests). Full tool-server suite, `tsc --noEmit`, eslint and prettier are clean. Verified on macOS 26.5 / Xcode 26.4 that `launchd_sim` appears within a second of `simctl boot` and disappears after shutdown.

No docs update needed, nothing user-facing changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary simulator polling when no simulator is running.
  - Pauses simulator monitoring after extended client inactivity, helping conserve system resources.
  - Resumes monitoring when activity returns, maintaining simulator state updates.
- **Reliability**
  - Improved simulator detection and shutdown handling, including fallback behavior when system checks are unavailable.
- **Tests**
  - Added coverage for idle monitoring, simulator detection, shutdown disposal, polling fallback, and activity resumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->