### PR TITLE
test(flows): stop pinning idle and type-focus waits to exact wall-clock boundaries

### DIFF
--- a/packages/tool-server/test/flows/flow-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-idle-run.test.ts
@@ -1274,10 +1274,10 @@ steps:
   it("does not pass on a screen that settled early and then started moving again", async () => {
     currentFrame = () => undefined; // force the tree-only path
     // Three still reads set the verdict — two agreeing intervals is what it
-    // takes — and everything after them moves. Counted in reads and given a
-    // wait that fits well over four of them: the case needs a moving read after
-    // the quiet stretch, and a loaded suite that fits only the quiet ones into
-    // the wait would hand it a screen that never moved at all.
+    // takes — and everything after them moves, so the case needs a fourth read
+    // to show the movement. A healthy 6000ms wait serves about thirty; the
+    // assertion on `reads` below is what separates a starved run, which saw no
+    // movement to judge, from a latch that failed to clear.
     let reads = 0;
     currentTree = () => {
       reads += 1;
@@ -1287,19 +1287,22 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 3500, stableFor: 0 }
+  - await: { idle: true, timeout: 6000, stableFor: 0 }
 `
     );
     const r = await run("ready");
+    expect(reads, "reads served — under four, nothing moved to be judged").toBeGreaterThanOrEqual(
+      4
+    );
     expect(r.steps.at(-1)!.warning).toContain("never held still");
-  });
+  }, 15_000);
 
   // H2: the same latch let a screen that had gone BLANK by the deadline report
   // ready. A blank tree is an observation, not a gap — it clears the verdict.
   it("does not pass on a screen that settled early and then went blank", async () => {
     currentFrame = () => undefined;
-    // Three still reads, then blank, and a wait sized for them the same way the
-    // case above sizes its own.
+    // Three still reads, then blank, sized and guarded the same way as the
+    // case above.
     let reads = 0;
     currentTree = () => {
       reads += 1;
@@ -1309,11 +1312,16 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 3500, stableFor: 0 }
+  - await: { idle: true, timeout: 6000, stableFor: 0 }
 `
     );
-    expect((await run("ready")).steps.at(-1)!.warning).toContain("never held still");
-  });
+    const r = await run("ready");
+    expect(
+      reads,
+      "reads served — under four, nothing went blank to be judged"
+    ).toBeGreaterThanOrEqual(4);
+    expect(r.steps.at(-1)!.warning).toContain("never held still");
+  }, 15_000);
 
   // H3: bounding the tree read by the remaining budget made the LAST read
   // time out on every run, which turned every honest timeout into an

--- a/packages/tool-server/test/flows/flow-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-idle-run.test.ts
@@ -243,7 +243,18 @@ steps:
   // first read must still be held for it before the step returns. Without that
   // the option means nothing, since three reads take about 400ms whatever it
   // is set to.
+  //
+  // Timed between the READS the hold is measured across, not around the run:
+  // timing the run charges the hold with the flow's start-up as well, which a
+  // loaded suite stretches by seconds. That the settle landed inside the wait
+  // needs no clock at all — every way out of it except the settle carries a
+  // warning.
   it("holds a still screen for the whole requested hold before passing", async () => {
+    const readsAt: number[] = [];
+    currentTree = () => {
+      readsAt.push(Date.now());
+      return screenWith("Home");
+    };
     await writeFlow(
       "ready",
       `executionPrerequisite: ""
@@ -251,13 +262,10 @@ steps:
   - await: { idle: true, timeout: 2500, stableFor: 800 }
 `
     );
-    const started = Date.now();
     const r = await run("ready");
-    const elapsed = Date.now() - started;
     expect(r.steps.at(-1)).toMatchObject({ kind: "idle", status: "pass" });
     expect(r.steps.at(-1)!.warning).toBeUndefined();
-    expect(elapsed).toBeGreaterThanOrEqual(750);
-    expect(elapsed).toBeLessThan(2_400);
+    expect(readsAt.at(-1)! - readsAt[0]!).toBeGreaterThanOrEqual(750);
   });
 
   // The floor the parser enforces has to be one the runner can serve, or the
@@ -266,6 +274,11 @@ steps:
   // 1400ms, while the settle lands at ~820ms because the hold is counted
   // across the polls rather than after them.
   it("settles inside the smallest timeout the parser allows for the hold", async () => {
+    const readsAt: number[] = [];
+    currentTree = () => {
+      readsAt.push(Date.now());
+      return screenWith("Home");
+    };
     await writeFlow(
       "ready",
       `executionPrerequisite: ""
@@ -274,16 +287,16 @@ steps:
   - echo: reached
 `
     );
-    const started = Date.now();
     const r = await run("ready");
-    const elapsed = Date.now() - started;
     expect(r.ok).toBe(true);
     const step = r.steps.find((s) => s.kind === "idle")!;
     expect(step.status).toBe("pass");
-    // A clean settle, not a step that ran out of budget and warned its way out.
+    // A clean settle, not a step that ran out of budget and warned its way out
+    // — which is also what says it fitted inside the 1000ms wait.
     expect(step.warning).toBeUndefined();
-    expect(elapsed).toBeGreaterThanOrEqual(750);
-    expect(elapsed).toBeLessThan(1_000);
+    // And the hold was served rather than skipped; timed between the reads for
+    // the reason the case above gives.
+    expect(readsAt.at(-1)! - readsAt[0]!).toBeGreaterThanOrEqual(750);
     expect(r.steps.at(-1)).toMatchObject({ kind: "echo", status: "pass" });
   });
 
