### PR TITLE
feat(ios-device): small fixes related with ios-device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Argent drives a growing set of targets through a single toolkit, each with the r
 
 | Platform          | Targets                                                                 | Interaction      |
 | ----------------- | ----------------------------------------------------------------------- | ---------------- |
-| **iOS**           | Simulators and physical iPhones (USB)                                   | Touch / gesture  |
+| **iOS**           | Simulators and physical iPhones                                         | Touch / gesture  |
 | **Android**       | Emulators (AVDs) and physical devices over adb                          | Touch / gesture  |
 | **TV**            | Apple TV (tvOS), Android TV / Google TV, Amazon Fire TV (Vega)          | D-pad / remote   |
 | **Desktop & web** | Electron and Chromium apps (incl. React Native Web / Expo web) over CDP | Mouse / keyboard |

--- a/packages/docs/docs/features/physical-ios-devices.mdx
+++ b/packages/docs/docs/features/physical-ios-devices.mdx
@@ -40,15 +40,16 @@ Reading the screen does not change the screen. When the target app is in the bac
 
 ## What works
 
-The agent launches, restarts and reinstalls apps, opens URLs, reads the accessibility tree, takes screenshots, compares screenshots for visual regressions, taps and double-taps, swipes, long-presses and drags, presses the hardware buttons, types text, waits for elements, and records and replays [flows](/docs/features/flows). A flow replay never picks the phone automatically, even when no simulator is booted. Name the device in the instruction.
+The agent launches, restarts and reinstalls apps, opens URLs, reads the accessibility tree, takes screenshots, compares screenshots for visual regressions, taps and double-taps, swipes, long-presses and drags, presses the home, volume and action buttons, types text, waits for elements, and records and replays [flows](/docs/features/flows). A flow replay never picks the phone automatically, even when no simulator is booted. Name the device in the instruction.
 
-A web URL opens in Safari. For any other URL scheme, the agent names the app that receives the URL.
+A web URL opens in Safari, not in the app that owns the link. The agent names the app to hand it the URL. For any other URL scheme, the agent names the app that receives the URL.
 
-Some simulator capabilities do not exist on hardware. Each one fails with a message that names the alternative:
+Some simulator capabilities do not exist on hardware. Each one fails with a `not supported on ios device` message. The alternatives:
 
 - Two-finger gestures such as pinch and rotate are not possible. The agent drives the zoom controls of the app instead.
 - The device does not rotate or shake on command. Rotate or shake the phone by hand, or test motion on a simulator.
 - The agent changes an app permission in the Settings app of the phone, not with the permissions tool.
+- JavaScript debugging, React and native profiling, native view inspection, screen recording and paste work on a simulator only.
 
 ## Troubleshooting
 

--- a/packages/docs/docs/features/physical-ios-devices.mdx
+++ b/packages/docs/docs/features/physical-ios-devices.mdx
@@ -40,7 +40,7 @@ Reading the screen does not change the screen. When the target app is in the bac
 
 ## What works
 
-The agent launches, restarts and reinstalls apps, opens URLs, reads the accessibility tree, takes screenshots, compares screenshots for visual regressions, taps and double-taps, swipes, long-presses and drags, presses the home, volume and action buttons, types text, waits for elements, and records and replays [flows](/docs/features/flows). A flow replay never picks the phone automatically, even when no simulator is booted. Name the device in the instruction.
+The agent launches, restarts and reinstalls apps, opens URLs, reads the accessibility tree, takes screenshots, compares screenshots for visual regressions, taps and double-taps, swipes, long-presses and drags, presses the home and volume buttons, and the action button on models that have one, types text, waits for elements, and records and replays [flows](/docs/features/flows). A flow replay never picks the phone automatically, even when no simulator is booted. Name the device in the instruction.
 
 A web URL opens in Safari, not in the app that owns the link. The agent names the app to hand it the URL. For any other URL scheme, the agent names the app that receives the URL.
 

--- a/packages/docs/docs/reference/flow-yaml.mdx
+++ b/packages/docs/docs/reference/flow-yaml.mdx
@@ -96,14 +96,15 @@ A selector can scope its matches by the frames of other elements:
 
 The runner resolves a selector against a different tree than the `describe` tool:
 
-| Platform | Runner tree                                   | `describe` tree            |
-| -------- | --------------------------------------------- | -------------------------- |
-| iOS      | Native UIView hierarchy                       | Accessibility tree         |
-| Android  | Full accessibility hierarchy                  | Trimmed interactable nodes |
-| Chromium | DOM nodes with an id, label, value or handler | Full DOM                   |
-| Vega     | Toolkit page source                           | Same source                |
+| Platform        | Runner tree                                   | `describe` tree            |
+| --------------- | --------------------------------------------- | -------------------------- |
+| iOS simulator   | Native UIView hierarchy                       | Accessibility tree         |
+| Physical iPhone | Accessibility snapshot of `describe`          | Same snapshot              |
+| Android         | Full accessibility hierarchy                  | Trimmed interactable nodes |
+| Chromium        | DOM nodes with an id, label, value or handler | Full DOM                   |
+| Vega            | Toolkit page source                           | Same source                |
 
