### PR TITLE
fix(flows): say "no reason given" when a nested step's message is empty

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-nested-outcome.ts
+++ b/packages/tool-server/src/tools/flows/flow-nested-outcome.ts
@@ -32,6 +32,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+/** An empty reason is as uninformative as a missing one, and renders as a bare colon. */
+function reasonText(value: unknown): string {
+  return typeof value === "string" && value ? value : "no reason given";
+}
+
 function firstFailingStep(steps: unknown): string | undefined {
   if (!Array.isArray(steps)) return undefined;
   for (const entry of steps) {
@@ -45,8 +50,7 @@ function firstFailingStep(steps: unknown): string | undefined {
         : typeof entry.kind === "string"
           ? entry.kind
           : "step";
-    const why = typeof entry.reason === "string" ? entry.reason : "no reason given";
-    return `${what}: ${why}`;
+    return `${what}: ${reasonText(entry.reason)}`;
   }
   return undefined;
 }
@@ -112,7 +116,7 @@ function runSequenceOutcome(result: Record<string, unknown>): NestedOutcome | un
       status: "fail",
       reason:
         `run-sequence stopped at ${tool} after ${count(result.completed)} of ` +
-        `${count(result.total)} steps: ${String(failed.error)}`,
+        `${count(result.total)} steps: ${reasonText(failed.error)}`,
     };
   }
 

--- a/packages/tool-server/test/flows/flow-nested-outcome.test.ts
+++ b/packages/tool-server/test/flows/flow-nested-outcome.test.ts
@@ -234,3 +234,36 @@ describe("the check is deliberately scoped to the two orchestrator tools", () =>
     expect(out?.reason).toMatch(/assert: no reason given/);
   });
 });
+
+describe("a failure carrying no message still says something after the colon", () => {
+  // Both readers quote a message the sub-run built with `err.message`, which is
+  // the empty string for `new Error("")` and for a bare `throw ""`.
+  it("keeps a composed flow's fragment readable", () => {
+    const out = nestedOrchestratorOutcome("flow-execute", {
+      flow: "login",
+      ok: false,
+      passed: 0,
+      failed: 1,
+      errored: 0,
+      steps: [{ index: 0, kind: "tool", tool: "gesture-tap", status: "fail", reason: "" }],
+    });
+
+    expect(out?.status).toBe("fail");
+    expect(out?.reason).toBe(
+      'flow "login" failed: 0 passed, 1 failed, 0 errored (gesture-tap: no reason given)'
+    );
+  });
+
+  it("keeps a sequence's fragment readable", () => {
+    const out = nestedOrchestratorOutcome("run-sequence", {
+      completed: 0,
+      total: 1,
+      steps: [{ tool: "keyboard", error: "" }],
+    });
+
+    expect(out?.status).toBe("fail");
+    expect(out?.reason).toBe(
+      "run-sequence stopped at keyboard after 0 of 1 steps: no reason given"
+    );
+  });
+});


### PR DESCRIPTION
Fixes #963

**Cause.** `firstFailingStep` quoted a nested step's `reason` whenever it was a string, so an empty one - what `errMsg` returns for `new Error("")` or a bare `throw ""` - rendered `(gesture-tap: )`. `runSequenceOutcome` had the identical hole via `String(failed.error)`.

**Fix.** One `reasonText` guard, used by both readers: an empty message falls back to `no reason given`, the wording the file already used for a missing one.

| before | after |
| --- | --- |
| `flow "login" failed: 0 passed, 1 failed, 0 errored (gesture-tap: )` | `... (gesture-tap: no reason given)` |
| `run-sequence stopped at keyboard after 0 of 1 steps: ` | `... steps: no reason given` |

No docs change: this is an internal failure-report string, no tool, CLI, config key or flow directive moved.

<details>
<summary>Verification</summary>

Both new tests fail on the un-fixed source (stash the source change, keep the test):

```
Expected: "flow "login" failed: 0 passed, 1 failed, 0 errored (gesture-tap: no reason given)"
Received: "flow "login" failed: 0 passed, 1 failed, 0 errored (gesture-tap: )"

Expected: "run-sequence stopped at keyboard after 0 of 1 steps: no reason given"
Received: "run-sequence stopped at keyboard after 0 of 1 steps: "
```

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 368 files, 4834 passed, 1 skipped
- `npx prettier --write` on both changed files

Class check: the only other `no reason given` site is `flow-add-step.ts:542`, guarding a `DirectiveOutcome.reason` built exclusively from non-empty literals in `flow-actions.ts` - left alone.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