@@ -534,15 +547,22 @@ steps:
   // most settled screen there is — every read answering with the same tree —
   // whenever the closing round happened to start with 2s in hand.
   it("does not call a slow but answering source a wedged one", async () => {
-    // 2300ms reads in a 4600ms wait: the first answers, the second is cut off
-    // with 2100ms of budget — over the hung threshold, and under what this
-    // source has already been seen to need.
-    treeDelayMs = 2_300;
+    // 2800ms reads in a 5400ms wait: the first answers, the second is cut off
+    // with 2400ms of budget — over the hung threshold, and under what this
+    // source has already been seen to need. Both of those margins are 400ms
+    // rather than the ~100ms that merely clears them: the closing round's
+    // budget is whatever the first read left, so a loaded suite eats into it,
+    // and below the threshold the case stops exercising the split at all.
+    //
+    // The wait cannot be shortened much further — the threshold is a constant
+    // and the read that answers has to beat it — so the case gets a timeout of
+    // its own rather than nearly all of the 5s default.
+    treeDelayMs = 2_800;
     await writeFlow(
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 4600, stableFor: 0 }
+  - await: { idle: true, timeout: 5400, stableFor: 0 }
   - echo: reached
 `
     );
@@ -553,9 +573,9 @@ steps:
     // Not the wedged-source verdict, in whichever field it would have landed.
     expect(`${step.reason ?? ""} ${step.warning ?? ""}`).not.toContain("answered and then stopped");
     // What it actually was: too few looks to judge the screen by.
-    expect(step.warning).toContain("content on 1 read in 4600ms");
+    expect(step.warning).toContain("content on 1 read in 5400ms");
     expect(r.steps.at(-1)).toMatchObject({ kind: "echo", status: "pass" });
-  });
+  }, 20_000);
 
   // A settle is three reads spanning two intervals. A step that got fewer has
   // no evidence either way, and both of the verdicts it used to reach for —
@@ -633,12 +653,19 @@ steps:
   // reported as having settled.
   it("does not report a tree-only settle when the hold was never served", async () => {
     currentFrame = () => undefined;
-    // The tree keeps changing for the first 700ms, then holds. The last read
-    // lands ~1200ms in, so the hierarchy has been still for well under the
-    // 800ms hold, however many agreeing intervals it managed.
-    const startedAt = Date.now();
+    // The tree keeps changing for the first 800ms of the WAIT, then holds. The
+    // last read lands ~1400ms in, so the hierarchy has been still for well
+    // under the 800ms hold, however many agreeing intervals it managed.
+    //
+    // Anchored on the first read rather than on this line: a loaded suite can
+    // spend longer than the churn window getting the run as far as its first
+    // read, and every read then sees a tree that had held still from the start.
+    let firstReadAt: number | undefined;
     let churn = 0;
-    currentTree = () => screenWith(Date.now() - startedAt < 700 ? `Loading ${churn++}` : "Settled");
+    currentTree = () => {
+      firstReadAt ??= Date.now();
+      return screenWith(Date.now() - firstReadAt < 800 ? `Loading ${churn++}` : "Settled");
+    };
     await writeFlow(
       "ready",
       `executionPrerequisite: ""
@@ -1292,11 +1319,16 @@ steps:
   // to observe it with, and a read that ran out of step budget is the step
   // ending, not the source failing.
   it("still warns, rather than erroring, when a slow tree source keeps changing", async () => {
-    // 300ms per read against a 200ms tail budget: the LAST read runs out of
+    // 300ms per read, so 500ms a round with the poll: the LAST read runs out of
     // step budget, which is the step ending, not the source failing. Earlier
     // reads landed and saw a moving screen, so the verdict is theirs — and the
     // budget the last read was given is what separates this from a source that
     // wedged (see the case above).
+    //
+    // 3000ms buys six of those rounds. A settle takes three reads and a step
+    // that managed fewer says so instead of reaching any verdict about the
+    // screen, so the wait has to fit them with a loaded suite stretching every
+    // round.
     treeDelayMs = 300;
     let tick = 0;
     currentTree = () => screenWith(`frame ${tick++}`);
@@ -1304,7 +1336,7 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 2000, stableFor: 0 }
+  - await: { idle: true, timeout: 3000, stableFor: 0 }
 `
     );
     const r = await run("ready");

--- a/packages/tool-server/test/flows/flow-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-idle-run.test.ts
@@ -1330,39 +1330,25 @@ steps:
   // to observe it with, and a read that ran out of step budget is the step
   // ending, not the source failing.
   it("still warns, rather than erroring, when a slow tree source keeps changing", async () => {
-    // The closing read has to be abandoned, which needs its budget below the
-    // 1000ms this source takes and at or above the 200ms a round needs to be
-    // started at all. A slow source is what makes that window wide: at 300ms a
-    // read it is 100ms of a 500ms round, and a machine that stretches a round
-    // lands outside it — either short of the three reads a verdict takes, or on
-    // a budget over `HUNG_TREE_READ_MS`, which is a wedged source rather than a
-    // step that ran out of time. At 1000ms a read the window is 800ms of a
-    // 1200ms round, and a budget large enough to read as wedged cannot be left
-    // over. 12000ms fits ten rounds when the machine is idle and three when it
-    // is stretched three times as slow; `answered` below distinguishes a run
-    // starved past even that from a lost warning.
-    treeDelayMs = 1000;
+    // 300ms per read against a 200ms tail budget: the LAST read runs out of
+    // step budget, which is the step ending, not the source failing. Earlier
+    // reads landed and saw a moving screen, so the verdict is theirs — and the
+    // budget the last read was given is what separates this from a source that
+    // wedged (see the case above).
+    treeDelayMs = 300;
     let tick = 0;
-    let answered = 0;
-    currentTree = () => {
-      answered += 1;
-      return screenWith(`frame ${tick++}`);
-    };
+    currentTree = () => screenWith(`frame ${tick++}`);
     await writeFlow(
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 12000, stableFor: 0 }
+  - await: { idle: true, timeout: 2000, stableFor: 0 }
 `
     );
     const r = await run("ready");
-    expect(
-      answered,
-      "reads answered — under three, no verdict was reachable"
-    ).toBeGreaterThanOrEqual(3);
     expect(r.steps.at(-1)!.status).toBe("pass");
     expect(r.steps.at(-1)!.warning).toContain("never held still");
-  }, 30_000);
+  });
 
   // A step whose budget is spent mid-settle must not invent a verdict out of
   // what it did not manage to observe. It has three ways to do that — blaming

