### PR TITLE
fix(react-profiler): unsubscribe from the debugger's CDP client on dispose

### DIFF
--- a/packages/tool-server/src/blueprints/react-profiler-session.ts
+++ b/packages/tool-server/src/blueprints/react-profiler-session.ts
@@ -5,7 +5,7 @@ import {
   type ServiceBlueprint,
   type ServiceEvents,
 } from "@argent/registry";
-import type { CDPClient } from "../utils/debugger/cdp-client";
+import type { CDPClient, ScriptInfo } from "../utils/debugger/cdp-client";
 import type { JsRuntimeDebuggerApi } from "./js-runtime-debugger";
 import {
   FIBER_ROOT_TRACKER_SCRIPT,
@@ -119,14 +119,15 @@ export const reactProfilerSessionBlueprint: ServiceBlueprint<ReactProfilerSessio
 
     await cdp.send("Profiler.enable").catch(warnOnError("Profiler.enable"));
 
-    cdp.events.on("scriptParsed", (script) => {
+    const onScriptParsed = (script: ScriptInfo) => {
       if (script.sourceMapURL) {
         state.scriptSources.set(script.scriptId, {
           url: script.url,
           sourceMapURL: script.sourceMapURL,
         });
       }
-    });
+    };
+    cdp.events.on("scriptParsed", onScriptParsed);
 
     // Idempotent — guarded in JS
     await cdp.evaluate(FIBER_ROOT_TRACKER_SCRIPT).catch(warnOnError("FIBER_ROOT_TRACKER_SCRIPT"));
@@ -173,7 +174,7 @@ export const reactProfilerSessionBlueprint: ServiceBlueprint<ReactProfilerSessio
       warnOnError("Hermes version probe")(err);
     }
 
-    cdp.events.on("disconnected", (error) => {
+    const onDisconnected = (error?: Error) => {
       // Clear only mid-run, so a completed session's cached paths survive the disconnect.
       if (state.profilingActive) {
         clearCachedProfilerPaths(state.port, state.deviceId);
@@ -188,11 +189,17 @@ export const reactProfilerSessionBlueprint: ServiceBlueprint<ReactProfilerSessio
             error_kind: "network",
           })
       );
-    });
+    };
+    cdp.events.on("disconnected", onDisconnected);
 
     return {
       api: state,
       dispose: async () => {
+        // `cdp.events` belongs to the JsRuntimeDebugger dependency and
+        // outlives every dispose but its own teardown; `react-profiler-stop`
+        // disposes only this node, once per run.
+        cdp.events.off("scriptParsed", onScriptParsed);
+        cdp.events.off("disconnected", onDisconnected);
         // `react-profiler-stop` stops the renderers and the sampler before
         // disposing; a dispose from `stop-all-simulator-servers` arrives
         // mid-run instead, leaving the in-app DevTools backend recording every

--- a/packages/tool-server/test/react-profiler/session-dispose.test.ts
+++ b/packages/tool-server/test/react-profiler/session-dispose.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { TypedEventEmitter } from "@argent/registry";
 import { reactProfilerSessionBlueprint } from "../../src/blueprints/react-profiler-session";
 import type { JsRuntimeDebuggerApi } from "../../src/blueprints/js-runtime-debugger";
@@ -21,10 +21,16 @@ interface SentCall {
   params?: Record<string, unknown>;
 }
 
+type CdpEvents = TypedEventEmitter<Record<string, (...args: unknown[]) => void>>;
+
+function cdpEventsOf(api: JsRuntimeDebuggerApi): CdpEvents {
+  return (api.cdp as unknown as { events: CdpEvents }).events;
+}
+
 function fakeDebuggerApi(sent: SentCall[]): JsRuntimeDebuggerApi {
-  // The CDP event map is not exported; nothing here subscribes, the emitter only
-  // has to exist for the factory's `cdp.events.on(...)` calls.
-  const events = new TypedEventEmitter<Record<string, (...args: unknown[]) => void>>();
+  // The CDP event map is not exported; the emitter is loosely typed so a test
+  // can emit into it the way the real client does.
+  const events: CdpEvents = new TypedEventEmitter();
   const cdp = {
     events,
     send: async (method: string, params?: Record<string, unknown>) => {
@@ -97,6 +103,34 @@ describe("ReactProfilerSession dispose", () => {
     await instance.dispose();
 
     expect(sent.map((c) => c.method)).toEqual(["Profiler.disable"]);
+  });
+
+  it("stops listening on the debugger's CDP client, which outlives the session", async () => {
+    // `react-profiler-stop` disposes only this node; the JsRuntimeDebugger and
+    // its client stay up, so a listener left on carries a dead session's state
+    // into every later run on the same connection.
+    const sent: SentCall[] = [];
+    const api = fakeDebuggerApi(sent);
+    const instance = await reactProfilerSessionBlueprint.factory(
+      { debugger: api },
+      "8081:AAAA-1111",
+      undefined
+    );
+
+    await instance.dispose();
+
+    const terminated = vi.fn();
+    instance.events.on("terminated", terminated);
+    const events = cdpEventsOf(api);
+    events.emit("scriptParsed", {
+      scriptId: "42",
+      url: "index.bundle",
+      sourceMapURL: "index.map",
+    });
+    events.emit("disconnected", new Error("connection lost"));
+
+    expect(instance.api.scriptSources.size).toBe(0);
+    expect(terminated).not.toHaveBeenCalled();
   });
 
   it("still disables the domain when the in-app stop throws", async () => {


### PR DESCRIPTION
Fixes #896

**Cause:** `ReactProfilerSession` subscribes to `scriptParsed` and `disconnected` on the CDP client owned by its `JsRuntimeDebugger` dependency, and never unsubscribes. `react-profiler-stop` disposes only this node, so every start/stop cycle leaves both listeners on a client that keeps running.

**Fix:** hoist both handlers into named consts and `cdp.events.off(...)` them in `dispose`, matching `chromium-js-runtime-debugger.ts`.

**Class check:** `network-inspector.ts` has the same relationship (a `disconnected` listener on `debuggerApi.cdp`) and is left as is: nothing disposes it while its debugger lives, so its listener always dies with the client. `js-runtime-debugger.ts` and `chromium-server/index.ts` own the clients they listen on; `chromium-server/network.ts` already offs; `screencast.ts` installs once.

**Docs:** none needed - no tool, CLI, config key or user-facing capability changes.

<details>
<summary>Verification</summary>

Test added to `test/react-profiler/session-dispose.test.ts`: after `dispose()`, emit `scriptParsed` and `disconnected` on the shared client and assert the dead session's `scriptSources` stays empty and it emits no `terminated`.

Mutation check - each `off` removed separately, test fails on both:

```
# without off("scriptParsed", ...)
AssertionError: expected 1 to be +0
  132|     expect(instance.api.scriptSources.size).toBe(0);

# without off("disconnected", ...)
  133|     expect(terminated).not.toHaveBeenCalled();
```

With both in place:

```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

Full package suite (`vitest run --root packages/tool-server`, sharded 1..3/3): 368 files, 4833 passed, 1 skipped.
`npx tsc --build` and `npm run typecheck:tests -w @argent/tool-server` clean; `prettier --write` reports both files unchanged.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
