### PR TITLE
docs: add a Limits section to the physical iOS devices page

### DIFF
--- a/packages/docs/docs/features/physical-ios-devices.mdx
+++ b/packages/docs/docs/features/physical-ios-devices.mdx
@@ -44,13 +44,6 @@ The agent launches, restarts and reinstalls apps, opens URLs, reads the accessib
 
 A web URL opens in Safari, not in the app that owns the link. The agent names the app to hand it the URL. For any other URL scheme, the agent names the app that receives the URL.
 
-Some simulator capabilities do not exist on hardware. Each one fails with a `not supported on ios device` message. The alternatives:
-
-- Two-finger gestures such as pinch and rotate are not possible. The agent drives the zoom controls of the app instead.
-- The device does not rotate or shake on command. Rotate or shake the phone by hand, or test motion on a simulator.
-- The agent changes an app permission in the Settings app of the phone, not with the permissions tool.
-- JavaScript debugging, React and native profiling, native view inspection, screen recording and paste work on a simulator only.
-
 ## Troubleshooting
 
 | Symptom                                           | Action                                                                                               |
@@ -62,6 +55,19 @@ Some simulator capabilities do not exist on hardware. Each one fails with a `not
 | Signing fails without a certificate               | Sign in to Xcode (Settings > Accounts), then Manage Certificates > + > Apple Development.            |
 | The runner exits twice for the same app           | The current screen of the app is likely crashing the runner. Restart the app and retry.              |
 | The runner stops launching after about a week     | The free-team signature expired. Retry: the next interaction rebuilds and re-signs the runner.       |
+
+## Limits
+
+Each tool that does not exist on hardware fails with a `not supported on ios device` message. The limits on a physical device:
+
+- Argent drives iPhones only. Argent does not show iPads in the device list.
+- Argent drives the device over a USB cable only. Argent does not use Wi-Fi.
+- Two-finger gestures such as pinch and rotate are not possible. The agent uses the zoom controls of the app instead.
+- The device does not rotate or shake on command. Rotate or shake the phone by hand, or test motion on a simulator.
+- The agent presses the home, volume and action buttons only. The power button and the app switcher are not available.
+- The agent types text, Enter and Backspace only. Other named keys are not available.
+- The agent changes an app permission in the Settings app of the phone, not with the permissions tool.
+- JavaScript debugging, React and native profiling, native view inspection, screen recording and paste work on a simulator only.
 
 ## In the device list
 

--- a/packages/docs/docs/features/physical-ios-devices.mdx
+++ b/packages/docs/docs/features/physical-ios-devices.mdx
@@ -69,6 +69,4 @@ Each tool that does not exist on hardware fails with a `not supported on ios dev
 - The agent changes an app permission in the Settings app of the phone, not with the permissions tool.
 - JavaScript debugging, React and native profiling, native view inspection, screen recording and paste work on a simulator only.
 
-## In the device list
-
 The device appears in the device list as an iOS entry with kind `device`, with state `connected` while the cable is attached. Argent drives the device with the same interaction tools it uses on simulators. The [tools reference](/docs/reference/tools#devices-and-apps) contains all tools and describes how a physical device appears in `list-devices`.


### PR DESCRIPTION
## Summary

- Adds a `## Limits` section to `packages/docs/docs/features/physical-ios-devices.mdx`, matching the shape of the other feature pages.
- Moves the unsupported-capability bullets out of "What works" into the new section.
- Adds limits that were undocumented: iPhone only, USB cable only, home/volume/action buttons only, Enter and Backspace only.

## Docs

This PR is a docs-only change. `npx docusaurus build` and `npm run format` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified limitations when using physical iOS devices.
  * Documented supported hardware: iPhones are available, while iPads are not currently shown.
  * Added details about USB-cable-only control, supported home, volume, and action buttons, and available text, Enter, and Backspace keys.
  * Moved simulator-specific limitations into a dedicated “Limits” section, including unavailable rotation, shake, permission changes, debugging, profiling, inspection, recording, and paste capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->