### PR TITLE
test(tool-server): bind the ten remaining test servers to loopback

### DIFF
--- a/packages/tool-server/test/debugger/debugger-status-not-connected.test.ts
+++ b/packages/tool-server/test/debugger/debugger-status-not-connected.test.ts
@@ -73,7 +73,7 @@ async function startEmptyMetro(): Promise<MockMetro> {
     res.statusCode = 404;
     res.end();
   });
-  await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
   const port = (server.address() as AddressInfo).port;
   return {
     port,

--- a/packages/tool-server/test/debugger/log-registry-not-connected.test.ts
+++ b/packages/tool-server/test/debugger/log-registry-not-connected.test.ts
@@ -70,7 +70,7 @@ async function startMetroWithDeadCdp(deadWsPort: number): Promise<MockServer> {
     res.statusCode = 404;
     res.end();
   });
-  await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
   return {
     port: (server.address() as AddressInfo).port,
     close: () => new Promise((resolve) => server.close(() => resolve())),

--- a/packages/tool-server/test/debugger/metro-cdp-harness.ts
+++ b/packages/tool-server/test/debugger/metro-cdp-harness.ts
@@ -87,7 +87,7 @@ export async function startMockMetroCdp(opts?: {
       ws.send(JSON.stringify({ id: msg.id, result: {} }));
     });
   });
