### PR TITLE
fix(tool-server): reject unknown params on the wait tools instead of dropping them

### DIFF
--- a/packages/tool-server/src/tools/await-screen-idle/index.ts
+++ b/packages/tool-server/src/tools/await-screen-idle/index.ts
@@ -25,37 +25,39 @@ const DEFAULT_TIMEOUT_MS = 3000;
 const DEFAULT_POLL_INTERVAL_MS = 200;
 const DEFAULT_MIN_STABLE_MS = 250;
 
-const zodSchema = z.object({
-  udid: z
-    .string()
-    .min(1)
-    .describe("Target device id from `list-devices` (iOS UDID, Android serial, or Chromium id)."),
-  timeoutMs: z
-    .number()
-    .int()
-    .positive()
-    .max(120_000)
-    .optional()
-    .describe(
-      `Max time to wait for the screen to settle before giving up (default ${DEFAULT_TIMEOUT_MS}).`
-    ),
-  pollIntervalMs: z
-    .number()
-    .int()
-    .min(50)
-    .max(5000)
-    .optional()
-    .describe(`How often to re-read the tree (default ${DEFAULT_POLL_INTERVAL_MS}).`),
-  minStableMs: z
-    .number()
-    .int()
-    .min(0)
-    .max(10_000)
-    .optional()
-    .describe(
-      `The screen must hold the same content for at least this long to count as settled (default ${DEFAULT_MIN_STABLE_MS}).`
-    ),
-});
+const zodSchema = z
+  .object({
+    udid: z
+      .string()
+      .min(1)
+      .describe("Target device id from `list-devices` (iOS UDID, Android serial, or Chromium id)."),
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .max(120_000)
+      .optional()
+      .describe(
+        `Max time to wait for the screen to settle before giving up (default ${DEFAULT_TIMEOUT_MS}).`
+      ),
+    pollIntervalMs: z
+      .number()
+      .int()
+      .min(50)
+      .max(5000)
+      .optional()
+      .describe(`How often to re-read the tree (default ${DEFAULT_POLL_INTERVAL_MS}).`),
+    minStableMs: z
+      .number()
+      .int()
+      .min(0)
+      .max(10_000)
+      .optional()
+      .describe(
+        `The screen must hold the same content for at least this long to count as settled (default ${DEFAULT_MIN_STABLE_MS}).`
+      ),
+  })
+  .strict();
 
 type Params = z.infer<typeof zodSchema>;
 

--- a/packages/tool-server/src/tools/await-ui-element/index.ts
+++ b/packages/tool-server/src/tools/await-ui-element/index.ts
@@ -142,6 +142,7 @@ const zodSchema = z
       .optional()
       .describe(`How often to re-check the tree (default ${DEFAULT_POLL_INTERVAL_MS}).`),
   })
+  .strict()
   .refine((p) => p.condition !== "text" || p.expectedText !== undefined, {
     message: "condition `text` requires expectedText",
     path: ["expectedText"],

--- a/packages/tool-server/test/await-screen-idle.test.ts
+++ b/packages/tool-server/test/await-screen-idle.test.ts
@@ -99,6 +99,35 @@ describe("await-screen-idle tool", () => {
     expect(result.waitedMs).toBeGreaterThanOrEqual(80);
   });
 
+  describe("schema validation", () => {
+    const schema = createAwaitScreenIdleTool(iosRegistry({} as AXServiceApi)).zodSchema!;
+
+    it.each(["minStableMS", "min_stable_ms", "frobnicate"])(
+      "rejects the top-level key %s instead of silently applying the default",
+      (key) => {
+        const result = schema.safeParse({ udid: IOS_UDID, [key]: 1000 });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues).toContainEqual(
+            expect.objectContaining({ code: "unrecognized_keys", keys: [key] })
+          );
+        }
+      }
+    );
+
+    it("accepts the declared fields", () => {
+      expect(
+        schema.safeParse({
+          udid: IOS_UDID,
+          timeoutMs: 3000,
+          pollIntervalMs: 200,
+          minStableMs: 250,
+        }).success
+      ).toBe(true);
+    });
+  });
+
   it("settles on the first non-empty read when minStableMs is 0", async () => {
     const tool = createAwaitScreenIdleTool(iosRegistry(makeSequencedAXService([content()])));
 

--- a/packages/tool-server/test/await-ui-element.test.ts
+++ b/packages/tool-server/test/await-ui-element.test.ts
@@ -1343,6 +1343,38 @@ describe("await-ui-element tool", () => {
       }
     });
 
+    it.each(["textMatches", "text_match", "TextMatch", "frobnicate"])(
+      "rejects the top-level key %s instead of silently falling back to `contains`",
+      (key) => {
+        const result = schema.safeParse({
+          condition: "text",
+          udid: IOS_UDID,
+          selector: { identifier: "cgj" },
+          expectedText: "Save",
+          [key]: "equals",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues).toContainEqual(
+            expect.objectContaining({ code: "unrecognized_keys", keys: [key] })
+          );
+        }
+      }
+    );
+
+    it("accepts the correctly spelled textMatch", () => {
+      expect(
+        schema.safeParse({
+          condition: "text",
+          udid: IOS_UDID,
+          selector: { identifier: "cgj" },
+          expectedText: "Save",
+          textMatch: "equals",
+        }).success
+      ).toBe(true);
+    });
+
     it.each([
       { text: "Order" },
       { identifier: "order-row" },


### PR DESCRIPTION
Fixes #997

**Cause:** `await-ui-element` and `await-screen-idle` built their top-level params with a plain `z.object({...})`, so an unknown key was dropped without a word and the wait silently used the default - `textMatch` back to `contains`, `minStableMs` back to 250 ms - reporting `success: true` for a check the caller did not ask for.

**Fix:** `.strict()` on both schemas (on `await-ui-element` it goes before `.refine()`, which yields a `ZodEffects`). Unknown keys now surface through the existing HTTP zod-validation path as `unrecognized_keys`, the same way the nested `selector` in the same call already rejects `textMatches`.

**Class:** the three verdict-returning tools are the ones where a dropped param flips a real check into a false pass. `screenshot-diff` was already `.strict()`; these were the remaining two. The other tool schemas are left non-strict on purpose - a dropped param there changes what the call *does*, and the result the caller reads reflects it, so it is not a silent false pass. Reachable through `run-sequence` too, which forwards step args verbatim; `flow-run` is unaffected because `bindDeviceArgs` already only injects device keys the schema declares.

**Docs:** no change needed - `packages/docs/docs/reference/tools.mdx` lists these tools without per-param detail, and no parameter was added, removed or renamed.

<details>
<summary>Verification</summary>

Discrimination (fix reverted, tests run, fix restored):

```
# .strict() removed from await-ui-element
 × rejects the top-level key textMatches instead of silently falling back to `contains`
 × rejects the top-level key text_match instead of silently falling back to `contains`
 × rejects the top-level key TextMatch instead of silently falling back to `contains`
 × rejects the top-level key frobnicate instead of silently falling back to `contains`
Tests  4 failed | 73 passed (77)

# .strict() removed from await-screen-idle
 × rejects the top-level key minStableMS instead of silently applying the default
 × rejects the top-level key min_stable_ms instead of silently applying the default
 × rejects the top-level key frobnicate instead of silently applying the default
Tests  3 failed | 6 passed (9)
```

With the fix in place:

```
npx tsc --build                                   clean
npm run typecheck:tests -w @argent/tool-server    clean
npm test -w @argent/tool-server                   368 files, 4841 passed | 1 skipped
npm test -w @argent/mcp                           6 files, 85 passed
npx prettier --write <changed files>              clean
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
