### PR TITLE
fix(flows): classify a flow step that omits a selector key

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-utils.ts
+++ b/packages/tool-server/src/tools/flows/flow-utils.ts
@@ -1547,10 +1547,12 @@ const MAX_ENTRY_RENDER_CHARS = 200;
 
 function badEntry(raw: unknown, detail: string): never {
   // A cyclic YAML alias materializes as a cyclic object — JSON.stringify would
-  // throw and mask the validation message.
+  // throw and mask the validation message. It also returns the *value*
+  // `undefined` for an omitted key (an absent `in:`/`into:`), a case its
+  // declared `string` return type hides.
   let rendered: string;
   try {
-    rendered = JSON.stringify(raw);
+    rendered = JSON.stringify(raw) ?? String(raw);
   } catch {
     rendered = "[cyclic entry]";
   }

--- a/packages/tool-server/test/flows/flow-utils.test.ts
+++ b/packages/tool-server/test/flows/flow-utils.test.ts
@@ -252,6 +252,17 @@ describe("parseFlow", () => {
     );
   });
 
+  it.each([
+    ["await.text.in", "steps:\n  - await: { text: { contains: Welcome } }\n"],
+    ["assert.text.in", "steps:\n  - assert: { text: { contains: Welcome } }\n"],
+    ["when.text.in", "steps:\n  - when: { text: { contains: Welcome } }\n    steps: [echo: hi]\n"],
+    ["type.into", "steps:\n  - type: { text: hello }\n"],
+  ])("classifies an omitted %s instead of crashing on the render", (where, content) => {
+    // An absent key reaches badEntry as `undefined`, which JSON.stringify
+    // renders as the value `undefined` rather than a string.
+    expect(entryRejectionMessage(content)).toContain(`Unrecognized flow entry (${where}:`);
+  });
+
   it("sugars a bare-string selector into a loose { text } for tap", async () => {
     const flow = parseFlow("steps:\n  - tap: Settings\n");
     // Bare string ⇒ loose: resolves identifier-first, then falls back to text.


### PR DESCRIPTION
Fixes #962

**Cause:** `badEntry` reads `.length` off `JSON.stringify(raw)`, which returns the *value* `undefined` (not a string) for an omitted key - so a step written without its `in:`/`into:` selector key crashed with `TypeError: Cannot read properties of undefined (reading 'length')` instead of the classified `FailureError`. The unclassified throw carries no `error_kind`, so `argent flow run <dir>` treats it as an infra error and stops the whole batch, against the CLI's documented "an invalid flow file fails alone" contract.

**Fix:** make the render total - `JSON.stringify(raw) ?? String(raw)`.

**Class:** `badEntry` is the single site; the only other `JSON.stringify(...)`-used-as-a-string in `packages/*/src` is `auto-capture.ts:112`, which already guards with `?.includes(...) ?? false`.

**Docs:** none needed - no tool, CLI, config key or flow-file surface changes; only the failure classification of an already-invalid flow.

<details>
<summary>Verification</summary>

Before (dist built from the branch with the source fix reverted):

```
await no in    | TypeError | Cannot read properties of undefined (reading 'length')
assert no in   | TypeError | Cannot read properties of undefined (reading 'length')
when no in     | TypeError | Cannot read properties of undefined (reading 'length')
type no into   | TypeError | Cannot read properties of undefined (reading 'length')
```

After:

```
await no in    | FailureError | Unrecognized flow entry (await.text.in: Invalid input: expected object, received undefined): undefined
assert no in   | FailureError | Unrecognized flow entry (assert.text.in: Invalid input: expected object, received undefined): undefined
when no in     | FailureError | Unrecognized flow entry (when.text.in: Invalid input: expected object, received undefined): undefined
type no into   | FailureError | Unrecognized flow entry (type.into: Invalid input: expected object, received undefined): undefined
```

Test discriminates: the four new cases in `flow-utils.test.ts` go through the existing `entryRejectionMessage` helper, which asserts `error_code === FLOW_ENTRY_UNRECOGNIZED`. On the unfixed source all four fail with `expected undefined to be 'FLOW_ENTRY_UNRECOGNIZED'`; with the fix all pass.

Ran from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 368 files, 4836 passed, 1 skipped
- `npx prettier --write` on both changed files - unchanged

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
