### PR TITLE
test(tool-server): scope the home the external-device suites discover against

### DIFF
--- a/packages/tool-server/test/external-attach.test.ts
+++ b/packages/tool-server/test/external-attach.test.ts
@@ -18,6 +18,7 @@ import {
   setSimulatorClipboardText,
 } from "../src/utils/simulator-client";
 import { resolveDevice } from "../src/utils/device-info";
+import { scopeTempHome } from "./helpers/temp-home";
 
 /**
  * The simulator-server blueprint's attach branch, against a stand-in speaking
@@ -198,6 +199,13 @@ function republishAt(simulatorServer: FakeSimulatorServer): void {
 
   fs.writeFileSync(descriptorPath, JSON.stringify(descriptor));
 }
+
+/**
+ * The hook below drops the suite-wide discovery guard, so discovery falls back
+ * to `~/.argent/providers` for as long as a test has published no descriptor
+ * of its own. Scope the home, so that fallback is a directory this run owns.
+ */
+scopeTempHome("argent-external-attach-home-");
 
 beforeEach(() => {
   temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "argent-attach-"));

--- a/packages/tool-server/test/external-attach.test.ts
+++ b/packages/tool-server/test/external-attach.test.ts
@@ -201,9 +201,9 @@ function republishAt(simulatorServer: FakeSimulatorServer): void {
 }
 
 /**
- * The hook below drops the suite-wide discovery guard, so discovery falls back
- * to `~/.argent/providers` for as long as a test has published no descriptor
- * of its own. Scope the home, so that fallback is a directory this run owns.
+ * The hook below drops the suite-wide discovery guard, so until a test
+ * publishes its own descriptor, discovery reads `~/.argent/providers`. Scoping
+ * the home keeps that a directory this run owns.
  */
 scopeTempHome("argent-external-attach-home-");
 

--- a/packages/tool-server/test/external-devices.test.ts
+++ b/packages/tool-server/test/external-devices.test.ts
@@ -45,6 +45,7 @@ import {
   simctlTargetForUdidSync,
   simctlTargetForWithdrawal,
 } from "../src/utils/ios-device-sets";
+import { scopeTempHome } from "./helpers/temp-home";
 
 const ANDROID_SERIAL = "emulator-5554";
 /** A pid nothing can be running under, so `kill(0)` fails with ESRCH. */
@@ -135,6 +136,18 @@ function useDescriptors(...files: string[]): void {
   process.env.ARGENT_DEVICE_PROVIDERS = files.join(",");
 }
 
+/**
+ * The hook below drops both the suite-wide discovery guard and
+ * `ARGENT_DEVICE_PROVIDERS`, so anything this file discovers without a
+ * descriptor of its own comes from `providersDirectory()`. Scoping the home
+ * makes that an empty directory this run owns rather than the developer's
+ * `~/.argent/providers`, where a provider they are actually running publishes
+ * real devices.
+ */
+const HOME_PREFIX = "argent-external-devices-home-";
+
+scopeTempHome(HOME_PREFIX);
+
 beforeEach(() => {
   temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "argent-providers-"));
   delete process.env.ARGENT_DEVICE_PROVIDERS;