-On iOS and Android, an id absent from `describe` can still resolve in a flow. On Chromium, an element absent from `describe` cannot resolve. On iOS, do not copy a `role` from `describe` into a selector: the runner derives the role from the view class, `describe` from the accessibility traits.
+On an iOS simulator and Android, an id absent from `describe` can still resolve in a flow. On Chromium, an element absent from `describe` cannot resolve. On an iOS simulator, do not copy a `role` from `describe` into a selector: the runner derives the role from the view class, `describe` from the accessibility traits. On a physical iPhone, the runner and `describe` read one tree: copy ids and roles from `describe`.
 
 ## Directives
 

--- a/packages/docs/docs/reference/tools.mdx
+++ b/packages/docs/docs/reference/tools.mdx
@@ -29,7 +29,7 @@ Run `argent tools` to list them from the terminal, `argent tools describe <name>
 | `stop-all-simulator-servers` | Stop every service a device owns: simulator servers, native devtools, TV daemons              |
 | `stop-metro`                 | Stop the Metro bundler listening on a given port                                              |
 
-Argent supports physical iPhones; physical iPads are not supported yet. `list-devices` shows a physical device as an iOS entry with kind `device`. The state is `connected` only while the device is attached by USB cable; Argent controls physical devices over the cable and does not use Wi-Fi. The state is `paired` when the device is paired but not reachable now. Argent does not select a `paired` device automatically. Connect the device again, or pass its udid explicitly. See [Physical iOS devices](/docs/features/physical-ios-devices) for the requirements, the signing model, and the app-scoped interaction contract.
+Argent supports physical iPhones; physical iPads are not supported yet. `list-devices` shows a physical device as an iOS entry with kind `device`. The state is `connected` only while the device is attached by USB cable; Argent controls physical devices over the cable and does not use Wi-Fi. The state is `paired` when the device is paired but not reachable now. Argent never selects a physical device automatically: name its udid. A `paired` device cannot be driven until it is connected by cable again. See [Physical iOS devices](/docs/features/physical-ios-devices) for the requirements, the signing model, and the app-scoped interaction contract.
 
 ## Inspecting the screen
 

--- a/packages/ios-device-runner/PROTOCOL.md
+++ b/packages/ios-device-runner/PROTOCOL.md
@@ -202,7 +202,7 @@ reasonCode?}`.
 `APP_BACKGROUNDED` (`snapshot` only: the target is alive but backgrounded, and
 observation never re-fronts it), `TEXT_INPUT_NOT_FOCUSED`,
 `UNSUPPORTED_OPERATION` (hardware or an API the device lacks: an absent
-button, a tap count above 2), `RUNNER_BUSY` (the one
+button), `RUNNER_BUSY` (the one
 retryable code), `RUNNER_WEDGED` (recycle the session),
 `XCTEST_RECORDED_FAILURE` (a mutation ran but XCTest recorded a real failure
 during it), `SNAPSHOT_FAILED`, `COMMAND_TIMED_OUT`, `COMMAND_FAILED`.

--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -83,7 +83,7 @@ Decision order:
   argent install, so an unscoped call tears down their devices too; reserve that form for a deliberate
   machine-wide cleanup.
   If the user started Metro separately, ask whether to call `stop-metro` (specify the port if not 8081).
-- If tools provided by mcp-server are not sufficient and action can be done using `xcrun`, `adb`, or other commands, use the command. Examples: changing device options, performing a device action such as lock, shake, etc.
+- If tools provided by mcp-server are not sufficient and action can be done using `xcrun`, `adb`, or other commands, use the command. Examples: changing device options, performing a device action such as lock, shake, etc. Not on a physical iPhone.
 - When waiting for an action, do not call `screenshot` repeatedly without a proper wait mechanism. Use the `await-ui-element` tool to block until the UI settles (e.g. wait for an element to become `visible`/`hidden`, or to contain expected `text`) instead of polling.
   </general_rules>
 
@@ -114,7 +114,7 @@ When: Beginning a task that involves the Android emulator, no emulator running y
 
 PHYSICAL iPHONE (USB)
 Skills: `argent-ios-device-setup` (cable, trust, signing), then `argent-ios-device-interact` (the app-scoped interaction contract)
-When: The user names a physical iPhone, a real device, or hardware, or the target `list-devices` iOS entry has kind `"device"`. Never for a simulator, and never because a cabled phone is listed first. On hardware every interaction starts with `launch-app`; `paste`, `settings-permissions`, two-finger gestures, `rotate` and `shake` do not exist there.
+When: The user names a physical iPhone, a real device, or hardware, or the target `list-devices` iOS entry has kind `"device"`. Never for a simulator, and never because a cabled phone is listed first. On hardware every interaction starts with `launch-app`; `paste`, `settings-permissions`, two-finger gestures, `rotate`, `shake`, screen recording, `debugger-*`, `react-profiler-*`, `native-profiler-*` and `native-*` do not exist there.
 Prompt keywords: physical iPhone, real device, on my phone, USB, hardware
 
 TAPPING, SWIPING, TYPING, GESTURES, SCREENSHOTS, SCROLLING

