### PR TITLE
fix(tool-server): bound a CDP HTTP probe that no caller has armed a signal for

### DIFF
--- a/packages/tool-server/src/chromium-server/cdp-session.ts
+++ b/packages/tool-server/src/chromium-server/cdp-session.ts
@@ -101,20 +101,31 @@ export async function browserWebSocketUrl(port: number, signal?: AbortSignal): P
   return url;
 }
 
+/**
+ * Bound on one CDP HTTP request when the caller arms no signal of its own. A
+ * port that completes the TCP handshake and then never answers otherwise
+ * stalls for undici's 300s headers timeout, outliving every caller's deadline.
+ */
+const CDP_HTTP_TIMEOUT_MS = 5_000;
+
 async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
   let res: Response;
   try {
-    res = await fetch(url, { signal });
+    res = await fetch(url, { signal: signal ?? AbortSignal.timeout(CDP_HTTP_TIMEOUT_MS) });
   } catch (err) {
     // A caller-driven abort is expected control flow, not a reachability failure.
     if (err instanceof Error && err.name === "AbortError") throw err;
+    // A stalled port produces no OS error at all — it arrives as the abort
+    // signal's TimeoutError, and is a reachability failure like any other.
+    const timedOut = err instanceof Error && err.name === "TimeoutError";
     // undici wraps the OS error: the ECONN* code lives on err.cause, not on
     // err itself — check both, so the class is precise instead of always
     // connection_refused.
     const code =
       (err as NodeJS.ErrnoException).code ?? (err as { cause?: NodeJS.ErrnoException }).cause?.code;
-    const network_failure =
-      code === "ECONNREFUSED"
+    const network_failure = timedOut
+      ? "timeout"
+      : code === "ECONNREFUSED"
         ? "connection_refused"
         : code === "ECONNRESET"
           ? "connection_reset"
@@ -122,8 +133,11 @@ async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
             ? "timeout"
             : "other";
     throw new FailureError(
-      `Chromium CDP discovery: GET ${url} could not connect. ` +
-        `Is the app running with --remote-debugging-port?`,
+      timedOut
+        ? `Chromium CDP discovery: GET ${url} timed out. ` +
+            `Something is holding port ${new URL(url).port} without answering CDP.`
+        : `Chromium CDP discovery: GET ${url} could not connect. ` +
+            `Is the app running with --remote-debugging-port?`,
       {
         error_code: FAILURE_CODES.CHROMIUM_CDP_UNREACHABLE,
         failure_stage: "chromium_cdp_discovery_connect",

--- a/packages/tool-server/test/failure-classification.test.ts
+++ b/packages/tool-server/test/failure-classification.test.ts
@@ -257,6 +257,16 @@ describe("chromium CDP discovery classifications", () => {
     expect(getFailureSignal(err)?.network_failure).toBe("connection_refused");
   });
 
+  it("classifies a port that accepts and never answers as CHROMIUM_CDP_UNREACHABLE", async () => {
+    // A handler that never responds: the TCP handshake completes and the
+    // headers never arrive. The only other bound on an unsignalled request is
+    // undici's 300s headers timeout, well past any caller's own deadline.
+    const port = await startServer(() => {});
+    const err = await captureError(ensureCdpReachable(port));
+    expectCode(err, FAILURE_CODES.CHROMIUM_CDP_UNREACHABLE);
+    expect(getFailureSignal(err)?.network_failure).toBe("timeout");
+  }, 20_000);
+
   it("classifies an endpoint with no page targets as CHROMIUM_CDP_NO_PAGE_TARGET", async () => {
     const port = await startServer((path, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });


### PR DESCRIPTION
Fixes #895

**Cause** - the CDP discovery helpers take an optional `AbortSignal`; `connectCdp`, the tab manager and the Electron ready-wait pass none, so a debug port that completes the TCP handshake and never answers rides undici's 300s headers timeout, past the 30s MCP per-attempt cap.

**Fix** - `fetchJson` arms `AbortSignal.timeout(5s)` when the caller supplies no signal, and classifies the resulting `TimeoutError` as `CHROMIUM_CDP_UNREACHABLE` with `network_failure: "timeout"`, so the caller gets the `cdp_unreachable` guidance instead of an aborted call.

Fixed at the shared `fetchJson` rather than inside `connectCdp`, so every unsignalled call site is bounded at once: `connectCdp` (x2), `tabs.ts` (`listPageTargets`, `browserWebSocketUrl`) and `boot-electron`'s `waitForCdpReady` (whose 30s deadline was never re-checked once a probe stalled). Callers that arm their own signal - `probePort` at 800ms, `flow-run`'s liveness re-probe - are unchanged.

Left alone: `CDPClient.connect`'s WebSocket handshake has no timeout either, but it is reached only after the port has already answered CDP twice - a different failure, worth its own issue.

**Docs** - none needed: no tool, CLI flag, config key, flow directive or user-facing capability changes.

<details>
<summary>Repro and verification</summary>

Repro against a bare `net` server that accepts and writes nothing, driving `connectCdp`:

```
before: STILL PENDING at 20001ms
after:  threw after 5005ms: FailureError Chromium CDP discovery:
        GET http://127.0.0.1:53169/json/version timed out.
        Something is holding port 53169 without answering CDP.
```

The new case in `failure-classification.test.ts` discriminates - with the source change reverted it does not fail on an assertion, it hangs:

```
FAIL packages/tool-server/test/failure-classification.test.ts >
  classifies a port that accepts and never answers as CHROMIUM_CDP_UNREACHABLE
Error: Test timed out in 20000ms.
Error: Hook timed out in 10000ms.   (afterEach, waiting on the stalled socket)
```

Checks, all from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 368 files, 4833 passed, 1 skipped
- `npx prettier --write` on both changed files
- `npx eslint` on the changed source - clean

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chromium CDP connection attempts now time out after 5 seconds when a port accepts a connection but does not respond.
  * Unresponsive connections are reported with a distinct timeout classification while preserving existing connection error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->