### PR TITLE
fix(cli): keep the batch tally when a directory run's artifact export throws

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -963,8 +963,8 @@ interface BatchFlowResult {
  * Run every discovered flow in `dir` sequentially. Reports failures only (no
  * live step lines), then a flow-level summary. A flow failing its steps — or
  * one the tool-server rejects as invalid — lets the batch continue, while an
- * infra error (transport throw, unclassified failure, non-report result) stops
- * it and counts the remaining flows skipped.
+ * infra error (transport throw, unclassified failure, non-report result, failed
+ * artifact export) stops it and counts the remaining flows skipped.
  */
 async function runFlowDirectory(
   dir: string,
@@ -1033,14 +1033,25 @@ async function runFlowDirectory(
       stopped = true;
       continue;
     }
-    // Key exports by the flow's subdirectory so recursive same-stem flows
-    // cannot clobber each other (exportFailureArtifacts keys by stem only).
-    await exportAndResolveArtifacts(
-      report,
-      outputBase ? path.join(outputBase, path.dirname(rel)) : undefined,
-      path.join(dir, rel),
-      baseUrl
-    );
+    try {
+      // Key exports by the flow's subdirectory so recursive same-stem flows
+      // cannot clobber each other (exportFailureArtifacts keys by stem only).
+      await exportAndResolveArtifacts(
+        report,
+        outputBase ? path.join(outputBase, path.dirname(rel)) : undefined,
+        path.join(dir, rel),
+        baseUrl
+      );
+    } catch (err) {
+      // A dead tool-server or an unwritable --output directory is the same
+      // wall for every remaining flow, so stop the batch rather than run them
+      // into it.
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(message);
+      results.push({ path: rel, status: "fail", error: message });
+      stopped = true;
+      continue;
+    }
     results.push({ path: rel, status: report.ok ? "pass" : "fail", report });
     if (!args.json) {
       for (const line of renderFailedSteps(report)) console.log(line);

--- a/packages/argent-cli/test/flow.test.ts
+++ b/packages/argent-cli/test/flow.test.ts
@@ -1740,6 +1740,47 @@ describe("argent flow run <dir>", () => {
     expect(logs.join("\n")).toContain("FAIL — 2 flows: 0 passed, 1 failed, 1 skipped");
   });
 
+  it("stops the batch on an artifact-export throw instead of losing the tally", async () => {
+    toolsClientMock.baseUrl.mockRejectedValueOnce(new Error("artifact fetch died"));
+
+    await expect(
+      flow(["run", flowsDir, "-r", "--output", path.join(tempRoot, "out-export-throw")], opts)
+    ).rejects.toThrow("process.exit:1");
+
+    // The flow itself ran — only its export died — so the outcome is one
+    // failed flow and the rest skipped, not a batch that ends mid-loop.
+    expect(toolsClientMock.callTool).toHaveBeenCalledTimes(1);
+    expect(errs.join("\n")).toContain("artifact fetch died");
+    const out = logs.join("\n");
+    expect(out).toContain("· not run (batch stopped)");
+    expect(out).toContain("FAIL — 3 flows: 0 passed, 1 failed, 2 skipped");
+  });
+
+  it("emits the --json aggregate when artifact export throws", async () => {
+    toolsClientMock.baseUrl.mockRejectedValueOnce(new Error("artifact fetch died"));
+
+    await expect(
+      flow(
+        ["run", flowsDir, "--json", "--output", path.join(tempRoot, "out-export-throw-json")],
+        opts
+      )
+    ).rejects.toThrow("process.exit:1");
+
+    // stdout stays parseable: a consumer piping into `jq` still gets the
+    // ledger, with the export failure as the flow's reason.
+    expect(JSON.parse(logs.join("\n"))).toMatchObject({
+      ok: false,
+      total: 2,
+      passed: 0,
+      failed: 1,
+      skipped: 1,
+      flows: [
+        { path: "a-login.yaml", status: "fail", error: "artifact fetch died" },
+        { path: "b-checkout.yaml", status: "skip" },
+      ],
+    });
+  });
+
   it("finds nested flows with --recursive, skipping dot-directories and node_modules", async () => {
     await expect(flow(["run", flowsDir, "--recursive"], opts)).rejects.toThrow("process.exit:0");
 


### PR DESCRIPTION
Fixes #1026

**Cause:** the artifact export in `runFlowDirectory` sat outside the loop's `try`, so a throw from `baseUrl()`/`exportFailureArtifacts` escaped the function - the batch lost its skip entries, its summary and the `--json` aggregate.

**Fix:** wrap the call the way the single-flow runner already does; the flow is recorded `fail`, the batch stops (an export failure is the same wall for every remaining flow) and the loop still emits the tally.

Docs: none needed - `reference/flow-yaml.mdx` already states "An infrastructure error stops the batch and counts the remaining flows as skipped"; the code now matches it.

<details>
<summary>Verification</summary>

Two tests in `packages/argent-cli/test/flow.test.ts` make `baseUrl` reject during a `--output` run. Reverting only the source fix:

```
FAIL  test/flow.test.ts > stops the batch on an artifact-export throw instead of losing the tally
  expected [Function] to throw error including 'process.exit:1' but got 'artifact fetch died'
FAIL  test/flow.test.ts > emits the --json aggregate when artifact export throws
  expected [Function] to throw error including 'process.exit:1' but got 'artifact fetch died'
```

With the fix restored:

```
npx tsc --build                      # clean
npm run typecheck:tests -w @argent/cli  # clean
npm test -w @argent/cli              # 27 files, 529 tests passed
npx prettier --write <changed files>
npx eslint packages/argent-cli/src/flow.ts  # clean
```

Class check: `exportAndResolveArtifacts` has exactly two production call sites - this one and the single-flow runner, which was already wrapped.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
