### PR TITLE
fix(tools-client): kill the wedged server before respawning it on Windows

### DIFF
--- a/packages/argent-tools-client/src/launcher.ts
+++ b/packages/argent-tools-client/src/launcher.ts
@@ -842,15 +842,23 @@ export async function ensureToolsServer(paths: ToolsServerPaths): Promise<ToolsS
     //   • bundlePath === ours — never a different version's server, which may be
     //     healthy and serving another project's session;
     //   • a command-line identity match, re-confirmed by terminatePid right
-    //     before each signal.
+    //     before each signal — only where `ps` exists. On Windows the check
+    //     always fails, so the kill stays unguarded there rather than leaving
+    //     the wedged server running, untracked, on a leaked port. The two
+    //     guards above still hold, so this site takes on less pid-reuse risk
+    //     than the other two kills that go unguarded on Windows.
+    const guarded = process.platform !== "win32";
     if (
       state &&
       state.managed === "autospawn" &&
       state.bundlePath === paths.bundlePath &&
       isProcessAlive(state.pid) &&
-      processCommandMatches(state.pid, state.bundlePath)
+      (!guarded || processCommandMatches(state.pid, state.bundlePath))
     ) {
-      await terminatePid(state.pid, () => processCommandMatches(state.pid, state.bundlePath));
+      await terminatePid(
+        state.pid,
+        guarded ? () => processCommandMatches(state.pid, state.bundlePath) : undefined
+      );
     }
     // Retire only OUR OWN record — another install's must survive so its server
     // stays reachable by its owner. The sweep then clears per-bundle files whose

--- a/packages/argent-tools-client/test/launcher-duplicate-spawn.test.ts
+++ b/packages/argent-tools-client/test/launcher-duplicate-spawn.test.ts
@@ -184,6 +184,55 @@ describe("ensureToolsServer — duplicate-spawn prevention (nvm node-version swi
   );
 
   it(
+    "still terminates the wedged server it respawns over where `ps` cannot identify it",
+    { timeout: 30_000 },
+    async () => {
+      // Windows has no `ps`, so processCommandMatches returns false for every
+      // pid. Gating the kill on it there would leave the wedged autospawned
+      // server holding its port after its record is unlinked, with nothing left
+      // to find it by. Its command line does not match the recorded bundle, so
+      // the guard would reject it on a platform that does have `ps`.
+      const wedged = spawn(process.execPath, ["-e", "setInterval(() => {}, 1e9)"], {
+        stdio: "ignore",
+      });
+      const wedgedPid = wedged.pid!;
+      spawnedPids.push(wedgedPid);
+      expect(launcher.isToolsServerProcessAlive(wedgedPid)).toBe(true);
+
+      await launcher.writeToolsServerState({
+        port: 1, // nothing listens here -> health check fails fast
+        pid: wedgedPid,
+        startedAt: new Date().toISOString(),
+        bundlePath: FAKE_BUNDLE,
+        host: "127.0.0.1",
+        token: "wedged-token",
+        managed: "autospawn",
+      });
+
+      const realPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      let handle: Awaited<ReturnType<typeof launcher.ensureToolsServer>>;
+      try {
+        handle = await launcher.ensureToolsServer(fakePaths());
+      } finally {
+        Object.defineProperty(process, "platform", {
+          value: realPlatform,
+          configurable: true,
+        });
+      }
+
+      await waitForDeath(wedgedPid);
+      expect(launcher.isToolsServerProcessAlive(wedgedPid)).toBe(false);
+
+      const state = await launcher.readToolsServerState(FAKE_BUNDLE);
+      expect(state).not.toBeNull();
+      expect(state!.pid).not.toBe(wedgedPid);
+      spawnedPids.push(state!.pid);
+      expect(handle.url).toBe(launcher.formatToolsServerUrl("127.0.0.1", state!.port));
+    }
+  );
+
+  it(
     "leaves a CLI-managed (`argent server start`) server alive instead of killing it on respawn",
     { timeout: 30_000 },
     async () => {


### PR DESCRIPTION
Fixes #832

**Cause:** `ensureToolsServer`'s kill-before-respawn gates on `processCommandMatches`, which shells out to `ps` - absent on Windows, so it returns false for every pid. The wedged autospawned server is never terminated, its record is then unlinked, and it keeps its listening port with nothing left to find it by (`server stop`/status and the sweep both need the record).

**Fix:** drop the command-line check on win32, exactly as its two siblings already do (`sweepDeadStateFiles`, `killToolServerForInstallDir`). This site keeps its two narrower guards - `managed === "autospawn"` and `bundlePath === ours` - so it takes on less pid-reuse risk than either sibling.

**Class:** those two were the only other `processCommandMatches` call sites, and both are already guarded. `killToolServer` also calls `terminatePid` unguarded, but on every platform by design - it is the explicit `argent server stop` kill of a record the user named, with no identity check to conditionalize.

**Docs:** none needed - no tool, CLI, config key, flow file or user-facing capability changes.

<details>
<summary>Verification</summary>

New test in `launcher-duplicate-spawn.test.ts`: a live bystander whose command line does not match the recorded bundle, recorded as the tracked autospawn server, with `process.platform` stubbed to `win32` for the `ensureToolsServer` call.

Fails on the unfixed source:

```
FAIL test/launcher-duplicate-spawn.test.ts > ensureToolsServer - duplicate-spawn prevention >
     still terminates the wedged server it respawns over where `ps` cannot identify it
AssertionError: expected true to be false
 ❯ expect(launcher.isToolsServerProcessAlive(wedgedPid)).toBe(false);
```

Passes with it. The pre-existing `never signals a recycled pid` test - same setup, real platform - still passes, so the non-Windows guard is unchanged.

```
npx tsc --build                                  exit 0
npm run typecheck:tests -w @argent/tools-client   exit 0
npm test -w @argent/tools-client                  12 files, 197 tests passed
npx prettier --write <changed files>              unchanged
npx eslint packages/argent-tools-client/src/launcher.ts   clean
```

Not run on a real Windows host; the platform branch is exercised through the stub.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
