### PR TITLE
docs(skills): drop the breakpoint capability argent has no tool for

### DIFF
--- a/packages/skills/skills/argent-test-ui-flow/SKILL.md
+++ b/packages/skills/skills/argent-test-ui-flow/SKILL.md
@@ -127,5 +127,5 @@ Steps:
 | `argent-ios-simulator-setup`       | Booting and connecting an iOS simulator                  |
 | `argent-android-emulator-setup`    | Booting and connecting an Android emulator               |
 | `argent-react-native-app-workflow` | Starting the app, Metro, build issues                    |
-| `argent-metro-debugger`            | Breakpoints, console logs, JS evaluation                 |
+| `argent-metro-debugger`            | Console logs, JS evaluation, component inspection        |
 | `argent-create-flow`               | Record a test sequence as a replayable flow              |

--- a/packages/tool-server/test/debugger/skill-index-capabilities.test.ts
+++ b/packages/tool-server/test/debugger/skill-index-capabilities.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { createRegistry } from "../../src/utils/setup-registry";
+import { definitionsById } from "../helpers/catalog";
+
+/**
+ * The Related Skills table is the cross-skill index an agent reads to choose a
+ * skill, so a capability named there has to exist before the skill is loaded.
+ */
+const SKILL = path.resolve(__dirname, "../../../skills/skills/argent-test-ui-flow/SKILL.md");
+
+/** Capability wording the index row may use, lowercased, and the tool behind it. */
+const CAPABILITY_TOOLS = new Map([
+  ["console logs", "debugger-log-registry"],
+  ["js evaluation", "debugger-evaluate"],
+  ["component inspection", "debugger-component-tree"],
+  ["element inspection", "debugger-inspect-element"],
+  ["network logs", "view-network-logs"],
+]);
+
+function debuggerRowCapabilities(): string[] {
+  const row = readFileSync(SKILL, "utf8")
+    .split("\n")
+    .find((line) => line.startsWith("| `argent-metro-debugger`"));
+  expect(row, `${SKILL} lists no argent-metro-debugger row`).toBeDefined();
+
+  const cells = row!.split("|").map((cell) => cell.trim());
+  return cells[2].split(",").map((capability) => capability.trim());
+}
+
+describe("argent-metro-debugger's row in the cross-skill index", () => {
+  it("advertises only capabilities the row's vocabulary covers", () => {
+    const capabilities = debuggerRowCapabilities();
+
+    expect(capabilities.length).toBeGreaterThan(0);
+    for (const capability of capabilities) {
+      expect(
+        CAPABILITY_TOOLS.has(capability.toLowerCase()),
+        `"${capability}" is advertised to agents but no argent tool implements it`
+      ).toBe(true);
+    }
+  });
+
+  it("names capabilities that map onto registered tools", () => {
+    const tools = definitionsById(createRegistry());
+
+    for (const [capability, toolId] of CAPABILITY_TOOLS) {
+      expect(tools.has(toolId), `${toolId} backs "${capability}" but is not registered`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #906

**Cause:** the cross-skill index in `argent-test-ui-flow` listed **Breakpoints** first in the `argent-metro-debugger` row. `packages/tool-server/src/tools/debugger/` ships seven tools and none sets, lists, removes or steps over a breakpoint - no `Debugger.setBreakpoint*` / `pause` / `resume` / `step*` call exists outside a test mock. An agent routed there by that row finds no tool and no explanation.

**Fix:** the row names three capabilities that do exist. A test parses the row and rejects any capability with no tool behind it.

| before | after |
| --- | --- |
| `argent-metro-debugger` - Breakpoints, console logs, JS evaluation | `argent-metro-debugger` - Console logs, JS evaluation, component inspection |

**Verified:** the new test fails on the old row (`"Breakpoints" is advertised to agents but no argent tool implements it`) and passes on the new one; full `@argent/tool-server` suite, `tsc --build`, `typecheck:tests` and prettier all green.

Docs site needs no update - `packages/docs/` never mentions breakpoints, and the only other index row for this skill (`argent-react-native-app-workflow` line 243) already lists component inspection, console logs and JS evaluation.

<details>
<summary>Checks</summary>

Discrimination (skill row stashed, test kept):

```
FAIL  test/debugger/skill-index-capabilities.test.ts > advertises only capabilities the row's vocabulary covers
AssertionError: "Breakpoints" is advertised to agents but no argent tool implements it: expected false to be true
Tests  1 failed | 1 passed (2)
```

Restored: `Tests  2 passed (2)`.

```
npx tsc --build                                     # clean
npm run typecheck:tests -w packages/tool-server     # clean
npm test -w packages/tool-server                    # Test Files 369 passed, Tests 4834 passed | 1 skipped
npx prettier --check <changed files>                # clean
```

Class check - `grep -rn -i breakpoint packages/skills packages/docs` now returns nothing; the surviving mentions in `packages/tool-server/src` are state descriptions in timeout guidance ("may be frozen, or paused at a breakpoint"), about a breakpoint the user set in their own devtools.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Metro debugger capability description to highlight console logs, JavaScript evaluation, and component inspection.
  * Breakpoint support is no longer listed among the advertised capabilities.

* **Tests**
  * Added validation to ensure documented debugger capabilities correspond to supported, registered tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->