### PR TITLE
docs(skills): describe what debugger-component-tree actually renders

### DIFF
--- a/packages/skills/skills/argent-metro-debugger/SKILL.md
+++ b/packages/skills/skills/argent-metro-debugger/SKILL.md
@@ -45,12 +45,12 @@ With two or more devices on one Metro, `debugger-connect` refuses a udid/serial 
 
 ### Inspection & console
 
-| Tool                       | Purpose                                                                                                                                                                                                              |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `debugger-component-tree`  | Full React fiber tree (names, depth, bounding rects, tap coordinates).                                                                                                                                               |
-| `debugger-inspect-element` | Inspect at (x, y) using **logical pixel coordinates** (not normalized 0-1): component hierarchy with source file:line and code fragment. See `references/source-maps.md`.                                            |
-| `debugger-log-registry`    | Get log summary (counts, clusters, file path). Then use `Grep`/`Read` on the flat log file for details. If it returns `status: "not_connected"`, there is **no** `file` — follow its `guidance` instead of grepping. |
-| `debugger-evaluate`        | Run a JS expression in the app runtime.                                                                                                                                                                              |
+| Tool                       | Purpose                                                                                                                                                                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debugger-component-tree`  | Pruned tree of the on-screen React components: name, text/accessibilityLabel, testID, and a normalized tap center. Carries no per-node geometry; for size, overlap or clipping use `describe`, which returns a bounding rect. |
+| `debugger-inspect-element` | Inspect at (x, y) using **logical pixel coordinates** (not normalized 0-1): component hierarchy with source file:line and code fragment. See `references/source-maps.md`.                                                     |
+| `debugger-log-registry`    | Get log summary (counts, clusters, file path). Then use `Grep`/`Read` on the flat log file for details. If it returns `status: "not_connected"`, there is **no** `file` — follow its `guidance` instead of grepping.          |
+| `debugger-evaluate`        | Run a JS expression in the app runtime.                                                                                                                                                                                       |
 
 ---
 
@@ -58,10 +58,10 @@ With two or more devices on one Metro, `debugger-connect` refuses a udid/serial 
 
 ### `debugger-component-tree` vs `debugger-inspect-element`
 
-|          | `debugger-component-tree`                                              | `debugger-inspect-element`                                      |
-| -------- | ---------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Best for | Layout overview; finding tap targets; user-defined component hierarchy | Identifying a visible element and tracing it to its source file |
-| Use when | "What's on screen and where?"                                          | "What component is this and where is it defined?"               |
+|          | `debugger-component-tree`                             | `debugger-inspect-element`                                      |
+| -------- | ----------------------------------------------------- | --------------------------------------------------------------- |
+| Best for | Finding tap targets; user-defined component hierarchy | Identifying a visible element and tracing it to its source file |
+| Use when | "What's on screen and where?"                         | "What component is this and where is it defined?"               |
 
 Both can point to source files, but `inspect-element` is purpose-built for source tracing. `component-tree` is for orientation and tap-target discovery.
 
@@ -129,6 +129,6 @@ When reading from the log file:
 | Reload JS (already connected)     | `debugger-reload-metro`                                             |
 | Relaunch app on device            | `restart-app`                                                       |
 | Inspect component at point        | `debugger-inspect-element`                                          |
-| Full component tree               | `debugger-component-tree`                                           |
+| On-screen component tree          | `debugger-component-tree`                                           |
 | Console log overview              | `debugger-log-registry` (summary + log file path for `Grep`/`Read`) |
 | Evaluate JS                       | `debugger-evaluate`                                                 |

--- a/packages/skills/skills/argent-metro-debugger/SKILL.md
+++ b/packages/skills/skills/argent-metro-debugger/SKILL.md
@@ -45,12 +45,12 @@ With two or more devices on one Metro, `debugger-connect` refuses a udid/serial 
 
 ### Inspection & console
 
-| Tool                       | Purpose                                                                                                                                                                                                                       |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `debugger-component-tree`  | Pruned tree of the on-screen React components: name, text/accessibilityLabel, testID, and a normalized tap center. Carries no per-node geometry; for size, overlap or clipping use `describe`, which returns a bounding rect. |
-| `debugger-inspect-element` | Inspect at (x, y) using **logical pixel coordinates** (not normalized 0-1): component hierarchy with source file:line and code fragment. See `references/source-maps.md`.                                                     |
-| `debugger-log-registry`    | Get log summary (counts, clusters, file path). Then use `Grep`/`Read` on the flat log file for details. If it returns `status: "not_connected"`, there is **no** `file` — follow its `guidance` instead of grepping.          |
-| `debugger-evaluate`        | Run a JS expression in the app runtime.                                                                                                                                                                                       |
+| Tool                       | Purpose                                                                                                                                                                                                              |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debugger-component-tree`  | Pruned tree of the on-screen React components: name, text/accessibilityLabel, testID, and a normalized tap center. Carries no bounding rects; for size, overlap or clipping use `describe`, which does return them.  |
+| `debugger-inspect-element` | Inspect at (x, y) using **logical pixel coordinates** (not normalized 0-1): component hierarchy with source file:line and code fragment. See `references/source-maps.md`.                                            |
+| `debugger-log-registry`    | Get log summary (counts, clusters, file path). Then use `Grep`/`Read` on the flat log file for details. If it returns `status: "not_connected"`, there is **no** `file` — follow its `guidance` instead of grepping. |
+| `debugger-evaluate`        | Run a JS expression in the app runtime.                                                                                                                                                                              |
 
 ---
 


