### PR TITLE
fix(profiler): declare longRunning on the tools that re-parse a native trace

### DIFF
--- a/packages/tool-server/src/tools/profiler/combined/profiler-combined-report.ts
+++ b/packages/tool-server/src/tools/profiler/combined/profiler-combined-report.ts
@@ -66,6 +66,10 @@ Fails if either react-profiler-analyze or native-profiler-analyze has not been c
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
   },
+  // The Android branch re-queries the .pftrace, so a cold trace-processor engine
+  // re-pays the full parse past the 30s MCP fetch timeout, whose abort replays
+  // rather than cancels.
+  longRunning: true,
   services: (params) => ({
     nativeSession: nativeProfilerSessionRef(resolveDevice(params.device_id)),
   }),

--- a/packages/tool-server/src/tools/profiler/native-profiler/native-profiler-analyze.ts
+++ b/packages/tool-server/src/tools/profiler/native-profiler/native-profiler-analyze.ts
@@ -44,6 +44,9 @@ export const nativeProfilerAnalyzeTool: ToolDefinition<
       `Failed to analyze native profile: ${failureSignal.error_code}`,
   },
   capability,
+  // Parsing a trace from a recording up to RECORDING_CAP_MS long routinely exceeds
+  // the 30s MCP fetch timeout, and an aborted call is replayed, not cancelled.
+  longRunning: true,
   description: `Analyze exported native trace data and return an LLM-optimized markdown report.
 iOS: parses CPU time profile, UI hangs, and memory leaks from the exported XML files.
 Android: queries the Perfetto .pftrace via the in-process Perfetto trace-processor engine for CPU hotspots, UI hangs with jank reason + main-thread state breakdown, GC annotation, and an RSS-growth weak signal.

--- a/packages/tool-server/src/tools/profiler/query/profiler-load.ts
+++ b/packages/tool-server/src/tools/profiler/query/profiler-load.ts
@@ -505,6 +505,9 @@ Fails if the session_id is not found or required XML files are missing from disk
   // The Hermes, xctrace and perfetto formats this loads have no Chromium
   // equivalent; the gate fails at the call site, not inside the trace parser.
   capability: RN_ONLY_TOOL_CAPABILITY,
+  // load_native re-parses the whole export, which can outlast the 30s MCP fetch
+  // timeout; an aborted call is replayed, not cancelled.
+  longRunning: true,
   services: (params) => {
     const svcs: Record<string, ServiceRef> = {};
     if (params.mode === "load_native") {

--- a/packages/tool-server/src/tools/profiler/query/profiler-stack-query.ts
+++ b/packages/tool-server/src/tools/profiler/query/profiler-stack-query.ts
@@ -447,6 +447,10 @@ Fails if native-profiler-analyze has not been run or no parsed trace data is in 
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
   },
+  // The Android branch re-queries the .pftrace, so a cold trace-processor engine
+  // re-pays the full parse past the 30s MCP fetch timeout, whose abort replays
+  // rather than cancels.
+  longRunning: true,
   services: (params) => ({
     session: nativeProfilerSessionRef(resolveDevice(params.device_id)),
   }),

--- a/packages/tool-server/test/profiler-trace-parse-long-running.test.ts
+++ b/packages/tool-server/test/profiler-trace-parse-long-running.test.ts
@@ -1,0 +1,29 @@
+/**
+ * The MCP adapter aborts a tool call at FETCH_TIMEOUT_MS (30 s) unless the tool
+ * declares `longRunning`, then replays the same POST up to MAX_RETRIES times
+ * (packages/argent-mcp/src/mcp-server.ts). The tool-server never cancels the
+ * work an aborted request started, so every profiler tool that can re-parse a
+ * whole native trace must opt out of that abort - otherwise each replay
+ * re-parses from scratch and the report is never returned.
+ */
+import { describe, expect, it } from "vitest";
+import { nativeProfilerAnalyzeTool } from "../src/tools/profiler/native-profiler/native-profiler-analyze";
+import { profilerLoadTool } from "../src/tools/profiler/query/profiler-load";
+import { profilerStackQueryTool } from "../src/tools/profiler/query/profiler-stack-query";
+import { profilerCombinedReportTool } from "../src/tools/profiler/combined/profiler-combined-report";
+
+const traceParsingTools: { id: string; longRunning?: boolean }[] = [
+  nativeProfilerAnalyzeTool,
+  profilerLoadTool,
+  profilerStackQueryTool,
+  profilerCombinedReportTool,
+];
+
+describe("profiler tools that re-parse a native trace", () => {
+  it.each(traceParsingTools)(
+    "$id is declared longRunning so the MCP fetch timeout cannot abort and replay the parse",
+    (tool) => {
+      expect(tool.longRunning).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
Fixes #1043

**Cause:** the MCP adapter aborts a tool call at 30 s unless the tool declares `longRunning`, then replays the same POST up to 4 more times; the tool-server never cancels the work an aborted request started. `native-profiler-analyze` parses the whole exported trace (recordings run up to the 10 min `RECORDING_CAP_MS`), so a big trace never returns a report and each replay starts another full parse.

**Fix:** declare `longRunning: true` on it, matching `native-profiler-stop`.

**Class:** three siblings re-pay the same parse and get it too - `profiler-load` (`load_native` re-parses the export from disk) and, on their Android branches, `profiler-stack-query` and `profiler-combined-report` (they re-query the `.pftrace`, so an evicted trace-processor engine means a full cold parse). `profiler-cpu-query` and `profiler-commit-query` are left alone: they read React-profiler data already in memory and never touch a native trace.

Behaviour-only; no tool, CLI, config key or flow surface changed, so no docs update.

<details>
<summary>Verification</summary>

New test `packages/tool-server/test/profiler-trace-parse-long-running.test.ts` asserts `longRunning` on all four tools. Discriminates - with the four source hunks stashed:

```
FAIL  test/profiler-trace-parse-long-running.test.ts > 'native-profiler-analyze' is declared longRunning ...
FAIL  test/profiler-trace-parse-long-running.test.ts > 'profiler-load' is declared longRunning ...
FAIL  test/profiler-trace-parse-long-running.test.ts > 'profiler-stack-query' is declared longRunning ...
FAIL  test/profiler-trace-parse-long-running.test.ts > 'profiler-combined-report' is declared longRunning ...
AssertionError: expected undefined to be true
 Tests  4 failed (4)
```

Restored, all four pass.

Also run from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 369 files, 4836 passed / 1 skipped
- `npx prettier --write` on the five changed files - unchanged

`npx eslint` on the changed files could not run locally: `packages/docs/tsconfig.json` fails to resolve `@docusaurus/tsconfig` because the root install skips that workspace. Pre-existing, unrelated to this diff.

</details>
