### PR TITLE
test(installer): stop 11 foreign-config tests stranding their temp dir on a failed assertion

### DIFF
--- a/packages/argent-installer/test/mcp-configs.test.ts
+++ b/packages/argent-installer/test/mcp-configs.test.ts
@@ -54,6 +54,17 @@ function setupTmpDir(): string {
   return dir;
 }
 
+// Temp dirs minted inside an it() body. Registering on creation keeps their
+// removal off the body's last line, where an assertion throwing above would
+// strand the directory.
+const bodyTempDirs: string[] = [];
+
+function mintTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  bodyTempDirs.push(dir);
+  return dir;
+}
+
 function readJsonFile(filePath: string): Record<string, unknown> {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
@@ -77,6 +88,9 @@ beforeEach(() => {
 
 afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  for (const dir of bodyTempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
   // Safety net for tests that set the override inside an it() body: a leaked
   // override points homedir() at an already-removed tmpdir, which silently
   // neutralizes the home-branch of every later detection/adapter test (and
@@ -2080,7 +2094,7 @@ describe("generated configs are portable across machines (issue #238)", () => {
 describe("installer preserves foreign MCP config", () => {
   it("remove keeps an unrelated server's empty env/args and a sibling user key (Cursor)", () => {
     const adapter = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-"));
+    const dir = mintTempDir("argent-fc-");
     const configPath = path.join(dir, ".cursor", "mcp.json");
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(
@@ -2101,12 +2115,11 @@ describe("installer preserves foreign MCP config", () => {
     const after = JSON.parse(fs.readFileSync(configPath, "utf8"));
     expect(after.mcpServers.other).toEqual({ command: "other-bin", args: [], env: {} });
     expect(after.userSettings).toEqual({ theme: "dark", overrides: {} });
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   it("VS Code write preserves a pre-existing server in a JSONC (commented) file", () => {
     const adapter = ALL_ADAPTERS.find((a) => a.name === "VS Code")!;
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-"));
+    const dir = mintTempDir("argent-fc-");
     const configPath = path.join(dir, ".vscode", "mcp.json");
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(
@@ -2119,7 +2132,6 @@ describe("installer preserves foreign MCP config", () => {
     }) as Record<string, any>;
     expect(after.servers).toHaveProperty("argent");
     expect(after.servers).toHaveProperty("myserver");
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   // Same Defect B, but for the { mcpServers } adapters: Cursor and Kiro are
@@ -2131,7 +2143,7 @@ describe("installer preserves foreign MCP config", () => {
   for (const name of ["Cursor", "Claude Code", "Windsurf", "Gemini", "Kiro"]) {
     it(`${name} write preserves a comment and a foreign server in a JSONC file`, () => {
       const adapter = ALL_ADAPTERS.find((a) => a.name === name)!;
-      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-"));
+      const dir = mintTempDir("argent-fc-");
       const configPath = path.join(dir, "mcp.json");
       fs.writeFileSync(
         configPath,
@@ -2143,7 +2155,6 @@ describe("installer preserves foreign MCP config", () => {
       const after = parseJsonc(raw, [], { allowTrailingComma: true }) as Record<string, any>;
       expect(after.mcpServers).toHaveProperty("argent");
       expect(after.mcpServers).toHaveProperty("myserver");
-      fs.rmSync(dir, { recursive: true, force: true });
     });
   }
 
@@ -2154,7 +2165,7 @@ describe("installer preserves foreign MCP config", () => {
   // file on disk (it still has a foreign server), with only argent gone.
   it("VS Code remove preserves a comment and a foreign server (uninstall round-trip)", () => {
     const adapter = ALL_ADAPTERS.find((a) => a.name === "VS Code")!;
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-"));
+    const dir = mintTempDir("argent-fc-");
     const configPath = path.join(dir, ".vscode", "mcp.json");
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(
@@ -2169,13 +2180,12 @@ describe("installer preserves foreign MCP config", () => {
     expect(after.servers).not.toHaveProperty("argent");
     expect(after.servers).toHaveProperty("myserver");
     expect(fs.existsSync(configPath)).toBe(true);
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   for (const name of ["Cursor", "Claude Code", "Windsurf", "Gemini", "Kiro"]) {
     it(`${name} remove preserves a comment and a foreign server (uninstall round-trip)`, () => {
       const adapter = ALL_ADAPTERS.find((a) => a.name === name)!;
-      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-"));
+      const dir = mintTempDir("argent-fc-");
       const configPath = path.join(dir, "mcp.json");
       fs.writeFileSync(
         configPath,
@@ -2188,7 +2198,6 @@ describe("installer preserves foreign MCP config", () => {
       const after = parseJsonc(raw, [], { allowTrailingComma: true }) as Record<string, any>;
       expect(after.mcpServers).not.toHaveProperty("argent");
       expect(after.mcpServers).toHaveProperty("myserver");
-      fs.rmSync(dir, { recursive: true, force: true });
     });
   }
 
@@ -2198,7 +2207,7 @@ describe("installer preserves foreign MCP config", () => {
     // tree (pruneEmptyConfig), silently stripping a foreign server's `args = []`
     // and any sibling empty table alongside deleting the argent entry.
     const adapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-"));
+    const dir = mintTempDir("argent-fc-");
     const configPath = path.join(dir, "config.toml");
     fs.writeFileSync(
       configPath,
@@ -2218,17 +2227,15 @@ describe("installer preserves foreign MCP config", () => {
     expect(after).toContain("[other_section]");
     expect(after).toContain("[mcp_servers.other]");
     expect(after).toContain("args = []");
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   it("Codex remove deletes the file when argent was the only content (TOML)", () => {
     const adapter = ALL_ADAPTERS.find((a) => a.name === "Codex")!;
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-"));
+    const dir = mintTempDir("argent-fc-");
     const configPath = path.join(dir, "config.toml");
     fs.writeFileSync(configPath, '[mcp_servers.argent]\ncommand = "argent"\nargs = ["mcp"]\n');
     expect(adapter.remove(configPath)).toBe(true);
     expect(fs.existsSync(configPath)).toBe(false);
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   // ── Allowlist writers (the last readJson → writeJson clobber path) ──────────
@@ -2245,7 +2252,7 @@ describe("installer preserves foreign MCP config", () => {
 
   it("Cursor addAllowlist preserves a comment and foreign rules in permissions.json", () => {
     const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
-    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    homedirOverride = mintTempDir("argent-fc-home-");
     const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
     fs.mkdirSync(path.dirname(permPath), { recursive: true });
     fs.writeFileSync(
@@ -2259,12 +2266,11 @@ describe("installer preserves foreign MCP config", () => {
     expect(after.mcpAllowlist).toContain("other:*"); // foreign rule survives
     expect(after.fileAllowlist).toEqual(["src/**"]); // foreign key survives
     expect(raw).toContain("do not touch"); // comment survives
-    fs.rmSync(homedirOverride, { recursive: true, force: true });
   });
 
   it("Cursor addAllowlist/removeAllowlist round-trip preserves foreign rules and keeps the file", () => {
     const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
-    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    homedirOverride = mintTempDir("argent-fc-home-");
     const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
     fs.mkdirSync(path.dirname(permPath), { recursive: true });
     fs.writeFileSync(permPath, `{\n  // keep me\n  "mcpAllowlist": ["other:*"]\n}\n`);
@@ -2275,17 +2281,15 @@ describe("installer preserves foreign MCP config", () => {
     const after = readJsoncFile(permPath);
     expect(after.mcpAllowlist).toEqual(["other:*"]); // argent gone, foreign kept
     expect(raw).toContain("keep me"); // comment survives
-    fs.rmSync(homedirOverride, { recursive: true, force: true });
   });
 
   it("Cursor removeAllowlist deletes the file when argent was the only rule", () => {
     const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
-    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    homedirOverride = mintTempDir("argent-fc-home-");
     const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
     cursor.addAllowlist!(tmpDir, "global"); // fresh create: { mcpAllowlist: ["argent:*"] }
     cursor.removeAllowlist!(tmpDir, "global");
     expect(fs.existsSync(permPath)).toBe(false);
-    fs.rmSync(homedirOverride, { recursive: true, force: true });
   });
 
   it("addClaudePermission preserves a comment and foreign permissions in settings.json", () => {
@@ -2422,7 +2426,7 @@ describe("installer preserves foreign MCP config", () => {
 
   it("Cursor removeAllowlist prunes an emptied mcpAllowlist but keeps the file for a foreign key", () => {
     const cursor = ALL_ADAPTERS.find((a) => a.name === "Cursor")!;
-    homedirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "argent-fc-home-"));
+    homedirOverride = mintTempDir("argent-fc-home-");
     const permPath = path.join(homedirOverride, ".cursor", "permissions.json");
     fs.mkdirSync(path.dirname(permPath), { recursive: true });
     fs.writeFileSync(
@@ -2434,7 +2438,6 @@ describe("installer preserves foreign MCP config", () => {
     const after = readJsoncFile(permPath);
     expect(after).not.toHaveProperty("mcpAllowlist"); // emptied array pruned
     expect(after.fileAllowlist).toEqual(["src/**"]); // foreign key survives
-    fs.rmSync(homedirOverride, { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
Fixes #1074

**Cause** - 11 tests in `describe("installer preserves foreign MCP config")` remove their temp dir as the last unguarded statement of the test body, so any assertion above it throwing strands the directory; the file's `afterEach` only covers `tmpDir`.

**Fix** - mint those dirs through a registry drained in the file's `afterEach`, the shape already used by `tool-server`'s `native-devtools-env.test.ts`. Test-only; no production code and no docs change (no tool, CLI, config key, flow file or user-facing capability moved).

**Verified** - break the same assertions on both sides, run the file with `TMPDIR` scoped to an empty dir: identical 25 failures, 12 stranded dirs before, 0 after. Full installer suite 555 passed, `tsc --build` and `typecheck:tests` clean.

<details>
<summary>Mutation repro - before vs after</summary>

Mutation (5 assertions, covering both the `argent-fc-` and `argent-fc-home-` sites):

```
sed -i '' \
  -e 's/expect(adapter.remove(configPath)).toBe(true);/expect(adapter.remove(configPath)).toBe(false);/' \
  -e 's/expect(after.mcpAllowlist).toContain("argent:\*");/expect(after.mcpAllowlist).toContain("nope:*");/' \
  -e 's/expect(after.mcpAllowlist).toEqual(\["other:\*"\]);/expect(after.mcpAllowlist).toEqual(["nope:*"]);/' \
  -e 's/expect(fs.existsSync(permPath)).toBe(false);/expect(fs.existsSync(permPath)).toBe(true);/' \
  -e 's/expect(after).not.toHaveProperty("mcpAllowlist");/expect(after).toHaveProperty("mcpAllowlist");/' \
  test/mcp-configs.test.ts
d=/tmp/fc; rm -rf $d; mkdir -p $d
TMPDIR=$d TMP=$d TEMP=$d npx vitest run test/mcp-configs.test.ts
ls $d
```

Both runs: `25 failed | 214 passed (239)`.

| | leftovers in the scoped temp dir |
|---|---|
| `main` | `argent-fc-{acrLbH,EkKAUK,O0pfPk,O55Nmh,XfBO0s,XOqFC4,yf8Zr9,Z1q7T8}`, `argent-fc-home-{F0R6QZ,shaUd9,v9FiKZ,zEhAc8}` - 12 |
| this branch | *(none)* |

Unmutated on this branch: `239 passed`, scoped temp dir empty.
</details>

<details>
<summary>Checks</summary>

```
npx tsc --build                                   # clean
npm run typecheck:tests -w @argent/installer      # clean
npm test -w @argent/installer                     # 17 files, 555 passed
npx prettier --write packages/argent-installer/test/mcp-configs.test.ts   # unchanged
```

`npx eslint` on the file cannot run in this checkout - it fails at `packages/docs/tsconfig.json(2,14): File '@docusaurus/tsconfig' not found`, a pre-existing local-only issue unrelated to the diff.
</details>

<details>
<summary>Class sweep</summary>

Every other `rmSync` of a minted temp dir under `packages/argent-installer/test/` and the same `rmSync(dir, ...)` shape in `packages/tool-server/test/` already sits in a hook: `init.test.ts:86,152` (`afterEach`), `preview-ui-dotfile.test.ts:28` (`afterAll`), `vega-cli-timeout.test.ts:164` (`afterAll`), `native-devtools-env.test.ts:12` (`afterEach`, the registry pattern copied here). `mcp-configs.test.ts:1891` removes a pre-existing config file, not a minted dir.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved temporary directory cleanup during installer tests.
  * Temporary directories are now cleaned up automatically after each test, including when assertions fail.
  * Consolidated repeated cleanup logic for more consistent test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->