### PR TITLE
fix(tool-server): stop boot-electron piping the app's stdout into nothing

### DIFF
--- a/packages/tool-server/src/tools/devices/boot-electron.ts
+++ b/packages/tool-server/src/tools/devices/boot-electron.ts
@@ -322,7 +322,10 @@ export async function bootElectronApp(options: BootElectronOptions): Promise<Ele
   try {
     child = spawn(launcher.command, args, {
       detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
+      // stdout is discarded, not piped: nothing reads it, and an unread pipe
+      // blocks the child's writes once the OS buffer fills. The
+      // ELECTRON_ENABLE_LOGGING below is what keeps it writing.
+      stdio: ["ignore", "ignore", "pipe"],
       // Strip ELECTRON_RUN_AS_NODE (see electronGuiChildEnv): inherited from an
       // Electron-based MCP host it would boot the binary in Node mode with no
       // CDP endpoint, failing boot-device instead of bringing the app up.

--- a/packages/tool-server/test/boot-electron-stdio.test.ts
+++ b/packages/tool-server/test/boot-electron-stdio.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression test for the stdio boot-electron gives its child. The Electron app
+ * is spawned with ELECTRON_ENABLE_LOGGING=1 and outlives the boot call, but
+ * nothing in the tool-server ever reads its stdout. Piping stdout therefore
+ * buffers it in the kernel and blocks the app's next write once that buffer
+ * fills, wedging CDP; only stderr, which has a forwarding listener, may be a
+ * pipe.
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { StdioOptions } from "node:child_process";
+import { scopeTempHome } from "./helpers/temp-home";
+
+scopeTempHome("argent-boot-electron-stdio-home-");
+
+const spawnMock = vi.fn();
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: (cmd: string, args: string[], opts: unknown) => spawnMock(cmd, args, opts),
+  };
+});
+// Keep the booted port out of the real on-disk state file.
+vi.mock("../src/utils/chromium-discovery", () => ({
+  trackChromiumPort: vi.fn(),
+  untrackChromiumPort: vi.fn(),
+}));
+
+import { bootElectronApp } from "../src/tools/devices/boot-electron";
+
+interface FakeChild extends EventEmitter {
+  pid: number | undefined;
+  stderr: EventEmitter;
+  unref: () => void;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeChild(): FakeChild {
+  const ee = new EventEmitter() as FakeChild;
+  ee.pid = 4242;
+  ee.stderr = new EventEmitter();
+  ee.unref = () => {};
+  ee.kill = vi.fn(() => true);
+  return ee;
+}
+
+let appDir: string;
+beforeAll(() => {
+  // resolveLauncher() fs-checks the app path before spawn; the spawn itself is
+  // mocked, so only the path's existence matters.
+  appDir = fs.mkdtempSync(path.join(os.tmpdir(), "argent-boot-electron-stdio-test-"));
+  fs.writeFileSync(
+    path.join(appDir, "package.json"),
+    JSON.stringify({ name: "fake-electron-app", main: "main.js" })
+  );
+  fs.writeFileSync(path.join(appDir, "main.js"), "// fake\n");
+});
+afterAll(() => {
+  if (appDir) fs.rmSync(appDir, { recursive: true, force: true });
+});
+
+vi.spyOn(process, "kill").mockImplementation(() => true);
+
+beforeEach(() => {
+  spawnMock.mockReset();
+});
+
+/** Minimal CDP stub: only /json/version, which is all waitForCdpReady probes. */
+async function startCdpStub(): Promise<{ port: number; close: () => void }> {
+  const srv = http.createServer((req, res) => {
+    res.setHeader("content-type", "application/json");
+    if (req.url === "/json/version") {
+      res.end(JSON.stringify({ "Browser": "Chrome/Test", "Protocol-Version": "1.3" }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  await new Promise<void>((resolve) => srv.listen(0, "127.0.0.1", resolve));
+  const { port } = srv.address() as { port: number };
+  return { port, close: () => srv.close() };
+}
+
+/** Boot once against a stub CDP endpoint and return the stdio it spawned with. */
+async function bootAndCaptureStdio(): Promise<StdioOptions> {
+  spawnMock.mockReturnValue(makeFakeChild());
+  const { port, close } = await startCdpStub();
+  try {
+    await bootElectronApp({ appPath: appDir, port, readyTimeoutMs: 5000 });
+  } finally {
+    close();
+  }
+  const opts = spawnMock.mock.calls[0]![2] as { stdio: StdioOptions };
+  return opts.stdio;
+}
+
+describe("bootElectronApp child stdio", () => {
+  it("leaves stdout unpiped and keeps stderr piped for the forwarding listener", async () => {
+    expect(await bootAndCaptureStdio()).toEqual(["ignore", "ignore", "pipe"]);
+  });
+
+  it("lets a child that floods stdout run to completion under those exact options", async () => {
+    const stdio = await bootAndCaptureStdio();
+    // The module-level spawn is mocked for the capture above; this case needs a
+    // real process.
+    const { spawn: realSpawn } =
+      await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    // 2 MiB dwarfs every OS pipe buffer (64 KiB on Linux, 16-64 KiB on macOS),
+    // so under a piped, unread stdout this child blocks mid-write and never
+    // exits - the wedge a logging Electron renderer hits.
+    const chatty = realSpawn(
+      process.execPath,
+      ["-e", "process.stdout.write('x'.repeat(2 * 1024 * 1024))"],
+      { stdio }
+    );
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      const exited = await Promise.race([
+        new Promise<boolean>((resolve) => chatty.once("exit", () => resolve(true))),
+        new Promise<boolean>((resolve) => {
+          timer = setTimeout(() => resolve(false), 3_000);
+        }),
+      ]);
+      expect(exited).toBe(true);
+    } finally {
+      clearTimeout(timer);
+      chatty.kill("SIGKILL");
+    }
+  }, 10_000);
+});


### PR DESCRIPTION
Fixes #905

**Cause:** `bootElectronApp` spawned the app with `stdio: ["ignore", "pipe", "pipe"]` and never read stdout. An unread pipe is buffered, not dropped, so once the OS pipe buffer fills the app blocks on its next `write(1, ...)` and CDP stops answering. The same spawn sets `ELECTRON_ENABLE_LOGGING: "1"`, which is what makes it write there.

**Fix:** `stdio: ["ignore", "ignore", "pipe"]`. stderr keeps its pipe - the existing forwarding listener drains it.

**Verified:** new `boot-electron-stdio.test.ts` asserts the spawned stdio and then spawns a real child under those exact options that writes 2 MiB to stdout; it must exit. Both cases fail on the unfixed line and pass with it. Full `@argent/tool-server` suite green (369 files, 4834 tests).

No docs change: this is the tool-server's internal spawn, no tool, CLI, config key or flow-file surface moves.

<details>
<summary>Discrimination proof and sibling spawn sites</summary>

Reverting only the source line, both cases fail:

```
FAIL  test/boot-electron-stdio.test.ts > leaves stdout unpiped and keeps stderr piped
  expected [ 'ignore', 'pipe', 'pipe' ] to deeply equal [ 'ignore', 'ignore', 'pipe' ]
FAIL  test/boot-electron-stdio.test.ts > lets a child that floods stdout run to completion
  AssertionError: expected false to be true   (the 2 MiB child never exits)
Tests  2 failed (2)
```

With the fix: `Tests  2 passed (2)`; package suite `Test Files 369 passed, Tests 4834 passed | 1 skipped`.

Also ran: `npx tsc --build`, `npm run typecheck:tests -w @argent/tool-server`, `npx prettier --write` on both files. Root eslint could not run in this checkout (`packages/docs/tsconfig.json` needs `@docusaurus/tsconfig`, which the root install skips).

Other spawns that pipe a stream, and why they are left alone:

- `argent-tools-client/src/launcher.ts` already calls `child.stdout?.resume()` once readline stops consuming - the precedent this fix follows.
- `blueprints/simulator-server.ts` and `blueprints/android-devtools.ts` read stdout with readline and `rl.close()` it at settle, leaving a piped stdout unread for the rest of a long-lived child. Same end state, but whether either child writes to stdout after its ready marker is unverified without a device, so it is not changed here.
- `boot-device.ts` (Windows) points stdout at a real log fd, `preview-window.ts` ignores stdout, and the `execFile`-style spawns are short-lived with a reader.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Electron app startup reliability by preventing unread standard output from blocking the app when it produces large amounts of output.
  * Continued forwarding standard error output for diagnostics.

* **Tests**
  * Added regression coverage for Electron process output handling, including high-volume output scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->