### PR TITLE
docs(skills): say the [L:<id>] log anchor must be matched literally

### DIFF
--- a/packages/skills/skills/argent-metro-debugger/SKILL.md
+++ b/packages/skills/skills/argent-metro-debugger/SKILL.md
@@ -99,7 +99,7 @@ One entry per line — fields (whitespace-separated, `|` delimiter before messag
 
 | Field         | Example                     | Notes                                               |
 | ------------- | --------------------------- | --------------------------------------------------- |
-| `[L:<id>]`    | `[L:42]`                    | Unique grep anchor                                  |
+| `[L:<id>]`    | `[L:42]`                    | Unique anchor; search it literally (see below)      |
 | `<timestamp>` | `2026-03-17T14:30:00.000Z`  | ISO 8601                                            |
 | `<LEVEL>`     | `ERROR`, `WARN `, `LOG  `   | Uppercase, padded to 5 chars                        |
 | `<source>`    | `src/api/user.ts:42` or `-` | Relative path from source map; `-` if unavailable   |
@@ -115,6 +115,7 @@ When reading from the log file:
 - Default to `-m 50` unless you need more.
 - Use `tail -N` recent entries.
 - `clusters[].message` gives you the exact text which you may look for
+- Search bracketed text such as `[L:42]` or `[object Object]` with `grep -F`, or escape the brackets (`\[L:42\]`). Unescaped, `[...]` is a character class: `grep '[L:42]'` matches every line in the file.
 
 > **If the file is too large** Delegate to an `Explore` subagent with the file path, the format spec above, the specific patterns you need, and Golden Rule 4's untrusted-data caveat.
 


### PR DESCRIPTION
Fixes #916

**Cause:** the flat-log table calls `[L:42]` a "unique grep anchor" and never says to match it literally - unescaped, `[L:42]` is a character class, and since every log line starts with `[L:`, it matches the whole file.

**Fix:** table cell points at the search rule, plus one bullet telling the agent to use `grep -F` (or `\[L:42\]`) for bracketed text like `[L:<id>]` and `[object Object]`.

**Verified:** wrote 46 entries through the real `LogFileWriter` and ran both engines against the file - `grep`/`rg` with the bare anchor return 46 lines, `-F` returns 1. Prose-only change to one SKILL.md, so no test applies; `npx tsc --build` and `prettier --check` are green. No docs-site page documents the log format or the anchor, so `packages/docs` needs no update.

<details>
<summary>Repro output</summary>

```
$ head -2 repro.log
[L:0] 2026-03-17T14:31:00.000Z LOG   - | filler 0
[L:1] 2026-03-17T14:31:00.000Z LOG   - | filler 1

lines: 46
grep -c '[L:42]'          -> 46
grep -cF '[L:42]'         -> 1
grep -c '\[L:42\]'        -> 1
rg   -c '[L:42]'          -> 46
rg   -cF '[L:42]'         -> 1
grep -c '[object Object]' -> 46
grep -cF '[object Object]'-> 1
```

Entry 42 is the only `TARGET ENTRY FORTY TWO` line; `[object Object]` appears in exactly one message.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the meaning of the `[L:<id>]` field in log registry output.
  - Added guidance for searching bracketed log text, including examples such as `[L:42]` and `[object Object]`.
  - Explained how to use fixed-string or escaped-bracket searches to avoid pattern-matching issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->