### PR DESCRIPTION
Fixes #927

`argent-metro-debugger/SKILL.md` sold `debugger-component-tree` as a "Full React fiber tree (names, depth, **bounding rects**, tap coordinates)". `formatLabel` reads each node's `rect` only to derive a normalized center - `x`/`y`/`w`/`h` reach the output nowhere - and seven filter passes prune the tree. Layout questions ("is this clipped", "do these overlap") were routed to a tool that cannot answer them.

Prose only, one file.

| | Before | After |
| --- | --- | --- |
| Tool table | Full React fiber tree (names, depth, bounding rects, tap coordinates). | Pruned tree of the on-screen React components: name, text/accessibilityLabel, testID, and a normalized tap center. Carries no bounding rects; for size, overlap or clipping use `describe`, which does return them. |
| Best-for row | Layout overview; finding tap targets; user-defined component hierarchy | Finding tap targets; user-defined component hierarchy |
| Quick reference | Full component tree | On-screen component tree |

**Docs:** no update needed - `packages/docs/docs/reference/tools.mdx` already says "compact React component text tree", and no tool, CLI, config key or capability changed.

<details>
<summary>Repro and verification</summary>

Drove `buildTextTree` with two nodes carrying `rect: {x:40, y:300, w:313, h:48}` on a 393x852 screen:

```
Screen: 393x852

HomeScreen (tap: 0.50,0.38)
  SubmitButton "Submit" [testID=submit] (tap: 0.50,0.38)
```

Nothing of `w`/`h` survives; the only geometry in the whole response is the `Screen: WxH` header. `describe` by contrast renders `(x, y, width, height)` per node (`packages/tool-server/src/tools/describe/format-tree.ts` `fmtFrame`), so the redirect is real.

`packages/skills` ships markdown only and has no test suite, so no discriminating test applies. `npx prettier --check` and `npx tsc --build` green.

**Class check:** every other mention of the tool (`argent-device-interact`, `argent-test-ui-flow`, `argent-react-native-app-workflow`, `rules/argent.md`, the tool's own `description`) already says names/text/testID/tap coords. This row was the only one claiming geometry.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the debugger component tree documentation to describe its pruned on-screen tree output.
  - Clarified that tap centers are normalized and bounding rectangles are not included.
  - Recommended using `describe` for size, overlap, and clipping details.
  - Updated comparison and quick-reference tables to reflect the revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->