### PR TITLE
fix(tool-server): stop-metro must not report a port free when it could not probe it

### DIFF
--- a/packages/tool-server/src/tools/simulator/stop-metro.ts
+++ b/packages/tool-server/src/tools/simulator/stop-metro.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import type { ToolDefinition } from "@argent/registry";
+
+// Absolute port probers, resolved once. A tool-server started from a GUI or
+// launchd context inherits a PATH that can be missing `/usr/sbin`, and a bare
+// name then ENOENTs. Bare name only when no canonical location exists.
+const LSOF_BIN = ["/usr/sbin/lsof", "/usr/bin/lsof"].find((p) => existsSync(p)) ?? "lsof";
+const NETSTAT_BIN =
+  [`${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\netstat.exe`].find((p) =>
+    existsSync(p)
+  ) ?? "netstat";
 
 /**
  * Deduped PIDs *listening* on `port`, parsed out of `netstat -ano` (Windows).
@@ -44,16 +54,16 @@ export function parseNetstatListeningPids(netstatOutput: string, port: number): 
  */
 function listeningPids(port: number): number[] {
   if (process.platform === "win32") {
-    const output = execFileSync("netstat", ["-ano"], {
+    const output = execFileSync(NETSTAT_BIN, ["-ano"], {
       encoding: "utf-8",
       timeout: 5_000,
-      // `netstat -ano` dumps every socket on the host; overflowing Node's
-      // default 1 MiB throws, which this tool would misread as "port is free".
+      // `netstat -ano` dumps every socket on the host; a busy box easily
+      // exceeds Node's default 1 MiB, which would abort the probe.
       maxBuffer: 16 * 1024 * 1024,
     });
     return parseNetstatListeningPids(output, port);
   }
-  const output = execFileSync("lsof", ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
+  const output = execFileSync(LSOF_BIN, ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
     encoding: "utf-8",
     timeout: 5_000,
   }).trim();
@@ -85,7 +95,7 @@ export const stopMetroTool: ToolDefinition<
     failedMsg: ({ params, failureSignal }) =>
       `Failed to stop Metro on port ${params.port}: ${failureSignal.error_code}`,
   },
-  description: `Stop the Metro bundler process listening on a given port (default 8081). Use when ending a React Native session or when Metro must be restarted. Returns { stopped, port, pids }; stopped=false if no process is found on the port. Fails if the port lookup command times out or the process cannot be killed. This is DESTRUCTIVE — always ask the user for confirmation before calling this tool.`,
+  description: `Stop the Metro bundler process listening on a given port (default 8081). Use when ending a React Native session or when Metro must be restarted. Returns { stopped, port, pids }; stopped=false if no process is found on the port. Fails if the port lookup cannot run or times out, or the process cannot be killed. This is DESTRUCTIVE — always ask the user for confirmation before calling this tool.`,
   zodSchema,
   services: () => ({}),
   async execute(_services, params) {
@@ -108,9 +118,18 @@ export const stopMetroTool: ToolDefinition<
       }
 
       return { stopped: true, port, pids };
-    } catch {
-      // `lsof` exits non-zero when nothing is listening on the port.
-      return { stopped: false, port, pids: [] };
+    } catch (error) {
+      // A non-zero exit is how the probe reports "nothing is listening". Any
+      // other failure (absent binary, timeout, overflowed output) never read
+      // the port, so it must not be answered with the positive claim
+      // `stopped: false`.
+      if (typeof (error as { status?: unknown }).status === "number") {
+        return { stopped: false, port, pids: [] };
+      }
+      throw new Error(
+        `Could not determine what is listening on port ${port}: ${(error as Error).message}`,
+        { cause: error }
+      );
     }
   },
 };

