### PR TITLE
fix(cli): keep flow help off stdout under --json

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -1092,16 +1092,18 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     return exitAfterFlush(2);
   }
 
-  // Once streaming is requested stdout belongs exclusively to NDJSON, so help
-  // goes to stderr as the diagnostic it is.
+  // Either flag claims stdout for machine-readable output, so help goes to
+  // stderr as the diagnostic it is.
   const jsonStream = rest.some(
     (tok) => tok === "--json-stream" || tok.startsWith("--json-stream=")
   );
+  const helpToStderr =
+    jsonStream || rest.some((tok) => tok === "--json" || tok.startsWith("--json="));
   // Checked before parseRunArgs so --help wins even when it trails a
   // value-taking flag (`--device --help` would otherwise throw "requires a
   // value" instead of printing help).
   if (rest.includes("--help") || rest.includes("-h")) {
-    printHelp(jsonStream);
+    printHelp(helpToStderr);
     return;
   }
   const fail = (message: string, code: number, err: unknown = message): Promise<never> => {
@@ -1117,7 +1119,7 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
     if (err instanceof FlagParseException) {
       if (jsonStream) writeJsonStreamError(err);
       console.error(`Error: ${err.message}\n`);
-      printHelp(jsonStream);
+      printHelp(helpToStderr);
       return exitAfterFlush(2);
     }
     throw err;
@@ -1127,7 +1129,7 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
       "argent flow run <flow|flow.yaml|dir> requires a flow name, a YAML file path, or a directory path.";
     if (jsonStream) writeJsonStreamError(message);
     console.error(message);
-    printHelp(jsonStream);
+    printHelp(helpToStderr);
     return exitAfterFlush(2);
   }
 

--- a/packages/argent-cli/test/flow.test.ts
+++ b/packages/argent-cli/test/flow.test.ts
@@ -1312,6 +1312,44 @@ describe("argent flow run", () => {
     expect(errs.join("\n")).toContain("--json-stream");
   });
 
+  it("keeps help off stdout for a bad flag under --json", async () => {
+    await expect(flow(["run", checkoutPath, "--json", "--platfrom", "ios"], opts)).rejects.toThrow(
+      "process.exit:2"
+    );
+
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+    expect(logs).toEqual([]);
+    expect(errs.join("\n")).toContain("Unknown flag: --platfrom");
+    expect(errs.join("\n")).toContain("Usage: argent flow");
+  });
+
+  it("keeps help off stdout for --json= carrying a value", async () => {
+    await expect(flow(["run", checkoutPath, "--json=true"], opts)).rejects.toThrow(
+      "process.exit:2"
+    );
+
+    expect(logs).toEqual([]);
+    expect(errs.join("\n")).toContain("--json does not take a value");
+    expect(errs.join("\n")).toContain("Usage: argent flow");
+  });
+
+  it("keeps help off stdout for --json --help", async () => {
+    await flow(["run", checkoutPath, "--json", "--help"], opts);
+
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+    expect(logs).toEqual([]);
+    expect(errs.join("\n")).toContain("Usage: argent flow");
+  });
+
+  it("keeps help off stdout for a --json run given no flow", async () => {
+    await expect(flow(["run", "--json"], opts)).rejects.toThrow("process.exit:2");
+
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+    expect(logs).toEqual([]);
+    expect(errs.join("\n")).toContain("requires a flow name");
+    expect(errs.join("\n")).toContain("Usage: argent flow");
+  });
+
   it("emits a structured error for a pre-flight refusal in streaming mode", async () => {
     const missing = path.join(path.dirname(checkoutPath), "missing.yaml");
     await expect(flow(["run", missing, "--json-stream"], opts)).rejects.toThrow("process.exit:2");


### PR DESCRIPTION
Fixes #1025

**Cause:** the three early-exit paths in `argent flow run` passed only the `--json-stream` flag to `printHelp`, so under `--json` the 3.4 KB usage screen went to `console.log`.

**Fix:** compute the "help is a diagnostic" flag from `--json` as well, and pass it to all three `printHelp` calls.

**Verified:** driving the built CLI, stdout for `run --json --platfrom ios` goes from 3404 bytes of usage text to 0; four new tests cover `--help`, a flag-parse error, `--json=` carrying a value, and a missing flow reference, and all four fail on the unfixed code.

Sibling `--json` commands (`config`, `flags`, `secrets`, `run`) already print usage only on an explicit `--help` and send errors to stderr, so nothing else had this shape. No docs change: `flow-yaml.mdx` documents `--json` as "print the raw JSON report", which is what it now does.

<details>
<summary>Repro and checks</summary>

Before (dist patched back to `printHelp(jsonStream)`):

```
$ node drive.mjs run --json --platfrom ios 2>/dev/null | wc -c
    3404
$ node drive.mjs run --json --platfrom ios 2>/dev/null | head -1
Usage: argent flow <subcommand> [options]
```

After:

```
$ node drive.mjs run --json --platfrom ios 2>/dev/null | wc -c
       0
$ node drive.mjs run --json --platfrom ios 2>&1 1>/dev/null | head -1
Error: Unknown flag: --platfrom
```

Test discrimination - with `printHelp(helpToStderr)` reverted to `printHelp(jsonStream)`:

```
 × keeps help off stdout for a bad flag under --json
 × keeps help off stdout for --json= carrying a value
 × keeps help off stdout for --json --help
 × keeps help off stdout for a --json run given no flow
 Tests  4 failed | 1 passed
```

Checks run from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/cli` - clean
- `npm test -w @argent/cli` - 27 files, 531 tests passed
- `npx prettier --write` on both changed files
- `npx eslint packages/argent-cli/src/flow.ts` - clean

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
