### PR TITLE
feat(flows): let flow-add-step take the tap selector the caller already has

### DIFF
--- a/packages/argent-cli/test/flag-parser.test.ts
+++ b/packages/argent-cli/test/flag-parser.test.ts
@@ -132,6 +132,14 @@ const flowAddStepSchema: JsonSchema = {
     project_root: { type: "string" },
     command: { type: "string" },
     args: { type: "string" },
+    selector: {
+      type: "object",
+      properties: {
+        text: { type: "string" },
+        identifier: { type: "string" },
+        role: { type: "string" },
+      },
+    },
     delayMs: { type: "integer" },
   },
   required: ["name", "project_root", "command"],

--- a/packages/argent-cli/test/run-flow-add-step-payload.test.ts
+++ b/packages/argent-cli/test/run-flow-add-step-payload.test.ts
@@ -63,6 +63,14 @@ function startServer(cap: Captured): Promise<{ url: string; close: () => Promise
                   project_root: { type: "string" },
                   command: { type: "string" },
                   args: { type: "string" },
+                  selector: {
+                    type: "object",
+                    properties: {
+                      text: { type: "string" },
+                      identifier: { type: "string" },
+                      role: { type: "string" },
+                    },
+                  },
                   delayMs: { type: "integer", minimum: 0, maximum: 9007199254740991 },
                 },
                 required: ["name", "project_root", "command"],

--- a/packages/argent-cli/test/run-help.test.ts
+++ b/packages/argent-cli/test/run-help.test.ts
@@ -29,7 +29,7 @@ vi.mock("@argent/telemetry", () => telemetryMock);
 // zodObjectToJsonSchema over the zod schema in
 // packages/tool-server/src/tools/flows/flow-add-step.ts. Recordings are keyed
 // by `name` + `project_root`, so both are required alongside `command` and only
-// `args` / `delayMs` are optional. The assertions below pin `required` in both
+// `args` / `selector` / `delayMs` are optional. The assertions below pin `required` in both
 // directions — each entry against its `(required)` marker, each non-entry
 // against a negative lookahead — so dropping or adding one here fails loudly.
 // The drift that does pass silently is the opposite one: if the real
@@ -52,6 +52,14 @@ const flowAddStepMeta = {
       project_root: { type: "string" },
       command: { type: "string" },
       args: { type: "string" },
+      selector: {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          identifier: { type: "string" },
+          role: { type: "string" },
+        },
+      },
       delayMs: { type: "integer", minimum: 0, maximum: 9007199254740991 },
     },
     required: ["name", "project_root", "command"],
@@ -140,8 +148,12 @@ describe("argent run --help — whole-payload --args advertisement", () => {
     expect(help).toMatch(/--name <value>\s+string \(required\)/);
     expect(help).toMatch(/--project_root <value>\s+string \(required\)/);
     expect(help).toMatch(/--command <value>\s+string \(required\)/);
-    // ...while the two genuinely optional fields must NOT carry the marker.
+    // ...while the three genuinely optional fields must NOT carry the marker.
+    // `selector` is the schema's only object field, so it is also the one that
+    // has to render as the `--<field>-json <json>` form rather than as a plain
+    // `--<field> <value>` flag no parser branch would accept.
     expect(help).toMatch(/--args <value>\s+string(?! \(required\))/);
+    expect(help).toMatch(/--selector-json <json>\s+object(?! \(required\))/);
     expect(help).toMatch(/--delayMs <value>\s+integer(?! \(required\))/);
     expect(toolsClientMock.callTool).not.toHaveBeenCalled();
   });

--- a/packages/docs/docs/features/flows.mdx
+++ b/packages/docs/docs/features/flows.mdx
@@ -66,7 +66,7 @@ A flow also runs without an agent. The `argent flow run` command replays a flow 
 ## Limits
 
 - A replay runs on one booted device. When more than one device is booted, name the device in the instruction.