--- a/packages/tool-server/test/stop-metro-probe.test.ts
+++ b/packages/tool-server/test/stop-metro-probe.test.ts
@@ -1,0 +1,85 @@
+// Coverage for stop-metro's split between "the probe says nothing is listening"
+// and "the probe never ran". Only the first may be answered with
+// `stopped: false`, which is a positive claim that the port is free.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const execFileSyncMock = vi.fn();
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, execFileSync: (...args: unknown[]) => execFileSyncMock(...args) };
+});
+
+import { stopMetroTool } from "../src/tools/simulator/stop-metro";
+
+// Production spawns lsof by absolute path (LSOF_BIN); match on basename so the
+// assertion holds wherever the binary lives.
+const isLsof = (cmd: unknown): boolean =>
+  typeof cmd === "string" && (cmd === "lsof" || cmd.endsWith("/lsof"));
+
+const runStopMetro = (port: number) => stopMetroTool.execute({}, { port });
+
+describe("stop-metro port probe", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports stopped:false when the probe exits non-zero, which is how lsof says the port is free", async () => {
+    // A real non-zero exit carries a numeric `status`.
+    execFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error("Command failed: lsof -ti tcp:8081 -sTCP:LISTEN"), {
+        status: 1,
+        signal: null,
+      });
+    });
+
+    await expect(runStopMetro(8081)).resolves.toEqual({ stopped: false, port: 8081, pids: [] });
+  });
+
+  it("fails instead of claiming the port is free when the probe binary is absent", async () => {
+    // spawnSync reports "could not run it at all" with a null `status` and an
+    // errno code, which is exactly what a host without lsof produces.
+    execFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error("spawnSync /usr/sbin/lsof ENOENT"), {
+        code: "ENOENT",
+        status: null,
+        signal: null,
+        errno: -2,
+      });
+    });
+
+    await expect(runStopMetro(8081)).rejects.toThrow(/port 8081.*lsof ENOENT/);
+  });
+
+  it("fails instead of claiming the port is free when the probe times out", async () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error("spawnSync /usr/sbin/lsof ETIMEDOUT"), {
+        code: "ETIMEDOUT",
+        status: null,
+        signal: "SIGTERM",
+        errno: -60,
+      });
+    });
+
+    await expect(runStopMetro(8081)).rejects.toThrow(/port 8081.*ETIMEDOUT/);
+  });
+
+  it("kills the listener the probe reports", async () => {
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+    execFileSyncMock.mockImplementation((cmd: unknown) => {
+      expect(isLsof(cmd)).toBe(true);
+      return "4242\n";
+    });
+
+    await expect(runStopMetro(8081)).resolves.toEqual({
+      stopped: true,
+      port: 8081,
+      pids: [4242],
+    });
+    expect(kill).toHaveBeenCalledWith(4242, "SIGTERM");
+  });
+});


### PR DESCRIPTION
Fixes #834

**Cause:** `stop-metro` resolved `lsof` / `netstat` through `PATH` and caught *every* failure as `{ stopped: false }`, so an `ENOENT` from a host with no `lsof` (stock Debian/Ubuntu, container CI) read as the positive claim "the port is free".

**Fix:** pin both probers to their canonical locations, and answer `stopped: false` only for a non-zero exit (how the probe really reports an idle port). A probe that never ran - missing binary, timeout, overflowed output - fails the tool with a message naming the port and the underlying error.

**Class:** `argent-tools-client/src/launcher.ts` `processCommandMatches` also spawns a bare `ps` and swallows the failure, but there the swallow is fail-safe by design (unreadable command line -> don't kill), not a positive claim; left as is.

**Docs:** none needed - `docs/reference/tools.mdx` describes the capability ("Stop the Metro bundler listening on a given port"), which is unchanged.

<details>
<summary>Verification</summary>

New `packages/tool-server/test/stop-metro-probe.test.ts` discriminates - with the source fix reverted (`git checkout -- stop-metro.ts`):

```
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
 FAIL  fails instead of claiming the port is free when the probe binary is absent
 FAIL  fails instead of claiming the port is free when the probe times out
AssertionError: promise resolved "{ stopped: false, port: 8081, pids: [] }" instead of rejecting
```

With the fix restored: 4 passed.

Ran from the worktree root:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - 369 files, 4836 passed / 1 skipped
- `npx prettier --write` on both changed files - unchanged

`execFileSync` error shapes the split relies on, confirmed on Node here:

```
spawnSync missing-binary ENOENT   -> { code: "ENOENT",    status: null, signal: null }
/bin/sh -c 'exit 1'               -> {                    status: 1,    signal: null }
timeout                           -> { code: "ETIMEDOUT", status: null, signal: "SIGTERM" }
maxBuffer overflow                -> { code: "ENOBUFS",   status: null, signal: "SIGTERM" }
```

`npx eslint` on the two files reports only the known `packages/docs/tsconfig.json` parse error (docs workspace has no `npm ci` locally), not a finding in the changed code.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
