### PR TITLE
fix(tool-server): match how `simctl spawn` words a shut-down simulator in shake

### DIFF
--- a/packages/tool-server/src/tools/shake/platforms/ios.ts
+++ b/packages/tool-server/src/tools/shake/platforms/ios.ts
@@ -46,9 +46,12 @@ function rejectTv(toolId: string, device: DeviceInfo): never {
 }
 
 function shakeFailure(udid: string, detail: string, cause?: Error): FailureError {
-  // The state error simctl raises for a shut-down device says nothing about
+  // The wording splits by verb: `simctl spawn` says "device is not booted", the
+  // host-side verbs "Unable to lookup in current state: Shutdown". Neither says
   // what to do next.
-  const shutdownHint = /current state:\s*shutdown|unable to lookup/i.test(detail)
+  const shutdownHint = /current state:\s*shutdown|unable to lookup|device is not booted/i.test(
+    detail
+  )
     ? " The simulator must be booted first — use boot-device."
     : "";
   return new FailureError(

--- a/packages/tool-server/test/shake.test.ts
+++ b/packages/tool-server/test/shake.test.ts
@@ -130,6 +130,32 @@ describe("shake tool — iOS", () => {
     await expect(shakeTool.execute(services, { udid: iosUdid })).rejects.toThrow(/Failed to shake/);
     expect(mockShaker.settle).not.toHaveBeenCalled();
   });
+
+  it("points a shut-down simulator at boot-device", async () => {
+    // Verbatim stderr from `xcrun simctl spawn <shut-down udid> notifyutil`.
+    // `spawn` is the only verb this tool runs and it words the state error
+    // differently from the host-side verbs ("Unable to lookup in current
+    // state: Shutdown"), so matching on those alone never fires here.
+    vi.mocked(execFile).mockImplementationOnce(((
+      _file: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (e: Error | null) => void
+    ) =>
+      cb(
+        new Error(
+          "An error was encountered processing the command " +
+            "(domain=com.apple.CoreSimulator.SimError, code=405):\n" +
+            "Process spawn via launchd failed because device is not booted.\n" +
+            "Underlying error (domain=com.apple.SimLaunchHostService.RequestError, code=3):\n" +
+            `\tBad or unknown session: com.apple.CoreSimulator.SimDevice.${iosUdid}`
+        )
+      )) as never);
+
+    await expect(shakeTool.execute(services, { udid: iosUdid })).rejects.toThrow(
+      /must be booted first — use boot-device\./
+    );
+  });
 });
 
 describe("shake tool — remote iOS (sim-remote)", () => {


### PR DESCRIPTION
Fixes #1029

**Cause:** `shake` only ever runs `xcrun simctl spawn`, which reports a shut-down device as `Process spawn via launchd failed because device is not booted.` - the hint matched only the host-side wordings (`Unable to lookup in current state: Shutdown`), so `use boot-device.` never fired.

**Fix:** one alternative added to the regex in `shakeFailure`. Hint text unchanged.

**Class:** the only sibling with this shape is `settings-permissions/platforms/ios.ts:164`, which runs `simctl privacy` - a host-side verb whose wording its regex already matches. Left as is.

**Docs:** none needed - no tool, CLI, config key, flow file or user-facing capability changed, only the text of an existing error.

<details>
<summary>Verification</summary>

The framework itself carries both wordings, so the split is by verb, not by Xcode version:

```
$ strings /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator \
    | grep -E "spawn via launchd|Unable to lookup in current state"
Process spawn via launchd failed because device is not booted.
Process spawn via launchd failed.
Unable to lookup in current state: %@
```

New test `shake tool - iOS > points a shut-down simulator at boot-device` feeds the verbatim `simctl spawn` stderr through the tool. Reverted the source hunk and re-ran it:

```
- Expected: /must be booted first — use boot-device\./
+ Received: "Failed to shake AAAAAAAA-…: An error was encountered processing the command
  (domain=com.apple.CoreSimulator.SimError, code=405):
  Process spawn via launchd failed because device is not booted. …"

Tests  1 failed | 23 passed (24)
```

Fix restored, all green:

- `npx tsc --build` - exit 0
- `npm run typecheck:tests -w @argent/tool-server` - exit 0
- `npm test -w @argent/tool-server` - 368 files, 4833 passed, 1 skipped
- `npx prettier --write` on both changed files - unchanged

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