--- a/packages/skills/skills/argent-create-flow/SKILL.md
+++ b/packages/skills/skills/argent-create-flow/SKILL.md
@@ -13,7 +13,7 @@ For a saved QA test case, ticket, or acceptance criterion, load `argent-qa-flows
 
 - Before creating or changing a flow, read [Live authoring](references/live-authoring.md) completely.
 - When polishing, composing, or manually reviewing YAML, read [Flow YAML](references/flow-yaml.md). For Vega, read its platform limits before recording remote or keyboard tools.
-- Flows run on physical iPhones (an iOS `list-devices` entry with kind `"device"`), but replay never auto-binds one, even when no simulator is booted: pass the phone's udid as `device` (CLI `--device`), and only a `connected` phone can run. `pinch`/`rotate` steps fail there like the live tools. See `argent-ios-device-interact` for the hardware contract.
+- Flows run on physical iPhones (an iOS `list-devices` entry with kind `"device"`), but replay never auto-binds one, even when no simulator is booted: pass the phone's udid as `device` (CLI `--device`), and only a `connected` phone can run. `pinch`/`rotate` steps fail there like the live tools. On hardware the flow tree is the `describe` tree: same ids and roles, no UIView hierarchy. See `argent-ios-device-interact` for the hardware contract.
 - On capture warnings, raw coordinates, unavailable trees, mistimed transitions, overlays, or replay failures, read [Reliability and recovery](references/reliability-and-recovery.md).
 
 ## Non-negotiable rules

--- a/packages/skills/skills/argent-ios-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-ios-device-interact/SKILL.md
@@ -9,10 +9,12 @@ Read this only for a physical iPhone. `argent-device-interact` still applies for
 
 ## Contract
 
-- Observation never changes the screen; mutation may. `describe` and `await-ui-element` fail on a backgrounded target instead of re-fronting it. Gestures and `keyboard` re-front it and return `reactivated: true`; re-describe before the next step.
-- Each tool's description states its own hardware limits (named keys, `gesture-custom` shapes, buttons, edge swipes, tap counts), and every failure names its fix.
+- Observation never changes the screen; mutation may. `describe`, `await-ui-element` and `await-screen-idle` fail on a backgrounded target instead of re-fronting it. Gestures and `keyboard` re-front it and return `reactivated: true`; re-describe before the next step.
+- `launch-app`, `open-url` and `restart-app` set the app under automation; `reinstall-app` clears it; a tool-server restart forgets it: launch again.
+- Each tool's description states its own hardware limits (named keys, `gesture-custom` shapes, buttons, edge swipes, tap counts). A gated tool fails with a bare `not supported on ios device`: the fix is in the list below, not in the error.
 
 ## Tools on hardware
 
-- Only these exist: `list-devices`, `launch-app`, `restart-app`, `reinstall-app`, `open-url`, `describe`, `screenshot`, `screenshot-diff`, `gesture-tap`, `gesture-swipe`, `gesture-custom`, `button`, `keyboard`, `await-ui-element`, `await-screen-idle`, `run-sequence`, the flow tools, and `stop-simulator-server`. Everything else fails with `not supported on ios device`.
-- No two-finger gestures, `rotate`, `shake`, `paste`, or `settings-permissions`: drive the app's own zoom and rotate UI with taps and drags, move the phone by hand, type with `keyboard`, and change permissions in the phone's Settings.
+- Only these exist: `list-devices`, `launch-app`, `restart-app`, `reinstall-app`, `open-url`, `describe`, `screenshot`, `screenshot-diff`, `gesture-tap`, `gesture-swipe`, `gesture-custom`, `button` (`home`, `volumeUp`, `volumeDown`, `actionButton`), `keyboard`, `await-ui-element`, `await-screen-idle`, `run-sequence`, the flow tools, `stop-simulator-server` and `stop-all-simulator-servers` (session end). Every other device tool fails with `not supported on ios device`.
+- No two-finger gestures, `rotate`, `shake`, `paste`, `settings-permissions`, screen recording, `debugger-*`, `react-profiler-*`, `native-profiler-*`, `native-*`, `boot-device`: drive the app's own zoom and rotate UI with taps and drags, move the phone by hand, type with `keyboard`, change permissions in the phone's Settings, and debug, profile or record on a simulator.
+- `gesture-swipe`: `durationMs` sets drag speed, not time; `momentum:false` only rests 300 ms at the end, no damping. `open-url` https lands in Safari, never in the app that owns the link: pass `bundleId`.

--- a/packages/skills/skills/argent-ios-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-ios-device-interact/SKILL.md
@@ -9,12 +9,12 @@ Read this only for a physical iPhone. `argent-device-interact` still applies for
 
 ## Contract
 
-- Observation never changes the screen; mutation may. `describe`, `await-ui-element` and `await-screen-idle` fail on a backgrounded target instead of re-fronting it. Gestures and `keyboard` re-front it and return `reactivated: true`; re-describe before the next step.
+- Observation never changes the screen; mutation may. `describe` and `await-ui-element` fail on a backgrounded target instead of re-fronting it; `await-screen-idle` returns `settled: false` with no reason. The first `describe` within a second of `button home` can still return the old tree; describe again. Gestures and `keyboard` re-front it and return `reactivated: true`; re-describe before the next step.
 - `launch-app`, `open-url` and `restart-app` set the app under automation; `reinstall-app` clears it; a tool-server restart forgets it: launch again.
 - Each tool's description states its own hardware limits (named keys, `gesture-custom` shapes, buttons, edge swipes, tap counts). A gated tool fails with a bare `not supported on ios device`: the fix is in the list below, not in the error.
 
 ## Tools on hardware
 
-- Only these exist: `list-devices`, `launch-app`, `restart-app`, `reinstall-app`, `open-url`, `describe`, `screenshot`, `screenshot-diff`, `gesture-tap`, `gesture-swipe`, `gesture-custom`, `button` (`home`, `volumeUp`, `volumeDown`, `actionButton`), `keyboard`, `await-ui-element`, `await-screen-idle`, `run-sequence`, the flow tools, `stop-simulator-server` and `stop-all-simulator-servers` (session end). Every other device tool fails with `not supported on ios device`.
+- Only these exist: `list-devices`, `launch-app`, `restart-app`, `reinstall-app`, `open-url`, `describe`, `screenshot`, `screenshot-diff`, `gesture-tap`, `gesture-swipe`, `gesture-custom`, `button` (`home`, `volumeUp`, `volumeDown`, `actionButton` on models that have one), `keyboard`, `await-ui-element`, `await-screen-idle`, `run-sequence`, the flow tools, `stop-simulator-server` and `stop-all-simulator-servers` (session end). Every other device tool fails with `not supported on ios device`.
 - No two-finger gestures, `rotate`, `shake`, `paste`, `settings-permissions`, screen recording, `debugger-*`, `react-profiler-*`, `native-profiler-*`, `native-*`, `boot-device`: drive the app's own zoom and rotate UI with taps and drags, move the phone by hand, type with `keyboard`, change permissions in the phone's Settings, and debug, profile or record on a simulator.
 - `gesture-swipe`: `durationMs` sets drag speed, not time; `momentum:false` only rests 300 ms at the end, no damping. `open-url` https lands in Safari, never in the app that owns the link: pass `bundleId`.

--- a/packages/skills/skills/argent-ios-device-setup/SKILL.md
+++ b/packages/skills/skills/argent-ios-device-setup/SKILL.md
@@ -10,11 +10,11 @@ Read this only for a physical iPhone. Simulators use `argent-ios-simulator-setup
 ## First run
 
 1. Cable the phone, unlock it, keep the screen awake, and turn on Developer Mode (Settings > Privacy & Security > Developer Mode). `list-devices` must show it `connected`.
