### PR TITLE
fix(windows): pass windowsHide on every console-subsystem spawn the tool-server makes

### DIFF
--- a/packages/argent-tools-client/src/launcher.ts
+++ b/packages/argent-tools-client/src/launcher.ts
@@ -310,6 +310,12 @@ export function spawnToolsServer(
       detached: true,
       stdio: ["ignore", "pipe", logFd],
       env: buildToolsServerEnv(paths, port, process.env, options),
+      // `detached: true` on Windows gives node.exe (a console-subsystem
+      // binary) its own console window — this is the ONE persistent popup
+      // that stays open for the tool-server's whole lifetime, distinct from
+      // the many short-lived adb.exe popups fixed in @argent/tool-server.
+      // No-op off Windows.
+      windowsHide: true,
     });
 
     child.unref();

--- a/packages/tool-server/src/blueprints/android-devtools.ts
+++ b/packages/tool-server/src/blueprints/android-devtools.ts
@@ -88,7 +88,14 @@ async function spawnHelper(serial: string): Promise<SpawnedHelper> {
   const proc = spawn(
     adbPath,
     ["-s", serial, "shell", "am", "instrument", "-w", manifest.instrumentationRunner],
-    { stdio: ["ignore", "pipe", "pipe"] }
+    {
+      stdio: ["ignore", "pipe", "pipe"],
+      // No-op off Windows. On Windows this is the adb spawn behind every
+      // Android `describe` call (this helper backs the accessibility tree) —
+      // without it, each one pops its own console window. See utils/adb.ts
+      // for the same fix on the rest of the adb call sites.
+      windowsHide: true,
+    }
   );
 
   return new Promise<SpawnedHelper>((resolve, reject) => {

--- a/packages/tool-server/src/tools/devices/boot-device.ts
+++ b/packages/tool-server/src/tools/devices/boot-device.ts
@@ -641,6 +641,10 @@ async function attemptBoot(params: {
   const child = spawn(params.emulatorBinary, params.emulatorArgs, {
     detached: true,
     stdio,
+    // `detached: true` on Windows gives the child its own console window
+    // unless this is also set — without it, every boot pops an extra cmd
+    // window alongside the emulator's own GUI window. No-op off Windows.
+    windowsHide: true,
   });
   child.unref();
   // The child holds its own handle for the log fd; close the parent's copy so a

--- a/packages/tool-server/src/tools/devices/boot-electron.ts
+++ b/packages/tool-server/src/tools/devices/boot-electron.ts
@@ -298,6 +298,9 @@ export async function bootElectronApp(options: BootElectronOptions): Promise<Ele
       // Electron-based MCP host it would boot the binary in Node mode with no
       // CDP endpoint, failing boot-device instead of bringing the app up.
       env: electronGuiChildEnv({ ELECTRON_ENABLE_LOGGING: "1" }),
+      // `detached: true` on Windows otherwise gives the child its own console
+      // window in addition to the Electron app's real window. No-op off Windows.
+      windowsHide: true,
     });
   } catch (err) {
     throw new FailureError(

--- a/packages/tool-server/src/tools/system/update-argent.ts
+++ b/packages/tool-server/src/tools/system/update-argent.ts
@@ -228,6 +228,11 @@ export const updateArgentTool: ToolDefinition<{
         detached: true,
         stdio: "ignore",
         env: { ...process.env, ARGENT_UPDATE_TRIGGER: "mcp_update" },
+        // `detached: true` on Windows otherwise pops a console window for the
+        // updater — worse here than most spawns in this codebase, since a bare
+        // "argent" resolves to argent.cmd, which Windows already routes
+        // through cmd.exe. No-op off Windows.
+        windowsHide: true,
       });
       // Without an error listener a spawn failure (ENOENT when `argent` isn't
       // on PATH — the norm in local mode) crashes the tool-server. The next

--- a/packages/tool-server/src/utils/adb.ts
+++ b/packages/tool-server/src/utils/adb.ts
@@ -98,6 +98,10 @@ export async function emulatorSupportsFlag(
       // this await has no deadline of its own.
       killSignal: "SIGKILL",
       maxBuffer: 8 * 1024 * 1024,
+      // No-op off Windows. On Windows, a console-subsystem child (emulator.exe)
+      // spawned from a console-less parent (the detached tool-server) otherwise
+      // gets its own popup console window — see runAdb below for the same fix.
+      windowsHide: true,
     });
     output = stdout + stderr;
   } catch (err) {
@@ -207,6 +211,12 @@ export async function runAdb(
       killSignal: ADB_KILL_SIGNAL,
       maxBuffer: 64 * 1024 * 1024,
       encoding: "utf-8",
+      // Every gesture-tap / screenshot / describe call on Android routes
+      // through here. Without this, each one pops a fresh console window on
+      // Windows — adb.exe is a console-subsystem binary, and the tool-server
+      // (a detached background process with no console of its own) is exactly
+      // the parent shape Windows does that for. No-op on macOS/Linux.
+      windowsHide: true,
     });
     return { stdout, stderr };
   } catch (err) {
@@ -228,6 +238,8 @@ async function runAdbBinary(args: string[], options: { timeoutMs?: number } = {}
       killSignal: ADB_KILL_SIGNAL,
       maxBuffer: 64 * 1024 * 1024,
       encoding: "buffer",
+      // See runAdb above — same popup-console fix, same no-op off Windows.
+      windowsHide: true,
     });
     return stdout as unknown as Buffer;
   } catch (err) {
@@ -671,6 +683,7 @@ export async function listAvds(): Promise<AvdInfo[]> {
     const { stdout } = await execFileAsync(emulatorPath, ["-list-avds"], {
       timeout: 5_000,
       killSignal: "SIGKILL",
+      windowsHide: true,
     });
     return stdout
       .split("\n")
@@ -715,6 +728,7 @@ export async function checkSnapshotLoadable(
       timeout: options.timeoutMs ?? 10_000,
       killSignal: "SIGKILL",
       maxBuffer: 4 * 1024 * 1024,
+      windowsHide: true,
     });
     const tail = stdout.split("\n").slice(-6).join("\n");
     // "WARNING | change of renderer detected" is noise; real incompatibility

--- a/packages/tool-server/src/utils/android-profiler/capture.ts
+++ b/packages/tool-server/src/utils/android-profiler/capture.ts
@@ -96,7 +96,13 @@ export async function startPerfetto(opts: StartPerfettoOptions): Promise<StartPe
    * stdin and the PID comes back on stdout, so the argv substitution `runAdb`
    * would have applied has to be applied here.
    */
-  const child = spawn(adbPath, adbArgv(args), { stdio: ["pipe", "pipe", "pipe"] });
+  const child = spawn(adbPath, adbArgv(args), {
+    stdio: ["pipe", "pipe", "pipe"],
+    // No-op off Windows; on Windows this bypasses runAdb's windowsHide (needed
+    // here for the stdin/stdout streaming this spawn depends on), so it would
+    // otherwise pop its own console window like the calls in ../adb.ts did.
+    windowsHide: true,
+  });
 
   let stdout = "";
   let stderr = "";

--- a/packages/tool-server/test/adb-hardening.test.ts
+++ b/packages/tool-server/test/adb-hardening.test.ts
@@ -30,7 +30,7 @@ vi.mock("../src/utils/android-binary", () => ({
   __resetAndroidBinaryCacheForTesting: () => {},
 }));
 
-import { checkSnapshotLoadable, listAndroidDevices, listAvds } from "../src/utils/adb";
+import { checkSnapshotLoadable, listAndroidDevices, listAvds, runAdb } from "../src/utils/adb";
 
 beforeEach(() => {
   execFileMock.mockReset();
@@ -175,6 +175,47 @@ describe("listAvds noise filter (review #9)", () => {
     });
     const avds = await listAvds();
     expect(avds.map((a) => a.name)).toEqual(["Pixel_7_API_34", "Pixel_3a_API_29"]);
+  });
+});
+
+describe("windowsHide (Windows console-popup fix)", () => {
+  /**
+   * Every adb/emulator spawn behind runAdb, listAvds and checkSnapshotLoadable
+   * must pass windowsHide: true. Without it, a console-subsystem binary
+   * (adb.exe, emulator.exe) spawned from the tool-server — a detached
+   * background process with no console of its own — gets a fresh popup
+   * console window on Windows for every call. The option is a documented
+   * no-op on macOS/Linux, so this is safe everywhere.
+   */
+
+  it("runAdb passes windowsHide: true", async () => {
+    execFileMock.mockReturnValue({ stdout: "", stderr: "" });
+    await runAdb(["devices"]);
+    expect(execFileMock).toHaveBeenCalledWith(
+      "adb",
+      ["devices"],
+      expect.objectContaining({ windowsHide: true })
+    );
+  });
+
+  it("listAvds passes windowsHide: true", async () => {
+    execFileMock.mockReturnValue({ stdout: "", stderr: "" });
+    await listAvds();
+    expect(execFileMock).toHaveBeenCalledWith(
+      "emulator",
+      ["-list-avds"],
+      expect.objectContaining({ windowsHide: true })
+    );
+  });
+
+  it("checkSnapshotLoadable passes windowsHide: true", async () => {
+    execFileMock.mockReturnValue({ stdout: "Loadable\n", stderr: "" });
+    await checkSnapshotLoadable("Pixel_7_API_34");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "emulator",
+      expect.arrayContaining(["-check-snapshot-loadable"]),
+      expect.objectContaining({ windowsHide: true })
+    );
   });
 });
 