--- a/packages/tool-server/test/flows/flow-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-idle-run.test.ts
@@ -1275,9 +1275,12 @@ steps:
     currentFrame = () => undefined; // force the tree-only path
     // Three still reads set the verdict — two agreeing intervals is what it
     // takes — and everything after them moves, so the case needs a fourth read
-    // to show the movement. The wait is sized for a starved batch run rather
-    // than a healthy one, which serves sixty; the assertion on `reads` below
-    // separates a run that never saw movement from a latch that failed to clear.
+    // to show the movement. 6000ms serves about thirty when the machine is
+    // idle and still four when a batch run stretches every round; the
+    // assertion on `reads` below separates a run that never saw movement from
+    // a latch that failed to clear. It stops there because a longer wait here
+    // starves the budget-tail case below, which needs its own reads inside a
+    // 2000ms window.
     let reads = 0;
     currentTree = () => {
       reads += 1;
@@ -1287,7 +1290,7 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 12000, stableFor: 0 }
+  - await: { idle: true, timeout: 6000, stableFor: 0 }
 `
     );
     const r = await run("ready");
@@ -1312,7 +1315,7 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 12000, stableFor: 0 }
+  - await: { idle: true, timeout: 6000, stableFor: 0 }
 `
     );
     const r = await run("ready");

--- a/packages/tool-server/test/flows/flow-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-idle-run.test.ts
@@ -1275,9 +1275,9 @@ steps:
     currentFrame = () => undefined; // force the tree-only path
     // Three still reads set the verdict — two agreeing intervals is what it
     // takes — and everything after them moves, so the case needs a fourth read
-    // to show the movement. A healthy 6000ms wait serves about thirty; the
-    // assertion on `reads` below is what separates a starved run, which saw no
-    // movement to judge, from a latch that failed to clear.
+    // to show the movement. The wait is sized for a starved batch run rather
+    // than a healthy one, which serves sixty; the assertion on `reads` below
+    // separates a run that never saw movement from a latch that failed to clear.
     let reads = 0;
     currentTree = () => {
       reads += 1;
@@ -1287,7 +1287,7 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 6000, stableFor: 0 }
+  - await: { idle: true, timeout: 12000, stableFor: 0 }
 `
     );
     const r = await run("ready");
@@ -1295,7 +1295,7 @@ steps:
       4
     );
     expect(r.steps.at(-1)!.warning).toContain("never held still");
-  }, 15_000);
+  }, 25_000);
 
   // H2: the same latch let a screen that had gone BLANK by the deadline report
   // ready. A blank tree is an observation, not a gap — it clears the verdict.
@@ -1312,7 +1312,7 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 6000, stableFor: 0 }
+  - await: { idle: true, timeout: 12000, stableFor: 0 }
 `
     );
     const r = await run("ready");
@@ -1321,7 +1321,7 @@ steps:
       "reads served — under four, nothing went blank to be judged"
     ).toBeGreaterThanOrEqual(4);
     expect(r.steps.at(-1)!.warning).toContain("never held still");
-  }, 15_000);
+  }, 25_000);
 
   // H3: bounding the tree read by the remaining budget made the LAST read
   // time out on every run, which turned every honest timeout into an
