### PR TITLE
fix(tool-server): treat an empty ARGENT_HOST/ARGENT_PORT as unset

### DIFF
--- a/packages/tool-server/src/index.ts
+++ b/packages/tool-server/src/index.ts
@@ -149,8 +149,11 @@ export function start(): void {
     );
   });
 
-  const PORT = parseInt(process.env.ARGENT_PORT ?? DEFAULT_PORT, 10);
-  const HOST = process.env.ARGENT_HOST ?? DEFAULT_HOST;
+  // An empty or blank override is an unset one: `export ARGENT_HOST=` would
+  // otherwise reach listen(), which reads "" as "no host" and binds every
+  // interface, with auth off unless ARGENT_AUTH_TOKEN is set.
+  const PORT = parseInt(process.env.ARGENT_PORT?.trim() || DEFAULT_PORT, 10);
+  const HOST = process.env.ARGENT_HOST?.trim() || DEFAULT_HOST;
   const idleMinutes = parseInt(
     process.env.ARGENT_IDLE_TIMEOUT_MINUTES ?? DEFAULT_IDLE_TIMEOUT_MINUTES,
     10

--- a/packages/tool-server/test/bind-env-overrides.test.ts
+++ b/packages/tool-server/test/bind-env-overrides.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const telemetryMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  attachRegistryTelemetry: vi.fn(() => ({
+    detach: vi.fn(),
+    recordInvocation: vi.fn(),
+    getTotalToolCalls: vi.fn(() => 0),
+  })),
+  track: vi.fn(),
+  shutdown: vi.fn().mockResolvedValue(undefined),
+  warmTelemetryIdentity: vi.fn().mockResolvedValue(undefined),
+  describeCrash: vi.fn(() => ({ crash_phase: "startup" })),
+  aiTelemetryFromMeta: vi.fn(() => ({})),
+  attachRegistryEventLogger: vi.fn(),
+}));
+
+const registryMock = vi.hoisted(() => ({
+  dispose: vi.fn().mockResolvedValue(undefined),
+}));
+
+// listen() deliberately never invokes its success callback: the assertions are
+// on the arguments it was handed, and leaving `listening` false keeps the
+// startup banner off the suite's stdout.
+const serverMock = vi.hoisted(() => ({
+  on() {
+    return this;
+  },
+  address: () => ({ port: 3001 }),
+  close: (cb: () => void) => cb(),
+}));
+
+const httpHandleMock = vi.hoisted(() => ({
+  dispose: vi.fn(),
+  attachChromiumWebsockets: vi.fn(),
+  app: {
+    listen: vi.fn(() => serverMock),
+  },
+}));
+
+vi.mock("@argent/telemetry", () => telemetryMock);
+vi.mock("@argent/registry", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@argent/registry")>();
+  return { ...actual, attachRegistryLogger: vi.fn() };
+});
+// Pinned off so a developer who enables the documented `tool-server-event-log`
+// flag does not have their real event log truncated by these runs.
+vi.mock("@argent/configuration-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@argent/configuration-core")>();
+  return { ...actual, isFlagEnabled: vi.fn(() => false) };
+});
+vi.mock("../src/utils/setup-registry", () => ({
+  createRegistry: vi.fn(() => registryMock),
+}));
+vi.mock("../src/utils/probe-argent-tool-server", () => ({
+  probeArgentToolServer: vi.fn().mockResolvedValue(false),
+}));
+vi.mock("../src/http", () => ({
+  createHttpApp: vi.fn(() => httpHandleMock),
+}));
+vi.mock("../src/utils/update-checker", () => ({
+  startUpdateChecker: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+vi.mock("../src/utils/simulator-watcher", () => ({
+  startSimulatorWatcher: vi.fn(() => ({
+    stop: vi.fn(),
+    ready: Promise.resolve(),
+  })),
+}));
+
+async function startAndReadBind(): Promise<{ port: unknown; host: unknown }> {
+  const { start } = await import("../src/index");
+  start();
+  await vi.waitFor(() => {
+    expect(httpHandleMock.app.listen).toHaveBeenCalled();
+  });
+  const [port, host] = httpHandleMock.app.listen.mock.calls[0] as unknown as [unknown, unknown];
+  return { port, host };
+}
+
+describe("tool-server bind overrides", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    delete process.env.ARGENT_HOST;
+    delete process.env.ARGENT_PORT;
+  });
+
+  it("binds loopback when ARGENT_HOST is exported empty", async () => {
+    process.env.ARGENT_HOST = "";
+
+    expect(await startAndReadBind()).toEqual({ port: 3001, host: "127.0.0.1" });
+  });
+
+  it("binds loopback when ARGENT_HOST is whitespace only", async () => {
+    process.env.ARGENT_HOST = "   ";
+
+    expect(await startAndReadBind()).toEqual({ port: 3001, host: "127.0.0.1" });
+  });
+
+  it("binds the default port when ARGENT_PORT is exported empty", async () => {
+    process.env.ARGENT_PORT = "";
+
+    expect(await startAndReadBind()).toEqual({ port: 3001, host: "127.0.0.1" });
+  });
+
+  it("honours a non-empty override, whitespace around it trimmed", async () => {
+    process.env.ARGENT_HOST = " 0.0.0.0 ";
+    process.env.ARGENT_PORT = " 43123 ";
+
+    expect(await startAndReadBind()).toEqual({ port: 43123, host: "0.0.0.0" });
+  });
+});