-2. Run the first interaction tool. It builds and signs the on-device runner: seconds from cache, minutes on a cold build.
+2. `launch-app` only registers the app. The first `describe`, gesture or `screenshot` builds, signs and starts the on-device runner: minutes cold, tens of seconds from cache or after a tool-server restart. Build cap 15 min, runner ready 120 s.
 3. On the first install the phone asks to trust the developer (Settings > General > VPN & Device Management), and an **ArgentRunner** app appears on the home screen. Tell the user it is argent's automation runner and must stay installed.
 
 ## Signing and failures
 
-Signing needs no configuration. The result note or the error text names the team picked, the `ARGENT_IOS_TEAM_ID` override, and the fix for every signing, cable, lock, or trust failure: apply it and retry the same call.
+Signing needs no configuration. The first phone call of a tool-server process carries a note naming the team picked and the `ARGENT_IOS_TEAM_ID` override (tool-server environment; a change forces a cold rebuild). Cable, lock, trust, expired-profile and missing-certificate errors name their fix: apply it, retry the same call. Also: `errSecInternalComponent`: run `security set-key-partition-list -S apple-tool:,apple:,codesign: -s ~/Library/Keychains/login.keychain-db` (asks the user's login password), retry. `team has no devices`: keep the phone cabled, retry. Bundle id registration failed: free-team app-id cap, wait days or sign under a paid team. Any other xcodebuild failure prints raw `error:` lines: read `~/.argent/ios-device-runner/logs/runner-<udid8>.log`. `RUNNER_WEDGED`: `stop-simulator-server` for the udid, retry.
 
 Then read `argent-ios-device-interact`.

--- a/packages/skills/skills/argent-ios-simulator-setup/SKILL.md
+++ b/packages/skills/skills/argent-ios-simulator-setup/SKILL.md
@@ -8,7 +8,7 @@ description: Set up and connect to an iOS simulator using argent MCP tools. Use 
 If you delegate simulator tasks to sub-agents, make sure they have MCP permissions.
 
 1. **Find a booted simulator**
-   Use `list-devices`. Filter for entries with `platform: "ios"` — booted iPhones are listed first.
+   Use `list-devices`. Filter for entries with `platform: "ios"` and skip any with `kind: "device"` (a physical iPhone, never a simulator target): booted simulators are listed first.
    If none are booted, call `boot-device` with `udid: <chosen UDID>`.
 
 2. **Verify connection**

--- a/packages/skills/skills/argent-metro-debugger/SKILL.md
+++ b/packages/skills/skills/argent-metro-debugger/SKILL.md
@@ -5,6 +5,8 @@ description: Debug a JS runtime via CDP using argent debugger tools. Primary pat
 
 ## 1. Prerequisites
 
+Physical iPhone: not supported; every `debugger-*` tool rejects `kind: "device"`. Use a simulator.
+
 For **React Native (iOS / Android)**: requires **Metro dev server running** (default `localhost:8081`) and **a React Native app connected to Metro** (at least one CDP target). Verify via `debugger-status` — it returns `status: "connected"` or `status: "not_connected"` with a `reason` and `guidance` (it does not fail when the debugger is unreachable).
 
 For **Vega (Fire TV)**: requires a **Debug `.vpkg`** (a Release build never attaches) and **Metro reachable from the device** (`vega device start-port-forwarding --port 8081 --forward false`). Verify via `debugger-status`. `debugger-component-tree`, `debugger-inspect-element`, `debugger-reload-metro` and the `react-profiler-*` / `profiler-*` tools are unavailable there — see the `argent-tv-interact` skill.

--- a/packages/skills/skills/argent-native-profiler/SKILL.md
+++ b/packages/skills/skills/argent-native-profiler/SKILL.md
@@ -10,6 +10,7 @@ description: Native profiling for CPU hotspots, UI hangs, memory issues. iOS via
 - `native-profiler-analyze` — parse exported trace data and return a structured bottleneck payload.
 - `profiler-stack-query` — drill into parsed data: hang stacks, function callers, thread breakdown, leak details.
 - `profiler-load` — list and reload previous trace sessions from disk for re-investigation.
+- Physical iPhone: not supported; use a simulator.
 
 ---
 

--- a/packages/skills/skills/argent-qa-flows/SKILL.md
+++ b/packages/skills/skills/argent-qa-flows/SKILL.md
@@ -11,7 +11,7 @@ Load `argent-create-flow` as the authoring engine. Follow its required reference
 
 **Apple TV and Android TV are out of scope.** The runner does not reject touch directives there, so they fail at the gesture layer instead of with authoring guidance. Use `argent-tv-interact` and report the limitation.
 
-**Physical iPhones** run QA flows, with two hardware limits: replay never auto-binds a phone, so pass its udid as `device` (CLI `--device`) and keep it `connected`, and `pinch`/`rotate` steps fail there like the live tools, so drive the app's own zoom UI instead. Read `argent-ios-device-interact` for the app-scoped contract before recording.
+**Physical iPhones** run QA flows, with three hardware limits: replay never auto-binds a phone, so pass its udid as `device` (CLI `--device`) and keep it `connected`; `pinch`/`rotate` steps fail there like the live tools, so drive the app's own zoom UI instead; the flow tree is the `describe` tree (same ids and roles), so a selector authored on a simulator can miss there. Read `argent-ios-device-interact` for the app-scoped contract before recording.
 
 ## Definition of done
 

--- a/packages/skills/skills/argent-react-native-app-workflow/SKILL.md
+++ b/packages/skills/skills/argent-react-native-app-workflow/SKILL.md
@@ -3,6 +3,8 @@ name: argent-react-native-app-workflow
 description: Step-by-step workflows for developing or debugging React Native apps on iOS simulator or Android emulator. Use when starting the app, debugging Metro, fixing builds, diagnosing runtime errors, or running tests.
 ---
 
+Physical iPhone (`kind: "device"`): Metro debugging and profiling tools reject it. Use a simulator.
+
 ## 1. Starting the React Native App
 
 ### 1.1 Explore Configuration (MANDATORY — Do This First)

--- a/packages/skills/skills/argent-react-native-profiler/SKILL.md
+++ b/packages/skills/skills/argent-react-native-profiler/SKILL.md
@@ -5,6 +5,8 @@ description: Profile a React Native Hermes app to measure re-render and CPU perf
 
 This skill is complementary to `argent-react-native-optimization`, not a replacement for it.
 
+Physical iPhone: not supported; `react-profiler-*` reject `kind: "device"`. Profile on a simulator.
+
 ## 2. Tool Overview
 
 ### React Profiler (Hermes / React commits)

--- a/packages/skills/skills/argent-test-ui-flow/SKILL.md
+++ b/packages/skills/skills/argent-test-ui-flow/SKILL.md
@@ -5,6 +5,8 @@ description: Autonomously test an app UI (iOS or Android) by running interact-sc
 
 ## Platform-agnostic
 
+Physical iPhone (`kind: "device"`): read `argent-ios-device-interact` first. `launch-app` before anything; `describe` fails while the app is backgrounded.
+
 The interaction tool names are identical on iOS and Android — `gesture-tap`, `gesture-swipe`, `describe`, `screenshot`, `launch-app`, etc. — and the tool-server auto-dispatches based on the `udid` you pass (UUID-shape → iOS, adb serial → Android).
 
 **Before testing, resolve which device to test on.** Call `list-devices` and follow `<device_selection_rule>`: prefer a running device on any platform;

--- a/packages/tool-server/src/http.ts
+++ b/packages/tool-server/src/http.ts
@@ -159,9 +159,16 @@ function extractDeviceArg(data: unknown): string | null {
   return null;
 }
 
-/** Whether the call names a physical iPhone as the device it acts on. */
+/**
+ * Whether the call names a physical iPhone as the device it acts on. Reads
+ * `device` as well as the three spellings above: `flow-execute` names its
+ * target that way, and a session that only replays flows on the phone must
+ * still be handed the signing note.
+ */
 function targetsIosPhysicalDevice(data: unknown): boolean {
-  const deviceArg = extractDeviceArg(data);
+  const record = data && typeof data === "object" ? (data as Record<string, unknown>) : null;
+  const flowDevice = typeof record?.device === "string" ? record.device : null;
+  const deviceArg = extractDeviceArg(data) ?? flowDevice;
   return deviceArg !== null && isIosPhysicalDevice(resolveDevice(deviceArg));
 }
 

--- a/packages/tool-server/src/tools/describe/index.ts
+++ b/packages/tool-server/src/tools/describe/index.ts
@@ -176,7 +176,7 @@ The tree carries no z-order or occlusion information: an element listed at a poi
 by an overlay (e.g. a toolbar over list rows), so check a screenshot when a tap lands unexpectedly.
 
 For app-scoped inspection with full UIKit properties (accessibilityIdentifier, viewClassName),
-use native-describe-screen with an explicit bundleId instead (iOS only).
+use native-describe-screen with an explicit bundleId instead (iOS simulator only).
 For React Native apps, debugger-component-tree returns React component names with tap coordinates.
 
 On a TV target (Apple TV / Android TV — a \`list-devices\` entry with runtimeKind 'tv') this returns

--- a/packages/tool-server/src/tools/flows/flow-device.ts
+++ b/packages/tool-server/src/tools/flows/flow-device.ts
@@ -103,7 +103,7 @@ function connectedIosDeviceHint(devices: RawDevice[], platform?: FlowPlatform): 
   if (ids.length === 0) return "";
   return (
     ` A physical iPhone is connected (${ids.join(", ")}); hardware is never picked ` +
-    `automatically, pass --device <udid> to run on it.`
+    `automatically, pass device <udid> (--device on the CLI) to run on it.`
   );
 }
 

--- a/packages/tool-server/src/tools/gesture-swipe/index.ts
+++ b/packages/tool-server/src/tools/gesture-swipe/index.ts
@@ -113,7 +113,7 @@ export const gestureSwipeTool: ToolDefinition<Params, Result> = {
 Generates interpolated Move events for a natural feel (~60fps).
 Swipe up (fromY > toY) to scroll content down.
 Use when you need to scroll a list, dismiss a modal, drag an element, or navigate between pages. Not supported on Chromium — use gesture-scroll there instead.
-Physical iOS: an edge gesture (back-swipe) needs fromX 0 exactly.
+Physical iOS: an edge gesture (back-swipe) needs fromX 0 exactly; durationMs sets drag speed, not time; momentum:false only rests 300ms at the end and does not damp.
 Pass momentum:false for a momentum-free swipe that lands where the finger lifts (little to no fling at the 300 default), when you need a deterministic scroll distance; it needs durationMs >= 150 and is rejected below that, a shorter ease-out leaving the OS too little wall clock to read the deceleration as a stop. At 150 it lands short of the lift point instead, and 2 of 47 runs still flung backwards. A plain swipe takes any duration up to 10000ms and is delivered as close to the speed it was authored as a 16ms frame allows: below ~32ms the whole travel lands in one or two frames, which the OS flings as hard as it flings anything. Returns { swiped: true, timestampMs }. On physical iOS, reactivated: true = app was re-fronted; re-describe. Fails if the simulator-server / emulator backend is not reachable for the given device.`,
   alwaysLoad: true,
   searchHint: "swipe scroll drag pan gesture device simulator emulator touch move",

--- a/packages/tool-server/src/utils/ios-device/team-detect.ts
+++ b/packages/tool-server/src/utils/ios-device/team-detect.ts
@@ -21,8 +21,7 @@ export interface DetectedSigningTeam {
   /**
    * Certificate kind and key id, e.g. "Apple Development (ABCD123456)". The
    * subject CN also carries the account identity (an Apple ID, often an
-   * e-mail), which is dropped: the note that prints this label travels into
-   * agent context and transcripts.
+   * e-mail), which is dropped here.
    */
   label: string;
   /** The newest certificate's notBefore, epoch ms. Orders the auto-pick. */

--- a/packages/tool-server/src/utils/ios-device/team-detect.ts
+++ b/packages/tool-server/src/utils/ios-device/team-detect.ts
@@ -18,7 +18,12 @@ const execFileAsync = promisify(execFile);
 export interface DetectedSigningTeam {
   /** Apple Developer Team ID, the certificate subject OU. */
   teamId: string;
-  /** Certificate subject CN, e.g. "Apple Development: dev@example.com (ABCD123456)". */
+  /**
+   * Certificate kind and key id, e.g. "Apple Development (ABCD123456)". The
+   * subject CN also carries the account identity (an Apple ID, often an
+   * e-mail), which is dropped: the note that prints this label travels into
+   * agent context and transcripts.
+   */
   label: string;
   /** The newest certificate's notBefore, epoch ms. Orders the auto-pick. */
   issuedAtMs: number;
@@ -68,6 +73,18 @@ function subjectValue(subject: string, key: string): string | null {
 }
 
 /**
+ * "Apple Development: dev@example.com (ABCD123456)" -> "Apple Development (ABCD123456)".
+ * A CN without the expected shape keeps only the text before the colon, or all
+ * of it when there is no colon, so no identity leaks through an unusual
+ * certificate either.
+ */
+export function signingLabel(commonName: string): string {
+  const match = /^([^:]+):.*\(([A-Za-z0-9]+)\)\s*$/.exec(commonName);
+  if (match) return `${match[1].trim()} (${match[2]})`;
+  return commonName.split(":")[0]!.trim();
+}
+
+/**
  * Parse concatenated PEM output into teams: dedup by team id keeping each
  * team's newest certificate, newest team first, notBefore ties broken by team
  * id so the auto-pick is deterministic. Blocks that do not parse as a
@@ -86,12 +103,14 @@ export function parseSigningTeams(pem: string): DetectedSigningTeam[] {
     }
 
     const teamId = subjectValue(cert.subject, "OU");
-    const label = subjectValue(cert.subject, "CN");
+    const commonName = subjectValue(cert.subject, "CN");
     const issuedAtMs = Date.parse(cert.validFrom);
 
-    if (!teamId || !label || Number.isNaN(issuedAtMs)) {
+    if (!teamId || !commonName || Number.isNaN(issuedAtMs)) {
       continue;
     }
+
+    const label = signingLabel(commonName);
 
     const known = newestByTeam.get(teamId);
 

--- a/packages/tool-server/test/flows/flow-deviceless.test.ts
+++ b/packages/tool-server/test/flows/flow-deviceless.test.ts
@@ -258,7 +258,7 @@ describe("a flow that does touch a device still demands one", () => {
       ],
     });
     await expect(runAuto(registry, "phone-only")).rejects.toThrow(
-      /No booted device found.*A physical iPhone is connected \(00008120-000A44443333801E\); hardware is never picked automatically, pass --device <udid> to run on it\..*\(ios, connected\)/
+      /No booted device found.*A physical iPhone is connected \(00008120-000A44443333801E\); hardware is never picked automatically, pass device <udid> \(--device on the CLI\) to run on it\..*\(ios, connected\)/
     );
   });
 

--- a/packages/tool-server/test/http-signing-detection-note.test.ts
+++ b/packages/tool-server/test/http-signing-detection-note.test.ts
@@ -48,7 +48,7 @@ function stubRegistry(): Registry {
 const DETECTED_TEAM = [
   {
     teamId: "ABCDE12345",
-    label: "Apple Development: alice@example.com (ALICEKEY01)",
+    label: "Apple Development (ALICEKEY01)",
     issuedAtMs: Date.parse("2024-01-15T12:00:00Z"),
   },
 ];

--- a/packages/tool-server/test/http-signing-detection-note.test.ts
+++ b/packages/tool-server/test/http-signing-detection-note.test.ts
@@ -31,7 +31,10 @@ function stubRegistry(): Registry {
         return {
           id: "test-tool",
           description: "A stub tool for testing",
-          inputSchema: { type: "object", properties: { udid: { type: "string" } } },
+          inputSchema: {
+            type: "object",
+            properties: { udid: { type: "string" }, device: { type: "string" } },
+          },
           services: () => ({}),
           execute: async () => ({ ok: true }),
         };
@@ -115,5 +118,24 @@ describe("HTTP signing-detection note", () => {
       .send({ udid: PHONE })
       .expect(200);
     expect(phone.body.note).toContain("Signing the on-device runner with team ABCDE12345");
+  });
+
+  it("recognises the phone under flow-execute's `device` spelling", async () => {
+    // A session that only replays flows on the phone names it as `device`,
+    // never as `udid`; the note must not wait for a call that never comes.
+    stageNote();
+    handle = createHttpApp(stubRegistry());
+
+    const simulatorFlow = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({ device: "7AFBC98C-76B5-4BD4-8B7F-24AE3E30BA37" })
+      .expect(200);
+    expect(simulatorFlow.body).not.toHaveProperty("note");
+
+    const phoneFlow = await request(handle.app)
+      .post("/tools/test-tool")
+      .send({ device: PHONE })
+      .expect(200);
+    expect(phoneFlow.body.note).toContain("Signing the on-device runner with team ABCDE12345");
   });
 });

--- a/packages/tool-server/test/ios-device-team-detect.test.ts
+++ b/packages/tool-server/test/ios-device-team-detect.test.ts
@@ -7,6 +7,7 @@ import {
   detectSigningTeams,
   parseSigningTeams,
   type DetectedSigningTeam,
+  signingLabel,
 } from "../src/utils/ios-device/team-detect";
 import {
   NO_TEAM_PEM,
@@ -23,14 +24,30 @@ import {
 beforeEach(() => __setCertificateListerForTests(async () => ""));
 afterEach(() => __setCertificateListerForTests(null));
 
+describe("signingLabel", () => {
+  it("keeps the certificate kind and key id and drops the account identity", () => {
+    expect(signingLabel("Apple Development: alice@example.com (ALICEKEY01)")).toBe(
+      "Apple Development (ALICEKEY01)"
+    );
+    expect(signingLabel("iPhone Developer: Alice Example (ALICEKEY01)")).toBe(
+      "iPhone Developer (ALICEKEY01)"
+    );
+  });
+
+  it("falls back to the kind alone when the CN has no key id", () => {
+    expect(signingLabel("Apple Development: alice@example.com")).toBe("Apple Development");
+    expect(signingLabel("Apple Development")).toBe("Apple Development");
+  });
+});
+
 describe("parseSigningTeams", () => {
-  it("reads team id (OU), label (CN) and notBefore out of a PEM block", () => {
+  it("reads team id (OU), the redacted label (CN) and notBefore out of a PEM block", () => {
     const teams = parseSigningTeams(TEAM_A_PEM);
 
     expect(teams).toEqual([
       {
         teamId: "ABCDE12345",
-        label: "Apple Development: alice@example.com (ALICEKEY01)",
+        label: "Apple Development (ALICEKEY01)",
         issuedAtMs: Date.parse("2024-01-15T12:00:00Z"),
       },
     ]);
@@ -52,7 +69,7 @@ describe("parseSigningTeams", () => {
     expect(teams).toHaveLength(1);
     expect(teams[0]).toMatchObject({
       teamId: "FGHIJ67890",
-      label: "Apple Development: bob@example.com (BOBKEY0002)",
+      label: "Apple Development (BOBKEY0002)",
     });
   });
 
@@ -152,7 +169,7 @@ describe("detectSigningTeams", () => {
 const ONE_TEAM: DetectedSigningTeam[] = [
   {
     teamId: "ABCDE12345",
-    label: "Apple Development: alice@example.com (ALICEKEY01)",
+    label: "Apple Development (ALICEKEY01)",
     issuedAtMs: Date.parse("2024-01-15T12:00:00Z"),
   },
 ];
@@ -160,13 +177,13 @@ const ONE_TEAM: DetectedSigningTeam[] = [
 const THREE_TEAMS: DetectedSigningTeam[] = [
   {
     teamId: "FGHIJ67890",
-    label: "Apple Development: bob@example.com (BOBKEY0002)",
+    label: "Apple Development (BOBKEY0002)",
     issuedAtMs: Date.parse("2025-06-01T09:00:00Z"),
   },
   ...ONE_TEAM,
   {
     teamId: "KLMNO13579",
-    label: "Apple Development: carol@example.com (CAROLKEY01)",
+    label: "Apple Development (CAROLKEY01)",
     issuedAtMs: Date.parse("2023-02-02T00:00:00Z"),
   },
 ];
@@ -175,7 +192,7 @@ describe("buildSigningDetectionNote", () => {
   it("names the single detected team and the override variable", () => {
     expect(buildSigningDetectionNote(ONE_TEAM)).toBe(
       "Signing the on-device runner with team ABCDE12345 " +
-        "(Apple Development: alice@example.com (ALICEKEY01)), detected from this Mac's " +
+        "(Apple Development (ALICEKEY01)), detected from this Mac's " +
         "keychain. Set ARGENT_IOS_TEAM_ID in the tool-server's environment to override."
     );
   });
@@ -183,10 +200,10 @@ describe("buildSigningDetectionNote", () => {
   it("lists the losing teams and the exact restart command when several exist", () => {
     expect(buildSigningDetectionNote(THREE_TEAMS)).toBe(
       "Signing the on-device runner with team FGHIJ67890 " +
-        "(Apple Development: bob@example.com (BOBKEY0002)), the newest of 3 signing " +
+        "(Apple Development (BOBKEY0002)), the newest of 3 signing " +
         "identities in this Mac's keychain. Also found: ABCDE12345 " +
-        "(Apple Development: alice@example.com (ALICEKEY01)), KLMNO13579 " +
-        "(Apple Development: carol@example.com (CAROLKEY01)). To sign under a different " +
+        "(Apple Development (ALICEKEY01)), KLMNO13579 " +
+        "(Apple Development (CAROLKEY01)). To sign under a different " +
         "team, set ARGENT_IOS_TEAM_ID in the tool-server's environment: " +
         "argent server stop && ARGENT_IOS_TEAM_ID=<team-id> argent server start --detach"
     );


### PR DESCRIPTION
Follow-up to #944: the fixes made after the review that did not make the squash.

## What changes

- **Signing note**: delivered only to a call whose device argument resolves to a physical iPhone, including `flow-execute`'s `device`, and held (not dropped) across other calls. The label is now `Apple Development (KEYID)`; the certificate CN's Apple ID no longer reaches agent context or logs.
- **Flow device resolution**: the no-device-matched refusal names the cabled phone and the exact `device <udid>` / `--device` spelling. A physical iPhone is never picked automatically.
- **`gesture-swipe`**: the description states the hardware semantics (edge gesture needs `fromX` 0, `durationMs` sets drag speed, `momentum:false` does not damp).
- **Skills**: `argent-ios-simulator-setup` skips `kind: "device"` entries; `argent-ios-device-setup` and `-interact` state the runner build timing, the full list of tools that do not exist on hardware, the backgrounded-target behaviour of each read tool, `actionButton` only on models that have one, and the swipe and `open-url` rules; the flow, Metro and profiler skills each carry one line on physical-iPhone limits.
- **Docs**: `physical-ios-devices`, `flows`, `flow-yaml` and `tools` corrected to match the behaviour above; README platform row; runner `PROTOCOL.md`.

## Verification

- tool-server suite 400 files / 5173 tests, `tsc`, lint, prettier and the docs build clean.
- Live re-check against 0.23.0 on three simulators and a physical iPhone 15: no regression; the note lands once on the first phone call with no e-mail address, and flow auto-detection is byte-identical to 0.23.0 with 0, 1 and 3 simulators booted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified physical iPhone capabilities, limitations, device selection, accessibility trees, gestures, URLs, setup, and troubleshooting.
  - Documented that debugging, profiling, screen recording, and several inspection tools require an iOS simulator.
  - Clarified physical-device button names, timing expectations, unsupported-operation messages, and simulator-only behavior.

- **Bug Fixes**
  - Physical iPhone sessions referenced through flow execution are now recognized correctly.
  - Signing-team labels now omit account email addresses while retaining certificate details.
  - Improved guidance when a connected iPhone requires explicit device selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->