### PR TITLE
style(docs): reflow the tool-server env-var table

### DIFF
--- a/packages/docs/docs/reference/configuration.mdx
+++ b/packages/docs/docs/reference/configuration.mdx
@@ -183,15 +183,15 @@ An environment variable changes the behavior of the process that reads it. Expor
 
 ### Tool-server
 
-| Variable                      | Default                              | Description                                                                                                                                                   |
-| ----------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ARGENT_PORT`                 | `3001`                               | The port the tool-server listens on                                                                                                                           |
-| `ARGENT_HOST`                 | `127.0.0.1`                          | The address the tool-server binds to                                                                                                                          |
-| `ARGENT_IDLE_TIMEOUT_MINUTES` | `0`                                  | Minutes without a request after which the tool-server exits. `0` disables the timeout                                                                         |
-| `ARGENT_EVENT_LOG`            | `~/.argent/tool-server-events.jsonl` | Path of the event log that the `tool-server-event-log` flag writes                                                                                            |
+| Variable                      | Default                              | Description                                                                                             |
+| ----------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `ARGENT_PORT`                 | `3001`                               | The port the tool-server listens on                                                                     |
+| `ARGENT_HOST`                 | `127.0.0.1`                          | The address the tool-server binds to                                                                    |
+| `ARGENT_IDLE_TIMEOUT_MINUTES` | `0`                                  | Minutes without a request after which the tool-server exits. `0` disables the timeout                   |
+| `ARGENT_EVENT_LOG`            | `~/.argent/tool-server-events.jsonl` | Path of the event log that the `tool-server-event-log` flag writes                                      |
 | `ARGENT_SCREENSHOT_SCALE`     | `0.25`                               | Scale factor of a captured screenshot, between `0.01` and `1`. A smaller value returns a smaller image. |
-| `ARGENT_CHROMIUM_PORTS`       | empty                                | Comma-separated CDP ports that Argent probes for Chromium apps, in addition to `9222`                                                                         |
-| `ARGENT_CHROMIUM_PORTS_FILE`  | `~/.argent/chromium-cdp-ports.json`  | Path of the file that remembers the CDP ports of apps that Argent started                                                                                     |
+| `ARGENT_CHROMIUM_PORTS`       | empty                                | Comma-separated CDP ports that Argent probes for Chromium apps, in addition to `9222`                   |
+| `ARGENT_CHROMIUM_PORTS_FILE`  | `~/.argent/chromium-cdp-ports.json`  | Path of the file that remembers the CDP ports of apps that Argent started                               |
 
 ### Devices
 


### PR DESCRIPTION
`prettier --check .` fails on `main`, so every push since #1151 has a red **Format** job.

#1151 shortened the `ARGENT_SCREENSHOT_SCALE` description. That cell was the widest in the column, so the whole table was left padded to a width nothing occupies any more. Reflowed it with Prettier; whitespace only.

| Before | After |
| --- | --- |
| `Format` ❌ on `main` (4 consecutive pushes) | `npx prettier --check .` → exit 0 |

<details>
<summary>Verification</summary>

```
$ npx prettier --check .          # the exact CI step
Checking formatting...
All matched files use Prettier code style!
EXIT=0
```

Re-running `prettier --write` produces no further change (idempotent).

`git diff -w` reduces to the separator row alone; no cell content changed. Docs still build and the table still renders:

```
$ npx docusaurus build            # packages/docs
[SUCCESS] Generated static files in "build".
BUILD_EXIT=0

$ # parsed build/docs/reference/configuration/index.html
rows=8   (header + 7), 3 cells each, all values intact
```

</details>
