### PR TITLE
fix(tool-server): support ios-remote in the await tools

### DIFF
--- a/packages/tool-server/src/tools/await-screen-idle/index.ts
+++ b/packages/tool-server/src/tools/await-screen-idle/index.ts
@@ -69,6 +69,7 @@ interface IdleResult {
 
 const capability: ToolCapability = {
   apple: { simulator: true, device: true },
+  appleRemote: { simulator: true },
   android: { emulator: true, device: true, unknown: true },
   chromium: { app: true },
 };
@@ -98,7 +99,10 @@ export function createAwaitScreenIdleTool(registry: Registry): ToolDefinition<Pa
     isTvOs: boolean,
     androidIsTv: boolean
   ): Promise<DescribeTreeData> {
-    if (device.platform === "ios") {
+    // ios-remote reads the same AX tree through describeIos: the ax-service
+    // blueprint routes it over the sim-remote tunnel, so only the preflight dep
+    // differs from the local branch. `isTvOs` is false for it, matching describe.
+    if (device.platform === "ios" || device.platform === "ios-remote") {
       // Physical devices poll the same XCUITest runner snapshot as describe.
       if (device.kind === "device") {
         return describeIosDevice(registry, device);
@@ -142,6 +146,7 @@ still before the timeout. Use after a launch/navigation to wait for the UI to re
       const device = resolveDevice(params.udid);
       assertSupported(AWAIT_SCREEN_IDLE_TOOL_ID, capability, device);
       if (device.platform === "ios") await ensureDeps(iosRequires);
+      else if (device.platform === "ios-remote") await ensureDeps(["sim-remote"]);
       else if (device.platform === "android") await ensureDeps(androidRequires);
 
       // Resolve tvOS / Android-TV once. Physical devices skip the tvOS probe. They are never tvOS simulators.

--- a/packages/tool-server/src/tools/await-ui-element/index.ts
+++ b/packages/tool-server/src/tools/await-ui-element/index.ts
@@ -248,6 +248,7 @@ function timeoutCause(
 
 const capability: ToolCapability = {
   apple: { simulator: true, device: true },
+  appleRemote: { simulator: true },
   android: { emulator: true, device: true, unknown: true },
   chromium: { app: true },
   vega: { vvd: true },
@@ -323,7 +324,10 @@ export function createAwaitUiElementTool(registry: Registry): ToolDefinition<Par
     isTvOs: boolean,
     androidIsTv: boolean
   ): Promise<DescribeTreeData> {
-    if (device.platform === "ios") {
+    // ios-remote reads the same AX tree through describeIos: the ax-service
+    // blueprint routes it over the sim-remote tunnel, so only the preflight dep
+    // differs from the local branch. `isTvOs` is false for it, matching describe.
+    if (device.platform === "ios" || device.platform === "ios-remote") {
       // Physical devices poll the same XCUITest runner snapshot as describe.
       if (device.kind === "device") {
         return describeIosDevice(registry, device);
@@ -392,6 +396,7 @@ tap/navigation to wait for the next screen, or before tapping an element that ap
       const device = resolveDevice(params.udid);
       assertSupported(AWAIT_UI_ELEMENT_TOOL_ID, capability, device);
       if (device.platform === "ios") await ensureDeps(iosRequires);
+      else if (device.platform === "ios-remote") await ensureDeps(["sim-remote"]);
       else if (device.platform === "android") await ensureDeps(androidRequires);
       else if (device.platform === "vega") await ensureDeps(vegaRequires);
 

--- a/packages/tool-server/test/await-screen-idle.test.ts
+++ b/packages/tool-server/test/await-screen-idle.test.ts
@@ -47,7 +47,7 @@ const content = () => axResponse([{ label: "Settings", frame: FRAME, traits: ["b
 describe("await-screen-idle tool", () => {
   beforeEach(() => {
     __resetDepCacheForTests();
-    __primeDepCacheForTests(["xcrun", "adb"]);
+    __primeDepCacheForTests(["xcrun", "adb", "sim-remote"]);
   });
 
   it("exposes the await-screen-idle id", () => {
@@ -109,5 +109,40 @@ describe("await-screen-idle tool", () => {
 
     expect(result.settled).toBe(true);
     expect(result.polls).toBe(1);
+  });
+
+  // ── ios-remote (a cloud sim reached through sim-remote) ──────────────────
+  // The AX service is the same one the local branch resolves; the blueprint
+  // puts it on a TCP transport across the tunnel. These pin that a remote udid
+  // actually EXECUTES, not merely that the capability gate lets it through.
+
+  it("settles on ios-remote through the same AX path as a local sim", async () => {
+    const tool = createAwaitScreenIdleTool(
+      iosRegistry(makeSequencedAXService([axResponse([]), content()]))
+    );
+
+    const result = await tool.execute(
+      {},
+      { udid: `remote:${IOS_UDID}`, timeoutMs: 2000, pollIntervalMs: 10, minStableMs: 20 }
+    );
+
+    expect(result.settled).toBe(true);
+    expect(result.polls).toBeGreaterThan(1);
+  });
+
+  it("does not settle on ios-remote while the screen keeps changing", async () => {
+    // a different label every poll never holds for minStableMs
+    const changing = Array.from({ length: 30 }, (_, i) =>
+      axResponse([{ label: `item-${i}`, frame: FRAME, traits: ["button"] }])
+    );
+    const tool = createAwaitScreenIdleTool(iosRegistry(makeSequencedAXService(changing)));
+
+    const result = await tool.execute(
+      {},
+      { udid: `remote:${IOS_UDID}`, timeoutMs: 80, pollIntervalMs: 5, minStableMs: 40 }
+    );
+
+    expect(result.settled).toBe(false);
+    expect(result.waitedMs).toBeGreaterThanOrEqual(80);
   });
 });

--- a/packages/tool-server/test/await-ui-element.test.ts
+++ b/packages/tool-server/test/await-ui-element.test.ts
@@ -100,7 +100,7 @@ function iosRegistry(ax: AXServiceApi) {
 describe("await-ui-element tool", () => {
   beforeEach(() => {
     __resetDepCacheForTests();
-    __primeDepCacheForTests(["xcrun", "adb"]);
+    __primeDepCacheForTests(["xcrun", "adb", "sim-remote"]);
   });
 
   it("exposes the await-ui-element id", () => {
@@ -1352,6 +1352,84 @@ describe("await-ui-element tool", () => {
       expect(schema.safeParse({ condition: "visible", udid: IOS_UDID, selector }).success).toBe(
         true
       );
+    });
+  });
+
+  // ── ios-remote (a cloud sim reached through sim-remote) ──────────────────
+  // The AX service is the same one the local branch resolves; the blueprint
+  // puts it on a TCP transport across the tunnel. These pin that a remote udid
+  // actually EXECUTES, not merely that the capability gate lets it through.
+
+  describe("ios-remote", () => {
+    const IOS_REMOTE_UDID = `remote:${IOS_UDID}`;
+
+    it("polls the AX tree and succeeds when the element appears", async () => {
+      const { api, calls } = makeSequencedAXService([
+        axResponse([]),
+        axResponse([{ label: "Submit", frame: FRAME, traits: ["button"] }]),
+      ]);
+      const tool = createAwaitUiElementTool(iosRegistry(api));
+
+      const result = await tool.execute(
+        {},
+        {
+          udid: IOS_REMOTE_UDID,
+          condition: "visible",
+          selector: { text: "Submit" },
+          timeoutMs: 2000,
+          pollIntervalMs: 10,
+        }
+      );
+
+      expect(result.success).toBe(true);
+      expect(calls()).toBeGreaterThan(1);
+    });
+
+    // The tree WAS read, so a miss is `unmet`. A failed read reports
+    // `unreadable`, which is what a wrong platform branch would produce.
+    it("reports `unmet`, not `unreadable`, when the selector misses", async () => {
+      const { api } = makeSequencedAXService([
+        axResponse([{ label: "Other", frame: FRAME, traits: ["button"] }]),
+      ]);
+      const tool = createAwaitUiElementTool(iosRegistry(api));
+
+      const result = await tool.execute(
+        {},
+        {
+          udid: IOS_REMOTE_UDID,
+          condition: "visible",
+          selector: { text: "Submit" },
+          timeoutMs: 40,
+          pollIntervalMs: 10,
+        }
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.cause).toBe("unmet");
+    });
+
+    // The second poll is a real re-rendered screen without the Spinner. A wholly
+    // empty tree is the ambiguous transient-blank case and must not confirm
+    // `hidden` — that rule holds on a remote sim exactly as it does locally.
+    it("resolves `hidden` once the element goes away", async () => {
+      const { api } = makeSequencedAXService([
+        axResponse([{ label: "Spinner", frame: FRAME, traits: [] }]),
+        axResponse([{ label: "Content", frame: FRAME, traits: [] }]),
+      ]);
+      const tool = createAwaitUiElementTool(iosRegistry(api));
+
+      const result = await tool.execute(
+        {},
+        {
+          udid: IOS_REMOTE_UDID,
+          condition: "hidden",
+          selector: { text: "Spinner" },
+          timeoutMs: 2000,
+          pollIntervalMs: 10,
+        }
+      );
+
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/packages/tool-server/test/flows/flow-record-cross-tree.test.ts
+++ b/packages/tool-server/test/flows/flow-record-cross-tree.test.ts
@@ -2044,14 +2044,21 @@ describe("a recorded wait is re-probed against the runner's tree", () => {
     expect(await recordedSteps("cancelmid")).toHaveLength(1);
   });
 
-  // No `ios-remote` arm: a remote sim never reaches the probe, assertSupported
-  // throws first. If appleRemote is added, both tables need that arm.
-  it("cannot be reached on ios-remote: await-ui-element refuses the device", () => {
+  // The wait tool itself now accepts a remote sim: it polls the same AX tree
+  // through describeIos, which the ax-service blueprint routes over the
+  // sim-remote tunnel. The recorder's tables still have no `ios-remote` arm
+  // (FLOW_TREE_SOURCES in flow-tree.ts, REPLAY_TREE_SOURCES in flow-add-step.ts),
+  // so the re-probe now REACHES them — the flow tools declare no capability at
+  // all, so nothing gates a remote udid out. `fetchTree` throws its
+  // not-supported error there, the recorder catches it, and the step records
+  // with the UNKNOWN-verdict warning rather than a known-bad one. Giving both
+  // tables an `ios-remote` arm is what would let the re-probe actually verify.
+  it("is reachable on ios-remote: await-ui-element accepts the device", () => {
     const tool = createAwaitUiElementTool(registryWhereWaitSucceeds());
-    expect(tool.capability?.appleRemote).toBeUndefined();
+    expect(tool.capability?.appleRemote).toEqual({ simulator: true });
     expect(() =>
       assertSupported("await-ui-element", tool.capability, resolveDevice(`remote:${IOS}`))
-    ).toThrow(/not supported on ios-remote/);
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Problem

The `await-ui-element` and `await-screen-idle` tools refused a remote simulator. The tool server sent this error:

```
Tool 'await-ui-element' is not supported on ios-remote simulator (no ios-remote support declared).
```

Both tools poll the same accessibility tree as `describe`. The `describe` tool reads that tree correctly on a remote simulator. Therefore the tree source was never the problem.

## Cause

Each tool declares its platform support in a capability record. The `describe` tool declares `appleRemote`. The two wait tools did not declare it. The HTTP layer rejects the request before the tool starts.

Three more branches test `platform === "ios"`. That test is false for a remote device. These branches select the tree source, the dependency preflight, and the tvOS probe.

Nobody excluded the platform deliberately. Git history has no commit that adds `appleRemote` to either file. The `appleRemote` concept arrived on 2026-07-01. The `await-screen-idle` tool arrived two days later.

## Effect on an agent session

The MCP layer calls `await-screen-idle` before each automatic screenshot. On a remote simulator that call failed. The fallback then slept for the full budget:

- 1500 ms for each tap or gesture
- 2000 ms for `open-url`
- 3000 ms for `launch-app` and `restart-app`
- 15000 ms for `run-sequence`

The user saw no error. The fallback exists for an old tool server, not for a current server that refuses a device.

## Change

This change adds three lines to each tool:

1. The capability record declares `appleRemote: { simulator: true }`.
2. The tree fetch sends a remote device to `describeIos`. Before, a remote device fell through to the Chromium branch.
3. The dependency preflight requires `sim-remote`, and not `xcrun`.

The `describe` tool uses the same three settings. The ax-service blueprint sends the accessibility read through the sim-remote tunnel.

## Test result

I ran the branch tool server against a leased Argent Cloud runner. The device was a remote iPhone 17 Pro on iOS 26.5. The app was Bluesky. The app read its bundle from a local Metro server through the sim-remote tunnel.

| ID | Case | Result |
| --- | --- | --- |
| T1 | `visible` by text | `success: true` |
| T2 | `exists` by identifier | `success: true` |
| T3 | `exists` by a second identifier | `success: true` |
| T4 | `text` condition matches the label | `success: true` |
| T5 | compound role and text selector | `success: true` |
| T6 | absent text gives `unmet` | `success: false` |
| T7 | wrong expected text gives `unmet` | note quotes the actual text |
| T8 | 5000 ms budget honoured | `elapsed: 5003` |
| T9 | `hidden` on an absent element | `success: true` |
| T10 | screen settles | `settled: true, polls: 2` |
| T11 | screen honours `minStableMs: 2000` | `waitedMs: 2265, polls: 8` |
| T12 | wait across an app restart | `success: true, elapsed: 27301` |
| T13 | `hidden` after the restart | `success: true` |
| T14 | flow record boundary | UNKNOWN verdict |

All 14 cases passed. Two results give the strongest evidence:

- Case T12 blocked for 27.3 seconds across an app restart. The app rebuilt its bundle, the element appeared, and the tool returned success.
- Case T6 returned `cause: "unmet"`. A failed tree read returns `cause: "unreadable"`. Therefore the tool read the remote tree and judged the condition.

### Unit tests

Five new unit tests drive both tools with a remote udid. They use a mock accessibility service. Each test fails against `main` and passes with this change.

Local checks:

- `npm run build`: clean
- `npm test -w @argent/tool-server`: 431 files, 6153 tests, 0 failures
- `npm run lint`: clean
- `npx prettier --check`: clean

## Note on flow records

The flow tools declare no capability. Therefore they accept a remote device today. This change lets the re-probe reach `fetchTree`, which has no support for `ios-remote`. The recorder catches that error. The recorder then keeps the step and marks the verdict UNKNOWN, not known-bad.

An earlier test asserted the refusal. This change inverts that test and records the new behavior in its comment.

## Documentation

This change needs no documentation update. The tool reference lists these two tools with a description only. That page has no platform column, and no page describes remote simulators.
