### PR TITLE
fix(settings-permissions): 400, not 500, for a permission the platform cannot map

### DIFF
--- a/packages/tool-server/src/tools/settings-permissions/platforms/android.ts
+++ b/packages/tool-server/src/tools/settings-permissions/platforms/android.ts
@@ -1,4 +1,5 @@
 import { FAILURE_CODES, FailureError, getFailureSignal } from "@argent/registry";
+import { InvalidToolInputError } from "../../../utils/capability";
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
 import { adbShell, isTerminalAdbError, shellQuote } from "../../../utils/adb";
 import type {
@@ -136,7 +137,7 @@ export const androidImpl: PlatformImpl<
 
     const permissions = permissionsFor(permission, action);
     if (permissions.length === 0) {
-      throw new FailureError(
+      throw new InvalidToolInputError(
         `Permission '${permission}' has no Android runtime-permission equivalent, so there is nothing to ${action}.`,
         {
           error_code: FAILURE_CODES.SETTINGS_PERMISSION_UNSUPPORTED,

--- a/packages/tool-server/src/tools/settings-permissions/platforms/ios.ts
+++ b/packages/tool-server/src/tools/settings-permissions/platforms/ios.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { FAILURE_CODES, FailureError, subprocessFailureMetadata } from "@argent/registry";
+import { InvalidToolInputError } from "../../../utils/capability";
 import type { PlatformImpl } from "../../../utils/cross-platform-tool";
 import { simctlArgsForUdid } from "../../../utils/ios-device-sets";
 import { simctlPrivacy as remoteSimctlPrivacy } from "../../../utils/sim-remote";
@@ -113,7 +114,7 @@ function buildIosHandler(
 
     const services = IOS_SERVICES[permission];
     if (services.length === 0) {
-      throw new FailureError(
+      throw new InvalidToolInputError(
         `Permission '${permission}' cannot be changed on the iOS simulator — ` +
           `\`xcrun simctl privacy\` has no service for it. ` +
           `Interact with the notification permission dialog in the app instead.`,

--- a/packages/tool-server/test/settings-permissions.test.ts
+++ b/packages/tool-server/test/settings-permissions.test.ts
@@ -24,6 +24,7 @@ import {
   getFailureSignal,
   zodObjectToJsonSchema,
 } from "@argent/registry";
+import { InvalidToolInputError } from "../src/utils/capability";
 import { settingsPermissionsTool } from "../src/tools/settings-permissions";
 import { iosImpl } from "../src/tools/settings-permissions/platforms/ios";
 import { androidImpl } from "../src/tools/settings-permissions/platforms/android";
@@ -263,6 +264,12 @@ describe("settings-permissions iOS branch", () => {
     await expect(
       iosImpl.handler({}, params({ permission: "notifications" }), iosDevice)
     ).rejects.toSatisfy(failsWith(FAILURE_CODES.SETTINGS_PERMISSION_UNSUPPORTED));
+    // The dispatcher keys the HTTP status on the error class, not on
+    // `error_kind`, so only this class turns the rejection into a 400 the agent
+    // reads as unretryable instead of a 500 it retries (#1032).
+    await expect(
+      iosImpl.handler({}, params({ permission: "notifications" }), iosDevice)
+    ).rejects.toBeInstanceOf(InvalidToolInputError);
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
@@ -817,6 +824,10 @@ describe("settings-permissions Android branch", () => {
     await expect(
       androidImpl.handler({}, params({ permission: "reminders" }), androidDevice)
     ).rejects.toSatisfy(failsWith(FAILURE_CODES.SETTINGS_PERMISSION_UNSUPPORTED));
+    // Same 400-via-the-error-class contract as the iOS arm (#1032).
+    await expect(
+      androidImpl.handler({}, params({ permission: "reminders" }), androidDevice)
+    ).rejects.toBeInstanceOf(InvalidToolInputError);
     expect(mockAdbShell).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Fixes #1032

**Cause** - both `settings-permissions` platform arms rejected an unmappable permission with a bare `FailureError`. The HTTP dispatcher keys the status on the error *class*, never on `error_kind`, so it fell through to **500** and the agent read caller input as the retryable class.

**Fix** - throw `InvalidToolInputError` instead (same message, same `SETTINGS_PERMISSION_UNSUPPORTED` signal), which the dispatcher maps to **400** while keeping the granular telemetry bucket. Same shape as the keyboard backends' "no keycode for this character" arm.

Both sites of this class inside `settings-permissions` are fixed (iOS + Android; there is no third platform arm). The two sites the issue also names in `devices/boot-device.ts` are left alone: `BOOT_IOS_UNSUPPORTED_HOST` (iOS asked for on a non-macOS host) and `VEGA_ALREADY_RUNNING` (a device-state conflict a `force:true` retry does resolve) each need a different class - a design call in its own right, not this fix.

No docs change: `packages/docs` documents what the tool does, not per-tool HTTP status codes.

<details>
<summary>Verification</summary>

Discriminating test - reverted just the two source files to `main` and re-ran the suite:

```
FAIL test/settings-permissions.test.ts > settings-permissions iOS branch > notifications is rejected as unsupported without calling simctl
  expected FailureError: Permission 'notifications' … to be an instance of InvalidToolInputError
FAIL test/settings-permissions.test.ts > settings-permissions Android branch > reminders is rejected as unsupported (no Android equivalent)
  expected FailureError: Permission 'reminders' has … to be an instance of InvalidToolInputError
Tests  2 failed | 59 passed (61)
```

With the fix restored: `61 passed (61)`.

Also run from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - full package suite green
- `npx prettier --check` on the three changed files - clean
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unsupported Android and iOS permissions are now reported as invalid input errors, providing more accurate error classification while preserving existing error details.
  - Existing rejection behavior and error codes remain unchanged.

- **Tests**
  - Added coverage to verify that unsupported Android and iOS permissions return the expected invalid-input error type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->