### PR TITLE
fix(describe): render `checked` on Chromium nodes that carry no `checkable`

### DIFF
--- a/packages/tool-server/src/tools/describe/format-tree.ts
+++ b/packages/tool-server/src/tools/describe/format-tree.ts
@@ -60,7 +60,10 @@ function formatFlags(n: DescribeNode): string {
   if (n.clickable) flags.push("clickable");
   if (n.longClickable) flags.push("long-clickable");
   if (n.scrollable) flags.push("scrollable");
-  if (n.checkable) flags.push(n.checked ? "checked" : "checkable");
+  // The Chromium walker reports `checked` without `checkable`, so the state
+  // flag cannot be gated on the pair.
+  if (n.checked) flags.push("checked");
+  else if (n.checkable) flags.push("checkable");
   if (n.focused) flags.push("focused");
   if (n.selected) flags.push("selected");
   if (n.disabled) flags.push("disabled");
@@ -80,6 +83,7 @@ function hasContent(n: DescribeNode): boolean {
     n.longClickable ||
     n.scrollable ||
     n.checkable ||
+    n.checked ||
     (typeof n.scrollHidden === "number" && n.scrollHidden > 0)
   );
 }

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -486,6 +486,49 @@ describe("formatDescribeTree", () => {
     expect(elementLines(out)).toHaveLength(0);
   });
 
+  // The Chromium walker sets `checked` alone, so a ticked box has to render
+  // differently from an unticked one without any `checkable` companion.
+  it("renders checked on a node that carries no checkable", () => {
+    const box = (checked: boolean): DescribeNode => ({
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "input",
+          label: "Accept terms",
+          identifier: "terms",
+          frame: { x: 0, y: 0.1, width: 0.04, height: 0.04 },
+          clickable: true,
+          checked,
+        }),
+      ],
+    });
+    const ticked = elementLines(formatDescribeTree(box(true), { source: "cdp-dom" }));
+    const unticked = elementLines(formatDescribeTree(box(false), { source: "cdp-dom" }));
+    expect(ticked[0]).toContain("[clickable,checked]");
+    expect(unticked[0]).toContain("[clickable]");
+    expect(ticked[0]).not.toEqual(unticked[0]);
+  });
+
+  // A `<div role="checkbox" aria-checked="true">` carries no other content
+  // signal, so hasContent() has to count `checked` or the node is dropped.
+  it("keeps an unlabeled node whose only content signal is checked", () => {
+    const root: DescribeNode = {
+      role: "Screen",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [
+        leaf({
+          role: "div",
+          frame: { x: 0.1, y: 0.1, width: 0.3, height: 0.05 },
+          checked: true,
+        }),
+      ],
+    };
+    const lines = elementLines(formatDescribeTree(root, { source: "cdp-dom" }));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("[checked]");
+  });
+
   // Regression: nested mode previously keyed on "uiautomator" only, so
   // "android-devtools" responses rendered flat and lost all descendants.
   it("renders android-devtools source in nested mode", () => {


### PR DESCRIPTION
Fixes #978

**Cause** - the Chromium DOM walker sets `checked` (from `input.checked` / `aria-checked`) but never `checkable`, and `format-tree` gated both the flag and `hasContent()` on `checkable`.

**Fix** - render `checked` on its own, and count it as a content signal. Android, the only other adapter that emits these, sets both fields and renders unchanged.

| | before | after |
| --- | --- | --- |
| ticked `<input type="checkbox">` | `input "Accept terms" id="terms" [clickable]` | `input "Accept terms" id="terms" [clickable,checked]` |
| unticked | `input "Accept terms" id="terms" [clickable]` | `input "Accept terms" id="terms" [clickable]` |
| `<div role="checkbox" aria-checked="true">` | dropped from the tree | `div [checked]` |

No docs change: `checkable`/`checked` are not mentioned anywhere in `packages/docs`, and no tool, CLI flag, config key or flow directive changed.

<details>
<summary>Verification</summary>

Both new tests fail on the unfixed renderer (source change stashed):

```
FAIL > renders checked on a node that carries no checkable
  expected '  input "Accept terms" id="terms" [clickable]  (0.000, 0.100, 0.040, 0.040)'
  to contain '[clickable,checked]'
FAIL > keeps an unlabeled node whose only content signal is checked
  expected [] to have a length of 1 but got +0
```

Green with the fix:

```
npx tsc --build                                  # clean
npm run typecheck:tests -w @argent/tool-server   # clean
npm test -w @argent/tool-server                  # 368 files, 4834 passed | 1 skipped
npx prettier --write <changed files>             # unchanged
```

Not run: a live Chromium target (no agent-browser in this environment). The walker's `node.checked = true` at `platforms/chromium.ts:431` is unchanged by this PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
