### PR TITLE
fix(cli): reject a --platform value flow run cannot use

### DIFF
--- a/packages/argent-cli/src/flow.ts
+++ b/packages/argent-cli/src/flow.ts
@@ -154,7 +154,10 @@ const RUN_OPTIONS = {
   "json-stream": { kind: "boolean" },
   "recursive": { kind: "boolean", alias: "r" },
   "device": { kind: "value" },
-  "platform": { kind: "value" },
+  // Constrained here because the tool-server's own rejection is a raw Zod issue
+  // dump — and in a directory run it lands only after the first flow has run,
+  // taking the rest of the batch down with it.
+  "platform": { kind: "value", choices: ["ios", "android", "chromium", "vega"] },
   "output": { kind: "value" },
 } as const satisfies OptionSpecs;
 

--- a/packages/argent-cli/test/flow.test.ts
+++ b/packages/argent-cli/test/flow.test.ts
@@ -163,6 +163,21 @@ describe("parseRunArgs", () => {
     );
   });
 
+  it("throws on a --platform value outside the four the help lists", () => {
+    for (const bad of ["iOS", "macos", "web", "android-tv"]) {
+      expect(() => parseRunArgs(["checkout.yaml", "--platform", bad])).toThrow(FlagParseException);
+      expect(() => parseRunArgs(["checkout.yaml", "--platform", bad])).toThrow(
+        `--platform must be "ios", "android", "chromium" or "vega", got "${bad}"`
+      );
+      expect(() => parseRunArgs(["checkout.yaml", `--platform=${bad}`])).toThrow(
+        FlagParseException
+      );
+    }
+    for (const good of ["ios", "android", "chromium", "vega"]) {
+      expect(parseRunArgs(["checkout.yaml", "--platform", good]).platform).toBe(good);
+    }
+  });
+
   it("treats a following flag as a missing value, not as the value", () => {
     expect(() => parseRunArgs(["checkout.yaml", "--device", "--json"])).toThrow(
       "--device requires a value"
@@ -1642,6 +1657,17 @@ describe("argent flow run <dir>", () => {
     ]);
     expect(errs.join("\n")).toContain(
       "--json-stream supports a single flow; directory runs are not supported"
+    );
+  });
+
+  it("rejects a misspelled --platform before running any flow in the batch", async () => {
+    await expect(flow(["run", flowsDir, "--platform", "iOS"], opts)).rejects.toThrow(
+      "process.exit:2"
+    );
+
+    expect(toolsClientMock.callTool).not.toHaveBeenCalled();
+    expect(errs.join("\n")).toContain(
+      '--platform must be "ios", "android", "chromium" or "vega", got "iOS"'
     );
   });
 


### PR DESCRIPTION
Fixes #823

**Cause:** `flow run`'s `--platform` spec was a bare `{ kind: "value" }`, so any string was stored and forwarded to `flow-execute`, whose `z.enum(LAUNCH_PLATFORMS)` answered with a raw Zod issue array. The flag is per-run, so a directory run spent its first flow on the rejection and marked every remaining one `not run (batch stopped)`.

**Fix:** give the spec `choices: ["ios", "android", "chromium", "vega"]` - the shared parser's existing facility, matching the four the `--platform` help line already lists and the server's enum exactly. The run now fails before the first request with `--platform must be "ios", "android", "chromium" or "vega", got "iOS"`, exit 2.

**Class:** `--platform` was the last fixed-set value option in the CLI without `choices` (`config`/`flags`/`telemetry --scope` and `lens --terminal` already have it). Left alone: `--device`, `--output`, `link --host/--port/--token`, `server start --port/--host/--idle-timeout` are free-form, and `lens --agent` is resolved against an interactive picker.

**Out of scope, from the same issue:** the tool-server's pre-invoke 400 carries neither `error_code` nor `error_kind` (`http.ts:750-768`), so no client can classify a schema rejection - that is a server-side design call, not this fix. Likewise the `flow-device.ts` disambiguation message that suggests `--platform` to a caller who already passed it.

**Docs:** none needed. `reference/flow-yaml.mdx` already documents the four accepted values; this only rejects an invalid invocation earlier, with no change to the tool, CLI surface, config keys or flow-file behaviour.

<details>
<summary>Verification</summary>

Repro on `main`'s build - `parseRunArgs` stores anything:

```
iOS        => {"flowRef":"./batch","platform":"iOS", ...}
macos      => {"flowRef":"./batch","platform":"macos", ...}
android-tv => {"flowRef":"./batch","platform":"android-tv", ...}
```

Same call on this branch:

```
"iOS"        => THROW: --platform must be "ios", "android", "chromium" or "vega", got "iOS"
"macos"      => THROW: --platform must be "ios", "android", "chromium" or "vega", got "macos"
"web"        => THROW: --platform must be "ios", "android", "chromium" or "vega", got "web"
"android-tv" => THROW: --platform must be "ios", "android", "chromium" or "vega", got "android-tv"
ios          => {"flowRef":"./batch","platform":"ios", ...}
```

Through the built `flow()` on a directory, no tool server reachable:

```
$ node -e "flow(['run','/tmp/i823batch','--platform','iOS'], ...)"
Error: --platform must be "ios", "android", "chromium" or "vega", got "iOS"
Usage: argent flow <subcommand> [options]
...
exit code: 2
```

Discriminating tests - `packages/argent-cli/test/flow.test.ts`: "throws on a --platform value outside the four the help lists" and "rejects a misspelled --platform before running any flow in the batch" (asserts `callTool` was never called). With `src/flow.ts` reverted both fail:

```
FAIL > parseRunArgs > throws on a --platform value outside the four the help lists
  expected [Function] to throw an error

FAIL > argent flow run <dir> > rejects a misspelled --platform before running any flow in the batch
  expected [Function] to throw error including 'process.exit:2' but got 'process.exit:0'

Tests  2 failed | 108 passed (110)
```

Ran from the worktree root: `npx tsc --build`, `npm run typecheck:tests -w @argent/cli`, `npm test -w @argent/cli` (27 files, 529 tests passed), `npx prettier --write` on both changed files (unchanged), `npx eslint packages/argent-cli/src/flow.ts` (clean).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
