### PR TITLE
test: make four non-discriminating test sites fail on what they claim to pin

### DIFF
--- a/packages/argent-cli/test/telemetry-command.test.ts
+++ b/packages/argent-cli/test/telemetry-command.test.ts
@@ -125,14 +125,17 @@ describe("argent telemetry — scopes", () => {
 
   // `argent <command> --help` is what the top-level help tells the user to run,
   // and every other subcommand honours it after its own subcommand too.
+  // One argv per row, nested so `%j` names all of it: un-nested, the single placeholder
+  // takes only argv[0], which renders the two `status` rows identically and reads the rest
+  // as claims about a bare `enable` / `disable`.
   it.each([
-    ["--help"],
-    ["-h"],
-    ["status", "--help"],
-    ["status", "-h"],
-    ["enable", "--help"],
-    ["disable", "-h"],
-  ])("prints usage for %s and writes nothing", async (...args) => {
+    [["--help"]],
+    [["-h"]],
+    [["status", "--help"]],
+    [["status", "-h"]],
+    [["enable", "--help"]],
+    [["disable", "-h"]],
+  ])("prints usage for %j and writes nothing", async (args) => {
     await telemetry(args);
     expect(output()).toContain("argent telemetry status");
     expect(errSpy).not.toHaveBeenCalled();

--- a/packages/argent-cli/test/tools-help.test.ts
+++ b/packages/argent-cli/test/tools-help.test.ts
@@ -42,9 +42,12 @@ const output = () => (logSpy.mock.calls as unknown[][]).map((c) => String(c[0] ?
 const invoke = (argv: string[]) => tools(argv, { paths: {} as never });
 
 describe("argent tools --help", () => {
-  it.each([["--help"], ["-h"], ["--help", "--json"], ["--json", "--help"]])(
+  // Each row is ONE argv, nested so `%j` renders the whole thing: spread rows against a
+  // single placeholder printed only argv[0], which duplicated the two-flag rows' names and
+  // read as a claim about a bare `--json` (which prints no usage and does hit the server).
+  it.each([[["--help"]], [["-h"]], [["--help", "--json"]], [["--json", "--help"]]])(
     "prints usage for %j without contacting the tool-server",
-    async (...argv) => {
+    async (argv) => {
       await invoke(argv);
 
       expect(output()).toContain("argent tools describe <name>");

--- a/packages/argent-cli/test/tools-help.test.ts
+++ b/packages/argent-cli/test/tools-help.test.ts
@@ -42,9 +42,9 @@ const output = () => (logSpy.mock.calls as unknown[][]).map((c) => String(c[0] ?
 const invoke = (argv: string[]) => tools(argv, { paths: {} as never });
 
 describe("argent tools --help", () => {
-  // Each row is ONE argv, nested so `%j` renders the whole thing: spread rows against a
-  // single placeholder printed only argv[0], which duplicated the two-flag rows' names and
-  // read as a claim about a bare `--json` (which prints no usage and does hit the server).
+  // One argv per row, nested so `%j` names all of it: un-nested, the single placeholder
+  // takes only argv[0], which duplicates the two-flag rows' names and reads as a claim about
+  // a bare `--json` — which prints no usage and does hit the server.
   it.each([[["--help"]], [["-h"]], [["--help", "--json"]], [["--json", "--help"]]])(
     "prints usage for %j without contacting the tool-server",
     async (argv) => {

--- a/packages/argent/test/installer-help.test.ts
+++ b/packages/argent/test/installer-help.test.ts
@@ -225,20 +225,23 @@ describe("INSTALLER_COMMAND_META", () => {
 describe("mcp is intercepted like the installers", () => {
   // `argent mcp --help` used to start the stdio server, which then blocked
   // reading JSON-RPC from stdin — the reason this command joined the set.
+  // Each row is ONE argv, nested so `%j` renders the whole thing: spread rows against a
+  // single placeholder printed only argv[0], so the last two both rendered as `treats
+  // "--foo"` — a bare `--foo` being the opposite of a help request.
   it.each([
-    ["--help"],
-    ["-h"],
-    ["-H"],
-    ["--HELP"],
-    ["-help"],
-    ["—help"],
-    ["–help"],
-    ["--help=x"],
-    ["help"],
-    ["HELP"],
-    ["--foo", "--help"],
-    ["--foo", "help"],
-  ])("treats %j as a help request", (...rest) => {
+    [["--help"]],
+    [["-h"]],
+    [["-H"]],
+    [["--HELP"]],
+    [["-help"]],
+    [["—help"]],
+    [["–help"]],
+    [["--help=x"]],
+    [["help"]],
+    [["HELP"]],
+    [["--foo", "--help"]],
+    [["--foo", "help"]],
+  ])("treats %j as a help request", (rest) => {
     expect(installerHelpRequested("mcp", rest)).toBe(true);
   });
 
@@ -247,9 +250,9 @@ describe("mcp is intercepted like the installers", () => {
     expect(installerHelpRequested("mcp", [])).toBe(false);
   });
 
-  it.each([["--helpme"], ["/help"], ["--metro-port", "8082"]])(
+  it.each([[["--helpme"]], [["/help"]], [["--metro-port", "8082"]]])(
     "does not treat %j as a help request",
-    (...rest) => {
+    (rest) => {
       expect(installerHelpRequested("mcp", rest)).toBe(false);
     }
   );

--- a/packages/argent/test/installer-help.test.ts
+++ b/packages/argent/test/installer-help.test.ts
@@ -225,9 +225,9 @@ describe("INSTALLER_COMMAND_META", () => {
 describe("mcp is intercepted like the installers", () => {
   // `argent mcp --help` used to start the stdio server, which then blocked
   // reading JSON-RPC from stdin — the reason this command joined the set.
-  // Each row is ONE argv, nested so `%j` renders the whole thing: spread rows against a
-  // single placeholder printed only argv[0], so the last two both rendered as `treats
-  // "--foo"` — a bare `--foo` being the opposite of a help request.
+  // One argv per row, nested so `%j` names all of it: un-nested, the single placeholder
+  // takes only argv[0], so the last two rows both read `treats "--foo"` — the opposite of
+  // what they assert.
   it.each([
     [["--help"]],
     [["-h"]],

--- a/packages/tool-server/test/capability.test.ts
+++ b/packages/tool-server/test/capability.test.ts
@@ -55,9 +55,8 @@ describe("NotImplementedOnPlatformError", () => {
     expect(err.toolId).toBe("demo-tool");
     expect(err.platform).toBe("android");
     expect(err.hint).toBe("Use `adb shell <command>`.");
-    // The whole sentence, not `toContain("demo-tool")` + `toContain("android")`: both of
-    // those are substrings of the path asserted below, so they would hold for a message
-    // that had dropped the prose naming the tool and the platform entirely.
+    // The whole sentence: "demo-tool" and "android" on their own are substrings of the
+    // path asserted below, so they hold for a message carrying no prose naming either.
     expect(err.message).toContain("Tool 'demo-tool' is not yet implemented on android.");
     expect(err.message).toContain("tools/demo-tool/platforms/android.ts");
     expect(err.message).toContain("capability declaration");

--- a/packages/tool-server/test/capability.test.ts
+++ b/packages/tool-server/test/capability.test.ts
@@ -55,8 +55,10 @@ describe("NotImplementedOnPlatformError", () => {
     expect(err.toolId).toBe("demo-tool");
     expect(err.platform).toBe("android");
     expect(err.hint).toBe("Use `adb shell <command>`.");
-    expect(err.message).toContain("demo-tool");
-    expect(err.message).toContain("android");
+    // The whole sentence, not `toContain("demo-tool")` + `toContain("android")`: both of
+    // those are substrings of the path asserted below, so they would hold for a message
+    // that had dropped the prose naming the tool and the platform entirely.
+    expect(err.message).toContain("Tool 'demo-tool' is not yet implemented on android.");
     expect(err.message).toContain("tools/demo-tool/platforms/android.ts");
     expect(err.message).toContain("capability declaration");
     expect(err.message).toContain("Use `adb shell");

--- a/packages/tool-server/test/native-profiler-missing-trace.test.ts
+++ b/packages/tool-server/test/native-profiler-missing-trace.test.ts
@@ -86,10 +86,10 @@ describe("native-profiler-analyze: missing trace file", () => {
       // The warning should mention the CPU category and reference the file.
       expect(result.report).toMatch(/-\s*\*\*cpu\*\*:[^\n]*missing_cpu\.xml/i);
       // Word it so the user understands the file is missing/unreadable, not
-      // that the export was simply empty. The wording has to land BEFORE the
+      // that the export was simply empty. The wording has to land before the
       // backticked path (`[^`\n]*` cannot cross into it): the path carries
       // "missing" in the fixture's own name, so a match allowed to reach it
-      // would hold for any wording at all.
+      // holds for any wording at all.
       expect(result.report).toMatch(/-\s*\*\*cpu\*\*:[^`\n]*(?:missing|not found|unreadable)/i);
     } finally {
       if (dir) await rm(dir, { recursive: true, force: true });

--- a/packages/tool-server/test/native-profiler-missing-trace.test.ts
+++ b/packages/tool-server/test/native-profiler-missing-trace.test.ts
@@ -86,8 +86,11 @@ describe("native-profiler-analyze: missing trace file", () => {
       // The warning should mention the CPU category and reference the file.
       expect(result.report).toMatch(/-\s*\*\*cpu\*\*:[^\n]*missing_cpu\.xml/i);
       // Word it so the user understands the file is missing/unreadable, not
-      // that the export was simply empty.
-      expect(result.report).toMatch(/missing|not found|unreadable/i);
+      // that the export was simply empty. The wording has to land BEFORE the
+      // backticked path (`[^`\n]*` cannot cross into it): the path carries
+      // "missing" in the fixture's own name, so a match allowed to reach it
+      // would hold for any wording at all.
+      expect(result.report).toMatch(/-\s*\*\*cpu\*\*:[^`\n]*(?:missing|not found|unreadable)/i);
     } finally {
       if (dir) await rm(dir, { recursive: true, force: true });
     }

--- a/packages/tool-server/test/vega-cli-timeout.test.ts
+++ b/packages/tool-server/test/vega-cli-timeout.test.ts
@@ -23,8 +23,9 @@ import { runVega, __resetVegaBinaryCacheForTests } from "../src/utils/vega-cli";
 // itself blocks on a same-group `sleep <secs>` so the launcher stays alive long
 // enough to be timed out and snapshotted. Once both workers exist the descendant sweep
 // reaps them by itself; the group kill covers the window before they do, which is what the
-// overflow tests hit — their reap trips on the launcher's first write, so under load it can
-// snapshot an empty tree and only killing the group stops the sleep from outliving the call.
+// overflow tests hit — their reap trips on the launcher's flood, so it can snapshot a tree
+// that does not yet hold the sleep the launcher spawns next, and only killing the group
+// stops that sleep from outliving the call.
 // Each test passes its OWN sentinel so one test's strays can't be mistaken for
 // another's, and every sentinel shares a per-run prefix so afterEach can sweep them
 // all with a single tight pattern (see sweep()).
@@ -77,7 +78,17 @@ beforeAll(() => {
     join(dir, "vega"),
     `#!/usr/bin/env node
 const { spawn, spawnSync } = require("node:child_process");
-const [cmd, secs] = process.argv.slice(2);
+const { existsSync } = require("node:fs");
+const [cmd, secs, gate] = process.argv.slice(2);
+// Block until the test creates \`gate\` — it does that once it has SEEN this branch's
+// sentinel worker. Bounded so a test that fails before writing it can't wedge the launcher
+// past the caller's timeoutMs; Atomics.wait sleeps without forking a process the sweep
+// would then have to account for.
+const awaitGate = () => {
+  const deadline = Date.now() + 3000;
+  const idle = new Int32Array(new SharedArrayBuffer(4));
+  while (!existsSync(gate) && Date.now() < deadline) Atomics.wait(idle, 0, 0, 20);
+};
 if (cmd === "hang") {
   // A worker that ESCAPES the launcher's process group (detached → its own session/
   // pgid, like the real CLI's setsid'd worker), so the group-only SIGKILL can't reach
@@ -98,17 +109,26 @@ if (cmd === "fail") {
   process.exit(3);
 }
 if (cmd === "flood") {
-  // Emit more than the test's maxOutputBytes, then hang on a sentinel sleep so the
+  // The worker comes FIRST and the flood waits on the gate: the cap trips on the first
+  // write, so a worker spawned after it is reaped 20-100ms later, and the test's look at
+  // it would be racing that reap.
+  const worker = spawn("sleep", [secs], { stdio: "ignore" });
+  worker.unref();
+  awaitGate();
+  // Emit more than the test's maxOutputBytes, then hang on a second sentinel sleep so the
   // OVERFLOW reap — not a natural exit — is what settles runVega. The reap must clear
-  // this sleep too. \`secs\` is the per-test sentinel.
+  // both. \`secs\` is the per-test sentinel.
   process.stdout.write("x".repeat(4096));
   spawnSync("sleep", [secs]);
   process.exit(0);
 }
 if (cmd === "flood-err") {
-  // Same as \`flood\` but floods STDERR instead of stdout — the cap applies per stream
-  // (like execFile's maxBuffer), so an stderr flood must also reap+reject rather than
-  // grow unbounded. Hangs on a sentinel sleep so the overflow reap is what settles it.
+  // Same as \`flood\` — gated worker, then the flood, then a sentinel sleep to hang on —
+  // but flooding STDERR instead of stdout. The cap applies per stream (like execFile's
+  // maxBuffer), so an stderr flood must also reap+reject rather than grow unbounded.
+  const worker = spawn("sleep", [secs], { stdio: "ignore" });
+  worker.unref();
+  awaitGate();
   process.stderr.write("x".repeat(4096));
   spawnSync("sleep", [secs]);
   process.exit(0);
@@ -330,9 +350,7 @@ describe("runVega timeout (real subprocess)", () => {
     // escaped, and the descendant sweep rather than the group SIGKILL the only thing that
     // can reap it; left unasserted, the fake's `detached: true` can be dropped and this
     // test stays green with the sweep deleted. The poll gets the whole deadline as its
-    // budget, for the reason the drain observation below spells out. The two output-cap
-    // reaps stay unpinned for want of such a window — theirs fires within ~100ms of the
-    // spawn (#841).
+    // budget, for the reason the drain observation below spells out.
     expect(await waitForWorkerGroups(SENTINEL_REAP, 2, REAP_DEADLINE_MS)).toEqual({
       workers: 2,
       groups: 2,
@@ -436,11 +454,20 @@ describe("runVega timeout (real subprocess)", () => {
     // A runaway child: output past the cap reaps the group and rejects. Like the
     // non-zero exit (and unlike a timeout) it is a misbehaving child, so it must
     // classify as `subprocess` — the killed=true shape would otherwise read as a
-    // wedged-agent "timeout". The sentinel sleep it hangs on must be reaped too.
-    const err = await runVega(["flood", SENTINEL_OVERFLOW], {
+    // wedged-agent "timeout". The sentinel sleeps it leaves behind must be reaped too.
+    const OVERFLOW_DEADLINE_MS = 5_000;
+    const gate = join(dir, "flood-gate");
+    const run = runVega(["flood", SENTINEL_OVERFLOW, gate], {
       maxOutputBytes: 100,
-      timeoutMs: 5_000,
+      timeoutMs: OVERFLOW_DEADLINE_MS,
     }).catch((e: unknown) => e);
+    // See a worker alive BEFORE the reap: `waitForClear` below reads 0 just as readily for
+    // a launcher that never spawned one. The cap trips on the first write, so the window to
+    // see one in exists only because the fake spawns its worker first and holds the flood —
+    // and so the reap — until this gate file lands.
+    expect(await waitForCount(SENTINEL_OVERFLOW, 1, OVERFLOW_DEADLINE_MS)).toBe(1);
+    writeFileSync(gate, "");
+    const err = await run;
     expect(err).toBeInstanceOf(Error);
     // The message prefers the child's captured output (matching execFile's maxBuffer
     // error), so it's the flood, not "output exceeded" — what matters is that it
@@ -454,11 +481,17 @@ describe("runVega timeout (real subprocess)", () => {
     // instead of stdout must trip the same overflow path, not grow stderr unbounded
     // until the timeout — otherwise a misbehaving CLI could exhaust the long-lived
     // tool-server's memory. Classifies `subprocess` (a misbehaving child, not a wedged
-    // agent) and the sentinel sleep it hangs on must be reaped too.
-    const err = await runVega(["flood-err", SENTINEL_OVERFLOW_ERR], {
+    // agent) and the sentinel sleeps it leaves behind must be reaped too.
+    const OVERFLOW_DEADLINE_MS = 5_000;
+    const gate = join(dir, "flood-err-gate");
+    const run = runVega(["flood-err", SENTINEL_OVERFLOW_ERR, gate], {
       maxOutputBytes: 100,
-      timeoutMs: 5_000,
+      timeoutMs: OVERFLOW_DEADLINE_MS,
     }).catch((e: unknown) => e);
+    // Same gated observation as the stdout twin, and for the same reason.
+    expect(await waitForCount(SENTINEL_OVERFLOW_ERR, 1, OVERFLOW_DEADLINE_MS)).toBe(1);
+    writeFileSync(gate, "");
+    const err = await run;
     expect(err).toBeInstanceOf(Error);
     expect(getFailureSignal(err)?.error_kind).toBe("subprocess");
     expect(await waitForClear(SENTINEL_OVERFLOW_ERR)).toBe(0);


### PR DESCRIPTION
Four tests could not fail on the thing they name: an assertion implied by the one below
it, an assertion satisfied by the fixture's own filename, a clearance poll with nothing
to clear, and `it.each` rows whose rendered name described only argv[0] - two of them
stating the opposite of what the row asserts.

Each site now fails when its claim is broken, proven by mutation. Tests only, no source
change, so no docs update.

Fixes #943
Fixes #942
Fixes #841
Fixes #861

<details>
<summary>#943 &mdash; capability: toolId/platform were substrings of the path assertion</summary>

`toContain("demo-tool")` + `toContain("android")` are both substrings of
`tools/demo-tool/platforms/android.ts`, asserted on the next line. Replaced by the prose
sentence, which names both outside the path.

Mutation - drop the sentence naming the tool and the platform:

```diff
-      `Tool '${opts.toolId}' is not yet implemented on ${opts.platform}. ` +
+      `Tool is not yet implemented. ` +
```

| | result |
|---|---|
| before | `Tests 7 passed (7)` - green |
| after | `AssertionError: expected 'Tool is not yet implemented. The cros…' to contain 'Tool \'demo-tool\' is not yet impleme…'` |

The sibling "works without a hint" assertions are load-bearing and untouched.
</details>

<details>
<summary>#942 &mdash; native-profiler: the wording assertion matched inside missing_cpu.xml</summary>

`/missing|not found|unreadable/i` matched the fixture filename, so any product copy
passed. The wording now has to land before the backticked path (a negated character class
cannot cross into it), which no path can satisfy.

Mutation - reword the ENOENT copy:

```diff
-    if (code === "ENOENT") return `not found at \`${filePath}\``;
+    if (code === "ENOENT") return `absent at \`${filePath}\``;
```

| | result |
|---|---|
| before | `Tests 1 passed (1)` - green (also green with the state word deleted outright) |
| after | `AssertionError: expected '# iOS Instruments Analysis…' to match /-\s*\*\*cpu\*\*:[^…]*(?:missing\|not found\|unreadable)/i` |
</details>

<details>
<summary>#841 &mdash; vega-cli: the output-cap reaps had nothing to observe</summary>

`expect(await waitForClear(SENTINEL_OVERFLOW)).toBe(0)` reads 0 just as readily for a
launcher that never spawned a worker. The cap trips on the first write, so there was no
window to see one in: the fake now spawns its sentinel worker **before** the flood and
holds the flood - and so the reap - until the test writes a gate file, having seen the
worker. Both the stdout and the stderr twin.

Gated rather than timed, so the observation is decided, not raced. Cost is ~+110ms and
~+50ms on the two tests (165/177ms to 278/226ms).

Mutation - the flood branches' workers stop carrying the sentinel, reap path untouched:

```diff
-  const worker = spawn("sleep", [secs], { stdio: "ignore" });
+  const worker = spawn("sleep", ["600.0"], { stdio: "ignore" });
   ...
-  spawnSync("sleep", [secs]);
+  spawnSync("sleep", ["600.0"]);
```

| | result |
|---|---|
| before | `Tests 12 passed (12)` - green, and `pgrep -f '^sleep 600\.0$'` empty (the reap works; nothing observed it) |
| after | both overflow tests `AssertionError: expected +0 to be 1` |

Cross-check that the pair pins the production reap: with `reapOnce()` made a no-op in
`vega-cli.ts`, both fail `expected 2 to be +0`.

**Flake runs: 30 consecutive passes** (2 x 15, before and after the comment pass),
`12 passed (12)` every time.
</details>

<details>
<summary>#861 &mdash; four it.each rows named only argv[0] (plus a fifth site)</summary>

A single `%j` against a multi-element row renders only the first element. Each row is now
one argv, nested, so `%j` names all of it.

`packages/argent-cli/test/tools-help.test.ts`

```
- prints usage for "--help" without contacting the tool-server   <- duplicate
- prints usage for "--json" without contacting the tool-server   <- false: a bare --json
                                                                    prints no usage and
                                                                    does hit the server
+ prints usage for ["--help","--json"] without contacting the tool-server
+ prints usage for ["--json","--help"] without contacting the tool-server
```

`packages/argent/test/installer-help.test.ts`

```
- treats "--foo" as a help request      <- rendered twice; a bare --foo is the opposite
+ treats ["--foo","--help"] as a help request
+ treats ["--foo","help"] as a help request
- does not treat "--metro-port" as a help request
+ does not treat ["--metro-port","8082"] as a help request
```

Swept the class across every `it.each` array-literal table in the repo (154 sites). One
more reproduces it - `packages/argent-cli/test/telemetry-command.test.ts`, fixed here:

```
- prints usage for status and writes nothing    <- rendered twice
- prints usage for disable and writes nothing   <- false: a bare `disable` writes config
+ prints usage for ["status","--help"] and writes nothing
+ prints usage for ["status","-h"] and writes nothing
+ prints usage for ["disable","-h"] and writes nothing
```

Left alone: ~64 sites with a discriminating label column (`_label` first, house style) and
16 whose first column is a real discriminator - names unique and truthful in both groups.
`providers-command.test.ts:440` drops a third "shape" column from its name but stays
unique and true, so it is a legibility nit, not this defect.
</details>

<details>
<summary>Checks run</summary>

- `npm run format`, `npm run lint` (the latter needs `npm ci` inside `packages/docs` locally)
- `npx tsc --noEmit -p packages/{tool-server,argent-cli,argent}/tsconfig.test.json`
- `packages/tool-server`: `npx vitest run --shard=1/6` .. `6/6` - 6163 passed, 1 skipped
- `npx vitest run --root packages/argent-cli` (619), `--root packages/argent` (80)
- `vega-cli-timeout.test.ts` x30 consecutive, zero flakes
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test parameterization so command-line help cases display complete argument lists accurately.
  * Strengthened error-message and profiler warning assertions to verify exact wording and placement.
  * Improved subprocess timeout and output-limit tests by synchronizing worker startup and cleanup checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->