### PR TITLE
fix(tool-server): prune a Chromium CDP port only when nothing is listening

### DIFF
--- a/packages/tool-server/src/utils/chromium-discovery.ts
+++ b/packages/tool-server/src/utils/chromium-discovery.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { FAILURE_CODES, getFailureSignal } from "@argent/registry";
 import { CHROMIUM_ID_PREFIX, chromiumIdFromPort } from "./device-info";
 import { ensureCdpReachable, discoverPrimaryPage } from "../blueprints/chromium-cdp";
 
@@ -43,7 +44,8 @@ const TRACKED_PORTS = new Set<number>();
  * Tracked ports are mirrored to a file: booted apps are detached and outlive
  * the tool-server (which auto-exits on idle), so without persistence a restart
  * hides running apps from `list-devices` and the agent boots a duplicate.
- * Failed probes prune the file, so it self-heals after the app quits.
+ * Probes that find nothing listening prune the file, so it self-heals after the
+ * app quits.
  */
 function portsFilePath(): string {
   return (
@@ -81,7 +83,7 @@ export function trackChromiumPort(port: number): void {
   persistPorts((ports) => ports.add(port));
 }
 
-/** Remove a port. Optional: a failed probe prunes it anyway. */
+/** Remove a port. Optional: an unreachable probe prunes it anyway. */
 export function untrackChromiumPort(port: number): void {
   TRACKED_PORTS.delete(port);
   persistPorts((ports) => ports.delete(port));
@@ -112,13 +114,18 @@ async function probePort(port: number, timeoutMs: number): Promise<ChromiumDevic
       browser: version.Browser ?? null,
       state: "Running",
     };
-  } catch {
-    // Drop dead tracked ports so list-devices stops probing a closed app.
-    TRACKED_PORTS.delete(port);
-    // Only touch the file when this port was persisted — a failed probe of
-    // 9222 or an env port must not create or rewrite it.
-    if (loadPersistedPorts().includes(port)) {
-      persistPorts((ports) => ports.delete(port));
+  } catch (err) {
+    // Drop the port only when nothing answers on it. Any other failure means
+    // something is still listening: an Electron app whose last window closed
+    // answers /json/version but lists no page target, and pruning it there
+    // hides a running app from list-devices for good.
+    if (getFailureSignal(err)?.error_code === FAILURE_CODES.CHROMIUM_CDP_UNREACHABLE) {
+      TRACKED_PORTS.delete(port);
+      // Only touch the file when this port was persisted — a failed probe of
+      // 9222 or an env port must not create or rewrite it.
+      if (loadPersistedPorts().includes(port)) {
+        persistPorts((ports) => ports.delete(port));
+      }
     }
     return null;
   } finally {

--- a/packages/tool-server/test/chromium-discovery.test.ts
+++ b/packages/tool-server/test/chromium-discovery.test.ts
@@ -20,7 +20,8 @@ interface FakeCdpServer {
 async function startFakeCdpServer(options?: {
   responses?: {
     version?: number | object;
-    list?: number | object;
+    /** A function is re-read per request, so a test can change the reply mid-run. */
+    list?: number | object | (() => number | object);
   };
 }): Promise<FakeCdpServer> {
   const server = http.createServer((req, res) => {
@@ -39,7 +40,8 @@ async function startFakeCdpServer(options?: {
       return;
     }
     if (req.url === "/json/list") {
-      const r = options?.responses?.list ?? [
+      const configured = options?.responses?.list;
+      const r = (typeof configured === "function" ? configured() : configured) ?? [
         {
           id: "abc",
           type: "page",
@@ -167,6 +169,45 @@ describe("discoverChromiumDevices", () => {
     serversToCleanup.push(server);
     const devices = await discoverChromiumDevices({ timeoutMs: 1500, ports: [server.port] });
     expect(devices).toEqual([]);
+  });
+
+  it("keeps a running app tracked while it has no page target", async () => {
+    // An Electron app whose last window closed keeps answering /json/version
+    // while /json/list reports no page. Pruning it there loses the app for
+    // good, since nothing but a fresh boot re-adds a port.
+    let pages: object[] = [];
+    const server = await startFakeCdpServer({ responses: { list: () => pages } });
+    serversToCleanup.push(server);
+    trackChromiumPort(server.port);
+    portsToCleanup.push(server.port);
+
+    expect(await discoverChromiumDevices({ timeoutMs: 1500, ports: [server.port] })).toEqual([]);
+    expect(getCandidateChromiumPorts()).toContain(server.port);
+    expect(JSON.parse(fs.readFileSync(TEST_PORTS_FILE, "utf8"))).toContain(server.port);
+
+    // The window comes back: the app must be discoverable again.
+    pages = [
+      {
+        id: "abc",
+        type: "page",
+        title: "Test Page",
+        url: "file:///tmp/index.html",
+        webSocketDebuggerUrl: "ws://127.0.0.1:0/devtools/page/abc",
+      },
+    ];
+    const devices = await discoverChromiumDevices({ timeoutMs: 1500 });
+    expect(devices.some((d) => d.port === server.port)).toBe(true);
+  });
+
+  it("keeps a tracked port whose endpoint answers with a non-2xx status", async () => {
+    const server = await startFakeCdpServer({ responses: { version: 500 } });
+    serversToCleanup.push(server);
+    trackChromiumPort(server.port);
+    portsToCleanup.push(server.port);
+
+    expect(await discoverChromiumDevices({ timeoutMs: 1500, ports: [server.port] })).toEqual([]);
+    expect(getCandidateChromiumPorts()).toContain(server.port);
+    expect(JSON.parse(fs.readFileSync(TEST_PORTS_FILE, "utf8"))).toContain(server.port);
   });
 
   it("untracks a port after it stops responding", async () => {


### PR DESCRIPTION
Fixes #886

**Cause:** `probePort` pruned a port from `TRACKED_PORTS` and the persisted file on *any* probe failure - including `CHROMIUM_CDP_NO_PAGE_TARGET`, which a live Electron app raises whenever its last window is closed (`/json/version` answers, `/json/list` has no `page`). One `list-devices` call in that window erased the port for good; the only recovery is booting a duplicate instance, exactly what the persistence layer exists to avoid.

**Fix:** prune only when the failure is `CHROMIUM_CDP_UNREACHABLE` - the code `fetchJson` raises when the connection itself fails. Any other failure proves something is still listening.

**Verified:** the issue's repro (a stub CDP endpoint with an empty `/json/list`), before vs after:

| | probe #1 (window closed) | probe #2 (window restored) |
| --- | --- | --- |
| `main` | 0 devices, file `[]` | **0 devices**, file `[]` |
| this branch | 0 devices, file `[61110]` | **1 device**, file `[61110]` |

Class check: `chromium-discovery.ts` holds the only prune-on-probe-failure path in the repo; `trackChromiumPort` / `untrackChromiumPort` have one caller each (`boot-electron.ts`, `flow-run.ts`) and are unaffected.

Docs: no change needed - no tool, CLI flag, config key or flow directive changes, and the `ARGENT_CHROMIUM_PORTS_FILE` row in `reference/configuration.mdx` still describes the file correctly.

<details>
<summary>Tests and checks</summary>

Two tests added to `packages/tool-server/test/chromium-discovery.test.ts`; both fail on the unfixed source:

```
 FAIL  keeps a running app tracked while it has no page target
 AssertionError: expected [ 9222 ] to include 51375
 FAIL  keeps a tracked port whose endpoint answers with a non-2xx status
 AssertionError: expected [ 9222 ] to include 51378
```

The first also asserts the app is rediscovered once its window returns; the second covers `CHROMIUM_CDP_INVALID_RESPONSE`. The existing "untracks a port after it stops responding" and "a dead persisted port is pruned" tests still pass - a closed listener yields `ECONNREFUSED`, so self-healing is intact.

Ran from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 368 files, 4834 passed, 1 skipped (baseline on `main`: 4832 passed)
- `npx prettier --write` on both changed files - unchanged

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
