### PR TITLE
fix(describe): name the gesture tools Chromium accepts

### DIFF
--- a/packages/skills/rules/argent.md
+++ b/packages/skills/rules/argent.md
@@ -17,7 +17,7 @@ Use cases:
 - Any request to execute manual QA, UI QA, or visual behavior validation for a mobile app
 - Running, debugging, or testing a React Native app (iOS, Android or Vega)
 - Profiling performance or diagnosing re-renders in a React Native app (iOS or Android)
-- Running, debugging, or testing a Chromium (CDP) app — an Electron app (boot with `boot-device` + `electronAppPath`) or a Chromium browser exposing CDP (auto-discovered on port `9222` / `ARGENT_CHROMIUM_PORTS`); on Chromium scroll with `gesture-scroll` and drag with `gesture-drag` — `gesture-swipe` is touch-only
+- Running, debugging, or testing a Chromium (CDP) app — an Electron app (boot with `boot-device` + `electronAppPath`) or a Chromium browser exposing CDP (auto-discovered on port `9222` / `ARGENT_CHROMIUM_PORTS`); on Chromium scroll with `gesture-scroll` and drag with `gesture-drag` — `gesture-swipe` is not supported there
   </description>
 
 <availability_check>

--- a/packages/skills/skills/argent-device-interact/SKILL.md
+++ b/packages/skills/skills/argent-device-interact/SKILL.md
@@ -21,7 +21,7 @@ Use `list-devices` to get a target id. Results are tagged with `platform` (`ios`
 
 1. **Always refer to tapping_rule** from your argent.md rule before tapping.
 2. Before performing interactions, consider whether they can be **dispatched sequentially** - more on that in `run-sequence`.
-3. **Use `gesture-swipe` for lists/scrolling**, not `gesture-custom`, unless you need non-linear movement. On Chromium use `gesture-scroll` instead — `gesture-swipe` is touch-only. Consider whether you need multiple swipes, if yes - use `run-sequence`. Pass `momentum: false` when the swipe should decelerate before ending for a precise movement.
+3. **Use `gesture-swipe` for lists/scrolling**, not `gesture-custom`, unless you need non-linear movement. On Chromium use `gesture-scroll` instead — `gesture-swipe` is not supported there. Consider whether you need multiple swipes, if yes - use `run-sequence`. Pass `momentum: false` when the swipe should decelerate before ending for a precise movement.
 4. **Tap a text field before typing**, then use `keyboard` to enter text.
 5. **Coordinates are normalized** — always 0.0–1.0, not pixels.
 6. **For app navigation, use the element tree returned after each action** (`--- Elements after action (describe) ---`); call `describe` only when no fresh tree is available for the current screen. It works on any screen without app restart. Do not navigate from screenshot pixels on regular in-app screens unless the tree failed to expose a reliable target. Use `native-describe-screen` only when you need app-scoped UIKit properties.

--- a/packages/tool-server/src/tools/describe/format-tree.ts
+++ b/packages/tool-server/src/tools/describe/format-tree.ts
@@ -167,12 +167,15 @@ export function formatDescribeTree(root: DescribeNode, opts: FormatDescribeOptio
         'and count rows/columns to build the path (e.g. one row down and two columns right → ["down","right","right","select"]).'
     );
   } else {
-    // Physical iOS has no two-finger gestures. Do not recommend gesture-pinch for this source.
+    // Name only the gesture tools this platform accepts: agents follow this line verbatim.
     header.push(
       opts.source === "xcuitest-runner"
         ? "Pass them straight to gesture-tap / gesture-swipe, which expect this same space. " +
             "No two-finger gestures on physical iOS."
-        : "Pass them straight to gesture-tap / gesture-swipe / gesture-pinch, which expect this same space."
+        : opts.source === "cdp-dom"
+          ? "Pass them straight to gesture-tap / gesture-scroll / gesture-drag, which expect this same space. " +
+            "gesture-swipe and gesture-pinch are not supported on Chromium."
+          : "Pass them straight to gesture-tap / gesture-swipe / gesture-pinch, which expect this same space."
     );
     header.push(
       "To tap an element, use its centre: tap_x = frame.x + frame.width / 2, tap_y = frame.y + frame.height / 2."

--- a/packages/tool-server/src/tools/describe/index.ts
+++ b/packages/tool-server/src/tools/describe/index.ts
@@ -167,7 +167,8 @@ On a physical iOS device, launch-app \`com.apple.springboard\` first to read sys
 Returns \`{ description, source }\` where \`description\` is a text rendering of the UI tree — one
 line per element with its role, label/value/id, interactivity flags, and frame. Frame coordinates
 are normalized [0,1] fractions of the screen / window width/height (not pixels) — the same space as
-gesture-tap / gesture-swipe / gesture-pinch.
+gesture-tap / gesture-swipe / gesture-pinch. On Chromium use gesture-tap / gesture-scroll / gesture-drag
+(gesture-swipe and gesture-pinch are not supported there); a physical iOS device has no gesture-pinch.
 
 To tap an element use the centre of its frame: \`tap_x = frame.x + frame.width / 2\`,
 \`tap_y = frame.y + frame.height / 2\`. The same formula appears in the response header so it

--- a/packages/tool-server/test/describe-format-tree.test.ts
+++ b/packages/tool-server/test/describe-format-tree.test.ts
@@ -277,7 +277,7 @@ describe("formatDescribeTree", () => {
   });
 
   // The header text is part of the agent-visible response, so it must keep
-  // pointing at gesture-tap / gesture-swipe / gesture-pinch and the centre
+  // pointing at the gesture tools the target accepts and at the centre
   // formula. If this drifts again the runtime help is silently misleading.
   it("renders the coordinate-space + tap-formula header on every call", () => {
     const empty: DescribeNode = {
@@ -287,7 +287,7 @@ describe("formatDescribeTree", () => {
     };
     const out = formatDescribeTree(empty, { source: "ax-service" });
     expect(out).toContain("normalized [0,1] fractions of the screen");
-    expect(out).toContain("gesture-tap");
+    expect(out).toContain("gesture-tap / gesture-swipe / gesture-pinch");
     expect(out).toContain("tap_x = frame.x + frame.width / 2");
     expect(out).toContain("tap_y = frame.y + frame.height / 2");
   });
@@ -337,6 +337,23 @@ describe("formatDescribeTree", () => {
         "\n" +
         "ROOT  AXGroup (0.000, 0.000, 1.000, 1.000)\n"
     );
+  });
+
+  // gesture-swipe and gesture-pinch declare no chromium capability: naming them
+  // here would send every Chromium caller into a capability-gate rejection.
+  it("names the Chromium-capable gesture tools in the cdp-dom header", () => {
+    const empty: DescribeNode = {
+      role: "AXGroup",
+      frame: { x: 0, y: 0, width: 1, height: 1 },
+      children: [],
+    };
+    const out = formatDescribeTree(empty, { source: "cdp-dom" });
+    expect(out).toContain(
+      "Pass them straight to gesture-tap / gesture-scroll / gesture-drag, which expect this same space. " +
+        "gesture-swipe and gesture-pinch are not supported on Chromium."
+    );
+    expect(out).not.toContain("Pass them straight to gesture-tap / gesture-swipe / gesture-pinch");
+    expect(out).toContain("tap_x = frame.x + frame.width / 2");
   });
 
   // Bluesky-style names mix emoji, ZWJ sequences, and bidirectional isolate


### PR DESCRIPTION
Fixes #873

**Cause:** `describe`'s response header and tool description tell every caller to pass frames to `gesture-tap / gesture-swipe / gesture-pinch`, but only `gesture-tap` declares `chromium` support - swipe and pinch are rejected at the capability gate on a Chromium target.

**Fix:** on `source: "cdp-dom"` the header names `gesture-tap / gesture-scroll / gesture-drag` (the tools with `chromium: { app: true }`) and says swipe/pinch are not supported on Chromium. The tool description gets the same qualifier, plus the physical-iOS `gesture-pinch` gap the header already covers. Two skill lines that called `gesture-swipe` "touch-only" now say it is not supported on Chromium.

**Not "touch-only":** Chromium accepts CDP touch input (a touch swipe scrolls, a two-finger spread zooms - see details). The rejection is argent's: it drives Chromium with mouse events, where a drag selects text instead of scrolling - hence `gesture-scroll`.

**Docs:** none needed - `reference/tools.mdx` already labels `gesture-scroll` / `gesture-drag` as Chromium; no tool, CLI, config key or capability changed.

<details>
<summary>Verification</summary>

Chromium touch probe - headless Chrome 153 over raw CDP, no touch emulation (`navigator.maxTouchPoints === 0`):

| input | result |
|---|---|
| `Input.dispatchTouchEvent` tap | `pointerdown:touch`, `touchstart`, `touchend`, `click:touch` |
| `Input.dispatchTouchEvent` swipe up 400px | `scrollY` 0 → 484 |
| `Input.dispatchTouchEvent` two-finger spread | `visualViewport.scale` 1 → 3 |
| `Input.dispatchMouseEvent` drag up 400px (argent's Chromium path) | `scrollY` 0, 424 chars selected |

`test/describe-format-tree.test.ts` - "names the Chromium-capable gesture tools in the cdp-dom header" pins the exact line. Each mutation fails it (`Tests 1 failed | 23 passed (24)`):
- restore the "touch-only and are rejected on Chromium" wording
- drop the `cdp-dom` arm

From the worktree root:
- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - `Test Files 441 passed (441)`, `Tests 6241 passed | 1 skipped`
- `npx eslint --max-warnings 0` + `npx prettier --check` on the changed files - clean

E2E - the server's own `createRegistry()` + `createHttpApp()` served in-process, `POST /tools/<name>` against a live headless Chrome (`chromium-cdp-9853`), same entry bundled against `main` and this branch:

```
[after]  Pass them straight to gesture-tap / gesture-scroll / gesture-drag, which expect this same space. gesture-swipe and gesture-pinch are not supported on Chromium.
[before] Pass them straight to gesture-tap / gesture-swipe / gesture-pinch, which expect this same space.
```

Gate on that device: `gesture-tap` / `gesture-scroll` / `gesture-drag` 200; `gesture-swipe` / `gesture-pinch` 400 `Tool 'gesture-swipe' is not supported on chromium app (no chromium support declared).`

</details>
