### PR TITLE
fix(tool-server): bound the device-shutdown subprocesses

### DIFF
--- a/packages/tool-server/src/utils/device-shutdown.ts
+++ b/packages/tool-server/src/utils/device-shutdown.ts
@@ -6,6 +6,12 @@ import { simctlArgsForUdid } from "./ios-device-sets";
 
 const execFileAsync = promisify(execFile);
 
+// A wedged adb daemon or CoreSimulatorService never answers, and both ignore
+// execFile's default SIGTERM, so only timeout + SIGKILL keeps these awaits from
+// hanging forever (as ADB_KILL_SIGNAL in `adb.ts`, SIMCTL_KILL_SIGNAL in
+// `simctl-config.ts`); 30s is runAdb's ceiling.
+const SHUTDOWN_EXEC_OPTIONS = { timeout: 30_000, killSignal: "SIGKILL" } as const;
+
 /**
  * Shut down a device that Argent Lens booted itself (see
  * `VariantProposalStore.takeOwnedDevices`). Best-effort: a device that's
@@ -19,12 +25,16 @@ export async function shutdownOwnedDevice(id: string): Promise<void> {
     return;
   }
   if (platform === "ios") {
-    await execFileAsync("xcrun", await simctlArgsForUdid(id, ["shutdown", id])).catch(() => {});
+    await execFileAsync(
+      "xcrun",
+      await simctlArgsForUdid(id, ["shutdown", id]),
+      SHUTDOWN_EXEC_OPTIONS
+    ).catch(() => {});
   } else if (platform === "android") {
     // adb often isn't on PATH (notably on Windows); resolveAndroidBinary falls
     // back to the SDK roots.
     const adb = (await resolveAndroidBinary("adb")) ?? "adb";
-    await execFileAsync(adb, ["-s", id, "emu", "kill"]).catch(() => {});
+    await execFileAsync(adb, ["-s", id, "emu", "kill"], SHUTDOWN_EXEC_OPTIONS).catch(() => {});
   }
 }
 
@@ -53,12 +63,16 @@ export async function shutdownDevice(id: string): Promise<ShutdownResult> {
   }
   try {
     if (device.platform === "ios") {
-      await execFileAsync("xcrun", await simctlArgsForUdid(id, ["shutdown", id]));
+      await execFileAsync(
+        "xcrun",
+        await simctlArgsForUdid(id, ["shutdown", id]),
+        SHUTDOWN_EXEC_OPTIONS
+      );
       return { ok: true };
     }
     if (device.platform === "android" && device.kind === "emulator") {
       const adb = (await resolveAndroidBinary("adb")) ?? "adb";
-      await execFileAsync(adb, ["-s", id, "emu", "kill"]);
+      await execFileAsync(adb, ["-s", id, "emu", "kill"], SHUTDOWN_EXEC_OPTIONS);
       return { ok: true };
     }
     return {

--- a/packages/tool-server/test/device-shutdown.test.ts
+++ b/packages/tool-server/test/device-shutdown.test.ts
@@ -22,18 +22,21 @@ import {
   shutdownDevice,
 } from "../src/utils/device-shutdown";
 
-// Default: exec succeeds (callback style: (file, args, cb) => cb(err, {stdout,stderr})).
+// Default: exec succeeds (callback style: (file, args, options, cb) => cb(err, {stdout,stderr})).
 function execSucceeds() {
-  execFileMock.mockImplementation(
-    (_file: string, _args: string[], cb: (e: unknown, r: unknown) => void) =>
-      cb(null, { stdout: "", stderr: "" })
+  execFileMock.mockImplementation((...args: unknown[]) =>
+    (args.at(-1) as (e: unknown, r: unknown) => void)(null, { stdout: "", stderr: "" })
   );
 }
 function execFails(message: string) {
-  execFileMock.mockImplementation((_file: string, _args: string[], cb: (e: unknown) => void) =>
-    cb(new Error(message))
+  execFileMock.mockImplementation((...args: unknown[]) =>
+    (args.at(-1) as (e: unknown) => void)(new Error(message))
   );
 }
+
+// Every shutdown spawn must be bounded, and SIGKILL-reaped: a wedged adb
+// daemon ignores execFile's default SIGTERM.
+const boundedExec = { timeout: 30_000, killSignal: "SIGKILL" };
 
 beforeEach(() => {
   execFileMock.mockReset();
@@ -49,6 +52,7 @@ describe("shutdownOwnedDevice (best-effort, swallows errors)", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "xcrun",
       ["simctl", "shutdown", "UDID-1"],
+      boundedExec,
       expect.any(Function)
     );
   });
@@ -60,6 +64,7 @@ describe("shutdownOwnedDevice (best-effort, swallows errors)", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "/sdk/platform-tools/adb",
       ["-s", "emulator-5554", "emu", "kill"],
+      boundedExec,
       expect.any(Function)
     );
   });
@@ -71,6 +76,7 @@ describe("shutdownOwnedDevice (best-effort, swallows errors)", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "adb",
       ["-s", "emulator-5554", "emu", "kill"],
+      boundedExec,
       expect.any(Function)
     );
   });
@@ -111,6 +117,7 @@ describe("shutdownDevice (surfaces the outcome)", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "xcrun",
       ["simctl", "shutdown", "UDID-1"],
+      boundedExec,
       expect.any(Function)
     );
   });
@@ -121,6 +128,7 @@ describe("shutdownDevice (surfaces the outcome)", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "/sdk/platform-tools/adb",
       ["-s", "emulator-5554", "emu", "kill"],
+      boundedExec,
       expect.any(Function)
     );
   });


### PR DESCRIPTION
Fixes #945

**Cause:** the four shutdown spawns in `utils/device-shutdown.ts` (`xcrun simctl shutdown`, `adb emu kill`, in both `shutdownOwnedDevice` and `shutdownDevice`) were awaited with no `timeout`, so a wedged adb daemon or CoreSimulatorService leaves the await unsettled forever - no error, no reap, teardown hangs.

**Fix:** pass `{ timeout: 30_000, killSignal: "SIGKILL" }` at all four sites - 30s is `runAdb`'s ceiling, SIGKILL because both an adb client blocked on its daemon and a simctl blocked on CoreSimulator ignore execFile's default SIGTERM (`ADB_KILL_SIGNAL` / `SIMCTL_KILL_SIGNAL` document this).

Docs: none needed - no tool, CLI, config key or user-facing behaviour changes.

<details>
<summary>Scope, tests, checks</summary>

**Left alone (different shape, not the same class):** `tools/devices/boot-device.ts` `shutdown`/`boot`/`bootstatus`, `restart-app`, `reinstall-app` - tool-level flows with their own error handling and much longer legitimate budgets; a single 30s shutdown ceiling would be wrong there.

**Test discriminates.** `test/device-shutdown.test.ts` now asserts the options object on every dispatch. With the source change stashed, 5 of 13 fail - one per production call site:

```
 × iOS -> xcrun simctl shutdown <udid>
 × Android -> resolved adb -s <serial> emu kill
 × Android with unresolvable adb -> falls back to bare "adb"
 × iOS -> ok:true and simctl argv
 × Android emulator -> ok:true and resolved adb emu kill
 Tests  5 failed | 8 passed (13)
```

Restored: 13 passed.

**Checks (worktree root):**
- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 368 files, 4832 passed, 1 skipped. One run out of four had a single unrelated flake that did not reproduce on re-run.
- `npx prettier --write` on both changed files
- `npx eslint` on both changed files - only the pre-existing `packages/docs` tsconfig resolution error this checkout has
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Device shutdown commands now stop waiting after 30 seconds if the underlying process becomes unresponsive.
  - Stalled shutdown processes are forcefully terminated to prevent shutdown operations from hanging indefinitely.
  - Applies consistently to both iOS simulators and Android emulators, including user-initiated and automatic shutdown flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->