-- A recorded tap with coordinates breaks when the layout changes. Give the element a stable text or identifier, then record the step again.
+- A recorded tap with coordinates breaks when the layout changes. Give the element a stable text or identifier, then record the step again. The agent can also name the field to match on while it records, which is worth doing when the identifier is positional and the text is the durable part.
 - A flow does not reset the data of the app. When a step creates data, for example a new item, each replay creates the data again. Start the flow with a launch of the app or with a step that restores a known state.
 - The agent records a launch step for iOS, Android and Vega apps. For a Chromium or Electron app, add the launch step to the file by hand.
 - A replay needs the same connected instrumentation as the recording. When the agent cannot read the UI tree, a step that still uses coordinates sends the tap anyway and adds a warning. A step that uses a stable identifier fails instead, because it has no coordinates to fall back on.

--- a/packages/skills/skills/argent-create-flow/references/live-authoring.md
+++ b/packages/skills/skills/argent-create-flow/references/live-authoring.md
@@ -99,13 +99,17 @@ Without step 1, `hidden` also passes for a typo or an element that never existed
 
 ### Taps
 
-`flow-add-step` cannot receive a flow selector directly. Discover the element first, then record `gesture-tap` at its frame center; the live coordinates are transport for the gesture, not a final locator. The recorder reads the pre-tap tree and derives the selector in a fixed order — `id`, then `text`, then `role` — giving three outcomes. Read the `recorded` line after every tap, because only two of them warn. It names the derived form — a selector map, or the kept point:
+Discover the element first, then record `gesture-tap` at its frame center; the live coordinates are transport for the gesture, not a final locator.
+
+**Pass `selector` when you know which field is the stable one.** You just read the element off a discovery call, so you can say what the step should match on instead of letting the recorder infer it: `flow-add-step { command: "gesture-tap", args: …, selector: { text: "Settings" } }`. The recorder is `id`-first, which is wrong whenever the id is positional (`row-3`) and the text is the durable part. A supplied selector is checked, not trusted — it runs through the same two guards below, so one that matches nothing on the replay tree, or that lands on an element not covering the tapped point, is rejected and the step keeps coordinates with a warning saying so. Passing `selector` with any other `command` - or with a `gesture-tap` carrying `delayMs`, which keeps its coordinates either way - records nothing and says which of the two it was.
+
+With no `selector`, the recorder reads the pre-tap tree and derives one in a fixed order — `id`, then `text`, then `role` — giving three outcomes. Read the `recorded` line after every tap, because only two of them warn. It names the derived form — a selector map, or the kept point:
 
 1. **`tap: { id: ... }` or `tap: { text: ... }`** — the good case.
 2. **`tap: { role: ... }`, appended with no warning.** An icon-only button with neither id nor visible label lands here. `role` matches as a case-insensitive substring, so a replay screen holding a second control of that role can win the [ranking](flow-yaml.md#the-runner-tree-is-not-the-discovery-tree) and the tap reports a pass on the wrong control.
 3. **A kept raw point**, with a warning naming the reason and the retarget.
 
-Treat outcomes 2 and 3 alike. Restore the source screen with direct MCP calls, record a corrected tap, then remove the weak step after finishing. Keep a point or a bare role only through the [coordinate fallback gate](reliability-and-recovery.md#coordinate-fallback-gate).
+Treat outcomes 2 and 3 alike. Re-record the tap with an explicit `selector` if the tree carries a stable field the derivation passed over; otherwise restore the source screen with direct MCP calls, record a corrected tap, then remove the weak step after finishing. Keep a point or a bare role only through the [coordinate fallback gate](reliability-and-recovery.md#coordinate-fallback-gate).
 
 Never tap the on-screen keyboard through the recorder. Some platforms expose it as one large node, so replay can tap the wrong key while reporting success. Record text with `keyboard`.
 

--- a/packages/tool-server/src/tools/flows/flow-add-step.ts
+++ b/packages/tool-server/src/tools/flows/flow-add-step.ts
@@ -41,6 +41,7 @@ import {
   deriveSelector,
   selectorToFrame,
   frameContains,
+  selectorSchema,
   type Selector,
   type TextMatchMode,
   type WaitCondition,
@@ -72,6 +73,18 @@ const zodSchema = z.object({
     .optional()
     .describe(
       'Tool arguments as a JSON string, e.g. \'{"udid": "ABC", "x": 0.5, "y": 0.3}\'. Omit for tools with no arguments.'
+    ),
+  selector: selectorSchema
+    .optional()
+    .describe(
+      "For a `gesture-tap` only: the selector to RECORD for this tap, when you already know it " +
+        "from the discovery call that gave you the coordinates. Give at least one of " +
+        "`identifier` / `text` / `role`. The coordinates still dispatch the tap; this only " +
+        "decides what the step matches on at replay, replacing what the recorder would otherwise " +
+        "infer from the tapped element (identifier, then text, then role). It is checked, not " +
+        "trusted: a selector that matches nothing on this screen, or that resolves to an element " +
+        "not covering the tapped point, is rejected and the step keeps coordinates with a warning " +
+        "naming the reason."
     ),
   delayMs: z
     .number()
@@ -605,7 +618,8 @@ async function captureTapSelector(
   registry: Registry,
   session: RecordingSession,
   udid: string,
-  point: { x: number; y: number }
+  point: { x: number; y: number },
+  supplied?: Selector
 ): Promise<{ selector?: Selector; warning?: string }> {
   try {
     const device = resolveDevice(udid);
@@ -615,28 +629,36 @@ async function captureTapSelector(
       device,
       launched ? { bundleId: launched, pinned: false, probeAnswered: false } : undefined
     );
-    const node = nodeAtPoint(tree, point);
-    if (!node) return { warning: "no element found under the tap; kept coordinates (brittle)" };
-    const selector = deriveSelector(node);
-    if (!selector)
-      return { warning: "tapped element has no stable text/id; kept coordinates (brittle)" };
+    // A supplied selector skips derivation but NOT the two checks below: the
+    // caller read it off the agent-facing describe tree, which is not the tree
+    // replay resolves against, so "I already know it" is not evidence it
+    // resolves here.
+    let selector = supplied;
+    if (!selector) {
+      const node = nodeAtPoint(tree, point);
+      if (!node) return { warning: "no element found under the tap; kept coordinates (brittle)" };
+      selector = deriveSelector(node) ?? undefined;
+      if (!selector)
+        return { warning: "tapped element has no stable text/id; kept coordinates (brittle)" };
+    }
     // Replay resolves through selectorToFrame, whose ranking (exact match →
     // smallest frame → reading order) is free to elect a DIFFERENT element than
     // the tapped one — e.g. the same label on an earlier row. Require the
     // winning frame to cover the tapped point, or the recorded step would
     // silently retarget and coordinates are safer.
+    const whose = supplied ? "the selector you passed" : "selector";
     const resolved = selectorToFrame(tree, selector);
     if (!resolved) {
-      // Defensive: a selector derived from a visible node matches that node
-      // under matchNode's semantics, so this should be unreachable. Kept in
-      // case derivation and matching drift apart again.
+      // Unreachable for a DERIVED selector — one taken from a visible node
+      // matches that node under matchNode's semantics — but the ordinary way a
+      // supplied one fails, since it was written against a different tree.
       return {
-        warning: `selector ${describeSelector(selector)} matches no element on this screen; kept coordinates (brittle)`,
+        warning: `${whose} ${describeSelector(selector)} matches no element on this screen; kept coordinates (brittle)`,
       };
     }
     if (!frameContains(resolved, point.x, point.y)) {
       return {
-        warning: `selector ${describeSelector(selector)} resolves to a different element on this screen; kept coordinates (brittle)`,
+        warning: `${whose} ${describeSelector(selector)} resolves to a different element on this screen; kept coordinates (brittle)`,
       };
     }
     return { selector, warning: fallbackSourceWarning(source, device.platform) };
@@ -1132,9 +1154,9 @@ export function createFlowAddStepTool(registry: Registry): ToolDefinition<
       failedMsg: ({ params, failureSignal }) =>
         `Failed to add ${params.command} step to flow ${params.name}: ${failureSignal.error_code}`,
     },
-    description: `Execute a tool call and record it as a step in the flow named by \`name\` + \`project_root\` (the recording must already be open — see flow-start-recording). Use when recording a flow and you want to run and capture each action. A coordinate \`gesture-tap\` is recorded as a portable \`tap: { selector }\` step when the tapped element has stable text/identifier (otherwise coordinates are kept with a warning); a \`restart-app\` is recorded as a \`launch\` step (record one FIRST to make the flow a self-contained e2e flow; restart-app has no chromium support, so a chromium flow records as a fragment — add the \`launch: { chromium: <app path> }\` line to the YAML afterward, deleting the executionPrerequisite line if one was recorded: a flow that starts with a launch must not declare it).
+    description: `Execute a tool call and record it as a step in the flow named by \`name\` + \`project_root\` (the recording must already be open — see flow-start-recording). Use when recording a flow and you want to run and capture each action. A coordinate \`gesture-tap\` is recorded as a portable \`tap: { selector }\` step: pass \`selector\` to say what it should match on (you already read it off the discovery call that gave you the coordinates), otherwise the recorder infers one from the tapped element - identifier, then text, then role. Either way it is checked against the replay tree and coordinates are kept with a warning if it matches nothing or lands on an element that does not cover the tapped point; a \`restart-app\` is recorded as a \`launch\` step (record one FIRST to make the flow a self-contained e2e flow; restart-app has no chromium support, so a chromium flow records as a fragment — add the \`launch: { chromium: <app path> }\` line to the YAML afterward, deleting the executionPrerequisite line if one was recorded: a flow that starts with a launch must not declare it).
 A recorded \`await-ui-element\` that PASSED is re-probed against the tree the RUNNER resolves \`await:\`/\`assert:\` directives against, which is NOT the tree the live call read; a wait that came back \`{ success: false }\` is not probed at all, and its warning says so; when the condition does not hold there the step is still recorded and \`message\` carries a warning to read before converting — whether the conversion actually breaks depends on WHY the two disagree, since a screen that moved on between the live wait and the re-probe reads the same way. If that tree could not be read at all, the warning says so instead: the conversion is UNKNOWN, not known-bad. The probe judges the selector exactly as recorded, so write the conversion in the strict map spelling (\`{ visible: { text: Continue } }\`, copying the step's \`selector:\`) — the bare-string spelling (\`{ visible: Continue }\`) re-parses as a loose selector that resolves identifier-first and falls back to text, which is a different check. \`message\` also warns when the live wait itself came back \`{ success: false }\` — that tool reports a failed wait by returning rather than throwing, so the step is recorded either way. That warning names the cause, because only one of them judges the condition: a genuine miss will stop the run at replay, while a wait whose tree source was unreadable, or one that was cancelled, observed nothing and leaves the condition UNKNOWN.
-Returns { message, toolResult, stepCount, recorded, savedTo } on success — \`message\` is \`Step added to "<name>" flow\` plus any warning about what was recorded (read it; a warning never means the step was skipped). If it fails an error is returned and nothing is recorded. Two calls SUCCEED while recording nothing, and omit \`recorded\` to say so: a \`command\` naming a recording tool, and one naming a flow-file directive rather than a tool. Both answer with what to do instead — usually the call to make (the tool that records that directive, or the recording tool called directly), but \`wait\`, \`long-press\`, \`scroll-to\`, \`snapshot\` and \`when\` have no recording tool, so those name no call and say what to record or add by hand in its place. Either way nothing runs at the device and the take is left untouched — read \`recorded\`, not the status, to know whether a step was appended.
+Returns { message, toolResult, stepCount, recorded, savedTo } on success — \`message\` is \`Step added to "<name>" flow\` plus any warning about what was recorded (read it; a warning never means the step was skipped). If it fails an error is returned and nothing is recorded. Three calls SUCCEED while recording nothing, and omit \`recorded\` to say so: a \`command\` naming a recording tool, one naming a flow-file directive rather than a tool, and a \`selector\` passed with anything other than a tap that would capture one. Each answers with what to do instead — usually the call to make (the tool that records that directive, or the recording tool called directly), but \`wait\`, \`long-press\`, \`scroll-to\`, \`snapshot\` and \`when\` have no recording tool, so those name no call and say what to record or add by hand in its place. Either way nothing runs at the device and the take is left untouched — read \`recorded\`, not the status, to know whether a step was appended.
 If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-recording\` rather than during the recording: against a remote client the in-memory copy is authoritative and every write serializes it over your edit, and in host mode a mid-recording edit renumbers the steps, which costs the finish the cross-tree verdicts anchored to them.`,
     // The recorded tool RUNS here, so this call lasts as long as whatever it
     // wraps, and the three it most often wraps declare this too. Without it the
@@ -1188,12 +1210,30 @@ If a step was recorded by mistake, remove it from the .yaml after \`flow-finish-
         typeof args.x === "number" &&
         typeof args.y === "number";
 
+      // Refused rather than ignored: `selector` only reaches the recorder on the
+      // tap path, so accepting it anywhere else would record a step that quietly
+      // matches on something the caller never asked for. `delayMs` is named
+      // because it is the non-obvious half — it suppresses selector capture, so
+      // a tap carrying one is not a tap for this purpose.
+      if (params.selector && !isTap) {
+        const why =
+          params.command !== "gesture-tap"
+            ? `\`selector\` applies to a recorded \`gesture-tap\`, not to \`${params.command}\`.`
+            : params.delayMs !== undefined
+              ? "A `gesture-tap` recorded with `delayMs` keeps its coordinates, so `selector` would be dropped. Record the tap without `delayMs`."
+              : "`selector` needs a `gesture-tap` whose args carry `udid`, `x` and `y`.";
+        return recordNothing(session, why);
+      }
+
       let captured: { selector?: Selector; warning?: string } | undefined;
       if (isTap) {
-        captured = await captureTapSelector(registry, session, args.udid as string, {
-          x: args.x as number,
-          y: args.y as number,
-        });
+        captured = await captureTapSelector(
+          registry,
+          session,
+          args.udid as string,
+          { x: args.x as number, y: args.y as number },
+          params.selector
+        );
       }
 
       let toolResult: unknown;

--- a/packages/tool-server/test/flows/flow-record-tap-explicit-selector.test.ts
+++ b/packages/tool-server/test/flows/flow-record-tap-explicit-selector.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Registry } from "@argent/registry";
+import type { DescribeNode, DescribeTreeData } from "../../src/tools/describe/contract";
+
+// Same mock as flow-record-tap.test.ts: capture must read the tree the RUNNER
+// resolves against, so each test controls exactly what it sees.
+let currentTreeData: () => DescribeTreeData;
+vi.mock("../../src/tools/flows/flow-tree", () => ({
+  fetchFlowTree: vi.fn(async (): Promise<DescribeTreeData> => currentTreeData()),
+}));
+
+import { createFlowAddStepTool } from "../../src/tools/flows/flow-add-step";
+import { flowStartRecordingTool } from "../../src/tools/flows/flow-start-recording";
+import { __resetRecordingsForTesting, parseFlow } from "../../src/tools/flows/flow-utils";
+
+const DEVICE = "00000000-0000-0000-0000-0000000000AB";
+const FLOW = "rec";
+const PREREQ = "App on home screen";
+
+let tmpDir: string;
+
+function n(partial: Partial<DescribeNode> & { frame: DescribeNode["frame"] }): DescribeNode {
+  return { role: "AXOther", children: [], ...partial };
+}
+
+function setTree(children: DescribeNode[]) {
+  currentTreeData = () => ({
+    tree: n({ role: "AXGroup", frame: { x: 0, y: 0, width: 1, height: 1 }, children }),
+    source: "native-devtools",
+  });
+}
+
+function mockRegistry(): Registry {
+  return {
+    invokeTool: vi.fn(async (id: string) => {
+      if (id === "gesture-tap") return { tapped: true };
+      if (id === "screenshot") return { path: "/tmp/x.png" };
+      throw new Error(`Tool "${id}" not found`);
+    }),
+    getTool: vi.fn(() => ({ inputSchema: { properties: { udid: {} } } })),
+  } as unknown as Registry;
+}
+
+async function record(params: Record<string, unknown>) {
+  return createFlowAddStepTool(mockRegistry()).execute({}, {
+    name: FLOW,
+    project_root: tmpDir,
+    ...params,
+  } as never);
+}
+
+async function recordedSteps() {
+  const content = await fs.readFile(path.join(tmpDir, ".argent", "flows", `${FLOW}.yaml`), "utf8");
+  return parseFlow(content).steps;
+}
+
+// One row carrying BOTH a positional identifier and stable text. `deriveSelector`
+// is identifier-first, so the recorder picks `row-3` - correct today, wrong the
+// moment the list reorders. Which of the two is stable is a judgement the caller
+// holds and the tree does not carry, and it is the reason to be able to say so.
+const POSITIONAL_ROW = [
+  n({
+    frame: { x: 0.1, y: 0.5, width: 0.4, height: 0.1 },
+    label: "Settings",
+    identifier: "row-3",
+  }),
+];
+const ON_ROW = { x: 0.2, y: 0.55 };
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-explicit-sel-"));
+  __resetRecordingsForTesting();
+  setTree(POSITIONAL_ROW);
+  await flowStartRecordingTool.execute(
+    {},
+    { name: FLOW, project_root: tmpDir, executionPrerequisite: PREREQ }
+  );
+});
+
+afterEach(async () => {
+  __resetRecordingsForTesting();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("flow-add-step records a caller-supplied tap selector", () => {
+  it("records the supplied text instead of the identifier the recorder prefers", async () => {
+    const res = (await record({
+      command: "gesture-tap",
+      args: JSON.stringify({ udid: DEVICE, ...ON_ROW }),
+      selector: { text: "Settings" },
+    })) as { message: string };
+
+    expect(await recordedSteps()).toEqual([{ kind: "tap", selector: { text: "Settings" } }]);
+    expect(res.message).not.toMatch(/kept coordinates/);
+  });
+
+  // The contrast that makes the parameter worth having: same tap, same tree.
+  it("differs from what the recorder derives on its own", async () => {
+    await record({
+      command: "gesture-tap",
+      args: JSON.stringify({ udid: DEVICE, ...ON_ROW }),
+    });
+    expect(await recordedSteps()).toEqual([{ kind: "tap", selector: { identifier: "row-3" } }]);
+  });
+
+  // A supplied selector is checked against the replay tree, not trusted: the
+  // caller read it off the agent-facing describe tree, which is a different one.
+  it("rejects a supplied selector that matches nothing, keeping coordinates", async () => {
+    const res = (await record({
+      command: "gesture-tap",
+      args: JSON.stringify({ udid: DEVICE, ...ON_ROW }),
+      selector: { identifier: "no-such-id" },
+    })) as { message: string };
+
+    expect(res.message).toMatch(/the selector you passed/);
+    expect(res.message).toMatch(/matches no element on this screen/);
+    expect((await recordedSteps())[0]).not.toHaveProperty("selector");
+  });
+
+  it("rejects a supplied selector that resolves away from the tapped point", async () => {
+    setTree([
+      ...POSITIONAL_ROW,
+      n({ frame: { x: 0.1, y: 0.1, width: 0.4, height: 0.1 }, label: "Elsewhere" }),
+    ]);
+    const res = (await record({
+      command: "gesture-tap",
+      args: JSON.stringify({ udid: DEVICE, ...ON_ROW }),
+      selector: { text: "Elsewhere" },
+    })) as { message: string };
+
+    expect(res.message).toMatch(/the selector you passed/);
+    expect(res.message).toMatch(/resolves to a different element/);
+    expect(await recordedSteps()).toEqual([{ kind: "tap", x: 0.2, y: 0.55 }]);
+  });
+
+  // Silently ignoring it would record a step matching on something the caller
+  // never asked for - the failure mode this parameter exists to remove.
+  it("refuses a selector on a command that is not a tap, recording nothing", async () => {
+    const res = (await record({
+      command: "screenshot",
+      args: JSON.stringify({ udid: DEVICE }),
+      selector: { identifier: "save-final" },
+    })) as { message: string; toolResult: unknown };
+
+    expect(res.message).toMatch(/applies to a recorded `gesture-tap`/);
+    expect(res.message).toMatch(/Nothing was executed and no step was recorded/);
+    expect(res.toolResult).toBeUndefined();
+    expect(await recordedSteps()).toHaveLength(0);
+  });
+
+  // delayMs suppresses selector capture entirely, so a selector passed with one
+  // would be dropped rather than applied.
+  it("refuses a selector on a tap carrying delayMs, naming delayMs", async () => {
+    const res = (await record({
+      command: "gesture-tap",
+      args: JSON.stringify({ udid: DEVICE, ...ON_ROW }),
+      selector: { identifier: "save-final" },
+      delayMs: 300,
+    })) as { message: string };
+
+    expect(res.message).toMatch(/delayMs/);
+    expect(await recordedSteps()).toHaveLength(0);
+  });
+
+  // The third refusal branch: `gesture-tap` by name, no delayMs, but args that
+  // carry no point for a selector to be checked against.
+  it("refuses a selector on a tap whose args carry no coordinates", async () => {
+    const res = (await record({
+      command: "gesture-tap",
+      args: JSON.stringify({ udid: DEVICE, x: 0.2 }),
+      selector: { text: "Settings" },
+    })) as { message: string };
+
+    expect(res.message).toMatch(/needs a `gesture-tap` whose args carry `udid`, `x` and `y`/);
+    expect(await recordedSteps()).toHaveLength(0);
+  });
+
+  it("still derives a selector when none is supplied", async () => {
+    setTree([n({ frame: { x: 0.1, y: 0.1, width: 0.3, height: 0.2 }, label: "Continue" })]);
+    await record({
+      command: "gesture-tap",
+      args: JSON.stringify({ udid: DEVICE, x: 0.2, y: 0.15 }),
+    });
+    expect(await recordedSteps()).toEqual([{ kind: "tap", selector: { text: "Continue" } }]);
+  });
+
+  it("needs at least one of identifier, text or role", async () => {
+    const schema = createFlowAddStepTool(mockRegistry()).zodSchema;
+    if (!schema) throw new Error("flow-add-step declares no zodSchema");
+    const base = { name: FLOW, project_root: tmpDir, command: "gesture-tap" };
+    expect(schema.safeParse({ ...base, selector: {} }).success).toBe(false);
+    expect(schema.safeParse({ ...base, selector: { role: "AXButton" } }).success).toBe(true);
+  });
+});

--- a/packages/tool-server/test/flows/flow-tools.test.ts
+++ b/packages/tool-server/test/flows/flow-tools.test.ts
@@ -2851,7 +2851,7 @@ describe("the flow-add-step schema the CLI tests hand-copy", () => {
   //
   // So the guard lives on this side, where the schema is. If this fails,
   // update those three fixtures in the same change.
-  const CLI_FIXTURE_PROPERTIES = ["name", "project_root", "command", "args", "delayMs"];
+  const CLI_FIXTURE_PROPERTIES = ["name", "project_root", "command", "args", "selector", "delayMs"];
   const CLI_FIXTURE_REQUIRED = ["name", "project_root", "command"];
 
   it("still declares exactly the properties and required keys those fixtures encode", () => {


### PR DESCRIPTION
Part of the "guidance mandates a call whose inputs already live server-side" audit (see #984).

## The defect

`argent-create-flow`'s live-authoring reference opened its Taps section with:

> `flow-add-step` cannot receive a flow selector directly.

So the agent, which has just read the element off a discovery call and knows exactly which of its fields is the durable one, is told to throw that away and let the recorder re-derive a selector from the tapped node - identifier, then text, then role.

That order is right on average and wrong in a specific, silent way: when the identifier is positional (`row-3`, `item_7`) and the visible text is the stable part, the recorder picks the identifier, warns about nothing, and the step replays green until the list reorders. Of the recorder's three outcomes the skill itself says only two warn.

The documented recovery is a manual loop: record the tap, read `recorded`, notice the derived selector is the brittle one, restore the source screen with direct MCP calls, re-record, then delete the weak step after `flow-finish-recording`.

## The change

`flow-add-step` takes an optional `selector` next to `args`:

```
flow-add-step {
  command: "gesture-tap",
  args: '{"udid": "…", "x": 0.2, "y": 0.55}',
  selector: { text: "Settings" }
}
```

The coordinates still dispatch the tap. `selector` only decides what the step matches on at replay, in place of what the recorder would infer.

**It is checked, not trusted.** The caller read it off the agent-facing describe tree, which is not the tree the runner resolves against - so "I already know it" is not evidence it resolves there. A supplied selector goes through the same two guards a derived one does, against `fetchFlowTree`:

- resolves to nothing on that tree -> refused, coordinates kept, warning
- resolves to an element that does not cover the tapped point -> refused, coordinates kept, warning

Both warnings say `the selector you passed …` rather than `selector …`, so a rejected supplied selector is distinguishable from a failed derivation. (The first branch was previously marked unreachable-and-defensive for derived selectors; it is now the ordinary failure path for supplied ones, and the comment says so.)

**Passed where it cannot apply, it refuses rather than being dropped.** `selector` only reaches the recorder on the tap path, so accepting it elsewhere would record a step matching on something the caller never asked for - the exact failure this parameter exists to remove. Three cases, each answered with `recordNothing` (nothing runs at the device, take untouched), naming which one it was:

- `command` is not `gesture-tap`
- `gesture-tap` carrying `delayMs`, which suppresses selector capture entirely
- `gesture-tap` whose args carry no `udid`/`x`/`y`

The tool description's "Two calls SUCCEED while recording nothing" now reads "Three" and lists this one.

## Schema drift

`flow-tools.test.ts`'s \"the flow-add-step schema the CLI tests hand-copy\" guard failed on the new property, as designed. All three fixtures it names are updated - `run-help.test.ts`, `flag-parser.test.ts`, `run-flow-add-step-payload.test.ts`.

`selector` is the schema's first object-typed field, so `run-help` also pins that it renders as `--selector-json <json>` (the `-json` escape hatch) rather than as a plain `--selector <value>` flag no parser branch accepts. Mutating the fixture's type to `string` fails that assertion.

## Tests

`packages/tool-server/test/flows/flow-record-tap-explicit-selector.test.ts` - 9 tests:

- records the supplied `text` on a node whose identifier is `row-3`
- the paired contrast: same tap, same tree, no `selector` -> `{ identifier: "row-3" }`
- supplied selector matching nothing -> coordinates kept, `the selector you passed`
- supplied selector resolving away from the tapped point -> coordinates kept
- the three refusal branches, each asserted on its own message
- derivation still works when nothing is supplied
- the schema rejects `selector: {}` and accepts `{ role: … }`

Mutation-checked - each of these leaves the file red:

| mutation | failures |
|---|---|
| guard removed (`false &&`) | 3 |
| supplied selector trusted (skip both checks) | 2 |
| supplied selector ignored (always derive) | 3 |

## Docs

- `argent-create-flow/references/live-authoring.md` - the Taps section no longer opens with the false claim; it leads with passing `selector`, keeps the derivation ladder for when you do not, and names the refusal cases.
- `docs/features/flows.mdx` - the coordinate-tap limit bullet.

## Verification

- `npm run build`, `npm run lint`, `npm run knip`, `npm run format`, `typecheck:tests -w @argent/tool-server`
- `npx docusaurus build` in `packages/docs`
- full `packages/tool-server` suite in 6 shards: 4846 passed. Two failures under 6-way parallel load - `lens-tools-platform-gate` and `ios-instruments/cold-start-retry`, both 5s timeouts - pass isolated and touch nothing here.
- `packages/argent-cli`: the three fixture files, 73 passed.