### PR TITLE
fix(react-profiler): reject a CPU sample index whose parallel arrays disagree

### DIFF
--- a/packages/tool-server/src/utils/react-profiler/pipeline/00-cpu-correlate.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/00-cpu-correlate.ts
@@ -257,7 +257,6 @@ export function serializeCpuSampleIndex(index: CpuSampleIndex): SerializedCpuSam
   };
 }
 
-/** One of the three parallel sample arrays, checked down to the element. */
 function isSampleArray(value: unknown, sampleCount: number): value is number[] {
   return (
     Array.isArray(value) &&
@@ -267,10 +266,9 @@ function isSampleArray(value: unknown, sampleCount: number): value is number[] {
 }
 
 export function deserializeCpuSampleIndex(raw: SerializedCpuSampleIndex): CpuSampleIndex {
-  // Validate rather than coerce. The three sample arrays are read at the same index
-  // and nothing downstream fails loudly: a missing or short one reads `undefined`
-  // and a non-numeric element reads NaN, which reach the user as NaN in every
-  // column, or as a confident "all of them were idle" (#950).
+  // The three sample arrays are read at the same index, and a bad one reaches the
+  // user as an answer rather than an error: `undefined` from a short array turns
+  // every column NaN, a string node id turns every sample "idle" (#950).
   const sampleCount = Array.isArray(raw?.timestampsMs) ? raw.timestampsMs.length : -1;
   if (
     raw?.version !== 2 ||

--- a/packages/tool-server/src/utils/react-profiler/pipeline/00-cpu-correlate.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/00-cpu-correlate.ts
@@ -257,20 +257,27 @@ export function serializeCpuSampleIndex(index: CpuSampleIndex): SerializedCpuSam
   };
 }
 
+/** One of the three parallel sample arrays, checked down to the element. */
+function isSampleArray(value: unknown, sampleCount: number): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.length === sampleCount &&
+    value.every((entry) => Number.isFinite(entry))
+  );
+}
+
 export function deserializeCpuSampleIndex(raw: SerializedCpuSampleIndex): CpuSampleIndex {
-  // Validate rather than coerce: `new Float64Array(undefined)` is zero-length, so a
-  // truncated or stale index would deserialize into a profile with no samples and
-  // answer every query with "no hotspots". The three sample arrays are read in
-  // lockstep, so a short one yields `undefined` per sample: NaN in every figure
-  // from interval starts, "all idle" from node ids.
+  // Validate rather than coerce. The three sample arrays are read at the same index
+  // and nothing downstream fails loudly: a missing or short one reads `undefined`
+  // and a non-numeric element reads NaN, which reach the user as NaN in every
+  // column, or as a confident "all of them were idle" (#950).
+  const sampleCount = Array.isArray(raw?.timestampsMs) ? raw.timestampsMs.length : -1;
   if (
     raw?.version !== 2 ||
-    !Array.isArray(raw.timestampsMs) ||
     !Array.isArray(raw.nodes) ||
-    !Array.isArray(raw.intervalStartsMs) ||
-    !Array.isArray(raw.sampleNodeIds) ||
-    raw.intervalStartsMs.length !== raw.timestampsMs.length ||
-    raw.sampleNodeIds.length !== raw.timestampsMs.length
+    !isSampleArray(raw.timestampsMs, sampleCount) ||
+    !isSampleArray(raw.intervalStartsMs, sampleCount) ||
+    !isSampleArray(raw.sampleNodeIds, sampleCount)
   ) {
     throw new Error("unsupported CPU sample index format");
   }

--- a/packages/tool-server/src/utils/react-profiler/pipeline/00-cpu-correlate.ts
+++ b/packages/tool-server/src/utils/react-profiler/pipeline/00-cpu-correlate.ts
@@ -260,8 +260,18 @@ export function serializeCpuSampleIndex(index: CpuSampleIndex): SerializedCpuSam
 export function deserializeCpuSampleIndex(raw: SerializedCpuSampleIndex): CpuSampleIndex {
   // Validate rather than coerce: `new Float64Array(undefined)` is zero-length, so a
   // truncated or stale index would deserialize into a profile with no samples and
-  // answer every query with "no hotspots".
-  if (raw?.version !== 2 || !Array.isArray(raw.timestampsMs) || !Array.isArray(raw.nodes)) {
+  // answer every query with "no hotspots". The three sample arrays are read in
+  // lockstep, so a short one yields `undefined` per sample: NaN in every figure
+  // from interval starts, "all idle" from node ids.
+  if (
+    raw?.version !== 2 ||
+    !Array.isArray(raw.timestampsMs) ||
+    !Array.isArray(raw.nodes) ||
+    !Array.isArray(raw.intervalStartsMs) ||
+    !Array.isArray(raw.sampleNodeIds) ||
+    raw.intervalStartsMs.length !== raw.timestampsMs.length ||
+    raw.sampleNodeIds.length !== raw.timestampsMs.length
+  ) {
     throw new Error("unsupported CPU sample index format");
   }
   const nodeMap = new Map<number, HermesProfileNode>();
@@ -270,7 +280,7 @@ export function deserializeCpuSampleIndex(raw: SerializedCpuSampleIndex): CpuSam
   }
   return {
     timestampsMs: new Float64Array(raw.timestampsMs),
-    intervalStartsMs: new Float64Array(raw.intervalStartsMs ?? []),
+    intervalStartsMs: new Float64Array(raw.intervalStartsMs),
     sampleNodeIds: raw.sampleNodeIds,
     nodeMap,
     childToParent: buildChildToParent(nodeMap),

--- a/packages/tool-server/test/react-profiler/cpu-correlate.test.ts
+++ b/packages/tool-server/test/react-profiler/cpu-correlate.test.ts
@@ -233,28 +233,40 @@ describe("serialized index", () => {
     expect(() => deserializeCpuSampleIndex({ version: 2 } as never)).toThrow(/unsupported/i);
   });
 
-  it("rejects an index whose sample arrays disagree in length", () => {
-    // A v2 file missing `intervalStartsMs` reads `undefined` per interval start,
-    // and `Math.max(startMs, undefined)` turns selfMs, totalMs and coverage into
-    // NaN for every window instead of failing.
-    const partial = {
-      version: 2,
-      timestampsMs: [1, 2, 3],
-      intervalStartsMs: [0, 1, 2],
-      sampleNodeIds: [2, 2, 2],
-      nodes: NODES,
-      durationMs: 3,
-    };
+  // A sample array that is absent, short, or holds a non-number reaches the user as
+  // a plausible answer, never as an error: interval starts turn selfMs, totalMs and
+  // coverage into NaN in every column, node ids turn samples into "idle" — which
+  // `profiler-cpu-query` reports as "the JS thread was not executing" (#950).
+  const VALID_INDEX = {
+    version: 2,
+    timestampsMs: [1, 2, 3],
+    intervalStartsMs: [0, 1, 2],
+    sampleNodeIds: [2, 2, 2],
+    nodes: NODES,
+    durationMs: 3,
+  };
 
-    for (const broken of [
-      { ...partial, intervalStartsMs: undefined },
-      { ...partial, intervalStartsMs: [0, 1] },
-      { ...partial, sampleNodeIds: undefined },
-      { ...partial, sampleNodeIds: [2] },
-    ]) {
-      expect(() => deserializeCpuSampleIndex(broken as never)).toThrow(/unsupported/i);
-    }
+  it.each([
+    ["intervalStartsMs absent", { intervalStartsMs: undefined }],
+    ["intervalStartsMs short", { intervalStartsMs: [0, 1] }],
+    ["sampleNodeIds absent", { sampleNodeIds: undefined }],
+    ["sampleNodeIds short", { sampleNodeIds: [2] }],
+    // JSON has no NaN literal — `JSON.stringify` writes a non-finite float out as
+    // `null`, which `new Float64Array` reads back as a silent 0.
+    ["intervalStartsMs holds null", { intervalStartsMs: [0, null, 2] }],
+    ["timestampsMs holds NaN", { timestampsMs: [1, NaN, 3] }],
+    ["timestampsMs holds strings", { timestampsMs: ["1", "2", "3"] }],
+    ["sampleNodeIds hold strings", { sampleNodeIds: ["2", "2", "2"] }],
+    ["intervalStartsMs holds objects", { intervalStartsMs: [{}, {}, {}] }],
+    ["nodes are absent", { nodes: undefined }],
+    ["version predates the interval-start clock fix", { version: 1 }],
+  ])("rejects an index whose %s", (_label, override) => {
+    expect(() => deserializeCpuSampleIndex({ ...VALID_INDEX, ...override } as never)).toThrow(
+      /unsupported/i
+    );
+  });
 
-    expect(() => deserializeCpuSampleIndex(partial as never)).not.toThrow();
+  it("accepts an index whose three sample arrays agree", () => {
+    expect(() => deserializeCpuSampleIndex(VALID_INDEX as never)).not.toThrow();
   });
 });

--- a/packages/tool-server/test/react-profiler/cpu-correlate.test.ts
+++ b/packages/tool-server/test/react-profiler/cpu-correlate.test.ts
@@ -232,4 +232,29 @@ describe("serialized index", () => {
     // a corrupt file into "this session had no CPU activity", permanently.
     expect(() => deserializeCpuSampleIndex({ version: 2 } as never)).toThrow(/unsupported/i);
   });
+
+  it("rejects an index whose sample arrays disagree in length", () => {
+    // A v2 file missing `intervalStartsMs` reads `undefined` per interval start,
+    // and `Math.max(startMs, undefined)` turns selfMs, totalMs and coverage into
+    // NaN for every window instead of failing.
+    const partial = {
+      version: 2,
+      timestampsMs: [1, 2, 3],
+      intervalStartsMs: [0, 1, 2],
+      sampleNodeIds: [2, 2, 2],
+      nodes: NODES,
+      durationMs: 3,
+    };
+
+    for (const broken of [
+      { ...partial, intervalStartsMs: undefined },
+      { ...partial, intervalStartsMs: [0, 1] },
+      { ...partial, sampleNodeIds: undefined },
+      { ...partial, sampleNodeIds: [2] },
+    ]) {
+      expect(() => deserializeCpuSampleIndex(broken as never)).toThrow(/unsupported/i);
+    }
+
+    expect(() => deserializeCpuSampleIndex(partial as never)).not.toThrow();
+  });
 });


### PR DESCRIPTION
Fixes #950

**Cause** - `deserializeCpuSampleIndex` validated only `timestampsMs` and `nodes`, and coerced a missing `intervalStartsMs` to `[]`. `queryCpuWindow` reads three parallel arrays at the same index, so anything the guard misses reaches the user as a plausible answer rather than an error.

**Fix** - all three sample arrays must be present, the same length, and finite numbers element by element. A malformed index throws and `profiler-cpu-query` takes the existing fallback: rebuild from the retained raw profile.

| malformed v2 index | before | after |
|---|---|---|
| `intervalStartsMs` missing (#950) | `NaN` in every column | correct table, from the rebuilt index |
| `intervalStartsMs: [{},{},{}]` | `NaN` in every column | correct table |
| `intervalStartsMs: [0,null,2]` | `4.0ms` covered in a 3ms profile | correct table |
| `sampleNodeIds: ["2","2","2"]` | _"all of them were idle - the JS thread was not executing"_ | correct table |

`null` is not hypothetical: `JSON.stringify` writes a non-finite float as `null`, and `new Float64Array([0, null, 2])` reads it back as a silent `0`.

**Left unfixed, deliberately:** `readCpuProfile` ([dump.ts:60](../blob/main/packages/tool-server/src/utils/react-profiler/debug/dump.ts#L60)) and the Hermes wire gate ([react-profiler-stop.ts:241](../blob/main/packages/tool-server/src/tools/profiler/react/react-profiler-stop.ts#L241)) carry the identical three-array guard on `samples`/`timeDeltas`, with the same missing length check - a short `timeDeltas` silently under-reports CPU instead of failing. Filed as #1154 rather than fixed here: `buildCpuSampleIndex` deliberately tolerates a missing delta, so tightening an ingest path that takes data straight off the device needs its own evidence about what Hermes really emits.

Also found while reviewing, filed rather than fixed here: the cached index this guards is itself a pessimization - 2.5-2.9x slower to load than rebuilding from the raw profile, for 3x the disk, with identical results (#1156). If that is acted on, this guard and the file it protects both go away.

No docs change: this only affects a malformed on-disk index, no tool, CLI, config key or flow file changed.

<details>
<summary>Verification</summary>

Driven through the real tool entry point (`profilerCpuQueryTool.execute`, `mode=top_functions`) against a temp session dir holding a valid raw profile and a corrupt v2 index:

```
main       **Samples:** 3 covering NaNms — sampling interval ~NaNms
           | `expensiveWork` | NaN | NaN | app.js:10 |
branch     **Samples:** 2 covering 2.0ms — sampling interval ~1.0ms
           | `expensiveWork` | 2 | 2 | app.js:10 |
```

Every clause of the guard is individually pinned - deleting any one fails the suite:

```
del Array.isArray(value)                    -> 2 failed
del value.length === sampleCount            -> 2 failed
del value.every(Number.isFinite)            -> 5 failed
Number.isFinite -> typeof entry === number  -> 1 failed
del !Array.isArray(raw.nodes)               -> 1 failed
del raw?.version !== 2                      -> 1 failed
del isSampleArray(raw.timestampsMs)         -> 2 failed
del isSampleArray(raw.intervalStartsMs)     -> 4 failed
del isSampleArray(raw.sampleNodeIds)        -> 3 failed
unmutated                                   -> 27 passed
```

The first commit's tests also fail on its own pre-fix source (`AssertionError: expected [Function] to throw an error`).

`tsc --noEmit -p tsconfig.json` and `-p tsconfig.test.json` clean, `vitest run test/react-profiler/` 133 passed (11 files), `prettier --check` clean on both files.

Compatibility checked: `version: 2` and `intervalStartsMs` landed in the same commit (`9e45b9813`, #685), and every tag containing it - v0.21.0 through v0.25.0 - writes all three arrays sized from `samples.length`. No shipped writer produces an index this rejects.

</details>
