### PR TITLE
fix(tool-server): stop asking about --remote-debugging-port on a port that answered

### DIFF
--- a/packages/tool-server/src/chromium-server/cdp-session.ts
+++ b/packages/tool-server/src/chromium-server/cdp-session.ts
@@ -63,7 +63,8 @@ export async function discoverPrimaryPage(port: number, signal?: AbortSignal): P
       );
     }
     throw new FailureError(
-      `Chromium CDP on port ${port} reported no page targets. Is the app started with --remote-debugging-port=${port}?`,
+      `Chromium CDP on port ${port} answered but exposes no page target ` +
+        `(the app is running with no window). Open an app window and retry.`,
       {
         error_code: FAILURE_CODES.CHROMIUM_CDP_NO_PAGE_TARGET,
         failure_stage: "chromium_cdp_discover_page_none",

--- a/packages/tool-server/test/chromium-no-page-target-message.test.ts
+++ b/packages/tool-server/test/chromium-no-page-target-message.test.ts
@@ -1,0 +1,66 @@
+import { createServer, type Server } from "node:http";
+import { describe, it, expect, afterEach } from "vitest";
+import { FAILURE_CODES, getFailureSignal } from "@argent/registry";
+import { discoverPrimaryPage } from "../src/chromium-server/cdp-session";
+
+/**
+ * Both CHROMIUM_CDP_NO_PAGE_TARGET throw sites are only reachable after
+ * `/json/list` answered, so neither may question the debug flag: a missing
+ * `--remote-debugging-port` fails earlier as CHROMIUM_CDP_UNREACHABLE. The
+ * message is what `debugger-status` hands the agent as `detail`, and its
+ * Chromium `cdp_unreachable` guidance defers to that detail, so a wrong
+ * diagnosis here is what the agent acts on.
+ */
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => s.close(() => r()))));
+});
+
+/** Serves `targets` from `/json/list`; returns the listening port. */
+async function serveTargets(targets: unknown[]): Promise<number> {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(targets));
+  });
+  servers.push(server);
+  await new Promise<void>((ok) => server.listen(0, "127.0.0.1", ok));
+  return (server.address() as { port: number }).port;
+}
+
+async function messageOf(port: number): Promise<string> {
+  try {
+    await discoverPrimaryPage(port);
+  } catch (err) {
+    expect(getFailureSignal(err)?.error_code).toBe(FAILURE_CODES.CHROMIUM_CDP_NO_PAGE_TARGET);
+    return (err as Error).message;
+  }
+  throw new Error("expected discoverPrimaryPage to throw");
+}
+
+describe("no-page-target message", () => {
+  it("reports a windowless app when the list holds no page target at all", async () => {
+    const message = await messageOf(
+      await serveTargets([{ id: "1", type: "service_worker", title: "sw", url: "chrome://x" }])
+    );
+    expect(message).not.toMatch(/--remote-debugging-port/);
+    expect(message).toMatch(/window/i);
+  });
+
+  it("reports a hidden or closed window when only devtools:// pages remain", async () => {
+    const message = await messageOf(
+      await serveTargets([
+        {
+          id: "1",
+          type: "page",
+          title: "DevTools",
+          url: "devtools://devtools/bundled/inspector.html",
+          webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/1",
+        },
+      ])
+    );
+    expect(message).not.toMatch(/--remote-debugging-port/);
+    expect(message).toMatch(/window/i);
+  });
+});


### PR DESCRIPTION
Fixes #880

**Cause.** `discoverPrimaryPage`'s no-page-target branch is only reached after `GET /json/list` succeeded, so the app provably has `--remote-debugging-port` (a missing flag fails earlier, as `CHROMIUM_CDP_UNREACHABLE`) - yet the message asked about the flag and withheld the window hint its `devtools://` sibling gives.

**Fix.** One message: the endpoint answered but exposes no page target, i.e. the app is running with no window. Same shape as the sibling branch two lines up.

| Before | After |
| --- | --- |
| `Chromium CDP on port N reported no page targets. Is the app started with --remote-debugging-port=N?` | `Chromium CDP on port N answered but exposes no page target (the app is running with no window). Open an app window and retry.` |

Why it matters: `CHROMIUM_CDP_NO_PAGE_TARGET` maps to `cdp_unreachable`, whose Chromium guidance says "see detail" - this string *is* the detail, and its relaunch implication leaves a second copy contending for the single-instance lock while the windowless one still holds the port.

**Class.** The other `--remote-debugging-port` question in the file (`fetchJson`'s connect catch) is correct - it fires only when the port did not answer - and is left. No docs/skills change: no prose surface quotes this string, and no tool, CLI flag, config key or flow behaviour changed.

<details>
<summary>Verification</summary>

New test `packages/tool-server/test/chromium-no-page-target-message.test.ts` drives `discoverPrimaryPage` against a local HTTP server serving a `/json/list` with no `page` entry (and, for the sibling, only a `devtools://` page).

Discriminates - source fix stashed:

```
FAIL test/chromium-no-page-target-message.test.ts > reports a windowless app when the list holds no page target at all
AssertionError: expected 'Chromium CDP on port 55564 reported n…' not to match /--remote-debugging-port/
+ Received: "Chromium CDP on port 55564 reported no page targets. Is the app started with --remote-debugging-port=55564?"
```

Fix restored: 2 passed.

Ran from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w packages/tool-server` - clean
- `npm test -w packages/tool-server` - 4833 passed, 1 skipped, 1 failed: `lens-tools-platform-gate.test.ts` timing out at 5000 ms, the known full-suite/cold-cache flake. Reproduced on a clean tree and passes on 3/3 warm reruns with the fix applied; it imports nothing this change touches.
- `npx prettier --write` on both changed files - unchanged

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