--- a/packages/tool-server/test/update-argent-tool.test.ts
+++ b/packages/tool-server/test/update-argent-tool.test.ts
@@ -132,6 +132,7 @@ describe("update-argent tool", () => {
         detached: true,
         stdio: "ignore",
         env: { ...process.env, ARGENT_UPDATE_TRIGGER: "mcp_update" },
+        windowsHide: true,
       }
     );
   });


### PR DESCRIPTION
## Summary

On Windows, every Android tool call — gesture-tap, screenshot, describe, list-devices, boot-device — pops a console window. Root cause: the tool-server is a detached background process with no console of its own, and it spawns console-subsystem binaries (`adb.exe`, `emulator.exe`) without `windowsHide`, which is exactly the parent/child shape Windows allocates a fresh popup console for.

- `utils/adb.ts` is the chokepoint nearly all Android tools route through (`runAdb`, `runAdbBinary`, `listAvds`, `checkSnapshotLoadable`, `emulatorSupportsFlag`) — none of its 5 `execFileAsync` call sites passed `windowsHide`.
- Three more spots use `spawn(..., { detached: true, ... })`: `boot-device.ts` (emulator launch), `boot-electron.ts` (Electron/Chromium launch), `update-argent.ts` (self-update). Node's own docs note a detached child gets its own console window on Windows unless `windowsHide` is also set — same bug, different call shape.
- `android-devtools.ts`'s `am instrument` spawn (the accessibility-helper injection behind every Android `describe`) and `android-profiler/capture.ts`'s raw adb spawn (bypasses `runAdb` for its stdin/stdout streaming) both spawn `adb` directly, outside `adb.ts`.

`windowsHide` is a documented no-op on macOS/Linux, so this only changes behavior on win32.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test -w @argent/tool-server -- adb-hardening android-adb` — 21/21 pass, including 3 new tests
- [x] Added regression tests (`windowsHide (Windows console-popup fix)` in `adb-hardening.test.ts`) pinning that `runAdb`, `listAvds`, and `checkSnapshotLoadable` pass `windowsHide: true` to `execFile`, so a future edit can't silently drop it
- [x] Full `npm test -w @argent/tool-server` — same 180 pre-existing failures on this branch as on a clean `main` checkout (verified via `git stash` A/B on the same machine — all Windows-environment issues unrelated to this change, mostly Unix-domain-socket tests that don't run on win32); zero new failures
- [x] `npx prettier --check` on all changed files — clean
- [x] `npm run knip` (both passes) — clean
- [x] Manually reproduced against a real Android emulator on Windows 11 (Claude Code + this tool-server) before the fix — every `gesture-tap`/`screenshot`/`describe` call visibly flashed a console window and stole focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_015SGhQu3bo4AetFZaxMpxER