### PR TITLE
fix(flows): key a snapshot crop by the selector's scopes too

### DIFF
--- a/packages/tool-server/src/tools/flows/flow-visual.ts
+++ b/packages/tool-server/src/tools/flows/flow-visual.ts
@@ -11,7 +11,7 @@ import {
   offscreenHint,
   type ActionEnv,
 } from "./flow-actions";
-import { describeSelector, type FlowSelector } from "./flow-utils";
+import { describeSelector, SELECTOR_RELATIONS, type FlowSelector } from "./flow-utils";
 import { diffPngFiles } from "../screenshot-diff/screenshot-diff";
 import { requireArtifacts, type ArtifactHandle } from "../../artifacts";
 
@@ -57,18 +57,31 @@ async function pngDimensions(file: string): Promise<{ w: number; h: number }> {
 }
 
 /**
- * Crop identity for a selector's own fields, in fixed order: the key is immune
- * to YAML key order, and to describeSelector's format (owned by failure prose).
- * `loose` counts — it changes resolution (identifier-first fallback).
+ * Crop identity for a selector, in fixed order: the key is immune to YAML key
+ * order, and to describeSelector's format (owned by failure prose). `loose`
+ * counts — it changes resolution (identifier-first fallback). A scoped
+ * selector appends `any` and its whole relation tree, so two crops differing
+ * only by `within`/`after`/`next` select different elements and key apart; a
+ * relation-free selector keeps the flat five-field tuple, so baselines
+ * committed for unscoped crops keep their filenames.
  */
-function cropIdentity(s: FlowSelector): string {
-  return JSON.stringify([
+function cropIdentityParts(s: FlowSelector): unknown[] {
+  const own = [
     s.text ?? null,
     s.textMatches ?? null,
     s.identifier ?? null,
     s.role ?? null,
     s.loose ?? false,
-  ]);
+  ];
+  const scopes = SELECTOR_RELATIONS.map((relation) => {
+    const nested = s[relation];
+    return nested === undefined ? null : cropIdentityParts(nested);
+  });
+  return scopes.every((scope) => scope === null) ? own : [...own, s.any ?? false, ...scopes];
+}
+
+function cropIdentity(s: FlowSelector): string {
+  return JSON.stringify(cropIdentityParts(s));
 }
 
 function baselineDir(flowsDir: string, flowName: string): string {
@@ -208,8 +221,8 @@ export async function runSnapshot(
   // The key stays on the FULL capture's dimensions even under cropOn: its job
   // is device-class identity (wrong-simulator/rotation detection), which
   // cropped dimensions — a function of layout — would destroy. A cropOn key
-  // additionally hashes the selector's own fields, so same-name snapshots
-  // cropping different elements do not share a baseline file.
+  // additionally hashes the selector, so same-name snapshots cropping
+  // different elements do not share a baseline file.
   const { w, h } = await pngDimensions(shot.image.hostPath);
   const cropSuffix =
     opts.cropOn === undefined

--- a/packages/tool-server/test/flows/flow-visual.test.ts
+++ b/packages/tool-server/test/flows/flow-visual.test.ts
@@ -629,6 +629,43 @@ describe("runSnapshot cropOn", () => {
     expect(files.sort()).toEqual([`${r1.snapshotKey}.png`, `${r2.snapshotKey}.png`].sort());
   });
 
+  it("keys same-name crops that differ only by scope to distinct baselines", async () => {
+    const r1 = await runSnapshot(
+      env,
+      opts({ updateBaselines: true, cropOn: { text: "Toggle", within: { identifier: "row-1" } } })
+    );
+    const r2 = await runSnapshot(
+      env,
+      opts({ updateBaselines: true, cropOn: { text: "Toggle", within: { identifier: "row-2" } } })
+    );
+
+    expect(r1.snapshotKey).not.toBe(r2.snapshotKey);
+    // Two baseline files on disk — row-2 did not overwrite row-1's baseline.
+    const files = await fs.readdir(path.join(tmpDir, "__baselines__", "checkout"));
+    expect(files.sort()).toEqual([`${r1.snapshotKey}.png`, `${r2.snapshotKey}.png`].sort());
+  });
+
+  it("keys the same scope reached through different relations apart", async () => {
+    const r1 = await runSnapshot(
+      env,
+      opts({ updateBaselines: true, cropOn: { text: "Toggle", after: { identifier: "row" } } })
+    );
+    const r2 = await runSnapshot(
+      env,
+      opts({ updateBaselines: true, cropOn: { text: "Toggle", next: { identifier: "row" } } })
+    );
+
+    expect(r1.snapshotKey).not.toBe(r2.snapshotKey);
+  });
+
+  it("keys an unscoped selector by its own fields alone", async () => {
+    // Committed baselines predate scope-aware keys; adding a scope must not
+    // rename the file an unscoped crop already writes.
+    const r = await runSnapshot(env, opts({ updateBaselines: true, cropOn }));
+
+    expect(r.snapshotKey).toBe(cropKey);
+  });
+
   it("keys a selector canonically regardless of property insertion order", async () => {
     const r1 = await runSnapshot(
       env,


### PR DESCRIPTION
Fixes #961

**Cause.** `cropIdentity` hashed five of `FlowSelector`'s fields and none of the relational ones (`within`/`after`/`next`), so two `snapshot` steps sharing a name whose `cropOn` differed only by scope hashed identically and landed on one baseline file - `--update-baselines` let the second overwrite the first, and a later run compared step one against step two's image (a silent pass).

**Fix.** `cropIdentity` recurses over `SELECTOR_RELATIONS` and appends `any` when a scope is present. A relation-free selector keeps the flat five-field tuple, so **existing crop baseline filenames do not change**.

```yaml
- snapshot: { name: toggle, cropOn: { text: Notifications, within: { id: row-1 } } }
- snapshot: { name: toggle, cropOn: { text: Notifications, within: { id: row-2 } } }
```

| | key for both steps |
| --- | --- |
| before | `toggle__ios-…-crop-6f0d05c4` for both - one file |
| after | `…-crop-216f7010` and `…-crop-dab05c84` - two files |

**Class.** `cropIdentity` is the only selector-hashing site in the package (`grep` for the field list returns one hit); `selectorTree` in `flow-utils.ts` already walks the relation tree.

**Docs.** None needed - `reference/flow-yaml.mdx` already states Argent keys a baseline "plus the selector for `cropOn`"; that claim only becomes true here.

<details>
<summary>Verification</summary>

Two new tests in `test/flows/flow-visual.test.ts` (scope-only difference; same scope under `after` vs `next`) plus one pinning the unscoped key. With the source change stashed:

```
 × keys same-name crops that differ only by scope to distinct baselines
   AssertionError: expected 'home__ios-100x200-crop-b0f48a9b'
     not to be 'home__ios-100x200-crop-b0f48a9b'
 × keys the same scope reached through different relations apart
      Tests  2 failed | 33 passed (35)
```

Restored: 35 passed. Full runs from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 368 files, 4835 passed, 1 skipped
- `npx prettier --write` on both changed files - unchanged

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
