### PR TITLE
fix(telemetry): give each scopeHome() its own saved HOME snapshot

### DIFF
--- a/packages/telemetry/test/helpers.test.ts
+++ b/packages/telemetry/test/helpers.test.ts
@@ -1,0 +1,32 @@
+import * as fs from "node:fs";
+import { afterAll, describe, expect, it } from "vitest";
+import { scopeHome } from "./helpers.js";
+
+describe("scopeHome", () => {
+  const ambientHome = process.env.HOME;
+  let homeAfterUnwind: string | undefined;
+  let outerTmp: string | undefined;
+
+  describe("outer", () => {
+    const outer = scopeHome();
+
+    describe("inner", () => {
+      const inner = scopeHome();
+
+      it("gives the inner scope its own temp home", () => {
+        expect(inner.tmp()).not.toBe(outer.tmp());
+        expect(process.env.HOME).toBe(inner.tmp());
+      });
+    });
+
+    afterAll(() => {
+      outerTmp = outer.tmp();
+      homeAfterUnwind = process.env.HOME;
+    });
+  });
+
+  it("restores the ambient HOME once nested scopes unwind", () => {
+    expect(homeAfterUnwind).toBe(ambientHome);
+    expect(fs.existsSync(outerTmp as string)).toBe(false);
+  });
+});

--- a/packages/telemetry/test/helpers.ts
+++ b/packages/telemetry/test/helpers.ts
@@ -5,41 +5,40 @@ import { afterEach, beforeEach } from "vitest";
 import { _resetConsentCacheForTest } from "../src/consent.js";
 import { _resetIdentityCacheForTest } from "../src/identity.js";
 
-let savedHome: string | undefined;
-let savedUserProfile: string | undefined;
-
 // Point telemetry home resolution at a vitest-scoped temp directory.
-export function useTempHome(): { tmp: string } {
+// The restorer closes over its own snapshot, so nested scopes unwind LIFO-correctly.
+function useTempHome(): { tmp: string; restore: () => void } {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "argent-telemetry-"));
-  savedHome = process.env.HOME;
-  savedUserProfile = process.env.USERPROFILE;
+  const savedHome = process.env.HOME;
+  const savedUserProfile = process.env.USERPROFILE;
   process.env.HOME = tmp;
   process.env.USERPROFILE = tmp;
-  return { tmp };
-}
-
-export function restoreHome(tmp: string): void {
-  if (savedHome === undefined) delete process.env.HOME;
-  else process.env.HOME = savedHome;
-  if (savedUserProfile === undefined) delete process.env.USERPROFILE;
-  else process.env.USERPROFILE = savedUserProfile;
-  try {
-    fs.rmSync(tmp, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
-  }
-  _resetConsentCacheForTest();
-  _resetIdentityCacheForTest();
+  return {
+    tmp,
+    restore: () => {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = savedUserProfile;
+      try {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+      _resetConsentCacheForTest();
+      _resetIdentityCacheForTest();
+    },
+  };
 }
 
 export function scopeHome(): { tmp: () => string } {
   let active: string;
+  let restore: () => void;
   beforeEach(() => {
-    const { tmp } = useTempHome();
-    active = tmp;
+    ({ tmp: active, restore } = useTempHome());
   });
   afterEach(() => {
-    restoreHome(active);
+    restore();
   });
   return { tmp: () => active };
 }


### PR DESCRIPTION
Fixes #1070

**Cause:** `useTempHome()` in `packages/telemetry/test/helpers.ts` stashed the ambient `HOME`/`USERPROFILE` in module-level variables, so two overlapping `scopeHome()` calls shared one slot - the inner call overwrote the outer's saved values with the outer's temp dir, and the outer restore put back an already-`rmSync`ed directory.

**Fix:** the temp home returns a restorer closing over its own snapshot, so nested scopes unwind LIFO-correctly. `restoreHome` is gone; nothing outside `helpers.ts` imported it or `useTempHome`.

**Class:** the only other reusable scoped-home helper, `packages/tool-server/test/helpers/temp-home.ts` (`scopeTempHome`), already captures per call and is nesting-safe. The remaining `savedHome` occurrences are file-local `beforeAll`/`afterAll` pairs in single test files, which cannot nest with themselves.

**Docs:** none needed - test helper only, no tool, CLI, config key, flow file or user-facing capability changed.

<details>
<summary>Verification</summary>

Discriminating test: `packages/telemetry/test/helpers.test.ts` nests two `scopeHome()` calls and asserts `HOME` is back to the ambient value after both unwind.

Before the fix (`git stash` of `helpers.ts` only):

```
 FAIL  test/helpers.test.ts > scopeHome > restores the ambient HOME once nested scopes unwind
AssertionError: expected '/var/folders/by/zbhy2lxd297cvhzlg_xkp…' to be '/Users/ignacylatka'

Expected: "/Users/ignacylatka"
Received: "/var/folders/.../T/argent-telemetry-m54KMm"

 Tests  1 failed | 1 passed (2)
```

After:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Ran from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/telemetry` - clean
- `npm test -w @argent/telemetry` - 18 files, 316 tests passed
- `npm run knip` - clean
- `npx prettier --check` on both changed files - clean

`npx eslint` on the two files could not run locally: it fails to parse the root tsconfig because `packages/docs` deps are not installed in this worktree (`packages/docs/tsconfig.json(2,14): error TS6053: File '@docusaurus/tsconfig' not found`) - a pre-existing environment issue, unrelated to these files.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
