### PR TITLE
fix(installer): quote the project root in the manual-install advice

### DIFF
--- a/packages/argent-installer/src/install-runner.ts
+++ b/packages/argent-installer/src/install-runner.ts
@@ -12,6 +12,7 @@ import {
   localInstallCommand,
   projectInstallCommand,
   formatShellCommand,
+  shellQuotePath,
   resolveProjectRoot,
   hasProjectPackageJson,
   isGloballyInstalled,
@@ -169,7 +170,9 @@ async function installLocally(opts: { fromTar: string | null; tel: InitTelemetry
           ? `${installError}`
           : `The install reported success but ${pc.cyan(PACKAGE_NAME)} is not in node_modules.`
       );
-      p.log.info(`Install manually with: ${pc.cyan(`cd ${projectRoot} && ${cmdStr}`)}`);
+      p.log.info(
+        `Install manually with: ${pc.cyan(`cd ${shellQuotePath(projectRoot)} && ${cmdStr}`)}`
+      );
     }
     await tel.trackPackageAction(
       "fresh_install",

--- a/packages/argent-installer/src/package-manager.ts
+++ b/packages/argent-installer/src/package-manager.ts
@@ -13,6 +13,13 @@ export function formatShellCommand(cmd: ShellCommand): string {
   return parts.join(" ");
 }
 
+// `dir` as one POSIX shell word, for a command the reader pastes. Single
+// quotes, because a discovered path can hold `$`, a backtick or `\`, which
+// double quotes leave live - retargeting the line.
+export function shellQuotePath(dir: string): string {
+  return "'" + dir.split("'").join("'\\''") + "'";
+}
+
 export function detectPackageManager(): PackageManager {
   const agent = process.env.npm_config_user_agent ?? "";
   if (agent.startsWith("yarn")) return "yarn";

--- a/packages/argent-installer/src/utils.ts
+++ b/packages/argent-installer/src/utils.ts
@@ -19,6 +19,7 @@ import { resolvePackageRoot } from "./package-root.js";
 // helpers moved into focused modules.
 export {
   formatShellCommand,
+  shellQuotePath,
   detectPackageManager,
   detectProjectPackageManager,
   globalInstallCommand,

--- a/packages/argent-installer/test/install-runner.test.ts
+++ b/packages/argent-installer/test/install-runner.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+import * as p from "@clack/prompts";
 import { runInstall } from "../src/install-runner.js";
 import { runShellCommand, ShellCommandError } from "../src/shell.js";
-import { isLocallyInstalled } from "../src/utils.js";
+import { isLocallyInstalled, resolveProjectRoot } from "../src/utils.js";
 import type { InitTelemetry } from "../src/init-telemetry.js";
 
 // Exercises installLocally's failure handling: the retry-once semantics, the
@@ -188,4 +193,41 @@ describe("installLocally failure handling", () => {
       platformSpy.mockRestore();
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "quotes the project root in the manual-install advice",
+    async () => {
+      // The advice is pasted into a shell, so the path has to survive as one
+      // word: `cd /a/My Project` runs `cd /a/My`.
+      const parent = fs.mkdtempSync(path.join(os.tmpdir(), "argent-install-advice-"));
+      const projectRoot = path.join(parent, "My 'Project' $x");
+      fs.mkdirSync(projectRoot);
+      try {
+        vi.mocked(p.log.info).mockClear();
+        vi.mocked(resolveProjectRoot).mockReturnValueOnce(projectRoot);
+        vi.mocked(runShellCommand).mockRejectedValue(
+          new ShellCommandError("registry down", 1, null)
+        );
+
+        await expect(localInstall(makeTel())).rejects.toThrow(ExitCalled);
+
+        const esc = String.fromCharCode(27);
+        const advice = vi
+          .mocked(p.log.info)
+          .mock.calls.map((c) =>
+            String(c[0])
+              .split(new RegExp(`${esc}\\[[0-9;]*m`, "g"))
+              .join("")
+          )
+          .find((line) => line.startsWith("Install manually with: "));
+        expect(advice).toBeDefined();
+
+        const cd = advice!.slice(advice!.indexOf("cd ")).split(" && ")[0];
+        const landed = execFileSync("/bin/sh", ["-c", `${cd} && pwd`], { encoding: "utf8" }).trim();
+        expect(landed).toBe(projectRoot);
+      } finally {
+        fs.rmSync(parent, { recursive: true, force: true });
+      }
+    }
+  );
 });


### PR DESCRIPTION
Fixes #1053

**Cause.** `installLocally`'s failure advice built `cd ${projectRoot} && ${cmdStr}` with the root interpolated raw. A project path with a space is cut in two when the user pastes it; one holding `$`, a backtick or `\` still runs, aimed elsewhere.

**Fix.** `shellQuotePath` in `package-manager.ts` single-quotes the path (escaping embedded `'`), and the advice uses it.

**Class.** This is the only discovered path interpolated into printed shell advice - the two other "Install manually with" lines print `cmdStr` alone. `cmdStr`'s one variable argument is `--from <tarball>`, a path the reader typed themselves and gets back in the form they gave; left as is.

**Docs.** No tool, CLI flag, config key or flow file changes - nothing in `packages/docs/` needs an update.

**Verified.** New test in `install-runner.test.ts` drives a failing local install with the root `.../My 'Project' $x`, extracts the printed `cd`, and runs it under `/bin/sh` - `pwd` must come back as the project root. It reproduces the issue's error on the unfixed line.

<details>
<summary>Test discriminates - fix reverted</summary>

```
 FAIL  test/install-runner.test.ts > installLocally failure handling > quotes the project root in the manual-install advice
/bin/sh: line 0: cd: /var/folders/.../argent-install-advice-UW3dHe/My: No such file or directory
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

with the fix in place:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```
</details>

<details>
<summary>Checks</summary>

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/installer` - clean
- `npm test -w @argent/installer` - 17 files, 556 tests passed
- `npx knip` - 30 lines, identical to the same run on the unchanged tree
- `npx eslint` on the three changed `src/` files - clean; `npx prettier --write` applied
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
