### PR TITLE
test(configuration-core): guard the detached tmpdir removal in secrets tests

### DIFF
--- a/packages/configuration-core/tests/secrets.test.ts
+++ b/packages/configuration-core/tests/secrets.test.ts
@@ -76,10 +76,13 @@ describe("dedicated secrets files", () => {
   it("exposes every key in the global file, which needs no project", () => {
     write(globalSecrets(), "APP_PASSWORD=from-home\n");
     const detached = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-detached-")));
-    expect(
-      lookupSecret("APP_PASSWORD", secretSources({ cwd: detached, homeDir, env: NO_ENV }))
-    ).toBe("from-home");
-    fs.rmSync(detached, { recursive: true, force: true });
+    try {
+      expect(
+        lookupSecret("APP_PASSWORD", secretSources({ cwd: detached, homeDir, env: NO_ENV }))
+      ).toBe("from-home");
+    } finally {
+      fs.rmSync(detached, { recursive: true, force: true });
+    }
   });
 
   it("accepts a redundant ARGENT_SECRET_ prefix on a key", () => {
@@ -173,9 +176,15 @@ describe("degradation", () => {
 
   it("skips project sources when the cwd is not inside a project", () => {
     const detached = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "argent-detached-")));
-    const sources = secretSources({ cwd: detached, homeDir, env: NO_ENV });
-    expect(sources.map((s) => s.label)).toEqual(["environment (ARGENT_SECRET_*)", globalSecrets()]);
-    fs.rmSync(detached, { recursive: true, force: true });
+    try {
+      const sources = secretSources({ cwd: detached, homeDir, env: NO_ENV });
+      expect(sources.map((s) => s.label)).toEqual([
+        "environment (ARGENT_SECRET_*)",
+        globalSecrets(),
+      ]);
+    } finally {
+      fs.rmSync(detached, { recursive: true, force: true });
+    }
   });
 
   it("lists a file shared by both scopes once", () => {


### PR DESCRIPTION
Fixes #1075

**Cause** - both `argent-detached-` tests removed their temp dir as the last unguarded statement of the test body, so a failing assertion above skipped it (the file's `afterEach` covers `homeDir`/`projectDir` only).

**Fix** - `try/finally` around each body, the form `flags.test.ts` in the same package already uses.

**Verified** - with both assertions deliberately broken and a private `TMPDIR`: 2 stranded `argent-detached-*` before, 0 after, same 2 test failures either way. Package suite green (122 passed), `tsc --build`, `typecheck:tests`, prettier.

Class: the same shape in `argent-installer/test/mcp-configs.test.ts` (11 sites) and `tool-server` is tracked separately by #1074 and #1077, left to those.

No docs change - test-only.

<details>
<summary>Repro output</summary>

```
--- unfixed: Tests  2 failed | 17 passed (19)
--- unfixed: residue: 2
--- fixed:   Tests  2 failed | 17 passed (19)
--- fixed:   residue: 0
```

```
npm test -w @argent/configuration-core
 Test Files  5 passed (5)
      Tests  122 passed (122)
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup to ensure temporary files and directories are removed even when assertions fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->