### PR TITLE
fix(tool-server): give the CDP binding timeout the same recovery guidance as its sibling

### DIFF
--- a/packages/tool-server/src/utils/debugger/cdp-client.ts
+++ b/packages/tool-server/src/utils/debugger/cdp-client.ts
@@ -340,12 +340,20 @@ export class CDPClient {
       const timer = setTimeout(() => {
         this.pendingBindings.delete(id);
         reject(
-          new FailureError(`Binding response for requestId=${id} timed out`, {
-            error_code: FAILURE_CODES.DEBUGGER_CDP_BINDING_TIMEOUT,
-            failure_stage: "debugger_cdp_binding",
-            failure_area: "tool_server",
-            error_kind: "timeout",
-          })
+          new FailureError(
+            `Binding response for requestId=${id} timed out — the runtime took the script ` +
+              `but never called back over the binding. It may be paused at a breakpoint ` +
+              `(the script is dispatched without awaiting it, so a paused runtime still ` +
+              `accepts it and never runs the callback), or frozen. Check the debugger and ` +
+              `resume it; if nothing is paused, restart the app. Do not retry in a loop — ` +
+              `each attempt waits out the full timeout.`,
+            {
+              error_code: FAILURE_CODES.DEBUGGER_CDP_BINDING_TIMEOUT,
+              failure_stage: "debugger_cdp_binding",
+              failure_area: "tool_server",
+              error_kind: "timeout",
+            }
+          )
         );
       }, timeout);
 

--- a/packages/tool-server/test/metro/cdp-client.test.ts
+++ b/packages/tool-server/test/metro/cdp-client.test.ts
@@ -287,6 +287,35 @@ describe("CDPClient", () => {
       await client.disconnect();
     });
 
+    it("an unanswered binding rejects with DEBUGGER_CDP_BINDING_TIMEOUT and paused-vs-frozen recovery", async () => {
+      const client = new CDPClient(`ws://localhost:${port}`);
+      await client.connect();
+      const ws = await waitForServer();
+      // The evaluate is answered, the binding never fires — exactly what a
+      // runtime paused at a breakpoint does, since the script is dispatched
+      // with awaitPromise off.
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(raw.toString());
+        ws.send(JSON.stringify({ id: msg.id, result: { result: { value: "ok" } } }));
+      });
+
+      const err = await rejection(client.evaluateWithBinding("s()", "req-t", { timeout: 50 }));
+      const message = (err as Error).message;
+      expect(message).toContain("Binding response for requestId=req-t timed out");
+      // Without recovery guidance an agent reads this as transient and
+      // retry-loops, each pass waiting out the full timeout.
+      expect(message).toMatch(/paused at a breakpoint/);
+      expect(message).toMatch(/resume/);
+      expect(message).toMatch(/restart the app/);
+      expect(message).toMatch(/Do not retry in a loop/);
+      expect(getFailureSignal(err)).toMatchObject({
+        error_code: FAILURE_CODES.DEBUGGER_CDP_BINDING_TIMEOUT,
+        failure_stage: "debugger_cdp_binding",
+        error_kind: "timeout",
+      });
+      await client.disconnect();
+    });
+
     it("server close mid-request rejects the pending send with DEBUGGER_CDP_CONNECTION_CLOSED", async () => {
       const client = new CDPClient(`ws://localhost:${port}`);
       await client.connect();


### PR DESCRIPTION
Fixes #947

**Cause.** `DEBUGGER_CDP_BINDING_TIMEOUT` rejected with a bare `Binding response for requestId=... timed out`, while the sibling `DEBUGGER_CDP_REQUEST_TIMEOUT` in the same file carries a full paused-vs-frozen recovery. It is the timeout where *paused* matters most: `evaluateWithBinding` dispatches the script with `awaitPromise: false`, so a runtime stopped at a breakpoint accepts the evaluate and never runs the callback.

**Fix.** Give the binding timeout the same shape of guidance - check/resume the debugger, else restart the app, do not retry in a loop (each attempt burns the full timeout).

**Deliberately not done:** the issue also suggests mapping the code into `NOT_CONNECTED_CODE_MAP`. That map is only consulted by `debugger-status` / `debugger-log-registry`, and neither calls `evaluateWithBinding` (only `debugger-component-tree` and `debugger-inspect-element` do), so the entry would be unreachable. The message is the only surface an agent actually sees.

**Class check:** `evaluateWithBinding` is the only other timeout surface in `cdp-client.ts`; `chromium-server/cdp-session.ts` has no bare timeout message. The wording stays platform-neutral ("restart the app", not `restart-app`) because `cdp-client` is shared with the Chromium blueprint.

**Docs:** none needed - no tool, CLI flag, config key or flow directive changed; this is an error-message string.

<details>
<summary>Verification</summary>

Test added to `packages/tool-server/test/metro/cdp-client.test.ts`: the fake CDP server answers the evaluate and never fires the binding, then the rejection is asserted for the code and each guidance clause.

Discriminates - with the source change stashed:

```
FAIL test/metro/cdp-client.test.ts > CDPClient > failure signal classification >
     an unanswered binding rejects with DEBUGGER_CDP_BINDING_TIMEOUT and paused-vs-frozen recovery
AssertionError: expected 'Binding response for requestId=req-t …' to match /paused at a breakpoint/
+ Received: "Binding response for requestId=req-t timed out"
```

Ran from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 368 files, 4833 passed, 1 skipped
- `npx prettier --write` on both changed files - unchanged
- `npx eslint` on the changed src file - clean (the test file only hits the known local `packages/docs` tsconfig resolution error)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved debugger timeout messages with clearer guidance when execution is paused or frozen.
  - Added recommendations to resume the debugger or restart the app, along with a warning against repeated retries.
- **Tests**
  - Added coverage to verify timeout messaging and failure metadata for unanswered debugger evaluation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->