@@ -206,6 +219,18 @@ describe("the contract's tool-server facade", () => {
    */
   it("resolves the same providers directory as the shared config paths do", () => {
     expect(providersDirectory()).toBe(path.join(argentHomeDir(), "providers"));
+  });
+
+  /**
+   * Every assertion in this file about an unclaimed device only holds while
+   * `providersDirectory()` is empty, and the suite reaches it whenever a test
+   * writes no descriptor of its own. Pin the directory to the run's own home,
+   * so a provider registered on the machine running the suite cannot answer
+   * for a fixture.
+   */
+  it("discovers against a providers directory this run owns", () => {
+    expect(providersDirectory()).toContain(HOME_PREFIX);
+    expect(discoverProviders()).toEqual([]);
   });
 
   /**

--- a/packages/tool-server/test/external-devices.test.ts
+++ b/packages/tool-server/test/external-devices.test.ts
@@ -138,11 +138,10 @@ function useDescriptors(...files: string[]): void {
 
 /**
  * The hook below drops both the suite-wide discovery guard and
- * `ARGENT_DEVICE_PROVIDERS`, so anything this file discovers without a
- * descriptor of its own comes from `providersDirectory()`. Scoping the home
- * makes that an empty directory this run owns rather than the developer's
- * `~/.argent/providers`, where a provider they are actually running publishes
- * real devices.
+ * `ARGENT_DEVICE_PROVIDERS`, so a test that writes no descriptor of its own
+ * discovers whatever `providersDirectory()` holds. Scoping the home makes that
+ * a directory this run owns rather than the developer's `~/.argent/providers`,
+ * where a provider they are running publishes its real devices.
  */
 const HOME_PREFIX = "argent-external-devices-home-";
 
@@ -222,11 +221,8 @@ describe("the contract's tool-server facade", () => {
   });
 
   /**
-   * Every assertion in this file about an unclaimed device only holds while
-   * `providersDirectory()` is empty, and the suite reaches it whenever a test
-   * writes no descriptor of its own. Pin the directory to the run's own home,
-   * so a provider registered on the machine running the suite cannot answer
-   * for a fixture.
+   * The precondition every "nothing claims this device" assertion in the file
+   * rests on: an empty providers directory, which only a scoped home gives.
    */
   it("discovers against a providers directory this run owns", () => {
     expect(providersDirectory()).toContain(HOME_PREFIX);

--- a/packages/tool-server/test/temp-home.test.ts
+++ b/packages/tool-server/test/temp-home.test.ts
@@ -5,7 +5,7 @@ import { scopeTempHome } from "./helpers/temp-home";
 // os.homedir() reads USERPROFILE on Windows and HOME elsewhere, so a helper that
 // pins only one of them is inert on the other platform and the suites relying on
 // it write into the developer's real home there. Nothing else asserts this: with
-// the USERPROFILE line deleted the twelve files that call scopeTempHome stay
+// the USERPROFILE line deleted every file that calls scopeTempHome stays
 // green, which is what these tests exist to stop.
 describe("scopeTempHome", () => {
   const seen: string[] = [];


### PR DESCRIPTION
Fixes #1072

**Cause** - `external-devices.test.ts` deletes both `ARGENT_DISABLE_DEVICE_PROVIDERS` and `ARGENT_DEVICE_PROVIDERS` in its `beforeEach`, so any test that writes no descriptor of its own has `discoverProviders()` read the developer's real `~/.argent/providers`.

**Fix** - call `scopeTempHome()` at file top level, so that fallback is a fresh, run-owned directory. `external-attach.test.ts` has the identical hook and gets the same guard.

**Verified** - planting a live provider descriptor claiming the suite's `IOS_UDID` fails 3 tests before, passes after; the new test fails deterministically with the `scopeTempHome` call removed, naming the real home in its message. Full `@argent/tool-server` suite green (6164 passed).

No docs change: test-only, no tool, CLI, config key or user-facing capability moves.

<details>
<summary>Repro and check output</summary>

Repro (a descriptor in `~/.argent/providers` claiming the udid the fixtures use, plus a live server on its `apiUrl` so it survives the discovery probe):

```
 × returns nothing when no provider is registered at all
 × is the identity for an ordinary device and performs no I/O
 × leaves an ordinary udid and the default set untouched
 Tests  3 failed | 104 passed (107)
```

Same planted home, after:

```
 Test Files  2 passed (2)
      Tests  119 passed (119)
```

The added test discriminates - with `scopeTempHome(HOME_PREFIX)` removed and no descriptor planted at all:

```
 × discovers against a providers directory this run owns
AssertionError: expected '/Users/<me>/.argent/providers' to contain 'argent-external-devices-home-'
 Tests  1 failed | 107 passed (108)
```

Checks from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 433 files, 6164 passed, 1 skipped
- `npx prettier --write` on the three files - unchanged

Sibling suites left alone: the other nine tool-server files that delete the discovery guard (`list-devices`, `metro-port`, `external-js-debugger`, `external-native-devtools`, `native-profiler-external-device`, `android-profiler-external-device`, `launch-restart-external-claim`, `simulator-watcher-external-claim`, `boot-device-external-refused`) set `ARGENT_DEVICE_PROVIDERS` in the same hook, which replaces the directory scan outright. All nine stay green under the planted home. `argent-cli/test/providers-command.test.ts` and `device-providers/test/read.test.ts` already stub `HOME`/`USERPROFILE` themselves.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
