### PR TITLE
fix(cli): stop `flow list` reporting an unreadable flows directory as absent

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -1081,7 +1081,13 @@ export async function flow(argv: string[], options: FlowCommandOptions): Promise
         .map((rel) => path.join(FLOWS_DIR, rel));
       if (paths.length === 0) console.log("No flows found in .argent/flows");
       else console.log(paths.join("\n"));
-    } catch {
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        // Unreadable is not absent: reported as absence, a caller reads success
+        // and concludes the project has no flows.
+        console.error(`Could not read flow directory: ${dir}`);
+        return exitAfterFlush(2);
+      }
       console.log("No .argent/flows directory in the current working directory.");
     }
     return;

--- a/packages/argent-cli/test/flow.test.ts
+++ b/packages/argent-cli/test/flow.test.ts
@@ -1153,6 +1153,51 @@ describe("argent flow run", () => {
     expect(logs.join("\n")).toBe(".argent/flows/linked.yaml");
   });
 
+  it("reports a missing flows directory on stdout, without failing", async () => {
+    const listRoot = path.join(tempRoot, "list-absent-project");
+    await fsp.mkdir(listRoot, { recursive: true });
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(listRoot);
+      await flow(["list"], opts);
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    expect(logs.join("\n")).toBe("No .argent/flows directory in the current working directory.");
+    expect(errs).toEqual([]);
+  });
+
+  // Skipped as root / on Windows, where a mode-000 directory is still readable —
+  // see canDenyRead.
+  it.skipIf(!canDenyRead)(
+    "fails an unreadable flows directory instead of calling it absent",
+    async () => {
+      const listRoot = path.join(tempRoot, "list-unreadable-project");
+      const flowsDir = path.join(listRoot, ".argent", "flows");
+      await fsp.mkdir(flowsDir, { recursive: true });
+      await fsp.writeFile(path.join(flowsDir, "checkout.yaml"), "steps: []\n");
+      await fsp.chmod(flowsDir, 0o000);
+      const previousCwd = process.cwd();
+      try {
+        process.chdir(listRoot);
+        await expect(flow(["list"], opts)).rejects.toThrow("process.exit:2");
+      } finally {
+        process.chdir(previousCwd);
+        // Restore before afterAll's rm walks the tree (see there).
+        await fsp.chmod(flowsDir, 0o700);
+      }
+
+      // Same wording and exit code as `flow run` on the same directory. The
+      // path is matched by its tail: cwd resolves symlinks, and tmpdir is one
+      // on macOS.
+      const line = errs.join("\n");
+      expect(line.startsWith("Could not read flow directory: ")).toBe(true);
+      expect(line.endsWith(path.join("list-unreadable-project", ".argent", "flows"))).toBe(true);
+      expect(logs).toEqual([]);
+    }
+  );
+
   it("prints the no-flows message when no entry in the directory is runnable", async () => {
     const listRoot = path.join(tempRoot, "list-empty-project");
     const flowsDir = path.join(listRoot, ".argent", "flows");


### PR DESCRIPTION
Fixes #960

**Cause:** the `list` arm's `catch` in `packages/argent-cli/src/flow.ts` had no discriminant, so any `readdir` failure on `.argent/flows` (EACCES on the directory or an ancestor, ELOOP, ENOTDIR) printed the missing-directory sentence on stdout and exited 0.

**Fix:** only ENOENT keeps that message; every other errno prints `Could not read flow directory: <path>` on stderr and exits 2 - the wording and exit code `argent flow run <dir>` already uses for the same directory.

**Verified:** driving the built CLI in a project whose `.argent/flows` is mode 000, `flow list` goes from "No .argent/flows directory..." on stdout with exit 0 to the read error on stderr with exit 2; a project with no `.argent/flows` still prints the old sentence with exit 0. Two tests cover both arms and the unreadable one fails on the unfixed code.

Class check: `flow.ts` is the only place with this shape - `runFlowDirectory` and the single-file arm already split "missing" from "unreadable", and the message string exists nowhere else in the repo.

Docs: none needed - `reference/flow-yaml.mdx` documents `argent flow list` as "List the flow files in `.argent/flows`" and says nothing about its error output or exit codes.

<details>
<summary>Repro and checks</summary>

Before (built `dist/flow.js` patched back to the bare `catch`):

```
$ chmod 000 proj/.argent/flows && cd proj
$ argent flow list 2>/dev/null
No .argent/flows directory in the current working directory.
EXIT=0
```

After:

```
$ argent flow list 2>/dev/null
EXIT=2
$ argent flow list 2>&1 1>/dev/null
Could not read flow directory: /.../proj/.argent/flows
$ chmod 755 .argent/flows && ls .argent/flows
smoke.yaml
```

Missing directory, unchanged:

```
$ cd empty-project && argent flow list
No .argent/flows directory in the current working directory.
EXIT=0
```

Test discrimination - with the source fix stashed:

```
FAIL  test/flow.test.ts > fails an unreadable flows directory instead of calling it absent
AssertionError: promise resolved "undefined" instead of rejecting
 Tests  1 failed | 1 passed
```

Checks run from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/cli` - clean
- `npm test -w @argent/cli` - 27 files, 529 tests passed
- `npx prettier --write` on both changed files
- `npx eslint` on both changed files - clean (only the known `packages/docs` tsconfig error, unrelated)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
