### PR TITLE
fix(tool-server): release the left button when a gesture-drag dispatch fails

### DIFF
--- a/packages/tool-server/src/tools/gesture-drag/index.ts
+++ b/packages/tool-server/src/tools/gesture-drag/index.ts
@@ -127,6 +127,13 @@ Pass momentum:false for a momentum-free drag that decelerates into the release, 
       err.name = "AbortError";
       return err;
     };
+    // Marks the button up before dispatching, so a release that rejects is not
+    // retried by the recovery path below.
+    let buttonDown = false;
+    const release = async (x: number, y: number): Promise<void> => {
+      buttonDown = false;
+      await chromium.dispatchMouseEvent({ type: "mouseReleased", x, y, clickCount: 1 });
+    };
     // Release where the pointer is: the delivered press would otherwise capture
     // every later click, and releasing at the end point delivers travel the caller
     // cancelled. Best effort - a cancel is when the CDP session can be going away
@@ -135,12 +142,7 @@ Pass momentum:false for a momentum-free drag that decelerates into the release, 
     const releaseAndAbort = async (frame: number): Promise<never> => {
       const err = abortError(frame);
       try {
-        await chromium.dispatchMouseEvent({
-          type: "mouseReleased",
-          x: lastX,
-          y: lastY,
-          clickCount: 1,
-        });
+        await release(lastX, lastY);
       } catch (releaseErr) {
         err.cause = releaseErr;
       }
@@ -154,31 +156,36 @@ Pass momentum:false for a momentum-free drag that decelerates into the release, 
       y: startPx.y,
       clickCount: 1,
     });
-    for (let i = 1; i < steps; i++) {
-      if (ctx?.signal?.aborted) await releaseAndAbort(i);
-      await sleep(Math.max(0, t0 + i * frameMs - Date.now()));
-      const t = i / steps;
-      const progress = momentumFree ? 1 - Math.pow(1 - t, MOMENTUM_FREE_EASE_EXPONENT) : t;
-      const x = startPx.x + (endPx.x - startPx.x) * progress;
-      const y = startPx.y + (endPx.y - startPx.y) * progress;
-      await chromium.dispatchMouseEvent({ type: "mouseMoved", x, y, button: "left" });
-      lastX = x;
-      lastY = y;
+    buttonDown = true;
+    try {
+      for (let i = 1; i < steps; i++) {
+        if (ctx?.signal?.aborted) await releaseAndAbort(i);
+        await sleep(Math.max(0, t0 + i * frameMs - Date.now()));
+        const t = i / steps;
+        const progress = momentumFree ? 1 - Math.pow(1 - t, MOMENTUM_FREE_EASE_EXPONENT) : t;
+        const x = startPx.x + (endPx.x - startPx.x) * progress;
+        const y = startPx.y + (endPx.y - startPx.y) * progress;
+        await chromium.dispatchMouseEvent({ type: "mouseMoved", x, y, button: "left" });
+        lastX = x;
+        lastY = y;
+      }
+      // The loop stops one short of the release, so the last frame is checked on
+      // both sides of its wait: before, to skip the wait; after, to catch an abort
+      // landing during it. Both report `steps` - a wait delivers no pointer events.
+      if (ctx?.signal?.aborted) await releaseAndAbort(steps);
+      // Spend the last frame's wait here rather than on another move at the
+      // endpoint: a move followed by a still frame reads as a hold.
+      await sleep(Math.max(0, t0 + durationMs - Date.now()));
+      if (ctx?.signal?.aborted) await releaseAndAbort(steps);
+      await release(endPx.x, endPx.y);
+    } catch (err) {
+      // A mid-drag dispatch that rejects leaves the renderer holding the button
+      // - the CDP session survives a timed-out send - and every later click on
+      // that page is then read as a drag. Best effort, and the caller keeps
+      // seeing the original failure.
+      if (buttonDown) await release(lastX, lastY).catch(() => {});
+      throw err;
     }
-    // The loop stops one short of the release, so the last frame is checked on
-    // both sides of its wait: before, to skip the wait; after, to catch an abort
-    // landing during it. Both report `steps` - a wait delivers no pointer events.
-    if (ctx?.signal?.aborted) await releaseAndAbort(steps);
-    // Spend the last frame's wait here rather than on another move at the
-    // endpoint: a move followed by a still frame reads as a hold.
-    await sleep(Math.max(0, t0 + durationMs - Date.now()));
-    if (ctx?.signal?.aborted) await releaseAndAbort(steps);
-    await chromium.dispatchMouseEvent({
-      type: "mouseReleased",
-      x: endPx.x,
-      y: endPx.y,
-      clickCount: 1,
-    });
     return { dragged: true, timestampMs };
   },
 };