-  await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
   port = (server.address() as AddressInfo).port;
   return {
     port,

--- a/packages/tool-server/test/http-upload.test.ts
+++ b/packages/tool-server/test/http-upload.test.ts
@@ -164,11 +164,13 @@ describe("POST /upload", () => {
       const entries = await fs.readdir(scratch);
       return new Set(entries.filter((e) => e.startsWith("argent-upload-")));
     };
-    const server = handle.app.listen(0);
+    const server = handle.app.listen(0, "127.0.0.1");
     try {
+      await new Promise<void>((resolve) => server.once("listening", resolve));
       const { port } = server.address() as { port: number };
       await new Promise<void>((resolve) => {
         const req = http.request({
+          host: "127.0.0.1",
           port,
           path: "/upload",
           method: "POST",

--- a/packages/tool-server/test/loopback-listen-guard.test.ts
+++ b/packages/tool-server/test/loopback-listen-guard.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// `listen(0)` with no host binds every interface, so an ephemeral-port server
+// meant for one process is reachable from the LAN for as long as it is up.
+const packageRoot = path.resolve(__dirname, "..");
+
+function sourceFiles(dir: string): string[] {
+  return fs
+    .readdirSync(dir, { withFileTypes: true, recursive: true })
+    .filter((entry) => entry.isFile() && /\.[cm]?tsx?$/.test(entry.name))
+    .map((entry) => path.join(entry.parentPath, entry.name));
+}
+
+describe("ephemeral-port listeners", () => {
+  it("bind loopback explicitly rather than every interface", () => {
+    const offenders: string[] = [];
+
+    for (const file of [
+      ...sourceFiles(path.join(packageRoot, "src")),
+      ...sourceFiles(path.join(packageRoot, "test")),
+    ]) {
+      fs.readFileSync(file, "utf8")
+        .split("\n")
+        .forEach((line, index) => {
+          if (/\.listen\(0\b/.test(line) && !/\.listen\(0,\s*"127\.0\.0\.1"/.test(line)) {
+            offenders.push(`${path.relative(packageRoot, file)}:${index + 1}`);
+          }
+        });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/tool-server/test/metro/integration.test.ts
+++ b/packages/tool-server/test/metro/integration.test.ts
@@ -151,7 +151,7 @@ beforeAll(async () => {
       ws.on("message", (raw) => handleCDPMessage(ws, raw.toString()));
     });
 
-    mockServer.listen(0, () => {
+    mockServer.listen(0, "127.0.0.1", () => {
       mockPort = (mockServer.address() as { port: number }).port;
       resolve();
     });

--- a/packages/tool-server/test/metro/legacy-runtime-guards.test.ts
+++ b/packages/tool-server/test/metro/legacy-runtime-guards.test.ts
@@ -65,7 +65,7 @@ beforeAll(async () => {
     });
     wss = new WebSocketServer({ server });
     wss.on("connection", (ws) => ws.on("message", (raw) => handleCDP(ws, raw.toString())));
-    server.listen(0, () => {
+    server.listen(0, "127.0.0.1", () => {
       port = (server.address() as { port: number }).port;
       resolve();
     });

--- a/packages/tool-server/test/metro/multi-device.test.ts
+++ b/packages/tool-server/test/metro/multi-device.test.ts
@@ -87,7 +87,7 @@ beforeAll(async () => {
     wss = new WebSocketServer({ server: mockServer });
     wss.on("connection", (ws) => ws.on("message", (raw) => handleCDPMessage(ws, raw.toString())));
 
-    mockServer.listen(0, () => {
+    mockServer.listen(0, "127.0.0.1", () => {
       mockPort = (mockServer.address() as { port: number }).port;
       resolve();
     });

--- a/packages/tool-server/test/metro/teardown-log-history.test.ts
+++ b/packages/tool-server/test/metro/teardown-log-history.test.ts
@@ -77,7 +77,7 @@ beforeAll(async () => {
     wss = new WebSocketServer({ server: mockServer });
     wss.on("connection", (ws) => ws.on("message", (raw) => handleCDPMessage(ws, raw.toString())));
 
-    mockServer.listen(0, () => {
+    mockServer.listen(0, "127.0.0.1", () => {
       mockPort = (mockServer.address() as { port: number }).port;
       resolve();
     });

--- a/packages/tool-server/test/metro/vega-target-routing.test.ts
+++ b/packages/tool-server/test/metro/vega-target-routing.test.ts
@@ -95,7 +95,7 @@ beforeAll(async () => {
     });
     wss = new WebSocketServer({ server: mockServer });
     wss.on("connection", (ws) => ws.on("message", (raw) => handleCDPMessage(ws, raw.toString())));
-    mockServer.listen(0, () => {
+    mockServer.listen(0, "127.0.0.1", () => {
       mockPort = (mockServer.address() as { port: number }).port;
       resolve();
     });

--- a/packages/tool-server/test/network/network-integration.test.ts
+++ b/packages/tool-server/test/network/network-integration.test.ts
@@ -324,7 +324,7 @@ beforeAll(async () => {
       ws.on("message", (raw) => handleCDPMessage(ws, raw.toString()));
     });
 
-    mockServer.listen(0, () => {
+    mockServer.listen(0, "127.0.0.1", () => {
       mockPort = (mockServer.address() as { port: number }).port;
       resolve();
     });


### PR DESCRIPTION
Fixes #853

**Cause:** `listen(0)` with no host binds every interface, so ten ephemeral-port test servers were LAN-reachable for as long as a suite ran.

**Fix:** pass `"127.0.0.1"` at all ten sites, matching the twenty-two siblings that already do. Adds a guard test that scans `src/` and `test/` for any `.listen(0)` missing the host, so a new one fails CI.

No sites left behind: `grep -rn "\.listen("` over every package turns up only these ten, the twenty-two already-loopback sites, the unix-socket listens in `native-devtools.ts` / `ax-service.ts` (no host applies), and `src/index.ts` which already passes `HOST`.

**Docs:** none needed - test-only, no tool, CLI, config key, flow file, or user-facing capability changes.

<details>
<summary>Verification</summary>

Guard test discriminates - with the ten fixes stashed it names every one of them:

```
+ [
+   "test/http-upload.test.ts:167",
+   "test/debugger/debugger-status-not-connected.test.ts:76",
+   "test/debugger/log-registry-not-connected.test.ts:73",
+   "test/debugger/metro-cdp-harness.ts:90",
+   "test/metro/integration.test.ts:154",
+   "test/metro/legacy-runtime-guards.test.ts:68",
+   "test/metro/multi-device.test.ts:90",
+   "test/metro/teardown-log-history.test.ts:80",
+   "test/metro/vega-target-routing.test.ts:98",
+   "test/network/network-integration.test.ts:327",
+ ]
```

`http-upload.test.ts` needed two extra lines: `listen(port)` binds synchronously, but `listen(port, host)` defers behind a DNS lookup, so `server.address()` came back `null`. It now awaits `listening`. The client `http.request` had no `host` (defaulting to `localhost`), and its `error` handler is a no-op, so a failed dial would have made the assertion pass vacuously - pinned to `127.0.0.1`. Probed that the request still reaches the server and a partial file is really created before cleanup:

```
PARTIALS ["argent-upload-d567a1aa-75a0-44e3-9e06-6d42544be1ee.tar.gz"]
ERR Error: socket hang up
```

Ran from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 369 files, 4833 passed, 1 skipped
- `npm run knip` - clean
- `npx prettier --write` on the changed files - no diff

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)