### PR TITLE
test(ios-device-runner): pin USERPROFILE alongside HOME so the fixtures redirect on Windows

### DIFF
--- a/packages/tool-server/test/ios-device-runner-artifact.test.ts
+++ b/packages/tool-server/test/ios-device-runner-artifact.test.ts
@@ -107,8 +107,9 @@ describe("ensureRunnerArtifact", () => {
   });
 
   /**
-   * Run `fn` with HOME moved under a per-test dir (so the build dir stays
-   * inside the fixture tree), PATH narrowed to `binDir` (empty by default, so
+   * Run `fn` with HOME — and USERPROFILE, which `os.homedir()` reads on
+   * Windows — moved under a per-test dir (so the build dir stays inside the
+   * fixture tree), PATH narrowed to `binDir` (empty by default, so
    * nothing reaches the real Xcode), and the project override pointed at
    * `project` (the shared empty fake by default), the env-swap fixture
    * pattern launchRunner's tests established.
@@ -120,10 +121,13 @@ describe("ensureRunnerArtifact", () => {
   ): Promise<T> {
     const saved = {
       HOME: process.env.HOME,
+      USERPROFILE: process.env.USERPROFILE,
       PATH: process.env.PATH,
       PROJECT: process.env.ARGENT_IOS_RUNNER_PROJECT,
     };
-    process.env.HOME = path.join(tmpRoot, `ensure-home-${name}`);
+    const home = path.join(tmpRoot, `ensure-home-${name}`);
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
     process.env.PATH = opts.binDir ?? emptyBin;
     process.env.ARGENT_IOS_RUNNER_PROJECT = opts.project ?? fakeProject;
     try {
@@ -157,6 +161,16 @@ describe("ensureRunnerArtifact", () => {
       return { xctestrunPath, derivedDataPath, fromCache: false };
     };
   }
+
+  // ensureRunnerArtifact builds under os.homedir(), which reads USERPROFILE on
+  // Windows and HOME elsewhere. Pinning one name leaves the fixture inert on
+  // the other platform and the build dir lands in the developer's real home.
+  it("redirects os.homedir() under both names it consults", async () => {
+    await withEnsureEnv("homedir-names", async () => {
+      expect(process.env.USERPROFILE).toBe(process.env.HOME);
+      expect(os.homedir()).toBe(path.join(tmpRoot, "ensure-home-homedir-names"));
+    });
+  });
 
   it("reports fromCache honestly and rebuilds the same key only when forced", async () => {
     await withEnsureEnv("hit-and-force", async () => {

--- a/packages/tool-server/test/ios-device-runner-launch.test.ts
+++ b/packages/tool-server/test/ios-device-runner-launch.test.ts
@@ -15,13 +15,19 @@ afterAll(async () => {
 
 /**
  * Run launchRunner with PATH replaced by `pathDir` (so "xcodebuild" resolves
- * to a stub, or to nothing) and HOME moved under tmpRoot (so the launch log
- * lands in the fixture tree, not the real ~/.argent).
+ * to a stub, or to nothing) and HOME — plus USERPROFILE, which `os.homedir()`
+ * reads on Windows — moved under tmpRoot (so the launch log lands in the
+ * fixture tree, not the real ~/.argent).
  */
 async function launchWithPath(pathDir: string): Promise<Awaited<ReturnType<typeof launchRunner>>> {
-  const saved = { PATH: process.env.PATH, HOME: process.env.HOME };
+  const saved = {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+  };
   process.env.PATH = pathDir;
   process.env.HOME = tmpRoot;
+  process.env.USERPROFILE = tmpRoot;
   try {
     return await launchRunner({
       udid: "00008120-000000000000001E",
@@ -59,10 +65,14 @@ describe("launchRunner", () => {
     await fsp.mkdir(stubBin, { recursive: true });
     // The stub echoes the port variable and its argv so the log pins that no
     // port is forced on the runner through TEST_RUNNER_<VAR> (the device picks
-    // it) and that the crash bundle path is pinned on the command line.
+    // it) and that the crash bundle path is pinned on the command line. It also
+    // echoes both names os.homedir() consults — USERPROFILE on Windows, HOME
+    // elsewhere — so the log pins that the fixture redirects the one this
+    // platform ignores too, rather than leaving it on the developer's real home.
     await fsp.writeFile(
       path.join(stubBin, "xcodebuild"),
-      '#!/bin/sh\necho "PORT=${TEST_RUNNER_ARGENT_RUNNER_PORT-unset} ARGS=$@"\nexit 0\n',
+      '#!/bin/sh\necho "PORT=${TEST_RUNNER_ARGENT_RUNNER_PORT-unset} ARGS=$@"\n' +
+        'echo "HOME=${HOME-unset} USERPROFILE=${USERPROFILE-unset}"\nexit 0\n',
       { mode: 0o755 }
     );
 
@@ -80,6 +90,7 @@ describe("launchRunner", () => {
     await once(launched.child, "exit");
     const log = await fsp.readFile(launched.logPath, "utf8");
     expect(log).toContain("PORT=unset");
+    expect(log).toContain(`HOME=${tmpRoot} USERPROFILE=${tmpRoot}`);
     expect(log).toContain("-resultBundlePath");
     // The swallow listener that keeps a late "error" from becoming uncaught.
     expect(launched.child.listenerCount("error")).toBe(1);


### PR DESCRIPTION
Fixes #1069

**Cause:** `os.homedir()` reads `USERPROFILE` on Windows and `HOME` elsewhere. The two `ios-device-runner` suites pinned `HOME` only, so on Windows the redirect was inert and they built into `%USERPROFILE%\.argent\ios-device-runner\` in the developer's real home.

**Fix (test-only):** pin `USERPROFILE` at the same directory as `HOME` in both fixtures, and add it to the saved record so the existing delete-or-assign restore puts it back. This is what every other `HOME`-swapping suite in the repo already does (`avd-snapshot`, `android-binary`, `adb-resolve-avd-path`, ...); these two files were the only ones left.

**Docs:** none needed - no tool, CLI, config key, flow file or user-facing capability changes.

<details>
<summary>Class check, discrimination proof and checks</summary>

Every file assigning `process.env.HOME` in `packages/`, and whether it also pins `USERPROFILE`:

```
$ for f in $(grep -rl "process\.env\.HOME *=" --include="*.ts" packages/); do echo "$(grep -c USERPROFILE $f)  $f"; done
...
0  packages/tool-server/test/ios-device-runner-artifact.test.ts
0  packages/tool-server/test/ios-device-runner-launch.test.ts
```

The other 20 already pin both, so the class is exactly these two files. Not moved onto `test/helpers/temp-home.ts`'s `scopeTempHome`: it is a file-level `beforeEach`, while both fixtures swap the home mid-test alongside `PATH` (and `ARGENT_IOS_RUNNER_PROJECT`), and `withEnsureEnv`'s per-test home name is its first argument at 11 call sites.

Discrimination - with only the two `process.env.USERPROFILE = ...` assignments deleted, tests kept:

```
FAIL  test/ios-device-runner-launch.test.ts > launchRunner > resolves with the launched child and per-device log and bundle paths
AssertionError: expected 'PORT=unset ARGS=test-without-building...' to contain 'HOME=/var/.../argent-runner-launch-QkW7KQ USERPROFILE=...'
+ HOME=/var/folders/.../argent-runner-launch-QkW7KQ USERPROFILE=unset

FAIL  test/ios-device-runner-artifact.test.ts > ensureRunnerArtifact > redirects os.homedir() under both names it consults

 Test Files  2 failed (2)
      Tests  2 failed | 25 passed (27)
```

Restored, both pass. Checks run from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - `Test Files  433 passed (433)`, `Tests  6164 passed | 1 skipped`
- `npx prettier --write` on both files - unchanged

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
