### PR TITLE
fix(tool-server): absorb the deferred spawn error after boot-electron's no-pid throw

### DIFF
--- a/packages/tool-server/src/tools/devices/boot-electron.ts
+++ b/packages/tool-server/src/tools/devices/boot-electron.ts
@@ -374,10 +374,12 @@ export async function bootElectronApp(options: BootElectronOptions): Promise<Ele
   child.once("error", spawnErrorListener);
 
   if (!child.pid) {
-    // No pid and no async error yet is still possible on some platforms when
-    // spawn fails very early. Detach first so an `error` event delivered after
-    // this throw can't reject an orphan promise and crash the tool-server.
+    // An unresolvable binary reports both ways: spawn() returns without a pid
+    // AND emits ENOENT on the next tick. Swap the rejecting listener for an
+    // absorber so that event neither rejects the promise this throw orphans nor
+    // escapes as an uncaught `error` event and kills the tool-server.
     child.removeListener("error", spawnErrorListener);
+    child.on("error", () => {});
     spawnErrorReject = null;
     throw new FailureError(
       `Electron boot: spawn returned without a pid (binary: ${launcher.command}).`,

--- a/packages/tool-server/test/boot-electron-spawn-error.test.ts
+++ b/packages/tool-server/test/boot-electron-spawn-error.test.ts
@@ -227,8 +227,9 @@ describe("bootElectronApp — spawn error handling", () => {
   });
 
   it("still rejects when spawn returns a child with no pid (early-fail path)", async () => {
-    // Some platforms produce a child without a pid AND no async error event.
-    // The synchronous "no pid" guard catches that case.
+    // `spawn()` reports an unresolvable binary synchronously as a missing pid,
+    // before any deferred `error` event can arrive. The "no pid" guard turns
+    // that into the rejection.
     spawnMock.mockReturnValue(makeFakeChild({ pid: undefined }));
 
     await expect(
@@ -382,12 +383,13 @@ describe("bootElectronApp — spawn error handling", () => {
     }
   });
 
-  it("detaches the error listener after the no-pid throw — a deferred 'error' must not become an unhandled rejection", async () => {
-    // Real-world regression scenario: a hostile platform returns a Child with
-    // no pid AND fires a deferred 'error' event after spawn returns. Before
-    // the fix, the error listener would still be attached and would call
-    // reject() on a promise that nobody is awaiting — Node's default
-    // --unhandled-rejections=throw would then crash the tool-server.
+  it("swallows the deferred 'error' that follows the no-pid throw — no uncaught exception, no unhandled rejection", async () => {
+    // Node reports an unresolvable binary both ways: `spawn()` returns a child
+    // with no pid AND emits ENOENT on the next tick, after the "no pid" guard
+    // has already thrown. That event must reach a listener that neither
+    // rejects the promise the throw orphaned nor lets EventEmitter escalate it
+    // to an uncaught exception — either one kills the whole tool-server,
+    // taking every other session's device connections with it.
     const child = makeFakeChild({ pid: undefined });
     spawnMock.mockReturnValue(child);
 
@@ -406,18 +408,12 @@ describe("bootElectronApp — spawn error handling", () => {
         })
       ).rejects.toThrow(/spawn returned without a pid/);
 
-      // After the synchronous throw, no listener should remain on the child.
-      expect(child.listenerCount("error")).toBe(0);
-
       // Fire the deferred error now — like Node would.
       const err = new Error("late ENOENT") as NodeJS.ErrnoException;
       err.code = "ENOENT";
-      // emit() with no listener on a stock EventEmitter would throw, but the
-      // test fake-child uses a vanilla EventEmitter, so emit just no-ops when
-      // there are no listeners on a non-'error' channel. For 'error' events
-      // specifically Node DOES throw — so guard the emit to confirm the
-      // listener was actually detached.
-      expect(() => child.emit("error", err)).toThrow(/late ENOENT/);
+      // An 'error' event with no listener is rethrown synchronously out of
+      // emit(); in the tool-server that surfaces as the uncaught exception.
+      expect(() => child.emit("error", err)).not.toThrow();
 
       // Give microtasks a tick to surface any unhandled rejection.
       await new Promise((r) => setImmediate(r));


### PR DESCRIPTION
Fixes #866

**Cause:** an unresolvable electron binary makes `spawn()` report failure twice - `child.pid` is `undefined` *and* an ENOENT `'error'` event lands on the next tick. `bootElectronApp`'s no-pid guard removed the only `'error'` listener before throwing, so that event escaped as an uncaught exception and killed the whole tool-server ~3 ms after `boot-device` had already returned its clean 500.

**Fix:** attach a no-op absorber (`child.on("error", () => {})`) in place of the rejecting listener. The deferred error is swallowed instead of escaping, the caller still gets `CHROMIUM_ELECTRON_SPAWN_FAILED`, and no orphan promise is rejected.

**Verified:** `npx tsc --build`, `npm run typecheck:tests -w @argent/tool-server`, and the full `@argent/tool-server` suite (4831 passed; one unrelated wall-clock flake, `flow-idle-run` "settles inside the smallest timeout", green in isolation). The rewritten no-pid test fails on the unfixed line.

No docs change: no tool, CLI, config key, flow file or user-facing capability moves.

<details>
<summary>Repro, discrimination proof, and the sibling guards left alone</summary>

Node reports both signals, so the guard's old premise ("no pid **and** no async error yet") never holds - Node v24.14.1, darwin arm64:

```
$ node -e 'const {spawn}=require("node:child_process");
  const c=spawn("definitely-not-a-real-binary-xyz",[],{detached:true});
  console.log("sync: child.pid =", c.pid);
  c.once("error",e=>console.log("async: error event ->", e.code));
  setTimeout(()=>{},300)'
sync: child.pid = undefined
async: error event -> ENOENT
```

`test/boot-electron-spawn-error.test.ts` previously asserted the crash as the expected behaviour (`expect(() => child.emit("error", err)).toThrow(/late ENOENT/)` on a child with zero listeners). That assertion is inverted, and the test now also keeps its original `unhandledRejection` check so both failure modes stay pinned. Removing only `child.on("error", () => {})` from the source:

```
FAIL  test/boot-electron-spawn-error.test.ts > swallows the deferred 'error' that follows the no-pid throw
  expected function not to throw an error but "Error: late ENOENT" was thrown
Tests  1 failed | 8 passed (9)
```

With the fix: `Tests  9 passed (9)`.

Sibling spawn-failure paths checked and left alone:

- `utils/ios-profiler/startup.ts` (`waitForXctraceReady`) already keeps its `'error'` listener attached for the child's lifetime, and says why - this fix follows that precedent.
- `platforms/ios.ts:647` throws on a pidless `xctrace` child while that listener is still attached, so the deferred error is handled.
- `blueprints/tv-control.ts` and `screen-recording/capture.ts` detach `'error'` only after a child that *did* get a pid settles, where no deferred spawn error is in flight.
- `boot-electron.ts`'s own `detachBootListeners()` is the same pid-bearing case: the child is intentionally long-lived and its later exit belongs to the next owner.

Root `npm run lint` could not run in this checkout - `packages/docs/tsconfig.json` needs `@docusaurus/tsconfig`, which the root install skips.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
