### PR TITLE
fix(cli): reject an empty --device/--platform/--output on flow run

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -197,6 +197,13 @@ export function parseRunArgs(argv: string[]): {
     json: options.json === true,
     jsonStream: options["json-stream"] === true,
   };
+  // The shared parser leaves a separately supplied "" for the command to judge
+  // (`--device "$UDID"` with UDID unset). Every read of these three is truthy-
+  // guarded, so an empty one is dropped and the run falls back to device
+  // auto-detection, against whatever happens to be booted.
+  for (const name of ["device", "platform", "output"] as const) {
+    if (options[name] === "") throw new FlagParseException(`--${name} requires a value`);
+  }
   if (positionals[0] !== undefined) out.flowRef = positionals[0];
   if (options.device !== undefined) out.device = options.device as string;
   if (options.platform !== undefined) out.platform = options.platform as string;

--- a/packages/argent-cli/test/flow.test.ts
+++ b/packages/argent-cli/test/flow.test.ts
@@ -172,6 +172,14 @@ describe("parseRunArgs", () => {
     );
   });
 
+  it("throws on a separately supplied empty value, like the --flag= form", () => {
+    for (const flag of ["--device", "--platform", "--output"]) {
+      expect(() => parseRunArgs(["checkout.yaml", flag, ""])).toThrow(FlagParseException);
+      expect(() => parseRunArgs(["checkout.yaml", flag, ""])).toThrow(`${flag} requires a value`);
+      expect(() => parseRunArgs(["checkout.yaml", `${flag}=`])).toThrow(`${flag} requires a value`);
+    }
+  });
+
   it("accepts the --flag=value form for every value-taking flag", () => {
     expect(
       parseRunArgs(["checkout.yaml", "--device=SIM-1", "--platform=ios", "--output=dir"])


### PR DESCRIPTION
Fixes #937

**Cause:** the shared arg parser deliberately passes a separately supplied `""` through for each command to judge; `parseRunArgs` never judged it, and every downstream read (`if (args.device)`, `if (args.platform)`, `args.output ? …`) is truthy-guarded - so `argent flow run checkout --device "$UDID"` with `UDID` unset dropped the value and fell back to device auto-detection, running against whatever happened to be booted.

**Fix:** `parseRunArgs` rejects an empty `--device` / `--platform` / `--output` with the same `--X requires a value` message the `--X=` spelling already produced.

**Class:** the other value options are already covered - `server start --port/--idle-timeout` and `link --host/--port` reject `""` in their validators, `server start --host ""` is intentionally a wildcard bind (`isWildcard` lists `""`) and warns, and the `choices`-constrained options (`--scope`, `lens --terminal`) reject it. Left alone: `lens --agent ""` falls through to the interactive agent picker, which is what omitting the flag does anyway.

**Docs:** none needed - this only rejects an invalid invocation; no tool, CLI surface, config key or flow-file behaviour changed.

<details>
<summary>Verification</summary>

Repro from the issue, against the built `dist` in this branch:

```
["checkout","--device",""]   => THROW: --device requires a value
["checkout","--device="]     => THROW: --device requires a value
["checkout","--platform",""] => THROW: --platform requires a value
["checkout","--output",""]   => THROW: --output requires a value
["checkout","--device","SIM-1"] => {...,"flowRef":"checkout","device":"SIM-1"}
```

Discriminating test - `packages/argent-cli/test/flow.test.ts`, "throws on a separately supplied empty value, like the --flag= form". With `src/flow.ts` stashed it fails (`expected function to throw an error, but it didn't`); with the fix it passes.

Ran from the worktree root: `npx tsc --build`, `npm run typecheck:tests -w @argent/cli`, `npm test -w @argent/cli` (27 files, 528 tests passed), `npx prettier --check` on both changed files.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
