### PR TITLE
fix(registry): snapshot the listener set before an emit walks it

### DIFF
--- a/packages/registry/src/event-emitter.ts
+++ b/packages/registry/src/event-emitter.ts
@@ -27,7 +27,11 @@ export class TypedEventEmitter<
   }
 
   emit<K extends keyof T>(event: K, ...args: Parameters<T[K]>): void {
-    this.listeners.get(event)?.forEach((fn) => {
+    const fns = this.listeners.get(event);
+    if (!fns) return;
+    // Snapshot, as Node's EventEmitter does: a listener detached by an earlier
+    // one still runs, and one attached by an earlier one waits for the next emit.
+    for (const fn of [...fns]) {
       try {
         fn(...args);
       } catch (err) {
@@ -35,7 +39,7 @@ export class TypedEventEmitter<
           `[registry] Event listener error (${String(event)}): ${err instanceof Error ? err.message : err}\n`
         );
       }
-    });
+    }
   }
 
   removeAllListeners(): void {

--- a/packages/registry/tests/event-emitter.test.ts
+++ b/packages/registry/tests/event-emitter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { TypedEventEmitter } from "../src/event-emitter";
+
+type Events = { x: () => void };
+
+describe("TypedEventEmitter.emit — listener set mutated during the emit", () => {
+  it("still calls a listener an earlier listener detached", () => {
+    const emitter = new TypedEventEmitter<Events>();
+    const ran: string[] = [];
+
+    const b = (): void => {
+      ran.push("B");
+    };
+    const a = (): void => {
+      emitter.off("x", b);
+      ran.push("A");
+    };
+
+    emitter.on("x", a);
+    emitter.on("x", b);
+    emitter.emit("x");
+
+    expect(ran).toEqual(["A", "B"]);
+  });
+
+  it("defers a listener an earlier listener attached to the next emit", () => {
+    const emitter = new TypedEventEmitter<Events>();
+    const ran: string[] = [];
+
+    const late = (): void => {
+      ran.push("LATE");
+    };
+    const c = (): void => {
+      emitter.on("x", late);
+      ran.push("C");
+    };
+
+    emitter.on("x", c);
+    emitter.emit("x");
+    expect(ran).toEqual(["C"]);
+
+    emitter.emit("x");
+    expect(ran).toEqual(["C", "C", "LATE"]);
+  });
+});


### PR DESCRIPTION
Fixes #870

**Cause:** `TypedEventEmitter.emit` iterated the live `Set`, so a listener detached by an earlier listener was skipped, and one attached by an earlier listener ran inside the same emit. Node's `EventEmitter` does neither - it snapshots first.

**Fix:** iterate a copy of the set (4 production lines).

**Class:** `packages/registry/src/event-emitter.ts:30` was the only site iterating a mutable listener collection in the repo. `lens-pty.ts`'s `observers` array is append-only (no detach API), so it cannot hit this.

**Docs:** none needed - no tool, CLI, config key, flow file or user-facing capability changed.

<details>
<summary>Verification</summary>

New test `packages/registry/tests/event-emitter.test.ts` pins both directions. Reverting only the source fix (`git stash push -- packages/registry/src/event-emitter.ts`) makes both cases fail:

```
FAIL  tests/event-emitter.test.ts > still calls a listener an earlier listener detached
AssertionError: expected [ 'A' ] to deeply equal [ 'A', 'B' ]

FAIL  tests/event-emitter.test.ts > defers a listener an earlier listener attached to the next emit
AssertionError: expected [ 'C', 'LATE' ] to deeply equal [ 'C' ]

Test Files  1 failed (1)
     Tests  2 failed (2)
```

With the fix restored:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/registry` - clean
- `npm test -w @argent/registry` - 8 files, 122 tests passed
- `npm test -w @argent/tool-server` - 368 files, 4832 passed / 1 skipped (the main consumer of this emitter, run against the rebuilt registry dist)
- `npx prettier --write` on both changed files - unchanged

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)