### PR DESCRIPTION
Fixes #860

**Cause** - `process.env.ARGENT_HOST ?? DEFAULT_HOST` falls back only on `undefined`, so `export ARGENT_HOST=` handed `""` to `app.listen()`, which Node reads as "no host" and binds to every interface - with authentication off unless `ARGENT_AUTH_TOKEN` is set. `export ARGENT_PORT=` gave `parseInt("") -> NaN` and a `RangeError` naming only Node internals.

**Fix** - `process.env.ARGENT_PORT?.trim() || DEFAULT_PORT` / `process.env.ARGENT_HOST?.trim() || DEFAULT_HOST`: an empty or blank override is an unset one, matching how `boot-device.ts` reads `ARGENT_EMULATOR_GPU_MODE` and `no-window-env.ts` reads its flags.

| | `env ARGENT_HOST= ARGENT_PORT=<p> node dist/index.js start` |
| --- | --- |
| before | `Tools server listening on http://:45933` / `node ... IPv6 TCP *:45933 (LISTEN)` |
| after | `Tools server listening on http://127.0.0.1:45913` / `node ... IPv4 TCP 127.0.0.1:45913 (LISTEN)` |

**Verified** - new `test/bind-env-overrides.test.ts` (4 cases) fails on the unfixed source and passes on the fix; `npx tsc --build`, `npm run typecheck:tests -w @argent/tool-server`, `npm test -w @argent/tool-server` (369 files, 4836 tests) all green; the bind was also confirmed end to end against the built `dist`.

No docs change: `docs/reference/configuration.mdx` already documents `127.0.0.1` / `3001` as the defaults, which the code now honours for an empty value.

<details>
<summary>Discriminating-test proof and E2E repro</summary>

Fix stashed, same test file:

```
 FAIL  test/bind-env-overrides.test.ts (4 tests | 4 failed)
  - binds loopback when ARGENT_HOST is exported empty
      expected { port: 3001, host: '' } to deeply equal { port: 3001, host: '127.0.0.1' }
  - binds loopback when ARGENT_HOST is whitespace only
      expected { port: 3001, host: '   ' } to deeply equal { port: 3001, host: '127.0.0.1' }
  - binds the default port when ARGENT_PORT is exported empty
      expected { port: NaN, ... } to deeply equal { port: 3001, ... }
  - honours a non-empty override, whitespace around it trimmed
      expected { host: ' 0.0.0.0 ' } to deeply equal { host: '0.0.0.0' }
```

Fix restored: `Test Files 1 passed (1) / Tests 4 passed (4)`.

End to end, built `dist`, the only difference between runs being the patched line:

```
# unfixed
$ env ARGENT_HOST= ARGENT_PORT=45933 node dist/index.js start
Tools server listening on http://:45933
$ lsof -nP -iTCP:45933 -sTCP:LISTEN
node  64174  IPv6  TCP *:45933 (LISTEN)

# fixed
$ env ARGENT_HOST= ARGENT_PORT=45913 node dist/index.js start
Tools server listening on http://127.0.0.1:45913
$ lsof -nP -iTCP:45913 -sTCP:LISTEN
node  62914  IPv4  TCP 127.0.0.1:45913 (LISTEN)
```

Class check - other `process.env.ARGENT_* ??` readers (`ARGENT_NATIVE_DEVTOOLS_*`, `ARGENT_SIMULATOR_SERVER_*`, `ARGENT_ARTIFACTS_DIR`, `ARGENT_CHROMIUM_PORTS_FILE`, `ARGENT_MCP_LOG`) are left alone: an empty value there resolves to a path that fails loudly at its point of use, with no silent widening. `ARGENT_IDLE_TIMEOUT_MINUTES` is unaffected as the issue notes - `NaN > 0` is false, the same disabled timer its `"0"` default produces.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
