### PR TITLE
fix(screenshot-diff): say the comparison was skipped on dimension_mismatch

### DIFF
--- a/packages/tool-server/src/tools/screenshot-diff/index.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/index.ts
@@ -21,6 +21,7 @@ import { androidDevtoolsRotationPeek } from "../../utils/android-devtools-rotati
 import type { RotationPeek } from "../../utils/device-orientation";
 import { requireArtifacts, type ArtifactHandle } from "../../artifacts";
 import { diffPngFiles } from "./screenshot-diff";
+import { summaryReportsDimensionMismatch } from "./screenshot-diff-summary";
 
 const zodSchema = z
   .object({
@@ -98,7 +99,10 @@ export const screenshotDiffTool: ToolDefinition<Params, ScreenshotDiffResult> = 
   id: "screenshot-diff",
   interaction: {
     startedMsg: () => "Comparing screenshots",
-    completedMsg: () => "Compared screenshots",
+    completedMsg: ({ result }) =>
+      summaryReportsDimensionMismatch(result.summary)
+        ? "Skipped comparison - screenshot dimensions differ"
+        : "Compared screenshots",
     failedMsg: ({ failureSignal }) => `Failed to compare screenshots: ${failureSignal.error_code}`,
   },
   description: `Compare two PNG screenshots and return a compact visual-diff summary.

--- a/packages/tool-server/src/tools/screenshot-diff/screenshot-diff-summary.ts
+++ b/packages/tool-server/src/tools/screenshot-diff/screenshot-diff-summary.ts
@@ -35,7 +35,7 @@ export function formatScreenshotDiffSummary(result: ScreenshotDiffSummaryInput):
   const coordinateSpace = coordinateSpaceForSummary(result.imageSize);
 
   const lines: string[] = ["Screenshot diff summary", "", "Overall:"];
-  lines.push(`- status: ${status}`);
+  lines.push(statusLine(status));
 
   if (result.sizeNormalization) {
     // Placed directly under the status so it frames every figure below it; the
@@ -107,6 +107,18 @@ export function formatScreenshotDiffSummary(result: ScreenshotDiffSummaryInput):
   }
 
   return lines.join("\n");
+}
+
+function statusLine(status: SummaryStatus): string {
+  return `- status: ${status}`;
+}
+
+/**
+ * The summary is the only place a tool result carries the status, so callers
+ * that need it read it back out of the text written here.
+ */
+export function summaryReportsDimensionMismatch(summary: string): boolean {
+  return summary.split("\n").includes(statusLine("dimension_mismatch"));
 }
 
 function screenshotDiffStatus(result: ScreenshotDiffSummaryInput): SummaryStatus {

--- a/packages/tool-server/test/interaction-messages.test.ts
+++ b/packages/tool-server/test/interaction-messages.test.ts
@@ -7,6 +7,7 @@ import { createRegistry } from "../src/utils/setup-registry";
 import { definitionsById, EXPECTED_TOOL_COUNT } from "./helpers/catalog";
 import { flowStartRecordingTool } from "../src/tools/flows/flow-start-recording";
 import { createFlowAddStepTool } from "../src/tools/flows/flow-add-step";
+import { formatScreenshotDiffSummary } from "../src/tools/screenshot-diff/screenshot-diff-summary";
 
 const failureSignal: FailureSignal = {
   error_code: FAILURE_CODES.ARGENT_UNCLASSIFIED_FAILURE,
@@ -95,6 +96,49 @@ describe("tool interaction messages", () => {
         failureSignal,
       })
     ).toBe(`Failed to tap at (50%, 25%): ${failureSignal.error_code}`);
+  });
+
+  it("does not claim a comparison for a dimension-mismatch screenshot-diff", () => {
+    // dimension_mismatch is not a failure - `execute` returns a summary and the
+    // registry emits the completion event - so the completion message is the only
+    // thing separating the one outcome that compares nothing from a real
+    // comparison in the event log.
+    const completedMsg =
+      definitionsById(createRegistry()).get("screenshot-diff")!.interaction!.completedMsg!;
+    const params = { udid: "device-1", baselinePath: "/a.png", currentPath: "/b.png" };
+
+    expect(
+      completedMsg({
+        params,
+        result: {
+          summary: formatScreenshotDiffSummary({
+            totalPixels: 288_000,
+            differentPixels: 0,
+            mismatchPercentage: 0,
+            dimensionMismatch: {
+              expected: { width: 360, height: 800 },
+              actual: { width: 800, height: 360 },
+            },
+            regions: [],
+          }),
+        },
+      })
+    ).toBe("Skipped comparison - screenshot dimensions differ");
+
+    expect(
+      completedMsg({
+        params,
+        result: {
+          summary: formatScreenshotDiffSummary({
+            totalPixels: 288_000,
+            differentPixels: 1_440,
+            mismatchPercentage: 0.5,
+            imageSize: { width: 360, height: 800 },
+            regions: [],
+          }),
+        },
+      })
+    ).toBe("Compared screenshots");
   });
 
   it("names the flow from either source in flow-execute messages", () => {


### PR DESCRIPTION
Fixes #820

**Cause:** `dimension_mismatch` returns normally, so the registry emitted the tool's fixed `completedMsg` - "Compared screenshots" - for the one outcome that compares nothing.

**Fix:** `completedMsg` reads the status line back out of the summary it is handed and says "Skipped comparison - screenshot dimensions differ" instead. The reader lives next to the formatter that writes the line, so the two cannot drift.

**Class:** `screenshot-diff` is the only tool whose completion message names an action it can skip without failing; the other fixed `completedMsg` strings describe reads that did happen even when the result is empty. `createScreenshotDiffTool` spreads the same `interaction`, so both registrations are covered.

**Docs:** none needed - the message lands in the tool-server event log, not in the tool's schema, description or any documented output.

<details>
<summary>Verification</summary>

Test added to `packages/tool-server/test/interaction-messages.test.ts`, built from the real `formatScreenshotDiffSummary` output rather than a hand-written summary string.

Reverting only the two source files (`git stash push` on them) fails it:

```
FAIL  test/interaction-messages.test.ts > tool interaction messages > does not claim a comparison for a dimension-mismatch screenshot-diff
Expected: "Skipped comparison - screenshot dimensions differ"
Received: "Compared screenshots"
```

Restored:

```
npx tsc --build                                   # clean
npm run typecheck:tests -w @argent/tool-server    # clean
npm test -w @argent/tool-server                   # 368 files, 4833 passed | 1 skipped
npx prettier --write <changed files>              # clean
```

(Root `eslint` on the changed files reports only the known `packages/docs` tsconfig resolution error, unrelated to this change.)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)