--- a/packages/tool-server/test/chromium-drag.test.ts
+++ b/packages/tool-server/test/chromium-drag.test.ts
@@ -600,3 +600,72 @@ describe("gesture-drag retired `settle` param", () => {
     expect("settle" in parsed.data!).toBe(false);
   });
 });
+
+// A `cdp.send` that times out rejects without closing the socket, so the session
+// outlives the failed drag with the left button still held - and the renderer
+// reads every later click on that page as a drag.
+describe("gesture-drag mid-drag dispatch failure", () => {
+  const params = {
+    udid: "chromium-cdp-19222",
+    fromX: 0.25,
+    fromY: 0.5,
+    toX: 0.75,
+    toY: 0.5,
+    durationMs: 64,
+  };
+
+  it("releases at the last dispatched position and rethrows the transport error", async () => {
+    const api = fakeChromiumApi();
+    const timeout = new Error("CDP request Input.dispatchMouseEvent timed out after 10000ms");
+    let dispatched = 0;
+    api.dispatchMouseEvent.mockImplementation(async () => {
+      if (++dispatched === 3) throw timeout;
+    });
+
+    await expect(gestureDragTool.execute({ chromium: api } as never, params as never)).rejects.toBe(
+      timeout
+    );
+
+    const calls = api.dispatchMouseEvent.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    expect(calls.map((c) => c.type)).toEqual([
+      "mousePressed",
+      "mouseMoved",
+      "mouseMoved",
+      "mouseReleased",
+    ]);
+    // The failed move never moved the pointer, so the release lands on the last
+    // one that was delivered.
+    expect(calls[3]).toMatchObject({ x: calls[1]!.x, y: calls[1]!.y });
+  });
+
+  it("keeps the transport error when the recovery release fails too", async () => {
+    const api = fakeChromiumApi();
+    const timeout = new Error("CDP request Input.dispatchMouseEvent timed out after 10000ms");
+    let dispatched = 0;
+    api.dispatchMouseEvent.mockImplementation(async (event: Record<string, unknown>) => {
+      if (++dispatched === 3) throw timeout;
+      if (event.type === "mouseReleased") throw new Error("CDP session closed");
+    });
+
+    await expect(gestureDragTool.execute({ chromium: api } as never, params as never)).rejects.toBe(
+      timeout
+    );
+  });
+
+  it("does not re-dispatch a release when the final release is what failed", async () => {
+    const api = fakeChromiumApi();
+    const closed = new Error("CDP session closed");
+    api.dispatchMouseEvent.mockImplementation(async (event: Record<string, unknown>) => {
+      if (event.type === "mouseReleased") throw closed;
+    });
+
+    await expect(gestureDragTool.execute({ chromium: api } as never, params as never)).rejects.toBe(
+      closed
+    );
+
+    const types = api.dispatchMouseEvent.mock.calls.map(
+      (c) => (c[0] as Record<string, unknown>).type
+    );
+    expect(types.filter((t) => t === "mouseReleased")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #868

**Cause:** `gesture-drag` had no recovery around its press -> moves -> release sequence, so a `dispatchMouseEvent` that rejects mid-drag (a `cdp.send` timing out at 10s does not close the socket) returned the error while the renderer kept holding the left button - every later click on that page then read as a drag.

**Fix:** the moves and the release run under a `catch` that dispatches a best-effort `mouseReleased` at the last delivered pointer position and rethrows the original failure. A `buttonDown` flag is cleared before each release dispatch, so the existing abort path (which already released) and a failing final release are not double-released.

**Class:** `gesture-tap` is the only other tool dispatching a press/release pair; between its `mousePressed` and `mouseReleased` there is only `sleep(TAP_HOLD_MS)`, which cannot reject, so it has no window to strand the button. `chromium-server/input.ts` dispatches one caller-driven Down/Up event per call and owns no span.

**Docs:** none needed - no tool, CLI, config key, flow file, or user-facing capability changed; this is a failure path that previously left corrupt state.

<details>
<summary>Verification</summary>

Test discriminates - with the source fix stashed, the new test fails on the exact assertion:

```
FAIL packages/tool-server/test/chromium-drag.test.ts > gesture-drag mid-drag dispatch failure
  > releases at the last dispatched position and rethrows the transport error
AssertionError: expected [ 'mousePressed', 'mouseMoved', ...(1) ] to deeply equal [ 'mousePressed', 'mouseMoved', ...(2) ]
  [
    "mousePressed",
    "mouseMoved",
    "mouseMoved",
-   "mouseReleased",
  ]
```

Mutation - deleting the `if (buttonDown)` guard fails 5 tests (2 new, 3 pre-existing abort tests that would then see a second release).

Ran from the worktree root:
- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 368 files, 4835 passed, 1 skipped
- `npx prettier --write` on both changed files

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
