### PR TITLE
fix(debugger): stop LogFileWriter retaining console lines no reader can reach

### DIFF
--- a/packages/tool-server/src/utils/debugger/log-file-writer.ts
+++ b/packages/tool-server/src/utils/debugger/log-file-writer.ts
@@ -64,7 +64,6 @@ const LINE_RE = /^\[L:(\d+)\] (\S+) (\S+)\s+(\S+) \| (.*)$/;
 export class LogFileWriter {
   private filePath: string;
   private fd: number | null = null;
-  private writeBuffer: string[] = [];
   private bytesWritten = 0;
   private entryCount = 0;
   private levelCounts: Record<string, number> = {};
@@ -84,19 +83,9 @@ export class LogFileWriter {
     try {
       this.fd = fs.openSync(this.filePath, "w");
       this.ready = true;
-      this.flushBuffer();
     } catch {
       // ignore
     }
-  }
-
-  private flushBuffer(): void {
-    if (!this.ready || this.fd === null) return;
-    for (const line of this.writeBuffer) {
-      const buf = Buffer.from(line);
-      fs.writeSync(this.fd, buf);
-    }
-    this.writeBuffer = [];
   }
 
   write(entry: Omit<RichLogEntry, "marker">): RichLogEntry {
@@ -123,11 +112,11 @@ export class LogFileWriter {
     const levelDisplay = LEVEL_DISPLAY[entry.level] ?? entry.level.toUpperCase().padEnd(5);
     const line = `[L:${entry.id}] ${entry.timestamp} ${levelDisplay} ${source} | ${flatMessage}\n`;
 
+    // Nothing reopens the file, and readAll() serves it alone, so a line with
+    // no file has no reader: the entry lives on only in the counts and clusters.
     if (this.ready && this.fd !== null) {
       const buf = Buffer.from(line);
       fs.writeSync(this.fd, buf);
-    } else {
-      this.writeBuffer.push(line);
     }
 
     this.bytesWritten += Buffer.byteLength(line);
@@ -184,7 +173,6 @@ export class LogFileWriter {
 
   readAll(): RichLogEntry[] {
     if (this.closed || !this.ready) return [];
-    this.flushBuffer();
     try {
       const content = fs.readFileSync(this.filePath, "utf-8");
       return content

--- a/packages/tool-server/test/debugger/log-file-writer.test.ts
+++ b/packages/tool-server/test/debugger/log-file-writer.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { LogFileWriter, type RichLogEntry } from "../../src/utils/debugger/log-file-writer";
 import { scopeTempHome } from "../helpers/temp-home";
 
@@ -257,5 +259,41 @@ describe("LogFileWriter", () => {
 
     const clusters = writer.getClusters();
     expect(clusters[0].sourceFile).toBe("src/api/user.ts");
+  });
+});
+
+// Mode bits do not bite on Windows, nor for uid 0.
+const CAN_MAKE_UNWRITABLE = process.platform !== "win32" && process.getuid?.() !== 0;
+
+describe.skipIf(!CAN_MAKE_UNWRITABLE)("LogFileWriter whose log file cannot be created", () => {
+  let dir: string;
+  let unwritableWriter: LogFileWriter;
+
+  beforeEach(() => {
+    dir = path.join(os.homedir(), ".argent", "tmp");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.chmodSync(dir, 0o555);
+    unwritableWriter = new LogFileWriter(9998);
+  });
+
+  afterEach(() => {
+    fs.chmodSync(dir, 0o755);
+    unwritableWriter.close();
+  });
+
+  it("keeps no copy of a line it could not write", () => {
+    unwritableWriter.write(makeEntry(0, { message: "unreadable line" }));
+
+    expect(fs.existsSync(unwritableWriter.getFilePath())).toBe(false);
+    expect(unwritableWriter.readAll()).toEqual([]);
+
+    const retainedLines = Object.values(unwritableWriter as unknown as Record<string, unknown>)
+      .filter((value): value is unknown[] => Array.isArray(value))
+      .flat();
+    expect(retainedLines).toEqual([]);
+
+    // The entry itself is still accounted for, through the counts and clusters.
+    expect(unwritableWriter.getStats().totalEntries).toBe(1);
+    expect(unwritableWriter.getClusters()[0].message).toBe("unreadable line");
   });
 });


### PR DESCRIPTION
Fixes #892

**Cause** - when `LogFileWriter`'s file cannot be created, `ready` stays false for the writer's life (nothing reopens it), so `write()` pushed every formatted line into `writeBuffer`. Both drains are closed in that state: `flushBuffer()` returns on `!this.ready`, and `readAll()` returns `[]` before reaching it. Up to `MAX_ENTRIES` (50 000) lines per wedged session, unreadable and never freed.

**Fix** - drop the dead buffering path; a line with no file is not retained. Entry counts, level tallies and clusters are tracked separately, so `getStats()` / `getClusters()` / `debugger-log-registry` are unchanged, as is `readAll()`, which already returned `[]` in this state.

`writeBuffer` / `flushBuffer` existed only in this file - no sibling writer has the same shape. No docs change: no tool, CLI flag, config key, flow directive or user-visible behaviour changed.

<details>
<summary>Verification</summary>

New test in `packages/tool-server/test/debugger/log-file-writer.test.ts` chmods a temp-`HOME` `~/.argent/tmp` to `0555`, writes one entry, and asserts the writer holds no line array while the counts and clusters still record it (skipped on Windows and under uid 0).

Without the source fix:

```
FAIL  packages/tool-server/test/debugger/log-file-writer.test.ts > LogFileWriter whose log file cannot be created > keeps no copy of a line it could not write
AssertionError: expected [ '[L:0] 2024-03-09T16:00:00.000Z LOG…' ] to deeply equal []
Tests  1 failed | 19 passed (20)
```

With it:

```
npx tsc --build                                  # clean
npm run typecheck:tests -w @argent/tool-server   # clean
npm test -w @argent/tool-server                  # 368 files, 4833 passed | 1 skipped
npx prettier --write <changed files>             # unchanged
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Log entries written before the log file is ready are no longer retained in the file.
  - Entry counts and in-memory clusters continue to reflect those writes.
  - Reading a log no longer triggers pending data to be flushed first.

- **Tests**
  - Added coverage for unwritable log directories, including platform- and privilege-aware handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->