### PR TITLE
test: stop tests leaving files in the shared system temp directory

### DIFF
--- a/packages/argent-mcp/test/content.test.ts
+++ b/packages/argent-mcp/test/content.test.ts
@@ -162,8 +162,17 @@ describe("toMcpContent", () => {
 });
 
 describe("screenshotDiffToMcpContent", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-mcp-content-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
   it("returns a context image followed by the summary text", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-mcp-content-"));
     const contextDiffPath = path.join(dir, "context.diff.png");
     const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
     await fs.writeFile(contextDiffPath, pngBytes);
@@ -323,13 +332,21 @@ describe("toMcpContent with artifact ctx", () => {
 
 describe("flowRunToMcpContent", () => {
   let originalFetch: typeof globalThis.fetch;
+  // The failure cases below drive the real materializeArtifacts, which writes
+  // under artifactsRoot() — tmpdir()/argent-artifacts unless pinned, a path no
+  // test would then own or remove.
+  let root: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     originalFetch = globalThis.fetch;
+    root = await mkdtemp(join(tmpdir(), "content-flow-artifacts-"));
+    process.env.ARGENT_ARTIFACTS_DIR = root;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     globalThis.fetch = originalFetch;
+    delete process.env.ARGENT_ARTIFACTS_DIR;
+    await rm(root, { recursive: true, force: true });
   });
 
   it("produces header and footer text blocks", async () => {

--- a/packages/argent-mcp/test/content.test.ts
+++ b/packages/argent-mcp/test/content.test.ts
@@ -623,6 +623,8 @@ describe("flowRunToMcpContent", () => {
     );
     expect(artifactText?.text).toContain("home-baseline.png");
     expect(artifactText?.text).toContain("home-current.png");
+    // Under the pinned root, not artifactsRoot()'s shared default.
+    expect(artifactText?.text).toContain(`diff: ${root}`);
     expect(artifactText?.text).toMatch(/diff: .*home-diff\.png/);
 
     // Exactly one inline image — the diff, not the full-res baseline/current.

--- a/packages/tool-server/test/chromium-cdp-blueprint.test.ts
+++ b/packages/tool-server/test/chromium-cdp-blueprint.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
 import * as http from "node:http";
 import { AddressInfo } from "node:net";
 import { WebSocketServer } from "ws";
@@ -134,9 +135,11 @@ async function startFakeCdp(): Promise<FakeCdp> {
 }
 
 const servers: FakeCdp[] = [];
+const filesToCleanup: string[] = [];
 
 afterEach(async () => {
   for (const s of servers.splice(0)) await s.close();
+  for (const p of filesToCleanup.splice(0)) await fs.rm(p, { force: true });
 });
 
 describe("chromiumCdpBlueprint (smoke)", () => {
@@ -190,6 +193,7 @@ describe("chromiumCdpBlueprint (smoke)", () => {
       // Screenshot — fake server returns a tiny PNG, we expect a real file
       // path in the unified media dir maintained by the chromium-server.
       const shot = await instance.api.captureScreenshot();
+      filesToCleanup.push(shot.path);
       expect(shot.path).toMatch(/argent-chromium-media/);
       expect(shot.path).toMatch(/argent-screenshot-/);
       expect(shot.url).toMatch(/^file:\/\//);

--- a/packages/tool-server/test/chromium-server-screenshot.test.ts
+++ b/packages/tool-server/test/chromium-server-screenshot.test.ts
@@ -42,7 +42,8 @@ describe("chromium-server/screenshot", () => {
 
   it("calls Page.captureScreenshot with format png + no captureBeyondViewport", async () => {
     const cdp = stubCdp();
-    await captureScreenshot({ cdp, deviceId: "test" });
+    const out = await captureScreenshot({ cdp, deviceId: "test" });
+    filesToCleanup.push(out.path);
     const send = (cdp as unknown as { send: ReturnType<typeof vi.fn> }).send;
     expect(send).toHaveBeenCalledWith("Page.captureScreenshot", {
       format: "png",

--- a/packages/tool-server/test/event-log.test.ts
+++ b/packages/tool-server/test/event-log.test.ts
@@ -1,12 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Registry } from "@argent/registry";
 import { attachRegistryEventLogger, createToolServerEventLog } from "../src/event-log";
 
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
 function eventLogPath(): string {
-  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "argent-events-")), "events.jsonl");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-events-"));
+  tempDirs.push(dir);
+  return path.join(dir, "events.jsonl");
 }
 
 function readEvents(filePath: string): Array<Record<string, unknown>> {

--- a/packages/tool-server/test/file-inputs-tar-upload.test.ts
+++ b/packages/tool-server/test/file-inputs-tar-upload.test.ts
@@ -16,7 +16,13 @@ beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tar-dir-test-"));
 });
 
+// A tar upload extracts into its own temp dir, released only by the cleanup
+// resolveFileInputs returns — the dispatcher's job in production, this list's
+// here.
+const cleanups: Array<() => Promise<void>> = [];
+
 afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -124,7 +130,7 @@ describe("resolveFileInputs — tar-upload kind", () => {
     const uploadId = "prefer-upload";
     const entry = await uploadEntry(tarPath);
 
-    const { args } = await resolveFileInputs(
+    const { args, cleanup } = await resolveFileInputs(
       { fileInputs: TAR_UPLOAD_SPEC },
       {
         appPath: wire({
@@ -139,6 +145,7 @@ describe("resolveFileInputs — tar-upload kind", () => {
       },
       (id) => (id === uploadId ? entry : undefined)
     );
+    cleanups.push(cleanup);
 
     expect(await fs.readFile(path.join(args.appPath as string, "MyApp"), "utf8")).toBe(
       "upload-bytes"
@@ -173,11 +180,12 @@ describe("resolveFileInputs — tar-upload kind", () => {
     const uploadId = "test-upload-id-apk";
     const entry = await uploadEntry(tarPath);
 
-    const { args, fileInputs } = await resolveFileInputs(
+    const { args, fileInputs, cleanup } = await resolveFileInputs(
       { fileInputs: TAR_UPLOAD_SPEC },
       { appPath: wireUpload("/client/app.apk", uploadId, entry) },
       (id) => (id === uploadId ? entry : undefined)
     );
+    cleanups.push(cleanup);
 
     const resolvedPath = args.appPath as string;
     expect(path.basename(resolvedPath)).toBe("app.apk");
@@ -192,11 +200,12 @@ describe("resolveFileInputs — tar-upload kind", () => {
     const uploadId = "test-upload-id-sidecar";
     const entry = await uploadEntry(tarPath);
 
-    const { args } = await resolveFileInputs(
+    const { args, cleanup } = await resolveFileInputs(
       { fileInputs: TAR_UPLOAD_SPEC },
       { appPath: wireUpload("/client/MyApp.app", uploadId, entry) },
       (id) => (id === uploadId ? entry : undefined)
     );
+    cleanups.push(cleanup);
 
     const resolvedPath = args.appPath as string;
     expect(path.basename(resolvedPath)).toBe("MyApp.app");

--- a/packages/tool-server/test/file-inputs-tar-upload.test.ts
+++ b/packages/tool-server/test/file-inputs-tar-upload.test.ts
@@ -224,6 +224,8 @@ describe("resolveFileInputs — tar-upload kind", () => {
       (id) => (id === uploadId ? entry : undefined)
     );
 
+    cleanups.push(cleanup);
+
     // tar should already be removed by resolveOne after extraction
     await expect(fs.stat(tarPath)).rejects.toThrow();
     await cleanup();

--- a/packages/tool-server/test/file-inputs.test.ts
+++ b/packages/tool-server/test/file-inputs.test.ts
@@ -12,7 +12,13 @@ beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "file-inputs-test-"));
 });
 
+// resolveFileInputs hands its caller the cleanup for whatever it materialized;
+// in production the dispatcher calls it. A test that keeps the result must too,
+// or the upload's temp dir outlives the run.
+const cleanups: Array<() => Promise<void>> = [];
+
 afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -135,7 +141,7 @@ describe("resolveFileInputs", () => {
     await fs.writeFile(filePath, "stale");
     const content = Buffer.from("fresh client bytes");
 
-    const { args, fileInputs } = await resolveFileInputs(
+    const { args, fileInputs, cleanup } = await resolveFileInputs(
       { fileInputs: FILE_SPEC },
       {
         input: wire({
@@ -145,6 +151,7 @@ describe("resolveFileInputs", () => {
         }),
       }
     );
+    cleanups.push(cleanup);
 
     expect(args.input).not.toBe(filePath);
     expect(await fs.readFile(args.input as string, "utf8")).toBe("fresh client bytes");
@@ -155,7 +162,7 @@ describe("resolveFileInputs", () => {
     const clientPath = path.join(tmpDir, "not-here", "flow.yaml");
     const content = Buffer.from("steps: []\n");
 
-    const { args } = await resolveFileInputs(
+    const { args, cleanup } = await resolveFileInputs(
       { fileInputs: FILE_SPEC },
       {
         input: wire({
@@ -165,6 +172,7 @@ describe("resolveFileInputs", () => {
         }),
       }
     );
+    cleanups.push(cleanup);
 
     expect(await fs.readFile(args.input as string, "utf8")).toBe("steps: []\n");
   });

--- a/packages/tool-server/test/file-inputs.test.ts
+++ b/packages/tool-server/test/file-inputs.test.ts
@@ -199,6 +199,8 @@ describe("resolveFileInputs", () => {
       }
     );
 
+    cleanups.push(cleanup);
+
     const materialized = args.b as string;
     expect(await fs.readFile(materialized, "utf8")).toBe("uploaded bytes");
 

--- a/packages/tool-server/test/flows/flow-visual.test.ts
+++ b/packages/tool-server/test/flows/flow-visual.test.ts
@@ -91,6 +91,7 @@ const env = {
 } as unknown as ActionEnv;
 
 let tmpDir: string;
+let restoreTmpdir: () => void = () => {};
 
 /** Minimal PNG stand-in: runSnapshot reads only the IHDR width/height bytes. */
 async function writeFakePng(file: string, w = 390, h_ = 844): Promise<void> {
@@ -155,6 +156,13 @@ const baselinePath = () => path.join(tmpDir, "__baselines__", "checkout", "home_
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "flow-visual-"));
+  // runSnapshot mkdtemps its crop and diff scratch dirs under os.tmpdir() and
+  // deliberately leaves whichever file it registered as an artifact in place —
+  // from there the dir belongs to whoever consumes the artifact. Here that is
+  // the test, so os.tmpdir() points inside tmpDir and the sweep below takes it.
+  const osTmpdir = path.join(tmpDir, "os-tmpdir");
+  await fs.mkdir(osTmpdir);
+  restoreTmpdir = redirectTmpdir(osTmpdir);
   h.shotPath = path.join(tmpDir, "shot.png");
   h.mismatchPercentage = 0;
   h.writeContextDiff = false;
@@ -169,6 +177,7 @@ beforeEach(async () => {
   await writeFakePng(h.shotPath);
 });
 afterEach(async () => {
+  restoreTmpdir();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 

--- a/packages/tool-server/test/flows/flow-visual.test.ts
+++ b/packages/tool-server/test/flows/flow-visual.test.ts
@@ -91,6 +91,7 @@ const env = {
 } as unknown as ActionEnv;
 
 let tmpDir: string;
+let osTmpdir: string;
 let restoreTmpdir: () => void = () => {};
 
 /** Minimal PNG stand-in: runSnapshot reads only the IHDR width/height bytes. */
@@ -160,7 +161,7 @@ beforeEach(async () => {
   // deliberately leaves whichever file it registered as an artifact in place —
   // from there the dir belongs to whoever consumes the artifact. Here that is
   // the test, so os.tmpdir() points inside tmpDir and the sweep below takes it.
-  const osTmpdir = path.join(tmpDir, "os-tmpdir");
+  osTmpdir = path.join(tmpDir, "os-tmpdir");
   await fs.mkdir(osTmpdir);
   restoreTmpdir = redirectTmpdir(osTmpdir);
   h.shotPath = path.join(tmpDir, "shot.png");
@@ -595,32 +596,21 @@ describe("runSnapshot cropOn", () => {
 
   it("fails a sub-pixel crop region instead of writing an empty PNG", async () => {
     h.cropFrame = { x: 0.5, y: 0.5, width: 0.001, height: 0.001 };
-    // runSnapshot builds its crop scratch dir with
-    // mkdtemp(join(os.tmpdir(), "argent-flow-crop-")). Point the tmpdir at a
-    // dir only this test owns, so the leftover sweep below sees this run's crop
-    // dirs and nothing else — scanning the machine-wide tmpdir would also list
-    // the in-flight crop dir of any concurrent run.
-    const scratch = await fs.mkdtemp(path.join(os.tmpdir(), "argent-flow-crop-scan-"));
-    const restoreTmpdir = redirectTmpdir(scratch);
+    const r = await runSnapshot(env, opts({ cropOn }));
 
-    try {
-      const r = await runSnapshot(env, opts({ cropOn }));
-
-      expect(r.status).toBe("fail");
-      expect(r.reason).toContain("empty at this resolution");
-      // The key still names the failure for an exporter (CLI --output), and the
-      // FULL capture is attached as `current` — no crop exists to show.
-      expect(r.snapshotKey).toBe(cropKey);
-      expect(r.artifacts?.current).toMatchObject({ hostPath: h.shotPath });
-      // The crop scratch dir (which never received a file) was swept.
-      const leftoverCropDirs = (await fs.readdir(scratch)).filter((e) =>
-        e.startsWith("argent-flow-crop-")
-      );
-      expect(leftoverCropDirs).toEqual([]);
-    } finally {
-      restoreTmpdir();
-      await fs.rm(scratch, { recursive: true, force: true });
-    }
+    expect(r.status).toBe("fail");
+    expect(r.reason).toContain("empty at this resolution");
+    // The key still names the failure for an exporter (CLI --output), and the
+    // FULL capture is attached as `current` — no crop exists to show.
+    expect(r.snapshotKey).toBe(cropKey);
+    expect(r.artifacts?.current).toMatchObject({ hostPath: h.shotPath });
+    // The crop scratch dir (which never received a file) was swept. os.tmpdir()
+    // is this test's own, so the listing shows this run's crop dirs and nothing
+    // a concurrent run left in flight.
+    const leftoverCropDirs = (await fs.readdir(osTmpdir)).filter((e) =>
+      e.startsWith("argent-flow-crop-")
+    );
+    expect(leftoverCropDirs).toEqual([]);
   });
 
   it("keys same-name snapshots with different cropOn selectors to distinct baselines", async () => {

--- a/packages/tool-server/test/ios-instruments/combined-report-frozen-anchor.test.ts
+++ b/packages/tool-server/test/ios-instruments/combined-report-frozen-anchor.test.ts
@@ -64,8 +64,15 @@ function parsedDataA(): NativeProfilerParsedData {
   };
 }
 
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+});
+
 async function writeReactCommits(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "p5-frozen-anchor-"));
+  tempDirs.push(dir);
   const commitsPath = path.join(dir, "commits.json");
   const commit = {
     commitIndex: 0,

--- a/packages/tool-server/test/react-profiler/ast-index.test.ts
+++ b/packages/tool-server/test/react-profiler/ast-index.test.ts
@@ -1,8 +1,20 @@
-import { describe, it, expect } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { afterEach, describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { buildAstIndexWithDiagnostics } from "../../src/utils/react-profiler/pipeline/06-resolve/ast-index";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
 
 /**
  * react-profiler-component-source returned found:false for every component in a
@@ -15,7 +27,7 @@ import { buildAstIndexWithDiagnostics } from "../../src/utils/react-profiler/pip
  */
 describe("buildAstIndexWithDiagnostics", () => {
   it("indexes export-default-function, plain-function, and arrow TSX components", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "ast-index-"));
+    const dir = makeTempDir("ast-index-");
     mkdirSync(join(dir, "components"), { recursive: true });
     writeFileSync(
       join(dir, "components", "foo.tsx"),
@@ -43,7 +55,7 @@ describe("buildAstIndexWithDiagnostics", () => {
     // entirely and returned found:false — and profiler findings are
     // disproportionately memo-wrapped. memo => isMemoized true; forwardRef alone
     // => false.
-    const dir = mkdtempSync(join(tmpdir(), "ast-index-wrap-"));
+    const dir = makeTempDir("ast-index-wrap-");
     mkdirSync(join(dir, "components"), { recursive: true });
     writeFileSync(
       join(dir, "components", "wrapped.tsx"),
@@ -74,7 +86,7 @@ describe("buildAstIndexWithDiagnostics", () => {
     // were thrown away, so a lookup could hand back the wrong platform variant's
     // source. Now the base file is the deterministic primary and the variants
     // are surfaced under otherMatches.
-    const dir = mkdtempSync(join(tmpdir(), "ast-index-dup-"));
+    const dir = makeTempDir("ast-index-dup-");
     mkdirSync(join(dir, "components"), { recursive: true });
     const base = join(dir, "components", "List.tsx");
     const web = join(dir, "components", "List.web.tsx");
@@ -96,7 +108,7 @@ describe("buildAstIndexWithDiagnostics", () => {
     // Only platform variants — there is no base file to prefer, so the tie
     // breaks on path (walk-order independent) rather than whatever the directory
     // happened to yield first.
-    const dir = mkdtempSync(join(tmpdir(), "ast-index-dup2-"));
+    const dir = makeTempDir("ast-index-dup2-");
     mkdirSync(join(dir, "components"), { recursive: true });
     const android = join(dir, "components", "List.android.tsx");
     const ios = join(dir, "components", "List.ios.tsx");
@@ -112,7 +124,7 @@ describe("buildAstIndexWithDiagnostics", () => {
   });
 
   it("omits otherMatches when a component name is unique", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "ast-index-uniq-"));
+    const dir = makeTempDir("ast-index-uniq-");
     writeFileSync(join(dir, "Solo.tsx"), `export function Solo() { return <View>x</View>; }\n`);
 
     const res = await buildAstIndexWithDiagnostics(dir);
@@ -126,7 +138,7 @@ describe("buildAstIndexWithDiagnostics", () => {
     // (not an inline `const X = memo(...)`). The decoy `memo(Ghost)` lives only
     // in a comment and a string literal — tree-sitter never emits a call node
     // there, so Ghost stays unmemoized. The old raw-source regex flagged it.
-    const dir = mkdtempSync(join(tmpdir(), "ast-index-memo-ref-"));
+    const dir = makeTempDir("ast-index-memo-ref-");
     mkdirSync(join(dir, "components"), { recursive: true });
     writeFileSync(
       join(dir, "components", "ref.tsx"),

--- a/packages/tool-server/test/react-profiler/component-source-duplicates.test.ts
+++ b/packages/tool-server/test/react-profiler/component-source-duplicates.test.ts
@@ -1,8 +1,20 @@
-import { describe, it, expect } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { afterEach, describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { reactProfilerComponentSourceTool } from "../../src/tools/profiler/react/react-profiler-component-source";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
 
 /**
  * End-to-end through the tool's execute(): when a component name resolves to
@@ -13,7 +25,7 @@ import { reactProfilerComponentSourceTool } from "../../src/tools/profiler/react
  */
 describe("react-profiler-component-source: duplicate component names", () => {
   it("returns the base-file primary source and surfaces variants under otherMatches", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "component-source-dup-"));
+    const dir = makeTempDir("component-source-dup-");
     mkdirSync(join(dir, "components"), { recursive: true });
     const base = join(dir, "components", "List.tsx");
     const web = join(dir, "components", "List.web.tsx");
@@ -34,7 +46,7 @@ describe("react-profiler-component-source: duplicate component names", () => {
   });
 
   it("omits otherMatches for a uniquely-named component", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "component-source-uniq-"));
+    const dir = makeTempDir("component-source-uniq-");
     writeFileSync(join(dir, "Solo.tsx"), `export function Solo() { return <View />; }\n`);
 
     const result = (await reactProfilerComponentSourceTool.execute(

--- a/packages/tool-server/test/screenshot-diff-tool.test.ts
+++ b/packages/tool-server/test/screenshot-diff-tool.test.ts
@@ -383,10 +383,18 @@ describe("screenshotDiffTool", () => {
   });
 
   it("demands the runner service when a direct caller requests a device live capture", async () => {
+    // outputDir is resolved before the service check, so omitting it would mint
+    // a fallback dir under argent-screenshot-diff that the throw then strands.
+    const outputDir = await makeTempDir("argent-screenshot-diff-norunner-");
     await expect(
       executeScreenshotDiffTool(
         {},
-        { baselinePath: "/tmp/baseline.png", captureCurrent: true, udid: PHYSICAL_UDID }
+        {
+          baselinePath: "/tmp/baseline.png",
+          captureCurrent: true,
+          udid: PHYSICAL_UDID,
+          outputDir,
+        }
       )
     ).rejects.toThrow("requires an iosDeviceRunner service");
   });
@@ -415,6 +423,9 @@ describe("screenshotDiffTool", () => {
     );
 
     const diffHostPath = (result.diffPath as { hostPath: string }).hostPath;
+    // The per-call dir the fallback minted, not the shared argent-screenshot-diff
+    // root above it — that one belongs to any tool-server running alongside.
+    tempDirs.push(path.dirname(diffHostPath));
     expect(diffHostPath.startsWith(outputDir)).toBe(false);
     expect(diffHostPath).toContain("argent-screenshot-diff");
   });

--- a/packages/tool-server/test/screenshot-diff-tool.test.ts
+++ b/packages/tool-server/test/screenshot-diff-tool.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ArtifactStore } from "@argent/registry";
 import { executeScreenshotDiffTool, screenshotDiffTool } from "../src/tools/screenshot-diff";
 import { RUNNER_COMMAND_TIMEOUT_MS } from "../src/utils/ios-device/runner-client";
+import { redirectTmpdir } from "./helpers/tmpdir-env";
 
 const tempDirs: string[] = [];
 
@@ -411,21 +412,30 @@ describe("screenshotDiffTool", () => {
     // Parent does not exist on this host — a remote client's own directory.
     const outputDir = path.join(dir, "no-such-parent", "nested", "diff-out");
 
-    const result = await executeScreenshotDiffTool(
-      {},
-      { baselinePath, currentPath, udid: "ABC", outputDir },
-      {
-        artifacts: new ArtifactStore(),
-        fileInputs: {
-          outputDir: { clientPath: outputDir, presentOnHost: false, viaUpload: false },
-        },
-      }
-    );
+    // resolveOutputDir mints the fallback under os.tmpdir() before anything
+    // validates the call, so a throw downstream would strand it with the path
+    // known only to the code that threw. Point os.tmpdir() at the dir already
+    // registered for removal and the sweep takes it either way — never the
+    // shared argent-screenshot-diff root, which belongs to any tool-server
+    // running alongside.
+    const restoreTmpdir = redirectTmpdir(dir);
+    let result;
+    try {
+      result = await executeScreenshotDiffTool(
+        {},
+        { baselinePath, currentPath, udid: "ABC", outputDir },
+        {
+          artifacts: new ArtifactStore(),
+          fileInputs: {
+            outputDir: { clientPath: outputDir, presentOnHost: false, viaUpload: false },
+          },
+        }
+      );
+    } finally {
+      restoreTmpdir();
+    }
 
     const diffHostPath = (result.diffPath as { hostPath: string }).hostPath;
-    // The per-call dir the fallback minted, not the shared argent-screenshot-diff
-    // root above it — that one belongs to any tool-server running alongside.
-    tempDirs.push(path.dirname(diffHostPath));
     expect(diffHostPath.startsWith(outputDir)).toBe(false);
     expect(diffHostPath).toContain("argent-screenshot-diff");
   });

--- a/packages/tool-server/test/screenshot-diff-tool.test.ts
+++ b/packages/tool-server/test/screenshot-diff-tool.test.ts
@@ -2,10 +2,22 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { PNG } from "pngjs";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ArtifactStore } from "@argent/registry";
 import { executeScreenshotDiffTool, screenshotDiffTool } from "../src/tools/screenshot-diff";
 import { RUNNER_COMMAND_TIMEOUT_MS } from "../src/utils/ios-device/runner-client";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
 
 describe("screenshotDiffTool", () => {
   it("rejects public tuning options so defaults stay internal", () => {
@@ -67,7 +79,7 @@ describe("screenshotDiffTool", () => {
   });
 
   it("returns only the summary and diff artifact paths", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-tool-"));
+    const dir = await makeTempDir("argent-screenshot-diff-tool-");
     const baselinePath = path.join(dir, "baseline.png");
     const currentPath = path.join(dir, "current.png");
     await writePng(baselinePath, 2, 2, { r: 10, g: 20, b: 30 });
@@ -103,7 +115,7 @@ describe("screenshotDiffTool", () => {
   });
 
   it("captures one live side at full resolution and copies it into outputDir", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-live-"));
+    const dir = await makeTempDir("argent-screenshot-diff-live-");
     const baselinePath = path.join(dir, "baseline.png");
     const capturedPath = path.join(dir, "captured.png");
     await writePng(baselinePath, 2, 2, { r: 0, g: 0, b: 0 });
@@ -147,7 +159,7 @@ describe("screenshotDiffTool", () => {
   });
 
   it("falls back to the default scale when the full-resolution capture fails (Android framebuffer mismatch)", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-fallback-"));
+    const dir = await makeTempDir("argent-screenshot-diff-fallback-");
     const baselinePath = path.join(dir, "baseline.png");
     const capturedPath = path.join(dir, "captured.png");
     await writePng(baselinePath, 2, 2, { r: 0, g: 0, b: 0 });
@@ -182,7 +194,7 @@ describe("screenshotDiffTool", () => {
   });
 
   it("propagates the error when both the full-res capture and the fallback fail", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-bothfail-"));
+    const dir = await makeTempDir("argent-screenshot-diff-bothfail-");
     const baselinePath = path.join(dir, "baseline.png");
     await writePng(baselinePath, 2, 2, { r: 0, g: 0, b: 0 });
     const captureScreenshot = vi.fn(
@@ -203,7 +215,7 @@ describe("screenshotDiffTool", () => {
   });
 
   it("uses a fresh hashed filename for each live capture so concurrent diffs do not collide", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-unique-"));
+    const dir = await makeTempDir("argent-screenshot-diff-unique-");
     const baselinePath = path.join(dir, "baseline.png");
     const capturedPath = path.join(dir, "captured.png");
     await writePng(baselinePath, 2, 2, { r: 0, g: 0, b: 0 });
@@ -253,7 +265,7 @@ describe("screenshotDiffTool", () => {
   // exactly like a remote client's own directory and was silently redirected to
   // a temp dir. A directory we can create next to an existing parent is ours.
   it("creates and honors an outputDir that does not exist yet on this host", async () => {
-    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-fresh-"));
+    const parent = await makeTempDir("argent-screenshot-diff-fresh-");
     const baselinePath = path.join(parent, "baseline.png");
     const currentPath = path.join(parent, "current.png");
     await writePng(baselinePath, 2, 2, { r: 10, g: 20, b: 30 });
@@ -283,7 +295,7 @@ describe("screenshotDiffTool", () => {
   // reaches mkdir as EEXIST. That is the directory the caller asked for, not a
   // reason to redirect them to a temp dir.
   it("honors an outputDir that raced into existence after the probe", async () => {
-    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-race-"));
+    const parent = await makeTempDir("argent-screenshot-diff-race-");
     const baselinePath = path.join(parent, "baseline.png");
     const currentPath = path.join(parent, "current.png");
     await writePng(baselinePath, 2, 2, { r: 10, g: 20, b: 30 });
@@ -337,7 +349,7 @@ describe("screenshotDiffTool", () => {
   });
 
   it("captures the live side through the runner on a physical iPhone and ignores rotation", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-device-"));
+    const dir = await makeTempDir("argent-screenshot-diff-device-");
     const baselinePath = path.join(dir, "baseline.png");
     await writePng(baselinePath, 2, 2, { r: 10, g: 20, b: 30 });
     const run = vi.fn(async () => ({
@@ -382,7 +394,7 @@ describe("screenshotDiffTool", () => {
   // The remote case must still fall back: a client-side path whose parent does
   // not exist here cannot be created, so diffs go to a temp dir as before.
   it("falls back to a temp dir when outputDir is not creatable on this host", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-remote-"));
+    const dir = await makeTempDir("argent-screenshot-diff-remote-");
     const baselinePath = path.join(dir, "baseline.png");
     const currentPath = path.join(dir, "current.png");
     await writePng(baselinePath, 2, 2, { r: 10, g: 20, b: 30 });

--- a/packages/tool-server/test/screenshot-diff.test.ts
+++ b/packages/tool-server/test/screenshot-diff.test.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { PNG } from "pngjs";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { diffPngFiles, type Rgb } from "../src/tools/screenshot-diff/screenshot-diff";
 
 const analyzeScreenshotTextChangesMock = vi.hoisted(() =>
@@ -533,8 +533,16 @@ describe("diffPngFiles", () => {
   );
 });
 
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+});
+
 async function makeTempDir(): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-"));
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "argent-screenshot-diff-"));
+  tempDirs.push(dir);
+  return dir;
 }
 
 async function writePng(


### PR DESCRIPTION
Three issues, one theme: tests and the shared system temp directory.

- **#858 / #854** were live leaks — three call sites captured a real temp path and never removed it. One reaches the cleanup its file already had; the other two get a cleanup the file lacked.
- **#836** turned out to be **already fixed on `main`** by #714, which scoped those three tests' `TMPDIR` to a directory they own. This PR verifies that rather than changing it — reproduction and mutation evidence below.
- Sweeping the same shape across the two packages turned up **six more test files** doing it, worth **44** leftover entries per run.
- A third shape, in **two** more files: `resolveFileInputs` hands its caller a `cleanup` for whatever it materialized — the dispatcher's job in production. Five call sites kept the result and never called it, stranding 5 dirs per run.

A scoped-`TMPDIR` run of all 12 affected files leaves **one** entry behind: an empty `argent-chromium-media/`, production's own fixed staging dir. 173 tests, no other file or directory.

Fixes #858
Fixes #854
Closes #836

<details>
<summary>#858 — before/after temp scope</summary>

```
rm -rf /tmp/scope && mkdir -p /tmp/scope
TMPDIR=/tmp/scope TMP=/tmp/scope TEMP=/tmp/scope \
  npx vitest run --root packages/tool-server test/chromium-server-screenshot.test.ts
```

| site | before | after |
|---|---|---|
| `chromium-server-screenshot.test.ts` | `argent-chromium-media/argent-screenshot-test-1788803062089-38318.png` | *(no PNG)* |
| `chromium-cdp-blueprint.test.ts` | `argent-chromium-media/argent-screenshot-chromium-cdp-52204-1788803091335-39401.png` | *(no PNG)* |

Both files keep an empty `argent-chromium-media/` — that is production's fixed staging dir (`src/chromium-server/cdp-session.ts:218`), shared with any live chromium-server on the machine and not per-run garbage. A test `rm`ing it would be the machine-global-resource defect #714 removed elsewhere, so it is left alone deliberately.
</details>

<details>
<summary>#854 — before/after temp scope</summary>

```
TMPDIR=/tmp/scope … npx vitest run --root packages/argent-mcp test/content.test.ts
```

Before (`34 passed`, two directories left):
```
argent-mcp-content-kPfgYa/context.diff.png
argent-artifacts/test-temp-dir-hygiene-037c31/20260907-174453-39458/home-diff.png
```

After: **empty**. The `mkdtemp` moved onto a `beforeEach`/`afterEach` pair mirroring the sibling describe, and `flowRunToMcpContent` now pins `ARGENT_ARTIFACTS_DIR` the way the artifact describe above it already did.

The unconditional `delete process.env.ARGENT_ARTIFACTS_DIR` is kept, not converted to a save/restore: it is what keeps any future unpinned write landing in `tmpdir` rather than a developer's configured artifacts directory.

The pin is not hygiene-only — it is asserted. Removing `process.env.ARGENT_ARTIFACTS_DIR = root` fails the test:
```
- diff: /tmp/scopeM4/content-flow-artifacts-LZKPAl
+   diff: /tmp/scopeM4/argent-artifacts/test-temp-dir-hygiene-037c31/20260908-100837-89701/home-diff.png
❯ test/content.test.ts:627  expect(artifactText?.text).toContain(`diff: ${root}`)
```
</details>

<details>
<summary>#836 — why no code changed, and the evidence</summary>

(This PR does change `file-inputs.test.ts`, but for the unrelated third shape above — not for the sites #836 cites.)

The issue cites `readdir(os.tmpdir())` at `file-inputs.test.ts:180-197` and `flow-visual.test.ts:586-602`. On current `main` neither exists: #714 replaced both (and the `http-upload.test.ts:154-158` sibling the issue also flags) with a per-test scratch directory the test creates, points `os.tmpdir()` at via `redirectTmpdir`, and removes. There is now **no** `readdir` of `os.tmpdir()` anywhere in either package.

The per-path assertion the issue asks for is not reachable at these three sites — every name is a `mkdtemp` random suffix or a server-side `randomUUID`, so the test cannot know the path. Scoping the tmpdir to a directory the test owns is the same guarantee, and is what landed.

**Reproduced the reported failure** by reverting each site to the global-listing shape, then running two simultaneous instances in a loop:

| file | pre-#714 shape | current |
|---|---|---|
| `file-inputs.test.ts` | **1 / 12** — `expected [ 'argent-file-input-00mPU7', …(1371) ] to deeply equal [ …(1370) ]` | **0 / 12** |
| `flows/flow-visual.test.ts` | **12 / 12** — `expected [ 'argent-flow-crop-00R9XZ', …(4853) ] to deeply equal []` | **0 / 12** |
| `http-upload.test.ts` | — | **0 / 12** |

**Mutation-tested all three assertions** — each still catches a real leak; production cleanup broken, test run, source restored:

| assertion | mutation | result |
|---|---|---|
| `file-inputs.test.ts:249` | drop `await cleanup()` from `resolveFileInputs`' catch path | ✗ `+ [ "argent-file-input-amPJuK" ]` |
| `flow-visual.test.ts:610` | drop `cleanupDiffDir(cropDir, …)` from the outer `finally` | ✗ `+ [ "argent-flow-crop-rWT9Bd" ]` |
| `http-upload.test.ts:187` | drop `rm(tarPath)` from the `req.on("close")` handler | ✗ `+ [ "argent-upload-43d82021-….tar.gz" ]` |
</details>

<details>
<summary>Sibling sweep — the same two shapes across both packages</summary>

**Shape "assertion diffing a listing of `os.tmpdir()`": zero remaining.** No `readdir`/`readdirSync`/`glob` over `os.tmpdir()`, `tmpdir()` or a literal `/tmp` in either test tree. Every literal `/tmp` string left is a fixture handed to a mocked API; the three that do touch disk were checked by hand and are clean (`native-devtools-socket-bind.test.ts` mkdtemps and removes, `flow-utils.test.ts` is pure path math, `native-profiler-external-device.test.ts` writes only inside its own per-test `mkdtemp`).

**Shape "a captured temp path never cleaned up": six files fixed.** Each gets one recording choke point plus an `afterEach`.

Running those six under a scoped `TMPDIR` (`48 passed` both times):

```
before: 44 entries      after: 1 entry
```

| file | sites |
|---|---|
| `screenshot-diff-tool.test.ts` | 9 |
| `react-profiler/ast-index.test.ts` | 6 |
| `event-log.test.ts` | 1 helper (4 dirs/run) |
| `screenshot-diff.test.ts` | 1 helper |
| `react-profiler/component-source-duplicates.test.ts` | 2 |
| `ios-instruments/combined-report-frozen-anchor.test.ts` | 1 |
| `flows/flow-visual.test.ts` | production's crop + diff dirs (5/run) |

**Left deliberately (1 entry):** an **empty** `argent-chromium-media/` — production's fixed staging dir (`src/chromium-server/cdp-session.ts:218`), shared with any live chromium-server on the machine. A test `rm`ing it would be the machine-global-resource defect #714 removed elsewhere.

Two further shapes turned up while checking that claim, both *production* dirs a test drove and then abandoned:

| site | per run | why the test could not just `rm` it |
|---|---|---|
| `screenshot-diff-tool.test.ts` | 2 dirs + 2 PNGs | `resolveOutputDir` mints `argent-screenshot-diff/<hex>` before anything validates the call, so the path exists before the test can learn it — and on a throw it never learns it at all |
| `flows/flow-visual.test.ts` | 5 dirs + 5 PNGs | `runSnapshot` leaves the file it registered as an artifact inside its `argent-flow-crop-*` / `argent-flow-diff-*` scratch dir; from there the dir belongs to whoever consumes the artifact, which here is the test |

Both are fixed the same way, with `redirectTmpdir` (already used by seven other test files): point `os.tmpdir()` at a directory the test already owns and removes, so whatever production mints lands inside it whether the call returns or throws. The `<hex>` and `mkdtemp` suffixes are per-call and never shared, so nothing a concurrent tool-server owns is touched — verified with a decoy file planted under the shared root, which survives the run.

Measured under a scoped `TMPDIR`, three consecutive runs each: `screenshot-diff-tool` 6 dirs + 6 PNGs → **0 + 0**; `flow-visual` 15 + 15 → **0 + 0**. The underlying production leak behind the first is still #790.

`argent-mcp` is now clean end to end: every `mkdtemp` in the package has a matching `rm`.
</details>

<details>
<summary>Checks</summary>

Run from the worktree root, exit codes read unpiped:

- `npm run format` → 0, no files rewritten
- `npx tsc --noEmit -p packages/tool-server/tsconfig.test.json` → 0
- `npx tsc --noEmit -p packages/argent-mcp/tsconfig.test.json` → 0
- `npm run lint` → 0
- `npm run knip` → 0
- no `it.only` / `describe.only` in the diff

Suites: `argent-mcp` **90 passed**; `tool-server` run as six shards under a scoped `TMPDIR`.

`lens-tools-platform-gate.test.ts` times out at the 5 s default under full-suite load and passes in isolation (`2 passed`, 3.14 s). It is not in this diff and #714 recorded the same behaviour before it.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by consistently cleaning up temporary files and directories after each test.
  - Added coverage verifying generated artifacts are stored under the configured artifacts directory.
  - Ensured screenshot, upload, event-log, profiling, visual-flow, and diff-test artifacts are removed reliably after execution.
  - Standardized temporary-directory handling and cleanup across test scenarios to reduce leftover test data and improve repeatability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

