### PR TITLE
fix(screen-recording): put the pid and a random suffix in the mp4 name

### DIFF
--- a/packages/tool-server/src/tools/screen-recording/capture.ts
+++ b/packages/tool-server/src/tools/screen-recording/capture.ts
@@ -287,9 +287,13 @@ async function startCaptureLocked(
     );
   }
 
+  // The pid and the random suffix are what keep two captures apart: the
+  // in-process session guard says nothing about a second tool-server on the
+  // same host, and the device sanitizer is not injective (`emulator:5554` and
+  // `emulator-5554` collapse onto one segment).
   const outputFile = path.join(
     os.tmpdir(),
-    `argent-screen-recording-${api.deviceId.replace(/[^A-Za-z0-9._-]/g, "-")}-${Date.now()}.mp4`
+    `argent-screen-recording-${process.pid}-${api.deviceId.replace(/[^A-Za-z0-9._-]/g, "-")}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.mp4`
   );
 
   const stream = await openMjpegStream(params.streamUrl, STREAM_CONNECT_TIMEOUT_MS);

--- a/packages/tool-server/test/screen-recording.test.ts
+++ b/packages/tool-server/test/screen-recording.test.ts
@@ -192,12 +192,8 @@ const androidDevice: DeviceInfo = {
   kind: "emulator",
 } as DeviceInfo;
 
-// startCapture names its output join(os.tmpdir(),
-// `argent-screen-recording-${deviceId}-${Date.now()}.mp4`). The device ids are
-// fixtures, and vi.useFakeTimers() seeds its clock from the real time rather
-// than a constant, so the millisecond two runs start in is the only thing
-// separating their paths — and each test ends by deleting the path it derived.
-// Scoping the tmpdir per test removes that window instead of leaving it narrow.
+// startCapture names its output under os.tmpdir(). Scoping that per test keeps
+// the mp4s these runs derive (and delete) out of the shared temp directory.
 let restoreTmpdir: () => void;
 let scratch: string;
 
@@ -451,6 +447,35 @@ describe("screen recording capture", () => {
     expect(api.recordingActive).toBe(true);
     expect(api.captureProcess).toBe(child as unknown as ChildProcess);
     expect(getActiveScreenRecordings()).toHaveLength(1);
+  });
+
+  it("names the output file after the recording process, not the device alone", async () => {
+    const api = await makeSession(iosDevice);
+    fakeStream();
+    fakeChild();
+
+    const result = await startAndSettle(api);
+
+    // A second tool-server on the same host is invisible to the in-process
+    // session guard, so the pid is what keeps its mp4 off this one's path.
+    expect(path.basename(result.outputFile)).toContain(`-${process.pid}-`);
+  });
+
+  it("keeps two device ids that sanitize alike on separate output paths", async () => {
+    // Both ids sanitize to `emulator-5554`, so the device segment alone cannot
+    // tell the two captures apart.
+    const outputs: string[] = [];
+    for (const id of ["emulator:5554", "emulator-5554"]) {
+      // Pin the clock: the readiness grace startAndSettle waits out advances it
+      // between the two starts, and the collision is a same-millisecond one.
+      vi.setSystemTime(1_700_000_000_000);
+      const api = await makeSession({ ...androidDevice, id });
+      fakeStream();
+      fakeChild();
+      outputs.push((await startAndSettle(api)).outputFile);
+    }
+
+    expect(outputs[0]).not.toBe(outputs[1]);
   });
 
   it("stamps the watermark in the same pass when the flag is on", async () => {


### PR DESCRIPTION
Fixes #914.

**Cause** - `startCapture` named its mp4 `argent-screen-recording-<sanitized device>-<ms>.mp4`. No pid, so two tool-servers on one host (a global install next to a dev server) recording the same device in the same millisecond derive one path and point two ffmpeg encoders at it; and `replace(/[^A-Za-z0-9._-]/g, "-")` is not injective, so `emulator:5554` and `emulator-5554` collapse onto one segment.

**Fix** - one line: `argent-screen-recording-${process.pid}-${sanitized}-${Date.now()}-${rand}.mp4`, the same shape `writeLogoTemp` in `watermark.ts` already uses for the watermark temp file.

**Class** - the only other artifact temp names of this shape are left alone: `chromium-server/screenshot.ts` already carries `${Date.now()}-${process.pid}`, and `tools/screenshot/index.ts` (`tvScreenshot`) stamps `process.hrtime.bigint()`, a host-wide monotonic nanosecond clock, so a collision there needs the same nanosecond rather than the same millisecond.

**Docs** - none needed: the name is a tool-server temp path, and nothing in `packages/docs/` or the skills documents its shape.

<details>
<summary>Verification</summary>

Both new tests fail on the unfixed source (`git stash` of `capture.ts` only):

```
 × names the output file after the recording process, not the device alone
   expected 'argent-screen-recording-6DBF83B4-0000-0000-0000-000000000000-1788975122156.mp4'
   to contain '-11818-'
 × keeps two device ids that sanitize alike on separate output paths
   expected '/var/folders/.../argent-screen-recording-emulator-5554-1700000000000.mp4'
   not to be the same path
```

With the fix restored, both pass. Also run from the worktree root:

```
npx tsc --build                              exit 0
npm run typecheck:tests -w @argent/tool-server   exit 0
npm test -w @argent/tool-server              368 files, 4834 passed, 1 skipped
npx prettier --write <changed files>         unchanged
```

`npx eslint` on the changed files could not run locally: `packages/docs/tsconfig.json` fails to resolve `@docusaurus/tsconfig` because the docs workspace is not installed here. Unrelated to this diff.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
