### PR TITLE
docs(skills): split includeSkipped guidance per tool in argent-metro-debugger

### DIFF
--- a/packages/skills/skills/argent-metro-debugger/SKILL.md
+++ b/packages/skills/skills/argent-metro-debugger/SKILL.md
@@ -67,9 +67,16 @@ Both can point to source files, but `inspect-element` is purpose-built for sourc
 
 ### `includeSkipped` guidance
 
-Applies to both `debugger-component-tree` and `debugger-inspect-element`. Set to `true` only when debugging filter behavior — e.g., an expected component is missing from output, or you need to inspect a very specific branch of the tree (not just an overview).
+**`debugger-component-tree`** — appends a bounded summary (about a dozen lines, whatever the app size) of what was pruned: total fibers walked, JS-side skip counts by component name, and TS-side filter-pass totals. It adds no node to the tree and never names the component you are looking for, so it tells you which filter removed things, not what was removed.
 
-> **Warning:** Output can be very large. Always combine with `maxNodes` (component-tree) or `maxItems` (inspect-element) and increase it incrementally (e.g., start at 50, then grow). Do not use `includeSkipped` without a limit on large apps.
+When a component you expect is missing from the tree:
+
+- scrolled or otherwise positioned off-canvas (`TS-side removed → Off-screen`) — re-run with `onScreenOnly: false`, which is the parameter that decides what the tree contains.
+- pruned JS-side (host views with no `testID`, framework wrappers, inactive navigation stacks) — no parameter brings it back. Give it a `testID`, or use `debugger-inspect-element` at its coordinates.
+
+**`debugger-inspect-element`** — filtered items stay in the result carrying `skipped: true` and a `skipReason`. Set to `true` only when debugging filter behavior — e.g., an expected component is missing from output, or you need to inspect a very specific branch of the hierarchy (not just an overview).
+
+> **Warning:** Output can be very large. Always combine with `maxItems` and increase it incrementally (e.g., start at 35, then grow). Do not use `includeSkipped` without a limit on large apps.
 
 ---
 


### PR DESCRIPTION
Fixes #928

**Cause** - one `includeSkipped` section covered both tools, but on `debugger-component-tree` the flag only appends a counts-only "--- Filtered ---" block: it adds no node and names no component, so "an expected component is missing" sent agents to a flag that cannot surface it (and paired with a `maxNodes` that shrinks the tree further), while the "output can be very large" warning describes a block capped at ~12 lines by construction.

**Fix** - split the section. `component-tree`: says the summary is bounded and names nothing, and routes a missing component to `onScreenOnly: false` (or, for JS-side pruning, a `testID` / `inspect-element`). `inspect-element`: keeps the existing retained-items text and the size warning, now scoped to `maxItems`.

**Verified** - claims re-read against source; `npx tsc --build` and `prettier --check` green.

<details>
<summary>Source backing each claim</summary>

- counts-only block, no node added: `packages/tool-server/src/tools/debugger/debugger-component-tree.ts:402-455` builds `--- Filtered ---` from `totalFibers` / `skippedCounts` / `filterStats` only.
- bounded: header + `Total fibers walked` + `JS-side skipped` (top 10 names on one line, `:425-427`) + `TS-side removed` + at most 7 detail lines.
- `TS-side removed -> Off-screen` is the one category `onScreenOnly` controls: `:90` gates the off-screen subtree prune on `opts.onScreenOnly` (default `true`, `:468-475`).
- JS-side pruning is unreachable from any parameter: `packages/tool-server/src/utils/debugger/scripts/component-tree.ts:262-275` (inactive `activityState` / `isPageFocused` subtrees), `:296-300` (host fibers with no `testID`), `:322-323` (the `else` arm that only increments `skippedCounts`).
- `inspect-element` really does retain filtered items: `packages/tool-server/src/tools/debugger/debugger-inspect-element.ts:32-34` (`skipped: true` + `skipReason`); `maxItems` default is 35 (`:137-141`).

No test: the change is prose in a skill file - `packages/skills` has no test suite and no code reads `SKILL.md`.

No docs update needed: no tool, CLI, config key, flow file or user-facing capability changed. `includeSkipped` appears in no page under `packages/docs/`.

Class check: `grep -rn includeSkipped --include='*.md'` matches only this file, so there is no sibling copy of the wrong guidance.

Out of scope, left alone: #631 (`onScreenOnly: false` reported as a no-op on a screen whose pruning was all JS-side) and the fact that the tool description does not name `onScreenOnly` outside its zod `.describe()`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
