### PR TITLE
docs(skills): debugger-reload-metro reloads one app, not every connected one

### DIFF
--- a/packages/skills/skills/argent-metro-debugger/SKILL.md
+++ b/packages/skills/skills/argent-metro-debugger/SKILL.md
@@ -38,10 +38,10 @@ With two or more devices on one Metro, `debugger-connect` refuses a udid/serial 
 
 ### Reload & recovery
 
-| Tool                    | Purpose                                                                                       |
-| ----------------------- | --------------------------------------------------------------------------------------------- |
-| `debugger-reload-metro` | Reload all connected apps (like pressing "r" in Metro terminal). Needs a CDP target.          |
-| `restart-app`           | Terminate and relaunch the app by device id and bundleId. Use when app lost Metro connection. |
+| Tool                    | Purpose                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `debugger-reload-metro` | Reload the JS bundle in the one app `device_id` resolved, via CDP `Page.reload`. Needs a CDP target. Falls back to Metro's `/reload` broadcast (the "press r" behaviour, hitting every connected app) when the runtime has no `Page.reload`; the returned `method` (`"cdp"` / `"http"`) says which ran. With several devices on one Metro port, call it once per device. |
+| `restart-app`           | Terminate and relaunch the app by device id and bundleId. Use when app lost Metro connection.                                                                                                                                                                                                                                                                            |
 
 ### Inspection & console
 


### PR DESCRIPTION
Fixes #922

**Cause:** the skill's tool row said `debugger-reload-metro` reloads "all connected apps", but its primary path is CDP `Page.reload` on the single session `device_id` resolved. Only the HTTP `/reload` fallback broadcasts.

**Fix:** the row now describes the per-target behaviour, the fallback, the returned `method` that distinguishes them, and says to call it once per device when one Metro port serves several.

**Verified:** read the tool source; `npx tsc --build` and `npx prettier --check` green.

Docs: no change needed - `packages/docs/docs/reference/tools.mdx` already describes the tool singularly ("Restart the Metro bundle without restarting the native process").

Tests: none - prose-only change in a package (`@argent/skills`) that ships no test suite.

<details>
<summary>Class check: other references to the tool</summary>

`grep -rn "reload-metro"` across the repo - every other mention is singular or scope-neutral, so nothing else needed the same edit:

- `packages/docs/docs/reference/tools.mdx:69` - "Restart the Metro bundle without restarting the native process"
- `packages/skills/skills/argent-metro-debugger/SKILL.md:129` - "Reload JS (already connected)"
- `packages/skills/skills/argent-react-native-app-workflow/SKILL.md:96,132,226` - "Reload tool" / "Reload JS bundle"
- `packages/skills/skills/argent-lens/SKILL.md:48` - "Reload the RN bundle"
- `argent-tv-interact` / `argent-metro-debugger` availability lines - platform gating only

</details>

<details>
<summary>Source the wording came from</summary>

`packages/tool-server/src/tools/debugger/debugger-reload-metro.ts`

```ts
try {
  await api.cdp.send("Page.reload");
  void disableLogBox();
  return { reloaded: true, port, method: "cdp", ...context };
} catch {
  /* fall through */
}

const res = await fetch(`http://127.0.0.1:${port}/reload`, { method: "POST" });
```

The CDP session is `JsRuntimeDebugger:${port}:${canonicalDeviceId(device_id)}` - one runtime.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
