### PR TITLE
feat(flows): let a flow run select a booted remote iOS simulator

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -128,7 +128,8 @@ Subcommands:
 
 Options (run):
   --device <id>          Device id to run against (auto-detected when omitted)
-  --platform <p>         ios | android | chromium | vega — narrow auto-detection
+  --platform <p>         ios | android | chromium | vega | ios-remote — narrow
+                         auto-detection (ios never picks a remote simulator)
   --update-baselines     Write/refresh screenshot baselines instead of diffing
   --output <dir>         Also write failed snapshot images (baseline/current/diff)
                          under <dir>/<flow>/ — a stable path for CI artifact

--- a/packages/docs/docs/reference/flow-yaml.mdx
+++ b/packages/docs/docs/reference/flow-yaml.mdx
@@ -330,16 +330,16 @@ On Chromium, Argent boots the app before step 1 only when the run has no `device
 | `argent flow run <dir>`       | Run every flow in the directory, one after the other |
 | `argent flow list`            | List the flow files in `.argent/flows`               |
 
-| Option               | Description                                                                                                                 |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `--device <id>`      | The device to run on. Argent detects the device when you omit the option. A physical iPhone is never detected; name it here |
-| `--platform <p>`     | `ios`, `android`, `chromium` or `vega`. Narrows the detection. `ios` still never picks a physical iPhone                    |
-| `--update-baselines` | Write the snapshot baselines instead of comparing them                                                                      |
-| `--output <dir>`     | Write the failed baseline, current and diff images to `<dir>/<flow>/`, for a CI artifact upload                             |
-| `-r, --recursive`    | With a directory, also run the flows in subdirectories. Dot-directories and `node_modules` are skipped                      |
-| `--json`             | Print the JSON report of the flow, or the JSON aggregate of the directory                                                   |
-| `--json-stream`      | Print one JSON record per line: each step, then the result. One flow, and not with `--json`                                 |
-| `--`                 | End of options, for a flow name that starts with `-`                                                                        |
+| Option               | Description                                                                                                                                                       |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--device <id>`      | The device to run on. Argent detects the device when you omit the option. A physical iPhone is never detected; name it here                                       |
+| `--platform <p>`     | `ios`, `android`, `chromium`, `vega` or `ios-remote`. Narrows the detection. `ios` still never picks a physical iPhone, and never picks a remote simulator either |
+| `--update-baselines` | Write the snapshot baselines instead of comparing them                                                                                                            |
+| `--output <dir>`     | Write the failed baseline, current and diff images to `<dir>/<flow>/`, for a CI artifact upload                                                                   |
+| `-r, --recursive`    | With a directory, also run the flows in subdirectories. Dot-directories and `node_modules` are skipped                                                            |
+| `--json`             | Print the JSON report of the flow, or the JSON aggregate of the directory                                                                                         |
+| `--json-stream`      | Print one JSON record per line: each step, then the result. One flow, and not with `--json`                                                                       |
+| `--`                 | End of options, for a flow name that starts with `-`                                                                                                              |
 
 ```bash
 argent flow run checkout --platform ios

--- a/packages/tool-server/src/tools/flows/flow-device.ts
+++ b/packages/tool-server/src/tools/flows/flow-device.ts
@@ -2,11 +2,14 @@ import type { DeviceInfo, Registry, ToolContext } from "@argent/registry";
 import { FAILURE_CODES, FailureError } from "@argent/registry";
 import { resolveDevice } from "../../utils/device-info";
 import { invokeSubTool } from "../../utils/sub-invoke";
-import { blockSteps, type FlowStep, type WhenPlatform } from "./flow-utils";
+import { blockSteps, type FlowStep, type SelectablePlatform } from "./flow-utils";
 
-// The flows directory's one platform set — LAUNCH_PLATFORMS in flow-utils,
-// reached through WhenPlatform.
-export type FlowPlatform = WhenPlatform;
+/**
+ * The platforms a run can be pointed at — SELECTABLE_PLATFORMS in flow-utils.
+ * Wider than the authoring set by `ios-remote`: a remote simulator is a device
+ * a run can select, never something a flow file names.
+ */
+export type FlowPlatform = SelectablePlatform;
 
 /**
  * Arg names that mean "the device to act on". Stripped from every recorded step
@@ -64,7 +67,8 @@ interface RawDevice {
 }
 
 function deviceEntryId(d: RawDevice): string | undefined {
-  if (d.platform === "ios") return d.udid;
+  // A remote row carries `udid` too (the `remote:`-prefixed id), not `serial`.
+  if (d.platform === "ios" || d.platform === "ios-remote") return d.udid;
   if (d.platform === "chromium") return d.id;
   return d.serial; // android, vega
 }
@@ -77,6 +81,11 @@ function isBooted(d: RawDevice): boolean {
       // hardware because a phone happens to be on the cable, and a cabled
       // phone must not turn a lone booted simulator into an ambiguity. Name
       // the phone with `device` to run on it.
+      return d.state === "Booted";
+    case "ios-remote":
+      // A remote simulator reports the same simctl states as a local one, and
+      // carries none of the physical-device ambiguity above: `ios-remote` is
+      // always kind "simulator" (utils/device-info.ts).
       return d.state === "Booted";
     case "android":
       return d.state === "device";

--- a/packages/tool-server/src/tools/flows/flow-run.ts
+++ b/packages/tool-server/src/tools/flows/flow-run.ts
@@ -35,7 +35,7 @@ import {
   type FlowFile,
   type FlowStep,
   type Launch,
-  LAUNCH_PLATFORMS,
+  SELECTABLE_PLATFORMS,
 } from "./flow-utils";
 import { createScriptLogBudget, type FlowScriptLogBudget } from "./script/flow-script-executor";
 import { canonicalFlowPath, resolveFlowRelativeFile } from "./flow-file-refs";
@@ -118,10 +118,10 @@ const zodSchema = z
         "Device id to run against (iOS UDID, Android/Vega serial, Chromium id) — the id list-devices reports. Auto-detected when omitted, but only when exactly one booted device matches (optionally narrowed by `platform`); with several booted the run fails and lists them, so pass this explicitly whenever more than one device is up."
       ),
     platform: z
-      .enum(LAUNCH_PLATFORMS)
+      .enum(SELECTABLE_PLATFORMS)
       .optional()
       .describe(
-        "Restrict auto-detection to this platform when several devices are booted. `chromium` does more than filter: with no `device` it SELECTS the self-boot branch for an e2e flow - the runner boots an Electron instance from the `launch` step's chromium value and tears it down after the run (a single-key `launch: { chromium: … }` map selects it on its own, without this parameter). When it selects that branch it never falls back to device auto-detection (a fragment, or an e2e launch map with no `chromium` key, still does), and the launch value must be a real Electron app path on the tool-server host: a bare-string `launch:` - what the recorder writes - holds an installed-app bundle id, so passing `chromium` for one fails the whole run with `Electron boot: path does not exist`. Edit the launch to `{ chromium: <app path> }` first."
+        "Restrict auto-detection to this platform when several devices are booted. `ios` selects local simulators only — pass `ios-remote` to select a remote one. `chromium` does more than filter: with no `device` it SELECTS the self-boot branch for an e2e flow - the runner boots an Electron instance from the `launch` step's chromium value and tears it down after the run (a single-key `launch: { chromium: … }` map selects it on its own, without this parameter). When it selects that branch it never falls back to device auto-detection (a fragment, or an e2e launch map with no `chromium` key, still does), and the launch value must be a real Electron app path on the tool-server host: a bare-string `launch:` - what the recorder writes - holds an installed-app bundle id, so passing `chromium` for one fails the whole run with `Electron boot: path does not exist`. Edit the launch to `{ chromium: <app path> }` first."
       ),
     updateBaselines: z
       .boolean()

--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -646,7 +646,8 @@ function selectorTree(sel: FlowSelector): FlowSelector[] {
 /**
  * The platforms a `when: { platform: … }` condition can name — derived from
  * {@link LAUNCH_PLATFORMS} so the parser's runtime check and this type cannot
- * drift (flow-device's `FlowPlatform` aliases it).
+ * drift. Narrower than {@link SelectablePlatform}, which a RUN is selected
+ * with: a guard is authored text, and `ios-remote` is not writable.
  */
 export type WhenPlatform = (typeof LAUNCH_PLATFORMS)[number];
 
@@ -2188,11 +2189,19 @@ function isIdleCondition(raw: unknown, kind: "await" | "assert"): boolean {
 }
 
 /**
- * The platform set, spelled once: launch maps, `when: { platform }` guards
- * ({@link WhenPlatform}), flow-device's `FlowPlatform`, and flow-run's
- * `platform` param enum all derive from this tuple.
+ * The platforms an AUTHOR can name in a flow file: launch-map keys and
+ * `when: { platform }` guards ({@link WhenPlatform}).
  */
-export const LAUNCH_PLATFORMS = ["ios", "android", "chromium", "vega"] as const;
+const LAUNCH_PLATFORMS = ["ios", "android", "chromium", "vega"] as const;
+
+/**
+ * The platforms a RUN can be pointed at — flow-device's `FlowPlatform` and
+ * flow-run's `platform` param. `ios-remote` is selectable but deliberately not
+ * writable: a flow says what it drives, not which machine hosts the simulator,
+ * so `when:` and launch maps stay on {@link LAUNCH_PLATFORMS}.
+ */
+export const SELECTABLE_PLATFORMS = [...LAUNCH_PLATFORMS, "ios-remote"] as const;
+export type SelectablePlatform = (typeof SELECTABLE_PLATFORMS)[number];
 
 // Keys a launch map accepts: the platforms plus the `native` shared-id shorthand.
 const LAUNCH_MAP_KEYS = ["native", ...LAUNCH_PLATFORMS] as const;

--- a/packages/tool-server/test/flows/flow-deviceless.test.ts
+++ b/packages/tool-server/test/flows/flow-deviceless.test.ts
@@ -651,3 +651,86 @@ describe("a connected physical iPhone never competes with simulators", () => {
     expect(result.device).toBe(PHONE);
   });
 });
+
+describe("a booted remote simulator", () => {
+  const REMOTE = "remote:73A22194-1D9E-4C0E-9D75-6C2A1F0B4E51";
+  const remoteSim = {
+    platform: "ios-remote",
+    udid: REMOTE,
+    state: "Booted",
+    name: "iPhone 17 Pro",
+    runtime: "iOS 26.5",
+  };
+
+  beforeEach(async () => {
+    await writeFlow("tapping", [{ kind: "tap", x: 0.5, y: 0.5 }]);
+  });
+
+  it("is auto-detected when it is the only booted device", async () => {
+    // A remote row carries `udid`, not `serial`, and reports simctl's own
+    // "Booted" — before this it was neither counted as booted nor identifiable,
+    // so a lone remote simulator resolved to "No booted device found".
+    const { registry } = mockRegistry({ devices: [remoteSim] });
+
+    const result = asRun(await runAuto(registry, "tapping"));
+
+    expect(result.ok).toBe(true);
+    expect(result.device).toBe(REMOTE);
+  });
+
+  it("is selected by platform ios-remote when local simulators are also booted", async () => {
+    const { registry } = mockRegistry({ booted: [DEVICE], devices: [remoteSim] });
+    const runFlow = createRunFlowTool(registry);
+
+    const result = asRun(
+      await runFlow.execute({}, { name: "tapping", project_root: tmpDir, platform: "ios-remote" })
+    );
+
+    expect(result.device).toBe(REMOTE);
+  });
+
+  it("is NOT matched by platform ios, which stays local-only", async () => {
+    // The two do not overlap on purpose: the flow file is identical either
+    // way, so which host runs it must be an explicit choice rather than
+    // whatever happens to be booted.
+    const { registry } = mockRegistry({ booted: [DEVICE], devices: [remoteSim] });
+    const runFlow = createRunFlowTool(registry);
+
+    const result = asRun(
+      await runFlow.execute({}, { name: "tapping", project_root: tmpDir, platform: "ios" })
+    );
+
+    expect(result.device).toBe(DEVICE);
+  });
+
+  it("leaves platform ios with nothing to bind when only a remote sim is up", async () => {
+    const { registry } = mockRegistry({ devices: [remoteSim] });
+    const runFlow = createRunFlowTool(registry);
+
+    await expect(
+      runFlow.execute({}, { name: "tapping", project_root: tmpDir, platform: "ios" })
+    ).rejects.toThrow(/No booted ios device found/);
+  });
+
+  it("is named by its id in a resolution error, never as `?`", async () => {
+    // `deviceEntryId` fell through to `serial`, which a remote row does not
+    // carry, so an ambiguity listed the one device the caller most needed the
+    // id of as "? (ios-remote, Booted)".
+    const other = "11111111-1111-1111-1111-111111111111";
+    const { registry } = mockRegistry({ booted: [DEVICE, other], devices: [remoteSim] });
+
+    await expect(runAuto(registry, "tapping")).rejects.toThrow(
+      new RegExp(`3 booted devices matched.*${REMOTE} \\(ios-remote, Booted\\)`)
+    );
+  });
+
+  it("is not treated as booted while it is shut down", async () => {
+    const { registry } = mockRegistry({
+      devices: [{ ...remoteSim, state: "Shutdown" }],
+    });
+
+    await expect(runAuto(registry, "tapping")).rejects.toThrow(
+      /No booted device found.*\(ios-remote, Shutdown\)/
+    );
+  });
+});


### PR DESCRIPTION
## What

A booted remote iOS simulator is now a device a flow run can be pointed at - both by auto-detection and by `--platform ios-remote`.

## Why

It was invisible to flow device resolution. With a remote simulator booted alongside local ones:

```
$ argent flow run checkout
7 booted devices matched - pass --device or --platform to disambiguate.
Available devices: 79EE0744 (ios, Booted), A1E0DF35 (ios, Booted), emulator-5554 (android, device), ...
```

Three local iPhones and four Android emulators, and the remote simulator absent entirely. Narrowing to it did not work either - `--platform ios-remote` was rejected by the parameter's enum. The only way onto a remote simulator was typing the full `remote:<uuid>` id.

The cause is one type. `RawDevice.platform` was typed from the tuple of platforms an author can *write* in a flow file, which has no `ios-remote`, so nothing forced the case to be handled and two functions quietly fell through:

- `isBooted` hit its `default: return false`, so a remote row never counted as booted.
- `deviceEntryId` fell through to `serial`, a field a remote row does not carry (it uses `udid`, prefixed `remote:`). Even once counted, it had no id - and a resolution error printed it as `? (ios-remote, Booted)`, hiding the very id the caller needed.

## How

The tuple served two different jobs at once - what an author may write, and what a run may be pointed at - so it is now two:

- `LAUNCH_PLATFORMS` - launch-map keys and `when:` guards. Unchanged.
- `SELECTABLE_PLATFORMS` - device selection. Adds `ios-remote`.

`ios-remote` is selectable but deliberately not writable. A flow says what it drives, not which machine hosts the simulator, so `when: { platform: ios-remote }` stays a parse error.

For the same reason `ios` and `ios-remote` do not overlap: `ios` selects local simulators only. The flow file is identical either way, so which host runs it is an explicit choice rather than something that changes with whatever happens to be booted.

## Scope

Selection only. A remote flow run is still coordinate-only - selector steps, `await: { idle: true }` and `snapshot: { cropOn }` need a UI tree source that `ios-remote` does not have yet, and `launch:` maps still have no `ios-remote` key. Those are separate changes.

## Verification

End-to-end against a booted cloud simulator (`remote:73A22194-…`, iPhone 17 Pro / iOS 26.5) driven through the branch tool-server, with three local simulators and four Android emulators also up:

| Run | Result |
| --- | --- |
| `platform: "ios-remote"` | resolves `remote:73A22194-…`, flow passes |
| no platform | 8 booted devices listed, including `remote:73A22194-… (ios-remote, Booted)` - named by its id, not `?` |
| `platform: "ios"` | 3 local simulators only, the remote one absent |

`npm run build` and the tool-server suite pass.

## Docs

`flow-yaml.mdx` and the `argent flow run --help` text both list `ios-remote` and note that `ios` never picks a remote simulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting remote iOS simulators with `--platform ios-remote`.
  * Remote simulators are automatically detected when booted and identified by their device ID.
  * Local `ios` selection continues to target only local simulators.

* **Documentation**
  * Updated command-line help and flow documentation to describe remote iOS simulator support and platform selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->