### PR TITLE
fix(tool-server): name the bundleId alphabet launch-app enforces on Chromium

### DIFF
--- a/packages/tool-server/src/tools/launch-app/index.ts
+++ b/packages/tool-server/src/tools/launch-app/index.ts
@@ -29,7 +29,7 @@ const zodSchema = z.object({
     .string()
     .regex(BUNDLE_ID_PATTERN, "bundleId may only contain letters, digits, '.', '_' and '-'")
     .describe(
-      "App identifier. iOS: bundle id (e.g. com.apple.MobileSMS). Android: package name from build.gradle `applicationId` (e.g. com.android.settings). Chromium: arbitrary tag; the call is a no-op since the renderer is already running."
+      "App identifier. iOS: bundle id (e.g. com.apple.MobileSMS). Android: package name from build.gradle `applicationId` (e.g. com.android.settings). Chromium: any tag matching the same alphabet (letters, digits, '.', '_' and '-'); the call is a no-op since the renderer is already running."
     ),
   activity: z
     .string()

--- a/packages/tool-server/test/tool-input-schema-contract.test.ts
+++ b/packages/tool-server/test/tool-input-schema-contract.test.ts
@@ -40,3 +40,27 @@ describe("advertised tool input schemas", () => {
     });
   }
 });
+
+// Zod validates a parameter's `pattern` before the platform dispatch runs, so
+// no platform is exempt from it. A description that calls such a value
+// free-form walks the agent into a rejection whose message names a rule the
+// description said did not apply — issue #901, where launch-app's `bundleId`
+// was an "arbitrary tag" on Chromium and a reverse-DNS identifier everywhere
+// else.
+describe("descriptions of pattern-constrained parameters", () => {
+  const definitions = definitionsById(createRegistry());
+  const UNCONSTRAINED = /arbitrary|free[- ]form|any (?:string|value|text)/i;
+
+  for (const [id, definition] of definitions) {
+    const properties = (advertisedSchema(definition)?.properties ?? {}) as Record<
+      string,
+      { pattern?: unknown; description?: unknown }
+    >;
+    for (const [name, property] of Object.entries(properties)) {
+      if (typeof property?.pattern !== "string") continue;
+      it(`${id}.${name}: states a constraint rather than promising an unconstrained value`, () => {
+        expect(String(property.description ?? "")).not.toMatch(UNCONSTRAINED);
+      });
+    }
+  }
+});


### PR DESCRIPTION
Fixes #901

**Cause.** `launch-app`'s `bundleId` description called the value an "arbitrary tag" on Chromium, but the field's `.regex(BUNDLE_ID_PATTERN, …)` is validated by zod before the platform dispatch runs - so Chromium is bound by it exactly as iOS and Android are. An agent that took the description at its word and passed a display name (`"My App"`) got a rejection naming a rule the description said did not apply.

**Fix.** The Chromium clause states the alphabet the regex enforces instead of claiming the value is free-form. `BUNDLE_ID_PATTERN` and the rejection message are untouched - the value really is inert on Chromium, only not unconstrained.

**Class check.** The description is the sole site: over every advertised tool schema, `launch-app.bundleId` is the only pattern-constrained parameter whose description promised an unconstrained value (`restart-app` / `reinstall-app` / `settings-permissions` `bundleId`, both `activity` fields and `profiler-load.session_id` all name a form). The new test walks the whole catalogue, so a future one has to as well.

**Docs.** No docs change needed - `reference/tools.mdx` lists `launch-app` by one-line summary and documents no parameter constraints.

<details>
<summary>Verification</summary>

The test is appended to the existing catalogue-wide schema contract, not a new file. Discrimination proved by stashing the source change and re-running:

```
 × launch-app.bundleId: states a constraint rather than promising an unconstrained value
 Tests  1 failed | 84 passed (85)
```

With the fix in place, from the worktree root:

```
npx tsc --build                                  OK
npm run typecheck:tests -w @argent/tool-server   OK
npm test -w @argent/tool-server                  368 files, 4839 passed | 1 skipped
npx prettier --write <changed files>             unchanged
```

`npx eslint` could not run in this checkout (`packages/docs/tsconfig.json` cannot resolve `@docusaurus/tsconfig` without a separate `npm ci` in that workspace, a pre-existing local-environment issue); the ESLint CI job covers it.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Chromium app identifier requirements to match the existing validation rules.

- **Tests**
  - Added contract checks to ensure documented string constraints do not describe restricted values as unconstrained.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->