### PR TITLE
fix(mcp): carry describe's hint into the auto-describe block

### DIFF
--- a/packages/argent-mcp/src/auto-capture.ts
+++ b/packages/argent-mcp/src/auto-capture.ts
@@ -94,6 +94,25 @@ export function shouldAutoDescribe(toolName: string): boolean {
 }
 
 /**
+ * The text block appended after an action, or null when the describe result
+ * carries nothing to show. `hint` is describe's only prose channel, and a read
+ * that failed still renders a few hundred characters of tree preamble with no
+ * elements under it - so without the hint the block reads as an empty screen
+ * rather than as a failed read.
+ */
+export function renderAutoDescribe(result: unknown): string | null {
+  const data = result as { description?: unknown; hint?: unknown } | null | undefined;
+  const parts: string[] = [];
+  if (typeof data?.description === "string" && data.description.length > 0) {
+    parts.push(data.description);
+  }
+  if (typeof data?.hint === "string" && data.hint.trim().length > 0) {
+    parts.push(data.hint.trim());
+  }
+  return parts.length === 0 ? null : `${AUTO_DESCRIBE_HEADER}\n${parts.join("\n\n")}`;
+}
+
+/**
  * Marker of a server-side secret placeholder (`{{secret:NAME}}`, resolved by
  * the tool-server before typing). Copy of SECRET_PLACEHOLDER_MARKER in
  * packages/tool-server/src/utils/secrets.ts, which argent-mcp does not depend

--- a/packages/argent-mcp/src/mcp-server.ts
+++ b/packages/argent-mcp/src/mcp-server.ts
@@ -38,7 +38,7 @@ import {
   getAutoScreenshotDelayMs,
   autoDescribeEnabled,
   shouldAutoDescribe,
-  AUTO_DESCRIBE_HEADER,
+  renderAutoDescribe,
 } from "./auto-capture.js";
 import { toMcpTool } from "./tool-mapping.js";
 import { getInstalledVersion } from "./installed-version.js";
@@ -375,19 +375,16 @@ export async function startMcpServer(options: StartMcpServerOptions): Promise<vo
           const t1 = Date.now();
           try {
             const d = await callTool("describe", { udid });
-            const desc = (d.result as { description?: unknown } | null)?.description;
-            if (typeof desc === "string" && desc.length > 0) {
-              content = [
-                ...content,
-                { type: "text" as const, text: `${AUTO_DESCRIBE_HEADER}\n${desc}` },
-              ];
+            const block = renderAutoDescribe(d.result);
+            if (block) {
+              content = [...content, { type: "text" as const, text: block }];
             }
             await spyLog({
               ts: new Date().toISOString(),
               event: "auto_describe",
               name: params.name,
               durationMs: Date.now() - t1,
-              chars: typeof desc === "string" ? desc.length : 0,
+              chars: block?.length ?? 0,
             });
           } catch (e) {
             await spyLog({

--- a/packages/argent-mcp/test/auto-capture.test.ts
+++ b/packages/argent-mcp/test/auto-capture.test.ts
@@ -15,6 +15,8 @@ import {
   normalizeToolName,
   shouldAutoScreenshot,
   getAutoScreenshotDelayMs,
+  renderAutoDescribe,
+  AUTO_DESCRIBE_HEADER,
 } from "../src/auto-capture.js";
 
 // ---------------------------------------------------------------------------
@@ -331,5 +333,50 @@ describe("containsSecretPlaceholder", () => {
       })
     ).toBe(true);
     expect(shouldAutoScreenshot("run-sequence")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderAutoDescribe
+// ---------------------------------------------------------------------------
+describe("renderAutoDescribe", () => {
+  // What `describe` returns for an iOS screen it could not read: the tree is
+  // empty, but formatDescribeTree still emits its 380-character preamble, so a
+  // length check on `description` alone never sees the failure.
+  const EMPTY_TREE_RENDER =
+    "Source: native-devtools\nMode: flat\n" +
+    "Coordinates are normalized [0,1] fractions of the screen (x, y, width, height), not pixels.\n" +
+    "\nROOT  AXApplication (0.000, 0.000, 0.000, 0.000)\n";
+  const HINT =
+    "com.example.app has no running process on this simulator, so there is no injected " +
+    "process to read. Call launch-app (or restart-app) then retry.";
+
+  it("carries the hint that diagnoses an empty tree", () => {
+    const block = renderAutoDescribe({
+      description: EMPTY_TREE_RENDER,
+      source: "native-devtools",
+      hint: HINT,
+      should_restart: true,
+    });
+    expect(block).toBe(`${AUTO_DESCRIBE_HEADER}\n${EMPTY_TREE_RENDER}\n\n${HINT}`);
+  });
+
+  it("emits the block for a hint that arrives with no tree at all", () => {
+    expect(renderAutoDescribe({ description: "", hint: HINT })).toBe(
+      `${AUTO_DESCRIBE_HEADER}\n${HINT}`
+    );
+  });
+
+  it("renders a readable tree on its own", () => {
+    expect(renderAutoDescribe({ description: "ROOT  AXApplication", source: "ax-service" })).toBe(
+      `${AUTO_DESCRIBE_HEADER}\nROOT  AXApplication`
+    );
+  });
+
+  it("returns null when there is nothing to show", () => {
+    expect(renderAutoDescribe({ description: "", hint: "   " })).toBeNull();
+    expect(renderAutoDescribe({})).toBeNull();
+    expect(renderAutoDescribe(null)).toBeNull();
+    expect(renderAutoDescribe("not an object")).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #1027

**Cause:** the auto-describe block rendered `description` only, and `describe`'s empty tree still formats to ~380 characters of preamble - so the `desc.length > 0` guard always passed and `hint`, the field explaining why the read failed, was dropped.

**Fix:** `renderAutoDescribe` appends `hint` after `description` and emits the block whenever either is present.

`should_restart` is deliberately not rendered: its only producer (`describe/platforms/ios/index.ts:246`) always sets `hint` alongside, and that hint text already names the restart remedy in English, so a second restart line would only repeat it. This is the one call site of its shape - nothing else in `argent-mcp` re-renders a describe result.

**Docs:** none needed. The block and its `disable-auto-describe` flag are unchanged; no tool, CLI, config key or flow file changed.

**Verified:** `npx tsc --build`, `npm run typecheck:tests -w @argent/mcp`, `npm test -w @argent/mcp` (89 passed), `npm run knip`, prettier - all green. The new tests fail on the pre-fix rendering.

<details>
<summary>Repro and discrimination proof</summary>

The empty tree `describeIos` returns, through `formatDescribeTree`:

```
LEN=380
"Source: native-devtools\nMode: flat\nCoordinates are normalized [0,1] fractions of the screen ...\n\nROOT  AXApplication (0.000, 0.000, 0.000, 0.000)\n"
```

Reverting `renderAutoDescribe` to the old description-only body:

```
 ❯ test/auto-capture.test.ts:365:65
   - Expected: "--- Elements after action (describe) ---\ncom.example.app has no running process ..."
   + Received: null

 Test Files  1 failed | 5 passed (6)
      Tests  2 failed | 87 passed (89)
```

With the fix restored: `Tests  89 passed (89)`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
