### PR TITLE
test(tool-server): flood with multi-byte output so the UTF-8 cap is pinned

### DIFF
--- a/packages/tool-server/test/ndjson-socket.test.ts
+++ b/packages/tool-server/test/ndjson-socket.test.ts
@@ -58,12 +58,14 @@ describe("attachNdjsonReader", () => {
 
   it("reports an unparseable frame with byte length and a sanitised preview, then continues", async () => {
     const { stream, messages, dropped } = harness();
-    stream.write("garbage\there\n" + '{"id":9}\n');
+    // Multi-byte frame: 13 characters, 15 UTF-8 bytes. An ASCII frame makes the two
+    // readings equal, so the reported count would pin neither.
+    stream.write("garbage\there✓\n" + '{"id":9}\n');
     await settle();
     expect(messages).toEqual([{ id: 9 }]);
     expect(dropped).toHaveLength(1);
-    expect(dropped[0]!.bytes).toBe(Buffer.byteLength("garbage\there"));
-    expect(dropped[0]!.preview).toBe("garbage·here");
+    expect(dropped[0]!.bytes).toBe(15);
+    expect(dropped[0]!.preview).toBe("garbage·here✓");
   });
 
   it("delivers a trailing frame without newline when the stream ends", async () => {

--- a/packages/tool-server/test/vega-cli-timeout.test.ts
+++ b/packages/tool-server/test/vega-cli-timeout.test.ts
@@ -89,6 +89,10 @@ const awaitGate = () => {
   const idle = new Int32Array(new SharedArrayBuffer(4));
   while (!existsSync(gate) && Date.now() < deadline) Atomics.wait(idle, 0, 0, 20);
 };
+// The flood is multi-byte on purpose: 60 characters but 180 UTF-8 bytes, so against the
+// overflow tests' \`maxOutputBytes: 100\` it only trips the cap under a byte reading. An
+// ASCII flood trips under a \`chunk.length\` reading just as well, and so pins nothing.
+const FLOOD = "✓".repeat(60);
 if (cmd === "hang") {
   // A worker that ESCAPES the launcher's process group (detached → its own session/
   // pgid, like the real CLI's setsid'd worker), so the group-only SIGKILL can't reach
@@ -118,7 +122,7 @@ if (cmd === "flood") {
   // Emit more than the test's maxOutputBytes, then hang on a second sentinel sleep so the
   // OVERFLOW reap — not a natural exit — is what settles runVega. The reap must clear
   // both. \`secs\` is the per-test sentinel.
-  process.stdout.write("x".repeat(4096));
+  process.stdout.write(FLOOD);
   spawnSync("sleep", [secs]);
   process.exit(0);
 }
@@ -129,7 +133,7 @@ if (cmd === "flood-err") {
   const worker = spawn("sleep", [secs], { stdio: "ignore" });
   worker.unref();
   awaitGate();
-  process.stderr.write("x".repeat(4096));
+  process.stderr.write(FLOOD);
   spawnSync("sleep", [secs]);
   process.exit(0);
 }


### PR DESCRIPTION
Fixes #849

**Cause:** both `runVega` overflow fakes flood with `"x".repeat(4096)` - pure ASCII, so `Buffer.byteLength === length` and the `maxOutputBytes: 100` cap trips under either reading. Replacing both `Buffer.byteLength(chunk, "utf-8")` in `vega-cli.ts` with `chunk.length` leaves `vega-cli-timeout.test.ts` green 12/12.

**Fix:** flood with 60 `U+2713` instead - 60 characters, 180 UTF-8 bytes. Over the cap on bytes, under it on length, so only a byte-counted cap still rejects.

Same class: `ndjson-socket`'s dropped-frame `bytes` had the same ASCII fixture, and asserted it with `Buffer.byteLength` itself, so a `raw.length` regression passed. Its frame is multi-byte with a literal expected count.

Left alone: `LogFileWriter.fileSizeBytes` also sums `Buffer.byteLength`, but its only assertions are `toBeGreaterThan(0)` / `toBe(0)` - the value is not pinned at all, a wider test gap than this issue.

Tests only - no production code, no tool/CLI/config/flow change, so no docs update needed.

<details>
<summary>Verification</summary>

All from the worktree root on `@argent/tool-server`, at base `e353e9bd8`.

Mutation (`stdoutBytes += chunk.length`, `stderrBytes += chunk.length`, `bytes: raw.length`) with the tests as they stand on `main`:

```
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

Same mutation, with this change:

```
 × reports an unparseable frame with byte length and a sanitised preview, then continues
 × rejects + reaps when output exceeds the cap, classified as `subprocess`
 × rejects + reaps when STDERR exceeds the cap, classified as `subprocess`
AssertionError: expected 13 to be 15
AssertionError: expected 'timeout' to be 'subprocess'
AssertionError: expected 'timeout' to be 'subprocess'
      Tests  3 failed | 15 passed (18)
```

Source restored, everything green:

- `npx tsc --build` - clean
- `npm run typecheck:tests -w @argent/tool-server` - clean
- `npm test -w @argent/tool-server` - `434 passed (434)` files, `6171 passed | 1 skipped`
- `npx prettier --check` on both files - clean

`npx eslint` on the two files could not run locally: it fails resolving `packages/docs/tsconfig.json` -> `@docusaurus/tsconfig`, a pre-existing local-install gap unrelated to this diff.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
