### PR TITLE
test(tool-server): reap three temp dirs an assertion failure strands

### DIFF
--- a/packages/tool-server/test/metro/source-resolver-empty-root.test.ts
+++ b/packages/tool-server/test/metro/source-resolver-empty-root.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from "vitest";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
@@ -24,6 +24,12 @@ import { createSourceResolver } from "../../src/utils/debugger/source-resolver";
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
   return { ...actual, realpath: vi.fn(actual.realpath), readFile: vi.fn(actual.readFile) };
+});
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
 describe("source-resolver with no project root (RN 0.72 / Vega Metro)", () => {
@@ -103,10 +109,10 @@ describe("source-resolver with no project root (RN 0.72 / Vega Metro)", () => {
 
   it("still resolves normally when Metro does report a project root", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "real-app-"));
+    tempDirs.push(root);
     fs.writeFileSync(path.join(root, "App.js"), "const OK = 'IN_PROJECT';\n");
     const r = createSourceResolver(8081, root);
     const out = await r.readSourceFragment({ file: "App.js", line: 1, column: 0 });
     expect(out).toContain("IN_PROJECT");
-    fs.rmSync(root, { recursive: true, force: true });
   });
 });

--- a/packages/tool-server/test/react-profiler/render-annotations.test.ts
+++ b/packages/tool-server/test/react-profiler/render-annotations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -47,12 +47,19 @@ const SESSION_CONTEXT: SessionContext = {
   platform: "ios",
 };
 
+const debugDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of debugDirs.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+});
+
 async function makeDebugDir(): Promise<string> {
   const dir = join(
     tmpdir(),
     `argent-render-annotations-${Date.now()}-${Math.random().toString(36).slice(2)}`
   );
   await fs.mkdir(dir, { recursive: true });
+  debugDirs.push(dir);
   return dir;
 }
 
@@ -85,8 +92,6 @@ describe("renderProfilingReport — annotation reference frame", () => {
 
     expect(between).toContain("(t=17.6s)");
     expect(after50).toContain("(t=192.3s)");
-
-    await fs.rm(debugDir, { recursive: true, force: true });
   });
 
   it("renders without annotations when none are provided", async () => {
@@ -104,7 +109,5 @@ describe("renderProfilingReport — annotation reference frame", () => {
     expect(report).toContain("### Commit #50");
     expect(report).toContain("### Commit #0");
     expect(report).not.toMatch(/> After:/);
-
-    await fs.rm(debugDir, { recursive: true, force: true });
   });
 });

--- a/packages/tool-server/test/workspace-reader.test.ts
+++ b/packages/tool-server/test/workspace-reader.test.ts
@@ -34,8 +34,16 @@ import {
 
 let tempDir: string;
 
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) await rm(dir, { recursive: true, force: true });
+});
+
 async function createTempDir(): Promise<string> {
-  return mkdtemp(join(tmpdir(), "ws-reader-test-"));
+  const dir = await mkdtemp(join(tmpdir(), "ws-reader-test-"));
+  tempDirs.push(dir);
+  return dir;
 }
 
 async function writeJson(dir: string, name: string, data: unknown) {
@@ -172,10 +180,6 @@ deploy.staging:
 describe("readWorkspaceSnapshot", () => {
   beforeEach(async () => {
     tempDir = await createTempDir();
-  });
-
-  afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true });
   });
 
   it("returns correct snapshot for a minimal RN project", async () => {
@@ -379,7 +383,6 @@ module.exports = getDefaultConfig(__dirname);`
       await writeText(dir, lockName, "");
       const snap = await readWorkspaceSnapshot(dir);
       expect(snap.lockfile).toBe(lockName);
-      await rm(dir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
Fixes #1077

**Cause** - three tool-server tests remove their temp dir as the *last statement of the test body*, so any assertion above it throwing abandons the directory in the shared system temp dir.

**Fix** - a module-scope list pushed to at the mint site and drained in an `afterEach` (the shape #1057 used), replacing the trailing `rm`. `render-annotations.test.ts` had no hook at all; `workspace-reader.test.ts`'s describe-level `afterEach` becomes redundant once `createTempDir` registers every dir it hands out, so it goes.

Test-only. No tool, CLI, config key, flow file or user-facing capability changes, so no docs update.

**Verified** - break one assertion per file, run under a scoped `TMPDIR`, list what survives.

| file | before | after |
|---|---|---|
| `metro/source-resolver-empty-root.test.ts` | `real-app-ouDGWh` | *(none)* |
| `react-profiler/render-annotations.test.ts` | `argent-render-annotations-…zmt1onhl4wj`, `…sriq0gyjyo` | *(none)* |
| `workspace-reader.test.ts` | `ws-reader-test-SIWls6` | *(none)* |

Same failure count on both sides (1, 2, 1) - only the leftovers differ.

<details>
<summary>Repro, both sides</summary>

Mutations applied to each file (`git show HEAD:<path>` for the "before" column, the branch for "after"):

```
sed -i '' 's/expect(out).toContain("IN_PROJECT");/expect(out).toContain("NOPE");/' \
  test/metro/source-resolver-empty-root.test.ts
sed -i '' 's/expect(after50).toContain("(t=192.3s)");/expect(after50).toContain("(t=999.9s)");/;
           s/expect(report).not.toMatch(\/> After:\/);/expect(report).toMatch(\/> After:\/);/' \
  test/react-profiler/render-annotations.test.ts
sed -i '' 's/expect(snap.lockfile).toBe(lockName);/expect(snap.lockfile).toBe("NOPE");/' \
  test/workspace-reader.test.ts
```

Each run, from `packages/tool-server`:

```
d=/tmp/scope/<label>; rm -rf $d; mkdir -p $d
TMPDIR=$d TMP=$d TEMP=$d npx vitest run <file>
ls -A $d
```

Before (unfixed, mutated):

```
unfixed_sr:  Tests 1 failed | 4 passed   ->  node-compile-cache  real-app-ouDGWh
unfixed_ra:  Tests 2 failed              ->  node-compile-cache
                                             argent-render-annotations-1788965985023-zmt1onhl4wj
                                             argent-render-annotations-1788965985027-sriq0gyjyo
unfixed_wr:  Tests 1 failed | 34 passed  ->  node-compile-cache  ws-reader-test-SIWls6
```

After (this branch, same mutations): identical failure counts, `node-compile-cache` only.
</details>

<details>
<summary>Checks</summary>

From the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - `368 passed (368)` files, `4832 passed | 1 skipped`
- `npx prettier --write` on the three files - unchanged

Class sweep: scanned every `*.test.ts` under `packages/tool-server/test` for an `rm`/`rmSync`/`unlink` as the final statement of an `it` body. Besides these three, only `react-profiler/dump.test.ts` and `screen-recording.test.ts` match, and both already point `os.tmpdir()` at a per-test scratch reaped in `afterEach`, so their unlinks strand nothing. The same shape in other packages is #1074 / #1075 and is left to those.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test cleanup by consistently removing temporary and debug directories after each test.
  - Consolidated cleanup handling across source resolution, profiler annotations, and workspace reader tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->