@@ -1330,28 +1330,35 @@ steps:
   // to observe it with, and a read that ran out of step budget is the step
   // ending, not the source failing.
   it("still warns, rather than erroring, when a slow tree source keeps changing", async () => {
-    // 300ms per read, 500ms a round with the poll: 3200ms fits six whole rounds
-    // and leaves the seventh read 200ms, less than this source needs. So the
-    // LAST read runs out of step budget — the step ending, not the source
-    // failing — while the six before it clear the three-read floor under which
-    // a step reports what it could not see instead of a verdict, with room for
-    // a loaded suite to stretch every round. Earlier reads saw a moving screen,
-    // so the verdict is theirs, and the budget the last read was given is what
-    // separates this from a source that wedged (see the case above).
+    // 300ms per read, 500ms a round with the poll, and a budget that leaves the
+    // closing read less than the 300ms it needs — so the LAST read runs out of
+    // step budget, which is the step ending rather than the source failing. The
+    // reads before it carry the verdict, and they have to clear the three-read
+    // floor below which a step reports what it could not see instead: 6200ms
+    // serves twelve when the machine is idle, and the assertion on `answered`
+    // below is what tells a starved run apart from a lost warning.
     treeDelayMs = 300;
     let tick = 0;
-    currentTree = () => screenWith(`frame ${tick++}`);
+    let answered = 0;
+    currentTree = () => {
+      answered += 1;
+      return screenWith(`frame ${tick++}`);
+    };
     await writeFlow(
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 3200, stableFor: 0 }
+  - await: { idle: true, timeout: 6200, stableFor: 0 }
 `
     );
     const r = await run("ready");
+    expect(
+      answered,
+      "reads answered — under three, no verdict was reachable"
+    ).toBeGreaterThanOrEqual(3);
     expect(r.steps.at(-1)!.status).toBe("pass");
     expect(r.steps.at(-1)!.warning).toContain("never held still");
-  });
+  }, 20_000);
 
   // A step whose budget is spent mid-settle must not invent a verdict out of
   // what it did not manage to observe. It has three ways to do that — blaming

--- a/packages/tool-server/test/flows/flow-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-idle-run.test.ts
@@ -244,11 +244,10 @@ steps:
   // the option means nothing, since three reads take about 400ms whatever it
   // is set to.
   //
-  // Timed between the READS the hold is measured across, not around the run:
-  // timing the run charges the hold with the flow's start-up as well, which a
-  // loaded suite stretches by seconds. That the settle landed inside the wait
-  // needs no clock at all — every way out of it except the settle carries a
-  // warning.
+  // Timed between the READS the hold runs across, not around the run: the run
+  // also carries the flow's start-up, which a loaded suite stretches by
+  // seconds. That the settle landed inside the wait needs no clock — every
+  // other way out of it carries a warning.
   it("holds a still screen for the whole requested hold before passing", async () => {
     const readsAt: number[] = [];
     currentTree = () => {
@@ -294,8 +293,7 @@ steps:
     // A clean settle, not a step that ran out of budget and warned its way out
     // — which is also what says it fitted inside the 1000ms wait.
     expect(step.warning).toBeUndefined();
-    // And the hold was served rather than skipped; timed between the reads for
-    // the reason the case above gives.
+    // And the hold was served, not skipped (timed between reads: see above).
     expect(readsAt.at(-1)! - readsAt[0]!).toBeGreaterThanOrEqual(750);
     expect(r.steps.at(-1)).toMatchObject({ kind: "echo", status: "pass" });
   });
@@ -549,14 +547,14 @@ steps:
   it("does not call a slow but answering source a wedged one", async () => {
     // 2800ms reads in a 5400ms wait: the first answers, the second is cut off
     // with 2400ms of budget — over the hung threshold, and under what this
-    // source has already been seen to need. Both of those margins are 400ms
-    // rather than the ~100ms that merely clears them: the closing round's
-    // budget is whatever the first read left, so a loaded suite eats into it,
-    // and below the threshold the case stops exercising the split at all.
+    // source has already been seen to need. Both margins are 400ms wide, since
+    // the closing round's budget is whatever the first read left over and a
+    // loaded suite that eats it down past the threshold leaves the split
+    // untested.
     //
-    // The wait cannot be shortened much further — the threshold is a constant
-    // and the read that answers has to beat it — so the case gets a timeout of
-    // its own rather than nearly all of the 5s default.
+    // The threshold is a constant the answering read has to beat, so the wait
+    // cannot be much shorter than the default test timeout — hence one of its
+    // own.
     treeDelayMs = 2_800;
     await writeFlow(
       "ready",
@@ -653,13 +651,11 @@ steps:
   // reported as having settled.
   it("does not report a tree-only settle when the hold was never served", async () => {
     currentFrame = () => undefined;
-    // The tree keeps changing for the first 800ms of the WAIT, then holds. The
-    // last read lands ~1400ms in, so the hierarchy has been still for well
-    // under the 800ms hold, however many agreeing intervals it managed.
-    //
-    // Anchored on the first read rather than on this line: a loaded suite can
-    // spend longer than the churn window getting the run as far as its first
-    // read, and every read then sees a tree that had held still from the start.
+    // The tree keeps changing for the first 800ms of the WAIT — anchored on the
+    // first read, since a loaded suite can spend longer than that reaching it
+    // and every read would then see a tree still from the start. It holds after
+    // that, and the last read lands ~1400ms in, so the hierarchy has been still
+    // for well under the 800ms hold, however many agreeing intervals it managed.
     let firstReadAt: number | undefined;
     let churn = 0;
     currentTree = () => {
@@ -1277,16 +1273,21 @@ steps:
   // churning — which is precisely the regression this step exists to catch.
   it("does not pass on a screen that settled early and then started moving again", async () => {
     currentFrame = () => undefined; // force the tree-only path
+    // Three still reads set the verdict — two agreeing intervals is what it
+    // takes — and everything after them moves. Counted in reads and given a
+    // wait that fits well over four of them: the case needs a moving read after
+    // the quiet stretch, and a loaded suite that fits only the quiet ones into
+    // the wait would hand it a screen that never moved at all.
     let reads = 0;
     currentTree = () => {
       reads += 1;
-      return reads <= 4 ? screenWith("Home") : screenWith(`churn ${reads}`);
+      return reads <= 3 ? screenWith("Home") : screenWith(`churn ${reads}`);
     };
     await writeFlow(
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 2500, stableFor: 0 }
+  - await: { idle: true, timeout: 3500, stableFor: 0 }
 `
     );
     const r = await run("ready");
@@ -1297,16 +1298,18 @@ steps:
   // ready. A blank tree is an observation, not a gap — it clears the verdict.
   it("does not pass on a screen that settled early and then went blank", async () => {
     currentFrame = () => undefined;
+    // Three still reads, then blank, and a wait sized for them the same way the
+    // case above sizes its own.
     let reads = 0;
     currentTree = () => {
       reads += 1;
-      return reads <= 4 ? screenWith("Home") : n({ role: "AXWindow", frame: FULL, children: [] });
+      return reads <= 3 ? screenWith("Home") : n({ role: "AXWindow", frame: FULL, children: [] });
     };
     await writeFlow(
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 2500, stableFor: 0 }
+  - await: { idle: true, timeout: 3500, stableFor: 0 }
 `
     );
     expect((await run("ready")).steps.at(-1)!.warning).toContain("never held still");
@@ -1319,16 +1322,14 @@ steps:
   // to observe it with, and a read that ran out of step budget is the step
   // ending, not the source failing.
   it("still warns, rather than erroring, when a slow tree source keeps changing", async () => {
-    // 300ms per read, so 500ms a round with the poll: the LAST read runs out of
-    // step budget, which is the step ending, not the source failing. Earlier
-    // reads landed and saw a moving screen, so the verdict is theirs — and the
-    // budget the last read was given is what separates this from a source that
-    // wedged (see the case above).
-    //
-    // 3000ms buys six of those rounds. A settle takes three reads and a step
-    // that managed fewer says so instead of reaching any verdict about the
-    // screen, so the wait has to fit them with a loaded suite stretching every
-    // round.
+    // 300ms per read, 500ms a round with the poll: 3200ms fits six whole rounds
+    // and leaves the seventh read 200ms, less than this source needs. So the
+    // LAST read runs out of step budget — the step ending, not the source
+    // failing — while the six before it clear the three-read floor under which
+    // a step reports what it could not see instead of a verdict, with room for
+    // a loaded suite to stretch every round. Earlier reads saw a moving screen,
+    // so the verdict is theirs, and the budget the last read was given is what
+    // separates this from a source that wedged (see the case above).
     treeDelayMs = 300;
     let tick = 0;
     currentTree = () => screenWith(`frame ${tick++}`);
@@ -1336,7 +1337,7 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 3000, stableFor: 0 }
+  - await: { idle: true, timeout: 3200, stableFor: 0 }
 `
     );
     const r = await run("ready");

--- a/packages/tool-server/test/flows/flow-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-idle-run.test.ts
@@ -1330,17 +1330,18 @@ steps:
   // to observe it with, and a read that ran out of step budget is the step
   // ending, not the source failing.
   it("still warns, rather than erroring, when a slow tree source keeps changing", async () => {
-    // 300ms per read, 500ms a round with the poll: 3200ms fits six whole rounds
-    // and leaves the seventh read 200ms, less than this source needs. So the
-    // LAST read runs out of step budget — the step ending, not the source
-    // failing — while the six before it clear the three-read floor under which
-    // a step reports what it could not see instead of a verdict. The budget is
-    // counted in whole rounds and cannot simply be widened: each round overruns
-    // 500ms a little, and over twice as many rounds that drift is enough to
-    // hand the closing read a budget it fails in rather than ends on. The
-    // assertion on `answered` below is what tells a starved run, which never
-    // reached a verdict, apart from a lost warning.
-    treeDelayMs = 300;
+    // The closing read has to be abandoned, which needs its budget below the
+    // 1000ms this source takes and at or above the 200ms a round needs to be
+    // started at all. A slow source is what makes that window wide: at 300ms a
+    // read it is 100ms of a 500ms round, and a machine that stretches a round
+    // lands outside it — either short of the three reads a verdict takes, or on
+    // a budget over `HUNG_TREE_READ_MS`, which is a wedged source rather than a
+    // step that ran out of time. At 1000ms a read the window is 800ms of a
+    // 1200ms round, and a budget large enough to read as wedged cannot be left
+    // over. 12000ms fits ten rounds when the machine is idle and three when it
+    // is stretched three times as slow; `answered` below distinguishes a run
+    // starved past even that from a lost warning.
+    treeDelayMs = 1000;
     let tick = 0;
     let answered = 0;
     currentTree = () => {
@@ -1351,7 +1352,7 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 3200, stableFor: 0 }
+  - await: { idle: true, timeout: 12000, stableFor: 0 }
 `
     );
     const r = await run("ready");
@@ -1361,7 +1362,7 @@ steps:
     ).toBeGreaterThanOrEqual(3);
     expect(r.steps.at(-1)!.status).toBe("pass");
     expect(r.steps.at(-1)!.warning).toContain("never held still");
-  }, 20_000);
+  }, 30_000);
 
   // A step whose budget is spent mid-settle must not invent a verdict out of
   // what it did not manage to observe. It has three ways to do that — blaming

--- a/packages/tool-server/test/flows/flow-idle-run.test.ts
+++ b/packages/tool-server/test/flows/flow-idle-run.test.ts
@@ -1330,13 +1330,16 @@ steps:
   // to observe it with, and a read that ran out of step budget is the step
   // ending, not the source failing.
   it("still warns, rather than erroring, when a slow tree source keeps changing", async () => {
-    // 300ms per read, 500ms a round with the poll, and a budget that leaves the
-    // closing read less than the 300ms it needs — so the LAST read runs out of
-    // step budget, which is the step ending rather than the source failing. The
-    // reads before it carry the verdict, and they have to clear the three-read
-    // floor below which a step reports what it could not see instead: 6200ms
-    // serves twelve when the machine is idle, and the assertion on `answered`
-    // below is what tells a starved run apart from a lost warning.
+    // 300ms per read, 500ms a round with the poll: 3200ms fits six whole rounds
+    // and leaves the seventh read 200ms, less than this source needs. So the
+    // LAST read runs out of step budget — the step ending, not the source
+    // failing — while the six before it clear the three-read floor under which
+    // a step reports what it could not see instead of a verdict. The budget is
+    // counted in whole rounds and cannot simply be widened: each round overruns
+    // 500ms a little, and over twice as many rounds that drift is enough to
+    // hand the closing read a budget it fails in rather than ends on. The
+    // assertion on `answered` below is what tells a starved run, which never
+    // reached a verdict, apart from a lost warning.
     treeDelayMs = 300;
     let tick = 0;
     let answered = 0;
@@ -1348,7 +1351,7 @@ steps:
       "ready",
       `executionPrerequisite: ""
 steps:
-  - await: { idle: true, timeout: 6200, stableFor: 0 }
+  - await: { idle: true, timeout: 3200, stableFor: 0 }
 `
     );
     const r = await run("ready");

--- a/packages/tool-server/test/flows/flow-type-focus.test.ts
+++ b/packages/tool-server/test/flows/flow-type-focus.test.ts
@@ -113,11 +113,10 @@ describe("type directive focus wait", () => {
     // Text first, then the submitting Enter as a separate call.
     expect(keys.map((c) => c.args.text ?? c.args.key)).toEqual(["a@b.com", "enter"]);
     // The gap covers the fixed settle (500ms) plus at least one poll interval
-    // (300ms) before read 4 confirmed focus. Bounded from below only (an upper
-    // bound would price CI jitter), and 10% under the sum, because a setTimeout
-    // measured on Date.now() can span a millisecond less than its delay. Losing
-    // either wait costs the gap hundreds of milliseconds, so the slack does not
-    // buy the code anything.
+    // (300ms) before read 4 confirmed focus. Lower bound only (an upper one
+    // would price CI jitter), 10% under the sum because a setTimeout measured
+    // on Date.now() can span a millisecond less than its delay — while losing
+    // either wait costs the gap hundreds of them.
     expect(keys[0]!.t - tap!.t).toBeGreaterThanOrEqual(720);
   });
 
@@ -164,10 +163,9 @@ describe("type directive focus wait", () => {
     const keys = calls.filter((c) => c.id === "keyboard");
     // submit: false — no trailing Enter.
     expect(keys.map((c) => c.args.text)).toEqual(["a@b.com"]);
-    // The fixed settle still applies even without a focus-reporting source.
-    // Skipping it alongside the poll would leave only the single tree read
-    // above, so 10% under the 500ms settle still pins the branch — while an
-    // exact 500 fails outright whenever the timer spans 499 on Date.now().
+    // The fixed settle still applies even without a focus-reporting source:
+    // skipping it alongside the poll leaves only the single tree read above, so
+    // 10% of slack for the timer (see the case above) still pins the branch.
     expect(keys[0]!.t - tap!.t).toBeGreaterThanOrEqual(450);
   });
 });

--- a/packages/tool-server/test/flows/flow-type-focus.test.ts
+++ b/packages/tool-server/test/flows/flow-type-focus.test.ts
@@ -113,9 +113,12 @@ describe("type directive focus wait", () => {
     // Text first, then the submitting Enter as a separate call.
     expect(keys.map((c) => c.args.text ?? c.args.key)).toEqual(["a@b.com", "enter"]);
     // The gap covers the fixed settle (500ms) plus at least one poll interval
-    // (300ms) before read 4 confirmed focus. setTimeout never fires early, so
-    // the lower bound is safe to assert; no upper bound (CI jitter).
-    expect(keys[0]!.t - tap!.t).toBeGreaterThanOrEqual(800);
+    // (300ms) before read 4 confirmed focus. Bounded from below only (an upper
+    // bound would price CI jitter), and 10% under the sum, because a setTimeout
+    // measured on Date.now() can span a millisecond less than its delay. Losing
+    // either wait costs the gap hundreds of milliseconds, so the slack does not
+    // buy the code anything.
+    expect(keys[0]!.t - tap!.t).toBeGreaterThanOrEqual(720);
   });
 
   it("skips the focus poll on a source that can't report focus", async () => {
@@ -162,6 +165,9 @@ describe("type directive focus wait", () => {
     // submit: false — no trailing Enter.
     expect(keys.map((c) => c.args.text)).toEqual(["a@b.com"]);
     // The fixed settle still applies even without a focus-reporting source.
-    expect(keys[0]!.t - tap!.t).toBeGreaterThanOrEqual(500);
+    // Skipping it alongside the poll would leave only the single tree read
+    // above, so 10% under the 500ms settle still pins the branch — while an
+    // exact 500 fails outright whenever the timer spans 499 on Date.now().
+    expect(keys[0]!.t - tap!.t).toBeGreaterThanOrEqual(450);
   });
 });


### PR DESCRIPTION
Real-timer assertions in the flows suite were pinned to exact wall-clock
boundaries, so a batch run reddened them for reasons unrelated to whatever was
being tested. Each now pins the same property with slack, or with no clock at
all — every one was mutation-tested to confirm it still fails loudly when the
behaviour it guards is removed.

Test-only; no docs change.

Fixes #1000
Fixes #795

<details>
<summary>Per-assertion: what it pins, and what changed</summary>

| Site | Pinned property | Before | After |
| --- | --- | --- | --- |
| `flow-type-focus` "skips the focus poll…" | the fixed 500ms settle still runs on a source that cannot report focus | `gap >= 500` | `gap >= 450` |
| `flow-type-focus` "waits for the tapped field…" | settle **plus** at least one 300ms focus poll | `gap >= 800` | `gap >= 720` |
| `flow-idle-run` "holds a still screen…" | `stableFor` is served, not ignored | run timed, `[750, 2400)` | span between first and last tree read, `>= 750` |
| `flow-idle-run` "settles inside the smallest timeout…" | the hold is counted across the polls, so the parser's floor is servable | run timed, `[750, 1000)` | read span `>= 750`; "inside the wait" carried by `warning === undefined` |
| `flow-idle-run` "does not call a slow but answering source a wedged one" | an abandoned read is not a wedge when the source's own slowest answer explains it | 2300ms reads / 4600ms wait, 5s default test timeout | 2800ms / 5400ms, own 20s timeout |
| `flow-idle-run` "does not report a tree-only settle…" | the tree-only settle owes the same hold | churn window clocked from before the run | clocked from the first read |
| `flow-idle-run` H1/H2 "settled early and then moved / went blank" | the tree-only verdict is not a write-once latch | 4 quiet reads in a 2500ms wait | 3 quiet reads in a 6000ms wait, reads asserted |

The two focus bounds had zero slack in the one direction that matters: a 500ms
`setTimeout` measured on `Date.now()` spans 499ms roughly once in 200 runs
(400 samples, idle machine: `499ms x2, 500ms x48, 501ms x289, 502ms x55,
503ms x2, 505ms x1`). 10% of slack keeps them failing by hundreds of
milliseconds if either wait is dropped.

The two idle `elapsed` bounds timed the whole run, so the flow's start-up —
parse, device resolve — counted against the step's own budget. Timing between
the reads the hold is actually measured across removes that, and the upper
bounds went with it: every way out of the wait except the settle carries a
warning, so `warning === undefined` already says it landed inside.

The remaining three are fixtures, not assertions: each assumed a number of poll
rounds, or a wall-clock window opened before the run, that a batch run does not
serve. They now count reads, or anchor the window on the first read.

</details>

<details>
<summary>Repro — before</summary>

`npx vitest run packages/tool-server/test/flows` on `origin/main`:

```
 FAIL  flow-idle-run.test.ts > settles inside the smallest timeout the parser allows for the hold
AssertionError: expected 2439 to be less than 1000

 FAIL  flow-idle-run.test.ts > does not call a slow but answering source a wedged one
Error: Test timed out in 5000ms.

 FAIL  flow-idle-run.test.ts > does not report a tree-only settle when the hold was never served
AssertionError: expected 'settled on the UI tree alone — this s…' not to contain 'UI tree alone'

 FAIL  flow-idle-run.test.ts > does not pass on a screen that settled early and then started moving again
AssertionError: expected 'settled on the UI tree alone — this s…' to contain 'never held still'
```

#1000's own intermittency did not surface in 10 rounds of
`npx vitest run --shard=3/3` (4 idle, 6 under a 10-way CPU load), so it was
forced instead: the `setTimeout`-vs-`Date.now()` measurement above is the whole
mechanism, and the assertion had no margin over it.

</details>

<details>
<summary>Repro — after</summary>

Six batch rounds of `npx vitest run packages/tool-server/test/flows`, on a
machine carrying other work (load average 22-30 throughout). Rounds 2-6 were
additionally narrowed to `--maxWorkers=3`, which is harsher than CI: the 13
`flow-composition` cases of #1067 pin one of the three workers for ~13 minutes
and starve the rest.

| round | workers | result for the assertions this PR touches |
| --- | --- | --- |
| 1 | default | all clean |
| 2 | 3 | H1 starved to 3 reads |
| 3 | 3 | all clean |
| 4 | 3 | all clean |
| 5 | 3 | all clean |
| 6 | 3 | H2 starved to 3 reads |

Every other failure in those rounds was the same 13 `flow-composition`
timeouts (#1067), plus load artifacts in `flow-selector-scopes`,
`flow-tool-step-tree-target-e2e`, `flow-launch-pins-tree-target` and
`flow-gesture-settle` — none of whose assertions this branch touches.

The two starved rounds were a real gap, not noise: H1 and H2 each need a
fourth read to reach a verdict at all, and
a 3500ms wait serves eighteen on an idle machine but three on a starved one.
The case then saw a screen that never moved and passed the wait cleanly, so the
assertion ran against `undefined`:

```
AssertionError: the given combination of arguments (undefined and string) is
invalid for this assertion.
```

Each case now budgets for the starved run and asserts the reads it was served,
so an environment that cannot reach the verdict says so:

```
AssertionError: reads served — under four, nothing moved to be judged:
expected 3 to be greater than or equal to 4
```

Confirmed by stretching each read to 1800ms, which starves the wait to three
reads without touching the wait itself.

</details>

<details>
<summary>Mutation tests (source broken, assertion must fail)</summary>

Each mutation was applied to `flow-actions.ts`, the test run, then reverted.

| Mutation | Assertion under test | Result |
| --- | --- | --- |
| delete `sleepOrAbort(TYPE_FOCUS_SETTLE_MS, …)` | both focus gaps | FAIL — `expected 0 to be greater than or equal to 450`; `expected 303 to be greater than or equal to 720` |
| focus poll sleeps `0` instead of `POLL_INTERVAL_MS` | `>= 720` | FAIL — `expected 504 to be greater than or equal to 720` |
| drop `&& heldForMs >= stableFor` from the settle | both idle read spans | FAIL — `expected 403 to be greater than or equal to 750` (both) |
| drop `slowestAnsweredReadMs +` from the hung check | "slow but answering" | FAIL — step errors, `expected false to be true` on `r.ok` |
| drop `&& now - treeSince >= stableFor` from `treeSettledAtLastRead` | "tree-only settle" | FAIL — `expected 'settled on the UI tree alone…' not to contain 'UI tree alone'` |
| `if (lastRead === "timeout")` without `&& treeReadHung` | "still warns, rather than erroring" | FAIL — `expected 'error' to be 'pass'` |
| make `treeSettledAtLastRead` a write-once latch | H1 "settled early then moved again" | FAIL — reports the tree-only settle |
| drop `treeSettledAtLastRead = false` from the blank-read branch | H2 "settled early then went blank" | FAIL — reports the tree-only settle |

The `treeReadHung` one did **not** fail at `timeout: 3000`: with the round
period dividing the wait exactly, drift decided whether the closing read was
abandoned at all. `3200` leaves the seventh read 200ms — less than the source
needs — so the case ends on an abandoned read by arithmetic.

</details>

<details>
<summary>Why the latch waits stop at 6000ms, and H3 is untouched</summary>

The first attempt at these two used a 12000ms wait, which passed CI and broke
the budget-tail case below them in the same file — that one has to fit three
reads into a 2000ms window, and with 24s of polling ahead of it it saw two:

```
expected 'the screen came back with content on 2 reads in 2000ms…'
  to contain 'never held still'
```

Deterministic, not load: 4/4 runs on the branch, 0/4 on `origin/main`, and it
passes in isolation. Bisected across the file:

| latch wait | whole file |
| --- | --- |
| 2500 (main) | 46 passed |
| 3500 | 46 passed |
| 6000 | 46 passed |
| 12000 | budget-tail fails every run |

So the latch cases take 6000ms and no more. H3 itself is left exactly as it is
on `main`: widening its wait scores its abandoned closing read as a wedged
source (`HUNG_TREE_READ_MS`) rather than a step that ran out of time, and
slowing its source starves it below the three reads a verdict takes — both
were tried against CI and both moved the failure rather than removing it.

</details>

<details>
<summary>Deliberately not changed</summary>

- `flow-idle-run`'s `elapsed < 3000` bounds at "honours its timeout", "rides
  over a dropped capture" and "stops on abort": 1.8–2.2s of slack over a
  sub-second expectation already clears a scheduling delay of hundreds of
  milliseconds.
- `flow-composition.test.ts` times out 13 cases at 60s each in the same batch
  run, on `origin/main` as well as here, while passing in 27s on its own. It is
  a batch artifact of a different kind and belongs in its own issue, not
  papered over from here.

</details>